### PR TITLE
Fix release job: add contents:read for private repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
When `permissions:` is set at the job level with only `id-token: write`, all other permissions default to `none`. Private repos need explicit `contents: read` to allow `actions/checkout` to clone the repo.

This was causing the release job to fail with `Repository not found`.