### PR TITLE
Add ToolErrorRecovery capability

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,61 @@
+# Tool Error Recovery Capability Plan
+
+## Goal
+
+Provide a reusable `AbstractCapability` subclass that catches unhandled tool execution errors and recovers gracefully, preventing agent run crashes and enabling the model to self-correct.
+
+| Hook used | Purpose |
+|---|---|
+| `wrap_tool_execute` | Retry logic (re-invokes the tool handler on failure) |
+| `on_tool_execute_error` | Inform and fallback strategies (post-failure recovery) |
+
+## Design Decisions
+
+### Three configurable strategies
+
+- **`'inform'`** (default): Return a descriptive error message to the model so it can adjust its approach. This mirrors Open SWE's `ToolErrorMiddleware` which returns errors as tool messages.
+- **`('retry', N)`**: Retry the tool call up to *N* times before falling back to `inform`. This mirrors Mastra's retryable error pattern. Implemented in `wrap_tool_execute` since it needs to re-invoke the handler.
+- **`('fallback', value)`**: Return a static value on error. Useful for optional/non-critical tools where a default is acceptable.
+
+### Per-tool configuration via `tool_strategies`
+
+A `tool_strategies: dict[str, Strategy]` field allows different strategies per tool name. Any tool not listed uses `default_strategy`. This enables fine-grained control: retry flaky APIs, use fallbacks for optional lookups, and inform for everything else.
+
+### Retry implemented in `wrap_tool_execute`, not `on_tool_execute_error`
+
+`on_tool_execute_error` fires after the tool has already failed and cannot re-invoke it. Only `wrap_tool_execute` has access to the handler and can call it multiple times. When all retries are exhausted, the wrapper falls back to `inform` (returning the error message as the tool result).
+
+### Per-run state isolation via `for_run()`
+
+Retry counts are tracked per-run in `_retry_counts`. The `for_run()` method returns a fresh instance for each agent run, preventing state leakage between runs (same pattern as `StuckLoopDetection`).
+
+### `include_traceback` option
+
+By default, error messages sent to the model contain only the exception type and message. Setting `include_traceback=True` adds the full Python traceback, useful for debugging but wasteful on tokens in production.
+
+### Convenience constructors
+
+`retry(max_retries=3)` and `fallback(value=None)` provide readable shorthand for tuple strategy construction, with validation at creation time.
+
+### Spec-serializable
+
+The capability only takes simple configuration (strings, tuples, dicts, bools), so `get_serialization_name()` returns `'ToolErrorRecovery'` for YAML/JSON spec support.
+
+## Prior Art
+
+- **Open SWE** (`ToolErrorMiddleware`): Catches exceptions during tool calls and returns errors as `ToolMessage` with `status="error"` so the LLM can self-correct.
+- **Mastra**: Emits retryable error events with `retryDelay` and queues follow-up messages to the agent.
+- **LangGraph**: Tool errors returned to state for agent inspection.
+- **smolagents**: `ToolError` shown to agent for approach adjustment.
+
+## Future Work (out of scope for this PR)
+
+- **Exponential backoff** for retry delays (useful for rate-limited APIs).
+- **Custom error formatters** via a callback for domain-specific error messages.
+- **Error budgets** to abort the run after too many total tool failures across all tools.
+- **Integration with `StuckLoopDetection`** to detect retry loops.
+
+## References
+
+- Harness issue #61: Tool Error Recovery capability
+- pydantic-ai `AbstractCapability.on_tool_execute_error` and `wrap_tool_execute` hooks

--- a/src/pydantic_harness/__init__.py
+++ b/src/pydantic_harness/__init__.py
@@ -7,4 +7,10 @@ Usage:
 # Each capability module is imported and re-exported here.
 # Capabilities are listed alphabetically.
 
-__all__: list[str] = []
+from pydantic_harness.tool_error_recovery import ToolErrorRecovery, fallback, retry
+
+__all__: list[str] = [
+    'ToolErrorRecovery',
+    'fallback',
+    'retry',
+]

--- a/src/pydantic_harness/tool_error_recovery.py
+++ b/src/pydantic_harness/tool_error_recovery.py
@@ -39,6 +39,7 @@ import traceback
 from dataclasses import dataclass, field
 from typing import Any
 
+import anyio
 from pydantic_ai.capabilities.abstract import AbstractCapability, ValidatedToolArgs, WrapToolExecuteHandler
 from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.tools import RunContext, ToolDefinition
@@ -48,7 +49,12 @@ from pydantic_ai.tools import RunContext, ToolDefinition
 # ---------------------------------------------------------------------------
 
 InformStrategy = str  # Literal['inform'], but we use str for 3.10 compat
-RetryStrategy = tuple[str, int]  # ('retry', max_retries)
+RetryStrategy = tuple[str, int] | tuple[str, int, float, tuple[type[Exception], ...]]
+"""A retry strategy tuple.
+
+Short form: ``('retry', max_retries)``
+Full form: ``('retry', max_retries, retry_delay, retryable_exceptions)``
+"""
 FallbackStrategy = tuple[str, Any]  # ('fallback', value)
 
 Strategy = InformStrategy | RetryStrategy | FallbackStrategy
@@ -56,6 +62,7 @@ Strategy = InformStrategy | RetryStrategy | FallbackStrategy
 
 - ``'inform'``: Return the error message to the model.
 - ``('retry', N)``: Retry up to *N* times, then fall back to ``inform``.
+- ``('retry', N, delay, exceptions)``: Retry with exponential backoff and exception filter.
 - ``('fallback', value)``: Return *value* on error.
 """
 
@@ -71,17 +78,34 @@ def _validate_strategy(strategy: Strategy, label: str = 'strategy') -> None:
         if strategy != 'inform':
             raise ValueError(f"Invalid {label}: string strategy must be 'inform', got {strategy!r}")
         return
-    # strategy is RetryStrategy | FallbackStrategy (a 2-tuple) per the type,
-    # but at runtime it could be anything if coming from untyped input.
-    try:
-        kind, value = strategy  # type: ignore[misc]
-    except (TypeError, ValueError):
-        raise ValueError(f'Invalid {label}: expected a string or 2-tuple, got {strategy!r}') from None
+    if not isinstance(strategy, tuple):  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise ValueError(f'Invalid {label}: expected a string or tuple, got {strategy!r}')
+    if len(strategy) < 2:
+        raise ValueError(f'Invalid {label}: expected a tuple of length 2 or 4, got {strategy!r}')
+    kind = strategy[0]
     if kind == 'retry':
-        if not isinstance(value, int) or value < 1:
-            raise ValueError(f'Invalid {label}: retry max_retries must be a positive integer, got {value!r}')
+        if len(strategy) == 2:
+            _, max_retries = strategy
+            if not isinstance(max_retries, int) or max_retries < 1:  # pyright: ignore[reportUnnecessaryIsInstance]
+                raise ValueError(f'Invalid {label}: retry max_retries must be a positive integer, got {max_retries!r}')
+        elif len(strategy) == 4:
+            _, max_retries, delay, exc_types = strategy  # type: ignore[misc]
+            if not isinstance(max_retries, int) or max_retries < 1:  # pyright: ignore[reportUnnecessaryIsInstance]
+                raise ValueError(f'Invalid {label}: retry max_retries must be a positive integer, got {max_retries!r}')
+            if not isinstance(delay, (int, float)) or delay < 0:  # pyright: ignore[reportUnnecessaryIsInstance]
+                raise ValueError(f'Invalid {label}: retry_delay must be a non-negative number, got {delay!r}')
+            if not isinstance(exc_types, tuple) or not all(  # pyright: ignore[reportUnnecessaryIsInstance]
+                isinstance(t, type) and issubclass(t, Exception)  # pyright: ignore[reportUnnecessaryIsInstance]
+                for t in exc_types
+            ):
+                raise ValueError(
+                    f'Invalid {label}: retryable_exceptions must be a tuple of Exception subclasses, got {exc_types!r}'
+                )
+        else:
+            raise ValueError(f'Invalid {label}: retry strategy must be a 2-tuple or 4-tuple, got {strategy!r}')
     elif kind == 'fallback':
-        pass  # any value is acceptable
+        if len(strategy) != 2:
+            raise ValueError(f'Invalid {label}: fallback strategy must be a 2-tuple, got {strategy!r}')
     else:
         raise ValueError(f"Invalid {label}: tuple strategy kind must be 'retry' or 'fallback', got {kind!r}")
 
@@ -100,15 +124,37 @@ def _format_error(tool_name: str, error: Exception, *, include_traceback: bool) 
 # ---------------------------------------------------------------------------
 
 
-def retry(max_retries: int = 3) -> RetryStrategy:
+def retry(
+    max_retries: int = 3,
+    *,
+    retry_delay: float = 0,
+    retryable_exceptions: tuple[type[Exception], ...] = (Exception,),
+) -> RetryStrategy:
     """Create a retry strategy.
 
     Args:
         max_retries: Maximum number of retry attempts before falling back to ``inform``.
+        retry_delay: Base delay in seconds for exponential backoff between retries.
+            When > 0, waits ``retry_delay * 2 ** attempt`` seconds before each retry.
+            Defaults to 0 (no delay).
+        retryable_exceptions: Exception types eligible for retry. If the raised
+            exception is not an instance of any of these types, it is not retried
+            and the inform strategy is used immediately. Defaults to ``(Exception,)``
+            (all exceptions are retryable).
     """
     if not isinstance(max_retries, int) or max_retries < 1:  # pyright: ignore[reportUnnecessaryIsInstance]
         raise ValueError(f'max_retries must be a positive integer, got {max_retries!r}')
-    return ('retry', max_retries)
+    if not isinstance(retry_delay, (int, float)) or retry_delay < 0:  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise ValueError(f'retry_delay must be a non-negative number, got {retry_delay!r}')
+    if not isinstance(retryable_exceptions, tuple) or not all(  # pyright: ignore[reportUnnecessaryIsInstance]
+        isinstance(t, type) and issubclass(t, Exception)  # pyright: ignore[reportUnnecessaryIsInstance]
+        for t in retryable_exceptions
+    ):
+        raise ValueError(f'retryable_exceptions must be a tuple of Exception subclasses, got {retryable_exceptions!r}')
+    # Use the short 2-tuple form when defaults are used, for backward compat.
+    if retry_delay == 0 and retryable_exceptions == (Exception,):
+        return ('retry', max_retries)
+    return ('retry', max_retries, retry_delay, retryable_exceptions)
 
 
 def fallback(value: Any = None) -> FallbackStrategy:
@@ -173,10 +219,21 @@ class ToolErrorRecovery(AbstractCapability[Any]):
     Useful for debugging but may waste tokens in production.
     """
 
+    max_total_errors: int | None = None
+    """Maximum number of total errors across all tools before recovery stops.
+
+    When set, the capability tracks every error that occurs (including errors
+    consumed by retry attempts).  Once the budget is exhausted, subsequent errors
+    propagate as-is instead of being recovered.  ``None`` (default) means no limit.
+    """
+
     # --- Per-run state (populated by ``for_run``) ---
 
     _retry_counts: dict[str, int] = field(default_factory=lambda: dict[str, int](), repr=False)
     """Tracks per-tool retry counts within a single run.  Keys are ``tool_name``."""
+
+    _total_errors: int = field(default=0, repr=False)
+    """Total errors observed in this run (for ``max_total_errors`` budget)."""
 
     def __post_init__(self) -> None:
         """Validate strategies at construction time."""
@@ -195,11 +252,16 @@ class ToolErrorRecovery(AbstractCapability[Any]):
             default_strategy=self.default_strategy,
             tool_strategies=self.tool_strategies,
             include_traceback=self.include_traceback,
+            max_total_errors=self.max_total_errors,
         )
 
     def _get_strategy(self, tool_name: str) -> Strategy:
         """Look up the strategy for a given tool."""
         return self.tool_strategies.get(tool_name, self.default_strategy)
+
+    def _budget_exhausted(self) -> bool:
+        """Return ``True`` if the error budget has been spent."""
+        return self.max_total_errors is not None and self._total_errors > self.max_total_errors
 
     async def wrap_tool_execute(
         self,
@@ -222,6 +284,10 @@ class ToolErrorRecovery(AbstractCapability[Any]):
             return await handler(args)
 
         max_retries: int = strategy[1]
+        retry_delay: float = strategy[2] if len(strategy) == 4 else 0  # type: ignore[misc]
+        retryable_exceptions: tuple[type[Exception], ...] = (
+            strategy[3] if len(strategy) == 4 else (Exception,)  # type: ignore[misc]
+        )
         last_error: Exception | None = None
 
         for attempt in range(1 + max_retries):
@@ -232,8 +298,20 @@ class ToolErrorRecovery(AbstractCapability[Any]):
                 return result
             except Exception as exc:
                 last_error = exc
+                self._total_errors += 1
                 self._retry_counts[call.tool_name] = attempt + 1
+
+                # If the exception isn't retryable, stop immediately.
+                if not isinstance(exc, retryable_exceptions):
+                    return _format_error(call.tool_name, exc, include_traceback=self.include_traceback)
+
+                # If the error budget is exhausted, let the error propagate.
+                if self._budget_exhausted():
+                    raise
+
                 if attempt < max_retries:
+                    if retry_delay > 0:
+                        await anyio.sleep(retry_delay * (2**attempt))
                     continue
                 # All retries exhausted -- fall through to inform.
                 return _format_error(call.tool_name, exc, include_traceback=self.include_traceback)
@@ -256,6 +334,12 @@ class ToolErrorRecovery(AbstractCapability[Any]):
         and this hook is not reached (the wrapper catches exceptions before
         they propagate to the hook).
         """
+        self._total_errors += 1
+
+        # If the error budget is exhausted, let the error propagate.
+        if self._budget_exhausted():
+            raise error
+
         strategy = self._get_strategy(call.tool_name)
 
         if isinstance(strategy, tuple) and strategy[0] == 'fallback':

--- a/src/pydantic_harness/tool_error_recovery.py
+++ b/src/pydantic_harness/tool_error_recovery.py
@@ -1,0 +1,277 @@
+"""Tool error recovery capability for PydanticAI agents.
+
+Catches unhandled tool execution errors and applies a configurable recovery
+strategy so the agent run can continue instead of crashing.
+
+Strategies:
+    - ``inform`` (default): Return a descriptive error message to the model
+      so it can adapt its approach.
+    - ``retry``: Retry the failed tool call up to *N* times before falling
+      back to ``inform``.
+    - ``fallback``: Return a static fallback value on error.
+
+Per-tool strategies can be configured via ``tool_strategies``, with a
+``default_strategy`` applied to any tools not listed.
+
+Example:
+    ```python
+    from pydantic_ai import Agent
+    from pydantic_harness import ToolErrorRecovery
+
+    agent = Agent(
+        'openai:gpt-4.1',
+        capabilities=[
+            ToolErrorRecovery(
+                default_strategy='inform',
+                tool_strategies={
+                    'flaky_api': ('retry', 3),
+                    'optional_lookup': ('fallback', None),
+                },
+            ),
+        ],
+    )
+    ```
+"""
+
+from __future__ import annotations
+
+import traceback
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic_ai.capabilities.abstract import AbstractCapability, ValidatedToolArgs, WrapToolExecuteHandler
+from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.tools import RunContext, ToolDefinition
+
+# ---------------------------------------------------------------------------
+# Strategy types
+# ---------------------------------------------------------------------------
+
+InformStrategy = str  # Literal['inform'], but we use str for 3.10 compat
+RetryStrategy = tuple[str, int]  # ('retry', max_retries)
+FallbackStrategy = tuple[str, Any]  # ('fallback', value)
+
+Strategy = InformStrategy | RetryStrategy | FallbackStrategy
+"""A recovery strategy.
+
+- ``'inform'``: Return the error message to the model.
+- ``('retry', N)``: Retry up to *N* times, then fall back to ``inform``.
+- ``('fallback', value)``: Return *value* on error.
+"""
+
+
+def _validate_strategy(strategy: Strategy, label: str = 'strategy') -> None:
+    """Raise ``ValueError`` if *strategy* is not a well-formed :data:`Strategy`.
+
+    Note: accepts ``Strategy`` at the type level but performs full runtime
+    validation (including shape checks) because strategies can come from
+    untyped sources like YAML specs.
+    """
+    if isinstance(strategy, str):
+        if strategy != 'inform':
+            raise ValueError(f"Invalid {label}: string strategy must be 'inform', got {strategy!r}")
+        return
+    # strategy is RetryStrategy | FallbackStrategy (a 2-tuple) per the type,
+    # but at runtime it could be anything if coming from untyped input.
+    try:
+        kind, value = strategy  # type: ignore[misc]
+    except (TypeError, ValueError):
+        raise ValueError(f'Invalid {label}: expected a string or 2-tuple, got {strategy!r}') from None
+    if kind == 'retry':
+        if not isinstance(value, int) or value < 1:
+            raise ValueError(f'Invalid {label}: retry max_retries must be a positive integer, got {value!r}')
+    elif kind == 'fallback':
+        pass  # any value is acceptable
+    else:
+        raise ValueError(f"Invalid {label}: tuple strategy kind must be 'retry' or 'fallback', got {kind!r}")
+
+
+def _format_error(tool_name: str, error: Exception, *, include_traceback: bool) -> str:
+    """Build a human-readable error string for the model."""
+    parts = [f'Error in tool `{tool_name}` ({type(error).__name__}): {error}']
+    if include_traceback:
+        tb = traceback.format_exception(type(error), error, error.__traceback__)
+        parts.append('Traceback:\n' + ''.join(tb))
+    return '\n'.join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Convenience constructors
+# ---------------------------------------------------------------------------
+
+
+def retry(max_retries: int = 3) -> RetryStrategy:
+    """Create a retry strategy.
+
+    Args:
+        max_retries: Maximum number of retry attempts before falling back to ``inform``.
+    """
+    if not isinstance(max_retries, int) or max_retries < 1:  # pyright: ignore[reportUnnecessaryIsInstance]
+        raise ValueError(f'max_retries must be a positive integer, got {max_retries!r}')
+    return ('retry', max_retries)
+
+
+def fallback(value: Any = None) -> FallbackStrategy:
+    """Create a fallback strategy.
+
+    Args:
+        value: The value to return when the tool fails.
+    """
+    return ('fallback', value)
+
+
+# ---------------------------------------------------------------------------
+# Capability
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ToolErrorRecovery(AbstractCapability[Any]):
+    """Catch tool execution errors and recover gracefully.
+
+    Instead of letting unhandled exceptions crash the agent run, this
+    capability intercepts failures via the ``on_tool_execute_error`` hook
+    and applies a configurable strategy per tool.
+
+    Strategies:
+        - ``'inform'`` (default) -- Return a descriptive error message to the
+          model so it can adjust its approach.
+        - ``('retry', N)`` -- Retry the tool call up to *N* times. If all
+          retries fail, fall back to ``inform``.
+        - ``('fallback', value)`` -- Return a static value on error.
+
+    Per-tool configuration is available via ``tool_strategies``.  Any tool
+    not listed uses ``default_strategy``.
+
+    Example::
+
+        from pydantic_ai import Agent
+        from pydantic_harness import ToolErrorRecovery
+
+        agent = Agent(
+            'openai:gpt-4.1',
+            capabilities=[
+                ToolErrorRecovery(
+                    tool_strategies={
+                        'flaky_api': ('retry', 3),
+                        'optional_lookup': ('fallback', None),
+                    },
+                ),
+            ],
+        )
+    """
+
+    default_strategy: Strategy = 'inform'
+    """Strategy applied to tools not listed in ``tool_strategies``."""
+
+    tool_strategies: dict[str, Strategy] = field(default_factory=lambda: dict[str, Strategy]())
+    """Per-tool strategy overrides.  Keys are tool names."""
+
+    include_traceback: bool = False
+    """Whether to include the Python traceback in error messages sent to the model.
+
+    Useful for debugging but may waste tokens in production.
+    """
+
+    # --- Per-run state (populated by ``for_run``) ---
+
+    _retry_counts: dict[str, int] = field(default_factory=lambda: dict[str, int](), repr=False)
+    """Tracks per-tool retry counts within a single run.  Keys are ``tool_name``."""
+
+    def __post_init__(self) -> None:
+        """Validate strategies at construction time."""
+        _validate_strategy(self.default_strategy, 'default_strategy')
+        for name, strat in self.tool_strategies.items():
+            _validate_strategy(strat, f'tool_strategies[{name!r}]')
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        """Return serialization name for spec construction."""
+        return 'ToolErrorRecovery'
+
+    async def for_run(self, ctx: RunContext[Any]) -> ToolErrorRecovery:
+        """Return a fresh instance with empty retry counts for each agent run."""
+        return ToolErrorRecovery(
+            default_strategy=self.default_strategy,
+            tool_strategies=self.tool_strategies,
+            include_traceback=self.include_traceback,
+        )
+
+    def _get_strategy(self, tool_name: str) -> Strategy:
+        """Look up the strategy for a given tool."""
+        return self.tool_strategies.get(tool_name, self.default_strategy)
+
+    async def wrap_tool_execute(
+        self,
+        ctx: RunContext[Any],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: ValidatedToolArgs,
+        handler: WrapToolExecuteHandler,
+    ) -> Any:
+        """Wrap tool execution to implement retry logic.
+
+        The ``retry`` strategy requires re-invoking the tool, which can only
+        be done from ``wrap_tool_execute`` (``on_tool_execute_error`` fires
+        after the tool has already failed and cannot re-invoke it).
+        """
+        strategy = self._get_strategy(call.tool_name)
+        if not (isinstance(strategy, tuple) and strategy[0] == 'retry'):
+            # Non-retry strategies are handled by on_tool_execute_error.
+            return await handler(args)
+
+        max_retries: int = strategy[1]
+        last_error: Exception | None = None
+
+        for attempt in range(1 + max_retries):
+            try:
+                result = await handler(args)
+                # Success -- reset retry count for this tool.
+                self._retry_counts.pop(call.tool_name, None)
+                return result
+            except Exception as exc:
+                last_error = exc
+                self._retry_counts[call.tool_name] = attempt + 1
+                if attempt < max_retries:
+                    continue
+                # All retries exhausted -- fall through to inform.
+                return _format_error(call.tool_name, exc, include_traceback=self.include_traceback)
+
+        # Unreachable, but satisfies the type checker.
+        raise last_error  # type: ignore[misc] # pragma: no cover
+
+    async def on_tool_execute_error(
+        self,
+        ctx: RunContext[Any],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: ValidatedToolArgs,
+        error: Exception,
+    ) -> Any:
+        """Handle tool execution errors for non-retry strategies.
+
+        For ``retry`` strategies, errors are handled by ``wrap_tool_execute``
+        and this hook is not reached (the wrapper catches exceptions before
+        they propagate to the hook).
+        """
+        strategy = self._get_strategy(call.tool_name)
+
+        if isinstance(strategy, tuple) and strategy[0] == 'fallback':
+            return strategy[1]
+
+        # Default: 'inform' strategy.
+        return _format_error(call.tool_name, error, include_traceback=self.include_traceback)
+
+
+# ---------------------------------------------------------------------------
+# Exports
+# ---------------------------------------------------------------------------
+
+__all__ = [
+    'ToolErrorRecovery',
+    'Strategy',
+    'retry',
+    'fallback',
+]

--- a/tests/test_tool_error_recovery.py
+++ b/tests/test_tool_error_recovery.py
@@ -98,12 +98,12 @@ class TestValidateStrategy:
         with pytest.raises(ValueError, match="'retry' or 'fallback'"):
             _validate_strategy(('nope', 1))
 
-    def test_bad_shape(self):
-        with pytest.raises(ValueError, match='2-tuple'):
+    def test_bad_shape_3_tuple(self):
+        with pytest.raises(ValueError, match='2-tuple or 4-tuple'):
             _validate_strategy(('retry', 1, 2))  # type: ignore[arg-type]
 
     def test_non_tuple_non_string(self):
-        with pytest.raises(ValueError, match='2-tuple'):
+        with pytest.raises(ValueError, match='string or tuple'):
             _validate_strategy(42)  # type: ignore[arg-type]
 
 
@@ -442,6 +442,330 @@ async def test_default_retry():
     result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
     assert 'RuntimeError' in result
     assert 'always fails' in result
+
+
+# ---------------------------------------------------------------------------
+# Exponential backoff
+# ---------------------------------------------------------------------------
+
+
+class TestRetryDelay:
+    def test_retry_with_delay_produces_4_tuple(self):
+        strategy = retry(2, retry_delay=0.5)
+        assert strategy == ('retry', 2, 0.5, (Exception,))
+
+    def test_retry_defaults_produce_2_tuple(self):
+        strategy = retry(3)
+        assert strategy == ('retry', 3)
+
+    def test_retry_delay_validation_negative(self):
+        with pytest.raises(ValueError, match='non-negative'):
+            retry(2, retry_delay=-1)
+
+    def test_retry_delay_validation_bad_type(self):
+        with pytest.raises(ValueError, match='non-negative'):
+            retry(2, retry_delay='fast')  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio()
+async def test_retry_exponential_backoff_timing(monkeypatch: pytest.MonkeyPatch):
+    """Verify that exponential backoff sleeps with increasing delays."""
+    from unittest.mock import AsyncMock, call
+
+    import anyio
+
+    import pydantic_harness.tool_error_recovery as module
+
+    mock_sleep = AsyncMock(side_effect=anyio.sleep)
+    monkeypatch.setattr(module.anyio, 'sleep', mock_sleep)
+
+    cap = ToolErrorRecovery(tool_strategies={'t': retry(3, retry_delay=0.1)})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('t')
+    td: object = _FakeToolDef()
+
+    call_count = 0
+
+    async def handler(args: dict[str, object]) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 3:
+            raise ConnectionError('transient')
+        return 'ok'
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert result == 'ok'
+    assert call_count == 4
+    # Delays: 0.1 * 2^0, 0.1 * 2^1, 0.1 * 2^2
+    assert mock_sleep.call_args_list == [call(0.1), call(0.2), call(0.4)]
+
+
+@pytest.mark.anyio()
+async def test_retry_no_delay_by_default(monkeypatch: pytest.MonkeyPatch):
+    """When retry_delay=0, anyio.sleep should not be called."""
+    from unittest.mock import AsyncMock
+
+    import anyio
+
+    import pydantic_harness.tool_error_recovery as module
+
+    mock_sleep = AsyncMock(side_effect=anyio.sleep)
+    monkeypatch.setattr(module.anyio, 'sleep', mock_sleep)
+
+    cap = ToolErrorRecovery(tool_strategies={'t': retry(2)})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('t')
+    td: object = _FakeToolDef()
+
+    call_count = 0
+
+    async def handler(args: dict[str, object]) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise ConnectionError('transient')
+        return 'ok'
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert result == 'ok'
+    mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Retryable exceptions filter
+# ---------------------------------------------------------------------------
+
+
+class TestRetryableExceptions:
+    def test_retry_with_filter_produces_4_tuple(self):
+        strategy = retry(2, retryable_exceptions=(ConnectionError, TimeoutError))
+        assert strategy == ('retry', 2, 0, (ConnectionError, TimeoutError))
+
+    def test_invalid_retryable_exceptions_not_tuple(self):
+        with pytest.raises(ValueError, match='retryable_exceptions'):
+            retry(2, retryable_exceptions=[ConnectionError])  # type: ignore[arg-type]
+
+    def test_invalid_retryable_exceptions_not_exception(self):
+        with pytest.raises(ValueError, match='retryable_exceptions'):
+            retry(2, retryable_exceptions=(str,))  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio()
+async def test_retryable_exception_match_retries():
+    """When the exception matches retryable_exceptions, it should be retried."""
+    cap = ToolErrorRecovery(tool_strategies={'t': retry(3, retryable_exceptions=(ConnectionError,))})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('t')
+    td: object = _FakeToolDef()
+
+    call_count = 0
+
+    async def handler(args: dict[str, object]) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ConnectionError('transient')
+        return 'recovered'
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert result == 'recovered'
+    assert call_count == 3
+
+
+@pytest.mark.anyio()
+async def test_non_retryable_exception_skips_retry():
+    """When the exception does not match retryable_exceptions, it should not be retried."""
+    cap = ToolErrorRecovery(tool_strategies={'t': retry(3, retryable_exceptions=(ConnectionError,))})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('t')
+    td: object = _FakeToolDef()
+
+    call_count = 0
+
+    async def handler(args: dict[str, object]) -> str:
+        nonlocal call_count
+        call_count += 1
+        raise ValueError('not retryable')
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    # Should return inform message immediately, no retries.
+    assert call_count == 1
+    assert isinstance(result, str)
+    assert 'ValueError' in result
+    assert 'not retryable' in result
+
+
+@pytest.mark.anyio()
+async def test_retryable_subclass_matches():
+    """Subclasses of retryable exceptions should also be retried."""
+    cap = ToolErrorRecovery(tool_strategies={'t': retry(2, retryable_exceptions=(OSError,))})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('t')
+    td: object = _FakeToolDef()
+
+    call_count = 0
+
+    async def handler(args: dict[str, object]) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise ConnectionError('subclass of OSError')  # ConnectionError is a subclass of OSError
+        return 'ok'
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert result == 'ok'
+    assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Error budget (max_total_errors)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorBudget:
+    def test_construction_with_budget(self):
+        cap = ToolErrorRecovery(max_total_errors=5)
+        assert cap.max_total_errors == 5
+        assert cap._total_errors == 0
+
+    def test_default_no_budget(self):
+        cap = ToolErrorRecovery()
+        assert cap.max_total_errors is None
+
+
+@pytest.mark.anyio()
+async def test_for_run_preserves_max_total_errors():
+    cap = ToolErrorRecovery(max_total_errors=10)
+    cap._total_errors = 7  # simulate errors from a previous run
+    fresh = await cap.for_run(_FakeCtx())  # type: ignore[arg-type]
+    assert fresh.max_total_errors == 10
+    assert fresh._total_errors == 0
+
+
+@pytest.mark.anyio()
+async def test_error_budget_inform_strategy():
+    """After max_total_errors is reached, inform strategy should let errors propagate."""
+    cap = ToolErrorRecovery(default_strategy='inform', max_total_errors=2)
+    ctx: object = _FakeCtx()
+    tc = _make_tc('tool')
+    td: object = _FakeToolDef()
+
+    # First two errors should be recovered.
+    result1 = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=RuntimeError('err1'))  # type: ignore[arg-type]
+    assert isinstance(result1, str)
+    assert 'err1' in result1
+
+    result2 = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=RuntimeError('err2'))  # type: ignore[arg-type]
+    assert isinstance(result2, str)
+    assert 'err2' in result2
+
+    # Third error should propagate (budget of 2 is exhausted).
+    with pytest.raises(RuntimeError, match='err3'):
+        await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=RuntimeError('err3'))  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio()
+async def test_error_budget_fallback_strategy():
+    """After budget is exhausted, fallback strategy should also let errors propagate."""
+    cap = ToolErrorRecovery(default_strategy=('fallback', 'safe'), max_total_errors=1)
+    ctx: object = _FakeCtx()
+    tc = _make_tc('tool')
+    td: object = _FakeToolDef()
+
+    # First error: fallback works.
+    result = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=RuntimeError('err'))  # type: ignore[arg-type]
+    assert result == 'safe'
+
+    # Second error: budget exhausted, propagates.
+    with pytest.raises(RuntimeError, match='err2'):
+        await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=RuntimeError('err2'))  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio()
+async def test_error_budget_retry_strategy():
+    """After budget is exhausted during retries, the error should propagate."""
+    cap = ToolErrorRecovery(tool_strategies={'t': retry(5)}, max_total_errors=3)
+    ctx: object = _FakeCtx()
+    tc = _make_tc('t')
+    td: object = _FakeToolDef()
+
+    async def handler(args: dict[str, object]) -> str:
+        raise RuntimeError('always fails')
+
+    # The retry loop counts each attempt. 3 errors are recovered, the 4th propagates.
+    with pytest.raises(RuntimeError, match='always fails'):
+        await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+
+    assert cap._total_errors == 4
+
+
+@pytest.mark.anyio()
+async def test_error_budget_across_tools():
+    """Error budget is shared across all tools."""
+    cap = ToolErrorRecovery(default_strategy='inform', max_total_errors=2)
+    ctx: object = _FakeCtx()
+    td: object = _FakeToolDef()
+
+    # Two different tools each use one error from the budget.
+    tc1 = _make_tc('tool_a')
+    tc2 = _make_tc('tool_b')
+    tc3 = _make_tc('tool_c')
+
+    await cap.on_tool_execute_error(ctx, call=tc1, tool_def=td, args={}, error=RuntimeError('a'))  # type: ignore[arg-type]
+    await cap.on_tool_execute_error(ctx, call=tc2, tool_def=td, args={}, error=RuntimeError('b'))  # type: ignore[arg-type]
+
+    # Third error from a different tool: budget exhausted.
+    with pytest.raises(RuntimeError, match='c'):
+        await cap.on_tool_execute_error(ctx, call=tc3, tool_def=td, args={}, error=RuntimeError('c'))  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio()
+async def test_no_budget_unlimited_recovery():
+    """Without max_total_errors, recovery should work indefinitely."""
+    cap = ToolErrorRecovery(default_strategy='inform')
+    ctx: object = _FakeCtx()
+    tc = _make_tc('tool')
+    td: object = _FakeToolDef()
+
+    for i in range(100):
+        result = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=RuntimeError(f'err{i}'))  # type: ignore[arg-type]
+        assert isinstance(result, str)
+
+    assert cap._total_errors == 100
+
+
+# ---------------------------------------------------------------------------
+# Validate strategy for extended retry tuples
+# ---------------------------------------------------------------------------
+
+
+class TestValidateStrategyExtended:
+    def test_valid_4_tuple_retry(self):
+        _validate_strategy(('retry', 3, 0.5, (ConnectionError, TimeoutError)))  # should not raise
+
+    def test_too_short_tuple(self):
+        with pytest.raises(ValueError, match='length 2 or 4'):
+            _validate_strategy(('retry',))  # type: ignore[arg-type]
+
+    def test_4_tuple_retry_invalid_max_retries(self):
+        with pytest.raises(ValueError, match='positive integer'):
+            _validate_strategy(('retry', 0, 0.5, (Exception,)))
+
+    def test_invalid_4_tuple_bad_delay(self):
+        with pytest.raises(ValueError, match='non-negative'):
+            _validate_strategy(('retry', 3, -1.0, (Exception,)))
+
+    def test_invalid_4_tuple_bad_exceptions(self):
+        with pytest.raises(ValueError, match='retryable_exceptions'):
+            _validate_strategy(('retry', 3, 0.0, (str,)))
+
+    def test_invalid_4_tuple_exceptions_not_tuple(self):
+        with pytest.raises(ValueError, match='retryable_exceptions'):
+            _validate_strategy(('retry', 3, 0.0, [Exception]))  # type: ignore[arg-type]
+
+    def test_fallback_3_tuple_invalid(self):
+        with pytest.raises(ValueError, match='fallback strategy must be a 2-tuple'):
+            _validate_strategy(('fallback', 'val', 'extra'))  # type: ignore[arg-type]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_error_recovery.py
+++ b/tests/test_tool_error_recovery.py
@@ -1,0 +1,459 @@
+"""Tests for the ToolErrorRecovery capability."""
+# pyright: reportPrivateUsage=false, reportArgumentType=false
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai.messages import ToolCallPart
+
+from pydantic_harness.tool_error_recovery import (
+    ToolErrorRecovery,
+    _format_error,
+    _validate_strategy,
+    fallback,
+    retry,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeCtx:
+    """Minimal stand-in for RunContext."""
+
+
+class _FakeToolDef:
+    """Minimal stand-in for ToolDefinition."""
+
+
+def _make_tc(name: str, args: dict[str, object] | None = None) -> ToolCallPart:
+    return ToolCallPart(tool_name=name, args=args)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for convenience constructors
+# ---------------------------------------------------------------------------
+
+
+class TestRetry:
+    def test_default(self):
+        assert retry() == ('retry', 3)
+
+    def test_custom(self):
+        assert retry(5) == ('retry', 5)
+
+    def test_invalid_zero(self):
+        with pytest.raises(ValueError, match='positive integer'):
+            retry(0)
+
+    def test_invalid_negative(self):
+        with pytest.raises(ValueError, match='positive integer'):
+            retry(-1)
+
+    def test_invalid_type(self):
+        with pytest.raises(ValueError, match='positive integer'):
+            retry('three')  # type: ignore[arg-type]
+
+
+class TestFallback:
+    def test_default(self):
+        assert fallback() == ('fallback', None)
+
+    def test_custom_value(self):
+        assert fallback('N/A') == ('fallback', 'N/A')
+
+    def test_custom_dict(self):
+        assert fallback({'error': True}) == ('fallback', {'error': True})
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for strategy validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateStrategy:
+    def test_inform(self):
+        _validate_strategy('inform')  # should not raise
+
+    def test_invalid_string(self):
+        with pytest.raises(ValueError, match="must be 'inform'"):
+            _validate_strategy('unknown')
+
+    def test_retry_valid(self):
+        _validate_strategy(('retry', 3))  # should not raise
+
+    def test_retry_invalid_count(self):
+        with pytest.raises(ValueError, match='positive integer'):
+            _validate_strategy(('retry', 0))
+
+    def test_retry_non_int(self):
+        with pytest.raises(ValueError, match='positive integer'):
+            _validate_strategy(('retry', 'x'))
+
+    def test_fallback_valid(self):
+        _validate_strategy(('fallback', None))  # should not raise
+
+    def test_unknown_tuple_kind(self):
+        with pytest.raises(ValueError, match="'retry' or 'fallback'"):
+            _validate_strategy(('nope', 1))
+
+    def test_bad_shape(self):
+        with pytest.raises(ValueError, match='2-tuple'):
+            _validate_strategy(('retry', 1, 2))  # type: ignore[arg-type]
+
+    def test_non_tuple_non_string(self):
+        with pytest.raises(ValueError, match='2-tuple'):
+            _validate_strategy(42)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for error formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatError:
+    def test_basic(self):
+        err = RuntimeError('file not found')
+        msg = _format_error('read_file', err, include_traceback=False)
+        assert 'read_file' in msg
+        assert 'RuntimeError' in msg
+        assert 'file not found' in msg
+        assert 'Traceback' not in msg
+
+    def test_with_traceback(self):
+        try:
+            raise ValueError('bad value')
+        except ValueError as exc:
+            msg = _format_error('validate', exc, include_traceback=True)
+        assert 'Traceback' in msg
+        assert 'ValueError' in msg
+        assert 'bad value' in msg
+
+
+# ---------------------------------------------------------------------------
+# Construction validation
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_defaults(self):
+        cap = ToolErrorRecovery()
+        assert cap.default_strategy == 'inform'
+        assert cap.tool_strategies == {}
+        assert cap.include_traceback is False
+        assert cap._retry_counts == {}
+
+    def test_custom_strategies(self):
+        cap = ToolErrorRecovery(
+            default_strategy=('retry', 2),
+            tool_strategies={'api_call': ('fallback', 'unavailable')},
+        )
+        assert cap.default_strategy == ('retry', 2)
+        assert cap._get_strategy('api_call') == ('fallback', 'unavailable')
+        assert cap._get_strategy('unknown_tool') == ('retry', 2)
+
+    def test_invalid_default_strategy(self):
+        with pytest.raises(ValueError, match="must be 'inform'"):
+            ToolErrorRecovery(default_strategy='bad')
+
+    def test_invalid_tool_strategy(self):
+        with pytest.raises(ValueError, match='positive integer'):
+            ToolErrorRecovery(tool_strategies={'foo': ('retry', -1)})
+
+
+# ---------------------------------------------------------------------------
+# for_run isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio()
+async def test_for_run_returns_fresh_instance():
+    cap = ToolErrorRecovery(
+        default_strategy=('retry', 2),
+        tool_strategies={'x': 'inform'},
+        include_traceback=True,
+    )
+    cap._retry_counts['x'] = 5
+
+    fresh = await cap.for_run(_FakeCtx())  # type: ignore[arg-type]
+    assert fresh is not cap
+    assert fresh._retry_counts == {}
+    assert fresh.default_strategy == cap.default_strategy
+    assert fresh.tool_strategies == cap.tool_strategies
+    assert fresh.include_traceback == cap.include_traceback
+
+
+# ---------------------------------------------------------------------------
+# on_tool_execute_error — inform strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio()
+async def test_inform_returns_error_message():
+    cap = ToolErrorRecovery()
+    ctx: object = _FakeCtx()
+    tc = _make_tc('read_file', {'path': '/missing'})
+    td: object = _FakeToolDef()
+    err = FileNotFoundError('/missing')
+
+    result = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={'path': '/missing'}, error=err)  # type: ignore[arg-type]
+    assert 'read_file' in result
+    assert 'FileNotFoundError' in result
+    assert '/missing' in result
+
+
+@pytest.mark.anyio()
+async def test_inform_with_traceback():
+    cap = ToolErrorRecovery(include_traceback=True)
+    ctx: object = _FakeCtx()
+    tc = _make_tc('do_thing')
+    td: object = _FakeToolDef()
+    try:
+        raise RuntimeError('boom')
+    except RuntimeError as exc:
+        result = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=exc)  # type: ignore[arg-type]
+    assert 'Traceback' in result
+    assert 'boom' in result
+
+
+# ---------------------------------------------------------------------------
+# on_tool_execute_error — fallback strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio()
+async def test_fallback_returns_value():
+    cap = ToolErrorRecovery(tool_strategies={'api_call': ('fallback', 'unavailable')})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('api_call')
+    td: object = _FakeToolDef()
+    err = ConnectionError('timeout')
+
+    result = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=err)  # type: ignore[arg-type]
+    assert result == 'unavailable'
+
+
+@pytest.mark.anyio()
+async def test_fallback_none():
+    cap = ToolErrorRecovery(tool_strategies={'x': ('fallback', None)})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('x')
+    td: object = _FakeToolDef()
+    err = ValueError('oops')
+
+    result = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=err)  # type: ignore[arg-type]
+    assert result is None
+
+
+@pytest.mark.anyio()
+async def test_fallback_dict():
+    cap = ToolErrorRecovery(tool_strategies={'lookup': fallback({'found': False})})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('lookup')
+    td: object = _FakeToolDef()
+
+    result = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=RuntimeError('x'))  # type: ignore[arg-type]
+    assert result == {'found': False}
+
+
+# ---------------------------------------------------------------------------
+# wrap_tool_execute — retry strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio()
+async def test_retry_succeeds_on_first_attempt():
+    cap = ToolErrorRecovery(tool_strategies={'flaky': retry(3)})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('flaky')
+    td: object = _FakeToolDef()
+
+    async def handler(args: dict[str, object]) -> str:
+        return 'ok'
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert result == 'ok'
+
+
+@pytest.mark.anyio()
+async def test_retry_succeeds_after_failures():
+    cap = ToolErrorRecovery(tool_strategies={'flaky': retry(3)})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('flaky')
+    td: object = _FakeToolDef()
+
+    call_count = 0
+
+    async def handler(args: dict[str, object]) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ConnectionError('transient')
+        return 'recovered'
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert result == 'recovered'
+    assert call_count == 3
+    # Retry count should be cleared on success.
+    assert 'flaky' not in cap._retry_counts
+
+
+@pytest.mark.anyio()
+async def test_retry_exhausted_falls_back_to_inform():
+    cap = ToolErrorRecovery(tool_strategies={'flaky': retry(2)})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('flaky')
+    td: object = _FakeToolDef()
+
+    async def handler(args: dict[str, object]) -> str:
+        raise RuntimeError('persistent failure')
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert isinstance(result, str)
+    assert 'flaky' in result
+    assert 'RuntimeError' in result
+    assert 'persistent failure' in result
+    # Retry count should reflect total attempts.
+    assert cap._retry_counts['flaky'] == 3  # 1 initial + 2 retries
+
+
+@pytest.mark.anyio()
+async def test_retry_with_traceback():
+    cap = ToolErrorRecovery(tool_strategies={'t': retry(1)}, include_traceback=True)
+    ctx: object = _FakeCtx()
+    tc = _make_tc('t')
+    td: object = _FakeToolDef()
+
+    async def handler(args: dict[str, object]) -> str:
+        raise ValueError('detail')
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert 'Traceback' in result
+
+
+@pytest.mark.anyio()
+async def test_non_retry_strategy_passes_through_to_error_hook():
+    """For inform/fallback strategies, wrap_tool_execute just calls handler directly."""
+    cap = ToolErrorRecovery(default_strategy='inform')
+    ctx: object = _FakeCtx()
+    tc = _make_tc('tool')
+    td: object = _FakeToolDef()
+
+    async def handler(args: dict[str, object]) -> str:
+        raise RuntimeError('boom')
+
+    # wrap_tool_execute should NOT catch the error for non-retry strategies;
+    # it re-raises so on_tool_execute_error can handle it.
+    with pytest.raises(RuntimeError, match='boom'):
+        await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Strategy resolution
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyResolution:
+    def test_tool_specific_overrides_default(self):
+        cap = ToolErrorRecovery(
+            default_strategy='inform',
+            tool_strategies={'special': ('fallback', 42)},
+        )
+        assert cap._get_strategy('special') == ('fallback', 42)
+        assert cap._get_strategy('other') == 'inform'
+
+    def test_default_strategy_used_for_unknown(self):
+        cap = ToolErrorRecovery(default_strategy=retry(5))
+        assert cap._get_strategy('anything') == ('retry', 5)
+
+
+# ---------------------------------------------------------------------------
+# Serialization name
+# ---------------------------------------------------------------------------
+
+
+def test_serialization_name():
+    assert ToolErrorRecovery.get_serialization_name() == 'ToolErrorRecovery'
+
+
+# ---------------------------------------------------------------------------
+# Retry resets on success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio()
+async def test_retry_count_resets_on_success():
+    cap = ToolErrorRecovery(tool_strategies={'t': retry(3)})
+    ctx: object = _FakeCtx()
+    tc = _make_tc('t')
+    td: object = _FakeToolDef()
+
+    # First call: fail once, then succeed.
+    call_count = 0
+
+    async def handler_fail_once(args: dict[str, object]) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError('transient')
+        return 'ok'
+
+    await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler_fail_once)  # type: ignore[arg-type]
+    assert 't' not in cap._retry_counts
+
+    # Second call: should start with a fresh retry budget.
+    call_count = 0
+    await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler_fail_once)  # type: ignore[arg-type]
+    assert 't' not in cap._retry_counts
+
+
+# ---------------------------------------------------------------------------
+# Default fallback strategy for all tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio()
+async def test_default_fallback():
+    cap = ToolErrorRecovery(default_strategy=fallback('default_value'))
+    ctx: object = _FakeCtx()
+    tc = _make_tc('any_tool')
+    td: object = _FakeToolDef()
+
+    result = await cap.on_tool_execute_error(ctx, call=tc, tool_def=td, args={}, error=RuntimeError('x'))  # type: ignore[arg-type]
+    assert result == 'default_value'
+
+
+# ---------------------------------------------------------------------------
+# Default retry strategy for all tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio()
+async def test_default_retry():
+    cap = ToolErrorRecovery(default_strategy=retry(1))
+    ctx: object = _FakeCtx()
+    tc = _make_tc('any_tool')
+    td: object = _FakeToolDef()
+
+    async def handler(args: dict[str, object]) -> str:
+        raise RuntimeError('always fails')
+
+    result = await cap.wrap_tool_execute(ctx, call=tc, tool_def=td, args={}, handler=handler)  # type: ignore[arg-type]
+    assert 'RuntimeError' in result
+    assert 'always fails' in result
+
+
+# ---------------------------------------------------------------------------
+# Public API import
+# ---------------------------------------------------------------------------
+
+
+def test_public_import():
+    from pydantic_harness import ToolErrorRecovery as TER
+    from pydantic_harness import fallback as fb
+    from pydantic_harness import retry as rt
+
+    assert TER is ToolErrorRecovery
+    assert fb is fallback
+    assert rt is retry


### PR DESCRIPTION

## Summary

- Adds `ToolErrorRecovery` capability that catches unhandled tool execution errors and recovers gracefully, preventing agent run crashes
- Three configurable strategies: `'inform'` (default, returns error message to model), `('retry', N)` (retries up to N times then informs), `('fallback', value)` (returns static value)
- Per-tool strategy configuration via `tool_strategies` dict, with `default_strategy` for unconfigured tools
- Per-run state isolation via `for_run()` for retry count tracking
- Convenience constructors `retry()` and `fallback()` for readable strategy definitions

## Test plan

- [x] Unit tests for convenience constructors (`retry`, `fallback`) including validation
- [x] Unit tests for strategy validation (`_validate_strategy`) covering all valid and invalid forms
- [x] Unit tests for error formatting with and without traceback
- [x] Construction validation tests (valid defaults, custom strategies, invalid input)
- [x] `for_run()` isolation: fresh instance with reset retry counts
- [x] `inform` strategy: error message returned to model (with/without traceback)
- [x] `fallback` strategy: static value returned (None, string, dict)
- [x] `retry` strategy: success on first attempt, success after failures, exhaustion falls back to inform
- [x] Non-retry strategies pass through to `on_tool_execute_error` (wrap_tool_execute re-raises)
- [x] Strategy resolution: tool-specific overrides and default fallthrough
- [x] Retry count resets on success across multiple calls
- [x] Public API import from `pydantic_harness`
- [x] 100% code coverage, pyright strict mode (0 errors), ruff lint and format clean

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)