### PR TITLE
Add Planning capability

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,49 @@
+# Planning Capability
+
+## Summary
+
+A `Planning` capability (`AbstractCapability` subclass) that gives agents structured task planning and tracking tools, with dynamic system prompt injection of current plan state.
+
+Addresses #39 (Planning capability) and #65 (Task Tracking capability).
+
+## Design
+
+### Tools provided
+
+- **`create_plan(steps: list[str])`** -- Create or replace the plan with a list of step descriptions. All steps start as `pending`.
+- **`update_task(index: int, status: TaskStatus)`** -- Update a task's status by zero-based index. Validates bounds and returns an error message for invalid indices.
+- **`get_plan()`** -- Return the current plan with status indicators and progress summary.
+
+### Task statuses
+
+`pending`, `in_progress`, `completed`, `skipped` -- modeled as a `str` enum (`TaskStatus`).
+
+### Per-run isolation
+
+`for_run()` returns a fresh `Planning` instance each run so plan state never leaks between runs.
+
+### Dynamic instructions
+
+`get_instructions()` returns a callable that reads the live task list and formats it into the system prompt on every model request, so the model always sees the current plan state.
+
+### Architecture
+
+Tool logic is extracted into module-level `*_impl` functions for testability:
+- `create_plan_impl(tasks, steps)`
+- `update_task_impl(tasks, index, status)`
+- `get_plan_impl(tasks)`
+
+The `get_toolset()` method registers thin closures that capture the shared task list and delegate to these functions.
+
+## Files
+
+- `src/pydantic_harness/planning.py` -- Capability implementation
+- `src/pydantic_harness/__init__.py` -- Public exports
+- `tests/test_planning.py` -- 32 tests, 100% coverage
+
+## Quality
+
+- ruff lint: clean
+- ruff format: clean
+- pyright strict: clean
+- pytest: 32 passed, 100% branch coverage

--- a/src/pydantic_harness/__init__.py
+++ b/src/pydantic_harness/__init__.py
@@ -7,4 +7,11 @@ Usage:
 # Each capability module is imported and re-exported here.
 # Capabilities are listed alphabetically.
 
-__all__: list[str] = []
+from pydantic_harness.planning import Planning, Task, TaskStatus, format_plan
+
+__all__: list[str] = [
+    'Planning',
+    'Task',
+    'TaskStatus',
+    'format_plan',
+]

--- a/src/pydantic_harness/planning.py
+++ b/src/pydantic_harness/planning.py
@@ -1,0 +1,205 @@
+"""Planning capability for structured task planning and tracking.
+
+Provides tools for creating and managing a step-by-step plan during agent runs,
+with dynamic system prompt injection of current plan state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from pydantic_ai._instructions import AgentInstructions
+from pydantic_ai.capabilities.abstract import AbstractCapability
+from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.toolsets import AgentToolset
+from pydantic_ai.toolsets.function import FunctionToolset
+
+
+class TaskStatus(str, Enum):
+    """Status of a task in the plan."""
+
+    pending = 'pending'
+    in_progress = 'in_progress'
+    completed = 'completed'
+    skipped = 'skipped'
+
+
+@dataclass
+class Task:
+    """A single task in the plan."""
+
+    description: str
+    status: TaskStatus = TaskStatus.pending
+
+
+def format_plan(tasks: list[Task]) -> str:
+    """Format the current plan as a readable string.
+
+    Args:
+        tasks: The list of tasks to format.
+
+    Returns:
+        A human-readable string representation of the plan.
+    """
+    if not tasks:
+        return 'No plan created yet.'
+
+    status_icons = {
+        TaskStatus.pending: '[ ]',
+        TaskStatus.in_progress: '[~]',
+        TaskStatus.completed: '[x]',
+        TaskStatus.skipped: '[-]',
+    }
+
+    lines: list[str] = []
+    for i, task in enumerate(tasks):
+        icon = status_icons[task.status]
+        lines.append(f'{i}. {icon} {task.description}')
+
+    total = len(tasks)
+    completed = sum(1 for t in tasks if t.status == TaskStatus.completed)
+    skipped = sum(1 for t in tasks if t.status == TaskStatus.skipped)
+    in_progress = sum(1 for t in tasks if t.status == TaskStatus.in_progress)
+    pending = sum(1 for t in tasks if t.status == TaskStatus.pending)
+
+    lines.append('')
+    lines.append(
+        f'Progress: {completed}/{total} completed, {in_progress} in progress, {pending} pending, {skipped} skipped'
+    )
+
+    return '\n'.join(lines)
+
+
+def create_plan_impl(tasks: list[Task], steps: list[str]) -> str:
+    """Create a new plan, replacing any existing one.
+
+    Args:
+        tasks: The shared task list to modify.
+        steps: Step descriptions for the new plan.
+
+    Returns:
+        A confirmation message with the formatted plan.
+    """
+    tasks.clear()
+    tasks.extend(Task(description=step) for step in steps)
+    return f'Plan created with {len(tasks)} steps.\n\n{format_plan(tasks)}'
+
+
+def update_task_impl(tasks: list[Task], index: int, status: TaskStatus) -> str:
+    """Update the status of a task.
+
+    Args:
+        tasks: The shared task list to modify.
+        index: Zero-based index of the task to update.
+        status: The new status.
+
+    Returns:
+        A confirmation message or an error description.
+    """
+    if not tasks:
+        return 'No plan exists. Use create_plan first.'
+    if index < 0 or index >= len(tasks):
+        return f'Invalid task index {index}. Valid range: 0-{len(tasks) - 1}.'
+    tasks[index].status = status
+    return f'Task {index} updated to {status.value}.\n\n{format_plan(tasks)}'
+
+
+def get_plan_impl(tasks: list[Task]) -> str:
+    """Get the current plan.
+
+    Args:
+        tasks: The task list to format.
+
+    Returns:
+        The formatted plan.
+    """
+    return format_plan(tasks)
+
+
+@dataclass
+class Planning(AbstractCapability[AgentDepsT]):
+    """Structured task planning and tracking capability.
+
+    Provides tools for the agent to create a step-by-step plan, update task
+    statuses as work progresses, and review the current plan. The current plan
+    state is dynamically injected into the system prompt so the model always
+    has context on what has been done and what remains.
+
+    Example:
+        ```python
+        from pydantic_ai import Agent
+        from pydantic_harness.planning import Planning
+
+        agent = Agent('openai:gpt-4o', capabilities=[Planning()])
+        ```
+    """
+
+    plan_tasks: list[Task] = field(default_factory=lambda: list[Task]())
+    """Per-run task list. Populated via ``for_run()``."""
+
+    async def for_run(self, ctx: RunContext[AgentDepsT]) -> Planning[AgentDepsT]:
+        """Return a fresh instance with isolated per-run state."""
+        return Planning[AgentDepsT]()
+
+    def get_instructions(self) -> AgentInstructions[AgentDepsT]:
+        """Return a dynamic instruction that injects the current plan state."""
+        tasks = self.plan_tasks
+
+        def _instructions(ctx: RunContext[AgentDepsT]) -> str:
+            plan_text = format_plan(tasks)
+            return (
+                'You have a planning capability. Use the planning tools to break complex tasks '
+                'into steps and track your progress. Before starting work, create a plan. '
+                'Update task statuses as you make progress.\n\n'
+                f'Current plan:\n{plan_text}'
+            )
+
+        return _instructions
+
+    def get_toolset(self) -> AgentToolset[AgentDepsT] | None:
+        """Return a toolset with plan management tools."""
+        tasks = self.plan_tasks
+        toolset: FunctionToolset[AgentDepsT] = FunctionToolset()
+
+        @toolset.tool
+        def create_plan(ctx: RunContext[AgentDepsT], steps: list[str]) -> str:  # pyright: ignore[reportUnusedFunction]
+            """Create a new plan with the given steps. Replaces any existing plan.
+
+            Args:
+                ctx: The run context.
+                steps: A list of step descriptions for the plan.
+            """
+            return create_plan_impl(tasks, steps)
+
+        @toolset.tool
+        def update_task(ctx: RunContext[AgentDepsT], index: int, status: TaskStatus) -> str:  # pyright: ignore[reportUnusedFunction]
+            """Update the status of a task in the plan.
+
+            Args:
+                ctx: The run context.
+                index: The zero-based index of the task to update.
+                status: The new status for the task.
+            """
+            return update_task_impl(tasks, index, status)
+
+        @toolset.tool
+        def get_plan(ctx: RunContext[AgentDepsT]) -> str:  # pyright: ignore[reportUnusedFunction]
+            """Get the current plan with all task statuses.
+
+            Args:
+                ctx: The run context.
+            """
+            return get_plan_impl(tasks)
+
+        return toolset
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        """Return the serialization name for spec support."""
+        return 'Planning'
+
+    @property
+    def tasks(self) -> list[Task]:
+        """Read-only access to the current task list."""
+        return list(self.plan_tasks)

--- a/src/pydantic_harness/planning.py
+++ b/src/pydantic_harness/planning.py
@@ -23,6 +23,7 @@ class TaskStatus(str, Enum):
     in_progress = 'in_progress'
     completed = 'completed'
     skipped = 'skipped'
+    blocked = 'blocked'
 
 
 @dataclass
@@ -31,10 +32,13 @@ class Task:
 
     description: str
     status: TaskStatus = TaskStatus.pending
+    parent_index: int | None = None
 
 
 def format_plan(tasks: list[Task]) -> str:
     """Format the current plan as a readable string.
+
+    Subtasks (those with a ``parent_index``) are indented under their parent.
 
     Args:
         tasks: The list of tasks to format.
@@ -50,22 +54,26 @@ def format_plan(tasks: list[Task]) -> str:
         TaskStatus.in_progress: '[~]',
         TaskStatus.completed: '[x]',
         TaskStatus.skipped: '[-]',
+        TaskStatus.blocked: '[!]',
     }
 
     lines: list[str] = []
     for i, task in enumerate(tasks):
         icon = status_icons[task.status]
-        lines.append(f'{i}. {icon} {task.description}')
+        indent = '  ' if task.parent_index is not None else ''
+        lines.append(f'{indent}{i}. {icon} {task.description}')
 
     total = len(tasks)
     completed = sum(1 for t in tasks if t.status == TaskStatus.completed)
     skipped = sum(1 for t in tasks if t.status == TaskStatus.skipped)
     in_progress = sum(1 for t in tasks if t.status == TaskStatus.in_progress)
     pending = sum(1 for t in tasks if t.status == TaskStatus.pending)
+    blocked = sum(1 for t in tasks if t.status == TaskStatus.blocked)
 
     lines.append('')
     lines.append(
-        f'Progress: {completed}/{total} completed, {in_progress} in progress, {pending} pending, {skipped} skipped'
+        f'Progress: {completed}/{total} completed, {in_progress} in progress, '
+        f'{pending} pending, {skipped} skipped, {blocked} blocked'
     )
 
     return '\n'.join(lines)
@@ -103,6 +111,106 @@ def update_task_impl(tasks: list[Task], index: int, status: TaskStatus) -> str:
         return f'Invalid task index {index}. Valid range: 0-{len(tasks) - 1}.'
     tasks[index].status = status
     return f'Task {index} updated to {status.value}.\n\n{format_plan(tasks)}'
+
+
+def add_subtask_impl(tasks: list[Task], parent_index: int, description: str) -> str:
+    """Add a subtask under an existing parent task.
+
+    The subtask is inserted immediately after the parent and any existing
+    subtasks of that parent.
+
+    Args:
+        tasks: The shared task list to modify.
+        parent_index: Zero-based index of the parent task.
+        description: Description of the subtask.
+
+    Returns:
+        A confirmation message or an error description.
+    """
+    if not tasks:
+        return 'No plan exists. Use create_plan first.'
+    if parent_index < 0 or parent_index >= len(tasks):
+        return f'Invalid parent index {parent_index}. Valid range: 0-{len(tasks) - 1}.'
+    if tasks[parent_index].parent_index is not None:
+        return f'Task {parent_index} is itself a subtask. Nested subtasks are not supported.'
+
+    # Find insertion point: after parent and its existing subtasks.
+    insert_at = parent_index + 1
+    while insert_at < len(tasks) and tasks[insert_at].parent_index == parent_index:
+        insert_at += 1
+
+    tasks.insert(insert_at, Task(description=description, parent_index=parent_index))
+
+    # Adjust parent_index references for tasks shifted by the insertion.
+    for task in tasks[insert_at + 1 :]:
+        if task.parent_index is not None and task.parent_index >= insert_at:
+            task.parent_index += 1
+
+    return f'Subtask added under task {parent_index} at index {insert_at}.\n\n{format_plan(tasks)}'
+
+
+def insert_task_impl(tasks: list[Task], index: int, description: str) -> str:
+    """Insert a new top-level task at a given position.
+
+    Args:
+        tasks: The shared task list to modify.
+        index: Zero-based position to insert at (clamped to list bounds).
+        description: Description of the new task.
+
+    Returns:
+        A confirmation message with the formatted plan.
+    """
+    clamped = max(0, min(index, len(tasks)))
+    tasks.insert(clamped, Task(description=description))
+
+    # Adjust parent_index references for tasks shifted by the insertion.
+    for task in tasks[clamped + 1 :]:
+        if task.parent_index is not None and task.parent_index >= clamped:
+            task.parent_index += 1
+
+    return f'Task inserted at index {clamped}.\n\n{format_plan(tasks)}'
+
+
+def remove_task_impl(tasks: list[Task], index: int) -> str:
+    """Remove a task by index.
+
+    If the removed task is a parent, its subtasks are also removed.
+
+    Args:
+        tasks: The shared task list to modify.
+        index: Zero-based index of the task to remove.
+
+    Returns:
+        A confirmation message or an error description.
+    """
+    if not tasks:
+        return 'No plan exists. Use create_plan first.'
+    if index < 0 or index >= len(tasks):
+        return f'Invalid task index {index}. Valid range: 0-{len(tasks) - 1}.'
+
+    removed = tasks[index]
+    # Collect indices to remove: the task itself, plus any subtasks if it's a parent.
+    indices_to_remove = {index}
+    if removed.parent_index is None:
+        # It's a top-level task; remove its subtasks too.
+        for i, task in enumerate(tasks):
+            if task.parent_index == index:
+                indices_to_remove.add(i)
+
+    # Remove in reverse order to keep indices stable.
+    for i in sorted(indices_to_remove, reverse=True):
+        tasks.pop(i)
+
+    # Adjust parent_index references: for each removed index (ascending),
+    # decrement references that pointed past it.
+    for removed_idx in sorted(indices_to_remove):
+        for task in tasks:
+            if task.parent_index is not None and task.parent_index > removed_idx:
+                task.parent_index -= 1
+
+    count = len(indices_to_remove)
+    suffix = f' (and {count - 1} subtask{"s" if count > 2 else ""})' if count > 1 else ''
+    return f'Task {index} removed{suffix}.\n\n{format_plan(tasks)}'
 
 
 def get_plan_impl(tasks: list[Task]) -> str:
@@ -182,6 +290,40 @@ class Planning(AbstractCapability[AgentDepsT]):
                 status: The new status for the task.
             """
             return update_task_impl(tasks, index, status)
+
+        @toolset.tool
+        def add_subtask(ctx: RunContext[AgentDepsT], parent_index: int, description: str) -> str:  # pyright: ignore[reportUnusedFunction]
+            """Add a subtask under an existing parent task.
+
+            Args:
+                ctx: The run context.
+                parent_index: The zero-based index of the parent task.
+                description: Description of the subtask.
+            """
+            return add_subtask_impl(tasks, parent_index, description)
+
+        @toolset.tool
+        def insert_task(ctx: RunContext[AgentDepsT], index: int, description: str) -> str:  # pyright: ignore[reportUnusedFunction]
+            """Insert a new task at a given position in the plan.
+
+            Args:
+                ctx: The run context.
+                index: The zero-based position to insert at.
+                description: Description of the new task.
+            """
+            return insert_task_impl(tasks, index, description)
+
+        @toolset.tool
+        def remove_task(ctx: RunContext[AgentDepsT], index: int) -> str:  # pyright: ignore[reportUnusedFunction]
+            """Remove a task from the plan by index.
+
+            If the task has subtasks, they are also removed.
+
+            Args:
+                ctx: The run context.
+                index: The zero-based index of the task to remove.
+            """
+            return remove_task_impl(tasks, index)
 
         @toolset.tool
         def get_plan(ctx: RunContext[AgentDepsT]) -> str:  # pyright: ignore[reportUnusedFunction]

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,275 @@
+"""Tests for the Planning capability."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+from pydantic_harness.planning import (
+    Planning,
+    Task,
+    TaskStatus,
+    create_plan_impl,
+    format_plan,
+    get_plan_impl,
+    update_task_impl,
+)
+
+
+class TestTaskStatus:
+    def test_values(self):
+        assert TaskStatus.pending == 'pending'
+        assert TaskStatus.in_progress == 'in_progress'
+        assert TaskStatus.completed == 'completed'
+        assert TaskStatus.skipped == 'skipped'
+
+    def test_all_statuses(self):
+        assert set(TaskStatus) == {
+            TaskStatus.pending,
+            TaskStatus.in_progress,
+            TaskStatus.completed,
+            TaskStatus.skipped,
+        }
+
+
+class TestTask:
+    def test_default_status(self):
+        task = Task(description='Do something')
+        assert task.description == 'Do something'
+        assert task.status == TaskStatus.pending
+
+    def test_explicit_status(self):
+        task = Task(description='Done thing', status=TaskStatus.completed)
+        assert task.status == TaskStatus.completed
+
+
+class TestFormatPlan:
+    def test_empty(self):
+        assert format_plan([]) == 'No plan created yet.'
+
+    def test_single_pending(self):
+        result = format_plan([Task(description='Step one')])
+        assert '0. [ ] Step one' in result
+        assert 'Progress: 0/1 completed' in result
+
+    def test_mixed_statuses(self):
+        tasks = [
+            Task(description='First', status=TaskStatus.completed),
+            Task(description='Second', status=TaskStatus.in_progress),
+            Task(description='Third', status=TaskStatus.pending),
+            Task(description='Fourth', status=TaskStatus.skipped),
+        ]
+        result = format_plan(tasks)
+        assert '0. [x] First' in result
+        assert '1. [~] Second' in result
+        assert '2. [ ] Third' in result
+        assert '3. [-] Fourth' in result
+        assert 'Progress: 1/4 completed, 1 in progress, 1 pending, 1 skipped' in result
+
+    def test_all_completed(self):
+        tasks = [
+            Task(description='A', status=TaskStatus.completed),
+            Task(description='B', status=TaskStatus.completed),
+        ]
+        result = format_plan(tasks)
+        assert 'Progress: 2/2 completed, 0 in progress, 0 pending, 0 skipped' in result
+
+
+class TestCreatePlanImpl:
+    def test_creates_tasks(self):
+        tasks: list[Task] = []
+        result = create_plan_impl(tasks, ['Step A', 'Step B', 'Step C'])
+        assert len(tasks) == 3
+        assert tasks[0].description == 'Step A'
+        assert tasks[1].description == 'Step B'
+        assert tasks[2].description == 'Step C'
+        assert all(t.status == TaskStatus.pending for t in tasks)
+        assert 'Plan created with 3 steps' in result
+
+    def test_replaces_existing(self):
+        tasks = [Task(description='Old', status=TaskStatus.completed)]
+        result = create_plan_impl(tasks, ['New'])
+        assert len(tasks) == 1
+        assert tasks[0].description == 'New'
+        assert tasks[0].status == TaskStatus.pending
+        assert 'Plan created with 1 steps' in result
+
+    def test_empty_steps(self):
+        tasks: list[Task] = []
+        result = create_plan_impl(tasks, [])
+        assert len(tasks) == 0
+        assert 'Plan created with 0 steps' in result
+
+
+class TestUpdateTaskImpl:
+    def test_update_status(self):
+        tasks = [Task(description='Do X'), Task(description='Do Y')]
+        result = update_task_impl(tasks, 0, TaskStatus.in_progress)
+        assert tasks[0].status == TaskStatus.in_progress
+        assert 'Task 0 updated to in_progress' in result
+
+    def test_update_to_completed(self):
+        tasks = [Task(description='Do X')]
+        result = update_task_impl(tasks, 0, TaskStatus.completed)
+        assert tasks[0].status == TaskStatus.completed
+        assert 'Task 0 updated to completed' in result
+
+    def test_update_to_skipped(self):
+        tasks = [Task(description='Do X')]
+        result = update_task_impl(tasks, 0, TaskStatus.skipped)
+        assert tasks[0].status == TaskStatus.skipped
+        assert 'Task 0 updated to skipped' in result
+
+    def test_no_plan_exists(self):
+        tasks: list[Task] = []
+        result = update_task_impl(tasks, 0, TaskStatus.completed)
+        assert result == 'No plan exists. Use create_plan first.'
+
+    def test_index_too_high(self):
+        tasks = [Task(description='Only one')]
+        result = update_task_impl(tasks, 5, TaskStatus.completed)
+        assert 'Invalid task index 5' in result
+        assert 'Valid range: 0-0' in result
+
+    def test_negative_index(self):
+        tasks = [Task(description='Only one')]
+        result = update_task_impl(tasks, -1, TaskStatus.completed)
+        assert 'Invalid task index -1' in result
+
+
+class TestGetPlanImpl:
+    def test_empty(self):
+        assert get_plan_impl([]) == 'No plan created yet.'
+
+    def test_with_tasks(self):
+        tasks = [Task(description='A', status=TaskStatus.completed)]
+        result = get_plan_impl(tasks)
+        assert '0. [x] A' in result
+
+
+class TestPlanning:
+    def test_serialization_name(self):
+        assert Planning.get_serialization_name() == 'Planning'
+
+    def test_tasks_property_empty(self):
+        cap: Planning[None] = Planning()
+        assert cap.tasks == []
+
+    def test_tasks_property_returns_copy(self):
+        cap: Planning[None] = Planning()
+        cap.plan_tasks.append(Task(description='test'))
+        tasks = cap.tasks
+        assert len(tasks) == 1
+        # Modifying the returned list doesn't affect the internal state.
+        tasks.clear()
+        assert len(cap.tasks) == 1
+
+    def test_get_toolset_returns_toolset(self):
+        cap: Planning[None] = Planning()
+        toolset = cap.get_toolset()
+        assert toolset is not None
+
+    def test_get_instructions_returns_callable(self):
+        cap: Planning[None] = Planning()
+        instructions = cap.get_instructions()
+        assert callable(instructions)
+
+    def test_instructions_content_no_plan(self):
+        cap: Planning[None] = Planning()
+        instructions = cap.get_instructions()
+        assert callable(instructions)
+        ctx = MagicMock()
+        result = instructions(ctx)  # pyright: ignore[reportCallIssue,reportUnknownVariableType]
+        assert isinstance(result, str)
+        assert 'No plan created yet.' in result
+        assert 'planning capability' in result
+
+    def test_instructions_reflect_plan_state(self):
+        cap: Planning[None] = Planning()
+        cap.plan_tasks.append(Task(description='Do X', status=TaskStatus.in_progress))
+        instructions = cap.get_instructions()
+        assert callable(instructions)
+        ctx = MagicMock()
+        result = instructions(ctx)  # pyright: ignore[reportCallIssue,reportUnknownVariableType]
+        assert isinstance(result, str)
+        assert '0. [~] Do X' in result
+
+
+class TestPlanningForRun:
+    def test_for_run_returns_fresh_instance(self):
+        cap: Planning[None] = Planning()
+        cap.plan_tasks.append(Task(description='leftover'))
+
+        ctx = MagicMock()
+        fresh = asyncio.run(cap.for_run(ctx))
+
+        assert fresh is not cap
+        assert fresh.plan_tasks == []
+        # Original is unchanged.
+        assert len(cap.plan_tasks) == 1
+
+
+class TestPlanningToolsIntegration:
+    """Test the tool functions through shared state with the capability."""
+
+    def test_toolset_has_expected_tools(self):
+        cap: Planning[None] = Planning()
+        toolset = cap.get_toolset()
+        assert toolset is not None
+        from pydantic_ai.toolsets.function import FunctionToolset
+
+        assert isinstance(toolset, FunctionToolset)
+        assert 'create_plan' in toolset.tools
+        assert 'update_task' in toolset.tools
+        assert 'get_plan' in toolset.tools
+
+    def test_tools_share_state_with_capability(self):
+        """The tool closures operate on the same list as plan_tasks."""
+        cap: Planning[None] = Planning()
+        # Use the impl functions with the capability's task list.
+        create_plan_impl(cap.plan_tasks, ['Alpha', 'Beta'])
+        assert len(cap.plan_tasks) == 2
+        assert cap.tasks[0].description == 'Alpha'
+
+        update_task_impl(cap.plan_tasks, 0, TaskStatus.completed)
+        assert cap.plan_tasks[0].status == TaskStatus.completed
+
+        result = get_plan_impl(cap.plan_tasks)
+        assert '0. [x] Alpha' in result
+
+    def test_tool_closures_delegate_correctly(self):
+        """Calling the registered tool functions exercises the closures."""
+        from pydantic_ai.toolsets.function import FunctionToolset
+
+        cap: Planning[None] = Planning()
+        toolset = cap.get_toolset()
+        assert isinstance(toolset, FunctionToolset)
+        ctx = MagicMock()
+
+        # Exercise create_plan closure.
+        result = toolset.tools['create_plan'].function(ctx, steps=['X', 'Y'])  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        assert isinstance(result, str)
+        assert 'Plan created with 2 steps' in result
+        assert len(cap.plan_tasks) == 2
+
+        # Exercise update_task closure.
+        result = toolset.tools['update_task'].function(ctx, index=0, status=TaskStatus.completed)  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        assert isinstance(result, str)
+        assert 'Task 0 updated to completed' in result
+
+        # Exercise get_plan closure.
+        result = toolset.tools['get_plan'].function(ctx)  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        assert isinstance(result, str)
+        assert '0. [x] X' in result
+
+    def test_plan_isolation_between_runs(self):
+        """Each for_run produces independent state."""
+        cap: Planning[None] = Planning()
+        ctx = MagicMock()
+
+        run1: Planning[None] = asyncio.run(cap.for_run(ctx))
+        run1.plan_tasks.append(Task(description='Run 1 task'))
+
+        run2: Planning[None] = asyncio.run(cap.for_run(ctx))
+        assert run2.plan_tasks == []
+        assert len(run1.plan_tasks) == 1

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -9,9 +9,12 @@ from pydantic_harness.planning import (
     Planning,
     Task,
     TaskStatus,
+    add_subtask_impl,
     create_plan_impl,
     format_plan,
     get_plan_impl,
+    insert_task_impl,
+    remove_task_impl,
     update_task_impl,
 )
 
@@ -22,6 +25,7 @@ class TestTaskStatus:
         assert TaskStatus.in_progress == 'in_progress'
         assert TaskStatus.completed == 'completed'
         assert TaskStatus.skipped == 'skipped'
+        assert TaskStatus.blocked == 'blocked'
 
     def test_all_statuses(self):
         assert set(TaskStatus) == {
@@ -29,6 +33,7 @@ class TestTaskStatus:
             TaskStatus.in_progress,
             TaskStatus.completed,
             TaskStatus.skipped,
+            TaskStatus.blocked,
         }
 
 
@@ -37,10 +42,15 @@ class TestTask:
         task = Task(description='Do something')
         assert task.description == 'Do something'
         assert task.status == TaskStatus.pending
+        assert task.parent_index is None
 
     def test_explicit_status(self):
         task = Task(description='Done thing', status=TaskStatus.completed)
         assert task.status == TaskStatus.completed
+
+    def test_explicit_parent_index(self):
+        task = Task(description='Sub', parent_index=0)
+        assert task.parent_index == 0
 
 
 class TestFormatPlan:
@@ -64,7 +74,7 @@ class TestFormatPlan:
         assert '1. [~] Second' in result
         assert '2. [ ] Third' in result
         assert '3. [-] Fourth' in result
-        assert 'Progress: 1/4 completed, 1 in progress, 1 pending, 1 skipped' in result
+        assert '1 in progress, 1 pending, 1 skipped, 0 blocked' in result
 
     def test_all_completed(self):
         tasks = [
@@ -72,7 +82,25 @@ class TestFormatPlan:
             Task(description='B', status=TaskStatus.completed),
         ]
         result = format_plan(tasks)
-        assert 'Progress: 2/2 completed, 0 in progress, 0 pending, 0 skipped' in result
+        assert 'Progress: 2/2 completed, 0 in progress, 0 pending, 0 skipped, 0 blocked' in result
+
+    def test_blocked_status(self):
+        tasks = [
+            Task(description='Setup', status=TaskStatus.completed),
+            Task(description='Blocked step', status=TaskStatus.blocked),
+        ]
+        result = format_plan(tasks)
+        assert '1. [!] Blocked step' in result
+        assert '1 blocked' in result
+
+    def test_subtask_indented(self):
+        tasks = [
+            Task(description='Parent'),
+            Task(description='Child', parent_index=0),
+        ]
+        result = format_plan(tasks)
+        assert '0. [ ] Parent' in result
+        assert '  1. [ ] Child' in result
 
 
 class TestCreatePlanImpl:
@@ -145,6 +173,179 @@ class TestGetPlanImpl:
         tasks = [Task(description='A', status=TaskStatus.completed)]
         result = get_plan_impl(tasks)
         assert '0. [x] A' in result
+
+
+class TestAddSubtaskImpl:
+    def test_add_subtask(self):
+        tasks = [Task(description='Parent'), Task(description='Other')]
+        result = add_subtask_impl(tasks, 0, 'Child')
+        assert len(tasks) == 3
+        assert tasks[1].description == 'Child'
+        assert tasks[1].parent_index == 0
+        assert 'Subtask added under task 0 at index 1' in result
+
+    def test_add_multiple_subtasks(self):
+        tasks = [Task(description='Parent'), Task(description='Other')]
+        add_subtask_impl(tasks, 0, 'Child A')
+        add_subtask_impl(tasks, 0, 'Child B')
+        assert len(tasks) == 4
+        assert tasks[1].description == 'Child A'
+        assert tasks[1].parent_index == 0
+        assert tasks[2].description == 'Child B'
+        assert tasks[2].parent_index == 0
+        assert tasks[3].description == 'Other'
+
+    def test_no_plan(self):
+        result = add_subtask_impl([], 0, 'Child')
+        assert result == 'No plan exists. Use create_plan first.'
+
+    def test_invalid_parent_index(self):
+        tasks = [Task(description='Only')]
+        result = add_subtask_impl(tasks, 5, 'Child')
+        assert 'Invalid parent index 5' in result
+
+    def test_negative_parent_index(self):
+        tasks = [Task(description='Only')]
+        result = add_subtask_impl(tasks, -1, 'Child')
+        assert 'Invalid parent index -1' in result
+
+    def test_nested_subtask_rejected(self):
+        tasks = [Task(description='Parent'), Task(description='Child', parent_index=0)]
+        result = add_subtask_impl(tasks, 1, 'Grandchild')
+        assert 'is itself a subtask' in result
+        assert len(tasks) == 2
+
+    def test_parent_index_adjustment(self):
+        """Subtasks of later parents get their parent_index adjusted on insertion."""
+        tasks = [
+            Task(description='A'),
+            Task(description='B'),
+            Task(description='B-child', parent_index=1),
+        ]
+        # Add subtask under A; B-child's parent_index should shift from 1 to 2.
+        add_subtask_impl(tasks, 0, 'A-child')
+        assert tasks[3].description == 'B-child'
+        assert tasks[3].parent_index == 2
+
+
+class TestInsertTaskImpl:
+    def test_insert_at_beginning(self):
+        tasks = [Task(description='Existing')]
+        result = insert_task_impl(tasks, 0, 'New first')
+        assert len(tasks) == 2
+        assert tasks[0].description == 'New first'
+        assert tasks[1].description == 'Existing'
+        assert 'Task inserted at index 0' in result
+
+    def test_insert_at_end(self):
+        tasks = [Task(description='Existing')]
+        result = insert_task_impl(tasks, 1, 'New last')
+        assert len(tasks) == 2
+        assert tasks[1].description == 'New last'
+        assert 'Task inserted at index 1' in result
+
+    def test_insert_in_middle(self):
+        tasks = [Task(description='A'), Task(description='C')]
+        insert_task_impl(tasks, 1, 'B')
+        assert [t.description for t in tasks] == ['A', 'B', 'C']
+
+    def test_index_clamped_high(self):
+        tasks = [Task(description='Only')]
+        result = insert_task_impl(tasks, 100, 'Clamped')
+        assert len(tasks) == 2
+        assert tasks[1].description == 'Clamped'
+        assert 'Task inserted at index 1' in result
+
+    def test_index_clamped_negative(self):
+        tasks = [Task(description='Only')]
+        result = insert_task_impl(tasks, -5, 'Clamped')
+        assert len(tasks) == 2
+        assert tasks[0].description == 'Clamped'
+        assert 'Task inserted at index 0' in result
+
+    def test_insert_into_empty(self):
+        tasks: list[Task] = []
+        result = insert_task_impl(tasks, 0, 'First')
+        assert len(tasks) == 1
+        assert 'Task inserted at index 0' in result
+
+    def test_parent_index_adjustment(self):
+        """Inserting before a parent adjusts subtask parent_index."""
+        tasks = [
+            Task(description='Parent'),
+            Task(description='Child', parent_index=0),
+        ]
+        insert_task_impl(tasks, 0, 'New first')
+        assert tasks[2].description == 'Child'
+        assert tasks[2].parent_index == 1
+
+
+class TestRemoveTaskImpl:
+    def test_remove_single(self):
+        tasks = [Task(description='A'), Task(description='B'), Task(description='C')]
+        result = remove_task_impl(tasks, 1)
+        assert len(tasks) == 2
+        assert [t.description for t in tasks] == ['A', 'C']
+        assert 'Task 1 removed' in result
+
+    def test_no_plan(self):
+        result = remove_task_impl([], 0)
+        assert result == 'No plan exists. Use create_plan first.'
+
+    def test_invalid_index(self):
+        tasks = [Task(description='Only')]
+        result = remove_task_impl(tasks, 5)
+        assert 'Invalid task index 5' in result
+
+    def test_negative_index(self):
+        tasks = [Task(description='Only')]
+        result = remove_task_impl(tasks, -1)
+        assert 'Invalid task index -1' in result
+
+    def test_remove_parent_cascades_subtasks(self):
+        tasks = [
+            Task(description='Parent'),
+            Task(description='Child A', parent_index=0),
+            Task(description='Child B', parent_index=0),
+            Task(description='Other'),
+        ]
+        result = remove_task_impl(tasks, 0)
+        assert len(tasks) == 1
+        assert tasks[0].description == 'Other'
+        assert 'and 2 subtasks' in result
+
+    def test_remove_parent_with_one_subtask(self):
+        tasks = [
+            Task(description='Parent'),
+            Task(description='Child', parent_index=0),
+            Task(description='Other'),
+        ]
+        result = remove_task_impl(tasks, 0)
+        assert len(tasks) == 1
+        assert tasks[0].description == 'Other'
+        assert 'and 1 subtask)' in result
+
+    def test_remove_subtask_only(self):
+        tasks = [
+            Task(description='Parent'),
+            Task(description='Child', parent_index=0),
+        ]
+        result = remove_task_impl(tasks, 1)
+        assert len(tasks) == 1
+        assert tasks[0].description == 'Parent'
+        assert 'Task 1 removed' in result
+
+    def test_parent_index_adjustment_after_remove(self):
+        """Removing a task adjusts parent_index of later subtasks."""
+        tasks = [
+            Task(description='A'),
+            Task(description='B'),
+            Task(description='B-child', parent_index=1),
+        ]
+        remove_task_impl(tasks, 0)
+        assert tasks[0].description == 'B'
+        assert tasks[1].description == 'B-child'
+        assert tasks[1].parent_index == 0
 
 
 class TestPlanning:
@@ -221,6 +422,9 @@ class TestPlanningToolsIntegration:
         assert isinstance(toolset, FunctionToolset)
         assert 'create_plan' in toolset.tools
         assert 'update_task' in toolset.tools
+        assert 'add_subtask' in toolset.tools
+        assert 'insert_task' in toolset.tools
+        assert 'remove_task' in toolset.tools
         assert 'get_plan' in toolset.tools
 
     def test_tools_share_state_with_capability(self):
@@ -257,10 +461,25 @@ class TestPlanningToolsIntegration:
         assert isinstance(result, str)
         assert 'Task 0 updated to completed' in result
 
+        # Exercise add_subtask closure.
+        result = toolset.tools['add_subtask'].function(ctx, parent_index=1, description='Sub')  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        assert isinstance(result, str)
+        assert 'Subtask added' in result
+
+        # Exercise insert_task closure.
+        result = toolset.tools['insert_task'].function(ctx, index=0, description='New first')  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        assert isinstance(result, str)
+        assert 'Task inserted' in result
+
+        # Exercise remove_task closure.
+        result = toolset.tools['remove_task'].function(ctx, index=0)  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        assert isinstance(result, str)
+        assert 'removed' in result
+
         # Exercise get_plan closure.
         result = toolset.tools['get_plan'].function(ctx)  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
         assert isinstance(result, str)
-        assert '0. [x] X' in result
+        assert '[x] X' in result
 
     def test_plan_isolation_between_runs(self):
         """Each for_run produces independent state."""


### PR DESCRIPTION

## Summary

- Adds a `Planning` capability (`AbstractCapability` subclass) providing `create_plan`, `update_task`, and `get_plan` tools for structured task planning and tracking
- Plan state is per-run isolated via `for_run()` and dynamically injected into the system prompt via `get_instructions()`
- Task statuses: `pending`, `in_progress`, `completed`, `skipped`

Closes #39, relates to #65.

## Test plan

- [x] 32 tests covering all public API, tool logic, per-run isolation, dynamic instructions, edge cases (empty plan, invalid index, negative index)
- [x] 100% branch coverage
- [x] ruff lint and format clean
- [x] pyright strict mode clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)