### PR TITLE
Add dual-model plan debate workflow

### DIFF
--- a/.github/plan-debate/ci-plan-debate.mjs
+++ b/.github/plan-debate/ci-plan-debate.mjs
@@ -20,7 +20,7 @@
  *   GITHUB_TOKEN — for gh CLI (set automatically in GH Actions)
  */
 
-import { spawn, execFileSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/.github/plan-debate/ci-plan-debate.mjs
+++ b/.github/plan-debate/ci-plan-debate.mjs
@@ -297,22 +297,22 @@ Investigation strategy:
 
 Output: ## Relevant Code, ## Type System & Interfaces, ## Call Chains, ## Test Coverage, ## Documentation, ## Constraints Found — each with citations.`;
 
-const COMPETITIVE_ANALYSIS_PROMPT = `You are a senior software engineer analyzing how other agentic AI frameworks implement a specific capability.
+const COMPETITIVE_ANALYSIS_PROMPT = `You are researching how competing agent frameworks implement a capability described in a GitHub issue.
 
-Web research tools available via bash:
-  node ${WEB_SEARCH_SCRIPT} gh-search-repos "query" --max 10
-  node ${WEB_SEARCH_SCRIPT} gh-search-code "query" --repo owner/repo --max 10
-  node ${WEB_SEARCH_SCRIPT} gh-readme owner/repo
+Look at SOURCE CODE only. Do not fetch docs pages, blog posts, or tutorials.
+
+Tools:
+  node ${WEB_SEARCH_SCRIPT} gh-search-code "keyword" --repo owner/repo --max 10
   node ${WEB_SEARCH_SCRIPT} gh-file owner/repo path/to/file.py
-  node ${WEB_SEARCH_SCRIPT} fetch "https://docs-url.com/page"
-  node ${WEB_SEARCH_SCRIPT} search "query"
 
-Frameworks to investigate: LangGraph (langchain-ai/langgraph), CrewAI (crewAIInc/crewAI), Mastra (mastra-ai/mastra), AutoGen (microsoft/autogen), LlamaIndex (run-llama/llama_index), Semantic Kernel (microsoft/semantic-kernel).
+Frameworks (only these three):
+1. LangGraph — langchain-ai/langgraph (Python, libs/langgraph/langgraph/)
+2. CrewAI — crewAIInc/crewAI (Python, src/crewai/)
+3. AutoGen — microsoft/autogen (Python, autogen/)
 
-For each: does it support this capability? Fetch actual source code. Show real examples. Cite URLs.
-Mark anything unverified as "UNVERIFIED".
+For each: search for relevant code, fetch 2-3 source files, read the implementation. Note if they don't support it. Do NOT guess at APIs.
 
-Output: ## Capability Under Analysis, ## Framework Analysis (per framework: Supports?, How, API, Limitations, Sources), ## Key Patterns, ## Recommendations.`;
+Output per framework: Supports? Implementation (cite paths). Code snippets. Gaps. Then: common patterns and what Pydantic AI should consider.`;
 
 const PLAN_GENERATION_PROMPT = `You are a senior software engineer writing an implementation plan for a GitHub issue in Pydantic AI.
 

--- a/.github/plan-debate/ci-plan-debate.mjs
+++ b/.github/plan-debate/ci-plan-debate.mjs
@@ -1,0 +1,504 @@
+#!/usr/bin/env node
+/**
+ * CI-mode plan-debate runner.
+ *
+ * Runs the same pipeline as the /plan-debate command but non-interactively:
+ *   - Models are specified via CLI args or env vars (no interactive picker)
+ *   - No editor review step (plan is written directly)
+ *   - PR creation is automatic
+ *   - Progress is logged to stdout
+ *
+ * Usage:
+ *   node ci-plan-debate.mjs --issue 4723 \
+ *     --repo pydantic/pydantic-ai \
+ *     --model-a anthropic/claude-opus-4-6 \
+ *     --model-b openai/gpt-4.1 \
+ *     --cwd /path/to/repo
+ *
+ * Environment variables:
+ *   ANTHROPIC_API_KEY, OPENAI_API_KEY — or use PI's auth storage
+ *   GITHUB_TOKEN — for gh CLI (set automatically in GH Actions)
+ */
+
+import { spawn, execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WEB_SEARCH_SCRIPT = path.join(__dirname, "web-search.mjs");
+
+// ─── Argument Parsing ────────────────────────────────────────────────────────
+
+function getArg(name) {
+	const idx = process.argv.indexOf(name);
+	return idx !== -1 && process.argv[idx + 1] ? process.argv[idx + 1] : null;
+}
+
+const ISSUE_NUMBER = parseInt(getArg("--issue") || process.env.ISSUE_NUMBER || "", 10);
+const REPO = getArg("--repo") || process.env.REPO || "pydantic/pydantic-ai";
+const MODEL_A = getArg("--model-a") || process.env.MODEL_A || "anthropic/claude-opus-4-6";
+const MODEL_B = getArg("--model-b") || process.env.MODEL_B || "openai/gpt-4.1";
+const CWD = getArg("--cwd") || process.env.CWD || process.cwd();
+const SKIP_PR = process.argv.includes("--skip-pr");
+const MAX_DEBATE_ROUNDS = parseInt(getArg("--rounds") || "2", 10);
+const MAX_LINKED_DEPTH = 3;
+const MAX_LINKED_ITEMS = 30;
+const MAX_CONCURRENCY = 4;
+
+if (!ISSUE_NUMBER || isNaN(ISSUE_NUMBER)) {
+	console.error("Usage: node ci-plan-debate.mjs --issue <number> [--repo owner/repo] [--model-a provider/model] [--model-b provider/model] [--cwd path] [--skip-pr] [--rounds N]");
+	process.exit(1);
+}
+
+// ─── Logging ─────────────────────────────────────────────────────────────────
+
+function log(msg) {
+	const ts = new Date().toISOString().slice(11, 19);
+	console.log(`[${ts}] ${msg}`);
+}
+
+// ─── Shell Helpers ───────────────────────────────────────────────────────────
+
+function exec(command, cwd = CWD) {
+	return new Promise((resolve) => {
+		const proc = spawn("bash", ["-c", command], { cwd, stdio: ["ignore", "pipe", "pipe"] });
+		let stdout = "";
+		let stderr = "";
+		proc.stdout.on("data", (d) => (stdout += d.toString()));
+		proc.stderr.on("data", (d) => (stderr += d.toString()));
+		proc.on("close", (code) => resolve({ stdout, stderr, code: code ?? 1 }));
+		proc.on("error", () => resolve({ stdout, stderr, code: 1 }));
+	});
+}
+
+// ─── Issue Graph Crawler ─────────────────────────────────────────────────────
+
+function extractIssueRefs(text) {
+	const refs = new Set();
+	for (const m of text.matchAll(/#(\d+)\b/g)) {
+		const n = parseInt(m[1], 10);
+		if (n > 0 && n < 100000) refs.add(n);
+	}
+	for (const m of text.matchAll(/GH-(\d+)\b/gi)) {
+		const n = parseInt(m[1], 10);
+		if (n > 0 && n < 100000) refs.add(n);
+	}
+	return Array.from(refs);
+}
+
+async function fetchItem(number) {
+	const issueResult = await exec(
+		`gh issue view ${number} --repo ${REPO} --json number,title,body,url,state,labels,comments 2>/dev/null`,
+	);
+	if (issueResult.code === 0) {
+		try {
+			const d = JSON.parse(issueResult.stdout);
+			return {
+				type: "issue", number: d.number, title: d.title || "", body: d.body || "",
+				url: d.url || `https://github.com/${REPO}/issues/${number}`,
+				state: d.state || "unknown",
+				labels: (d.labels || []).map((l) => typeof l === "string" ? l : l.name),
+				comments: (d.comments || []).map((c) => `**@${c.author?.login || "unknown"}**:\n${c.body || ""}`),
+			};
+		} catch { /* fall through */ }
+	}
+
+	const prResult = await exec(
+		`gh pr view ${number} --repo ${REPO} --json number,title,body,url,state,labels,comments,files 2>/dev/null`,
+	);
+	if (prResult.code === 0) {
+		try {
+			const d = JSON.parse(prResult.stdout);
+			return {
+				type: "pr", number: d.number, title: d.title || "", body: d.body || "",
+				url: d.url || `https://github.com/${REPO}/pull/${number}`,
+				state: d.state || "unknown",
+				labels: (d.labels || []).map((l) => typeof l === "string" ? l : l.name),
+				comments: (d.comments || []).map((c) => `**@${c.author?.login || "unknown"}**:\n${c.body || ""}`),
+				files: (d.files || []).map((f) => f.path || f),
+			};
+		} catch { /* ignore */ }
+	}
+	return null;
+}
+
+async function findCrossReferences(issueNumber) {
+	const refs = new Set();
+	for (const type of ["issues", "prs"]) {
+		const r = await exec(`gh search ${type} "${issueNumber}" --repo ${REPO} --json number --limit 20 2>/dev/null`);
+		if (r.code === 0) {
+			try {
+				for (const item of JSON.parse(r.stdout)) {
+					if (item.number && item.number !== issueNumber) refs.add(item.number);
+				}
+			} catch { /* ignore */ }
+		}
+	}
+	const timeline = await exec(
+		`gh api repos/${REPO}/issues/${issueNumber}/timeline --paginate --jq '.[].source.issue.number // empty' 2>/dev/null`,
+	);
+	if (timeline.code === 0) {
+		for (const line of timeline.stdout.split("\n")) {
+			const num = parseInt(line.trim(), 10);
+			if (num > 0 && num !== issueNumber) refs.add(num);
+		}
+	}
+	return Array.from(refs);
+}
+
+async function crawlIssueGraph(rootNumber) {
+	const visited = new Set();
+	const allItems = [];
+	const queue = [{ number: rootNumber, depth: 0 }];
+
+	while (queue.length > 0 && allItems.length < MAX_LINKED_ITEMS) {
+		const batch = queue.splice(0, MAX_CONCURRENCY);
+		const results = await Promise.all(
+			batch.map(async ({ number, depth }) => {
+				if (visited.has(number)) return null;
+				visited.add(number);
+				const item = await fetchItem(number);
+				if (!item) return null;
+				log(`  Fetched ${item.type} #${item.number}: ${item.title} (depth ${depth})`);
+
+				let newRefs = [];
+				if (depth < MAX_LINKED_DEPTH) {
+					const allText = [item.body, ...item.comments].join("\n");
+					const inlineRefs = extractIssueRefs(allText);
+					const crossRefs = depth === 0 ? await findCrossReferences(item.number) : [];
+					newRefs = [...new Set([...inlineRefs, ...crossRefs])].filter((n) => !visited.has(n) && n !== rootNumber);
+				}
+				return { item, newRefs, depth };
+			}),
+		);
+
+		for (const result of results) {
+			if (!result) continue;
+			allItems.push(result.item);
+			for (const ref of result.newRefs) {
+				if (!visited.has(ref) && allItems.length + queue.length < MAX_LINKED_ITEMS) {
+					queue.push({ number: ref, depth: result.depth + 1 });
+				}
+			}
+		}
+	}
+
+	const root = allItems.find((i) => i.number === rootNumber);
+	if (!root) throw new Error(`Could not fetch issue #${rootNumber}`);
+	const linked = allItems.filter((i) => i.number !== rootNumber);
+	return { root, linked, fullContext: formatIssueGraph(root, linked) };
+}
+
+function formatIssueGraph(root, linked) {
+	let ctx = formatItem(root, "ROOT");
+	if (linked.length > 0) {
+		ctx += `\n\n${"=".repeat(80)}\nLINKED ISSUES AND PRs (${linked.length})\n${"=".repeat(80)}\n`;
+		for (const item of linked) ctx += formatItem(item, "LINKED") + "\n";
+	}
+	return ctx;
+}
+
+function formatItem(item, tag) {
+	let ctx = `\n${"─".repeat(80)}\n[${tag}] ${item.type.toUpperCase()} #${item.number}: ${item.title}\nURL: ${item.url}\nState: ${item.state}\n`;
+	if (item.labels?.length > 0) ctx += `Labels: ${item.labels.join(", ")}\n`;
+	if (item.files?.length > 0) ctx += `Files changed: ${item.files.join(", ")}\n`;
+	ctx += `${"─".repeat(80)}\n\n${item.body}\n`;
+	if (item.comments?.length > 0) {
+		ctx += `\n### Comments (${item.comments.length})\n\n`;
+		for (const c of item.comments) ctx += `---\n${c}\n\n`;
+	}
+	return ctx;
+}
+
+// ─── Subagent Runner ─────────────────────────────────────────────────────────
+
+function runSubagent(task, model) {
+	return new Promise((resolve) => {
+		const args = ["-p", "--no-session", "--model", model, "--tools", "read,bash,grep,find,ls", task];
+		const proc = spawn("pi", args, { cwd: CWD, shell: false, stdio: ["ignore", "pipe", "pipe"] });
+		let stdout = "";
+		let stderr = "";
+		proc.stdout.on("data", (d) => (stdout += d.toString()));
+		proc.stderr.on("data", (d) => (stderr += d.toString()));
+		proc.on("close", (code) => resolve({ output: stdout, exitCode: code ?? 1, stderr }));
+		proc.on("error", () => resolve({ output: stdout, exitCode: 1, stderr }));
+	});
+}
+
+async function runConcurrent(tasks) {
+	const results = new Array(tasks.length);
+	let completed = 0;
+	let nextIndex = 0;
+
+	const workers = Array.from({ length: Math.min(MAX_CONCURRENCY, tasks.length) }, async () => {
+		while (true) {
+			const i = nextIndex++;
+			if (i >= tasks.length) return;
+			const { label, task, model } = tasks[i];
+			log(`  [${completed}/${tasks.length}] Starting: ${label}`);
+			results[i] = await runSubagent(task, model);
+			completed++;
+			log(`  [${completed}/${tasks.length}] ${results[i].exitCode === 0 ? "✓" : "✗"} ${label} (${(results[i].output.length / 1024).toFixed(1)}KB)`);
+		}
+	});
+	await Promise.all(workers);
+	return results;
+}
+
+// ─── LLM Complete (via pi -p) ────────────────────────────────────────────────
+// Instead of importing pi-ai complete(), use pi itself as the LLM backend.
+// This way auth is handled by pi's existing credential chain.
+
+function llmComplete(model, systemPrompt, userMessage) {
+	return new Promise((resolve, reject) => {
+		const fullPrompt = `${systemPrompt}\n\n---\n\n${userMessage}`;
+		const args = ["-p", "--no-session", "--no-tools", "--model", model, fullPrompt];
+		const proc = spawn("pi", args, { cwd: CWD, shell: false, stdio: ["ignore", "pipe", "pipe"] });
+		let stdout = "";
+		let stderr = "";
+		proc.stdout.on("data", (d) => (stdout += d.toString()));
+		proc.stderr.on("data", (d) => (stderr += d.toString()));
+		proc.on("close", (code) => {
+			if (code !== 0) reject(new Error(`pi exited ${code}: ${stderr.slice(0, 500)}`));
+			else resolve(stdout);
+		});
+		proc.on("error", (err) => reject(err));
+	});
+}
+
+// ─── Prompts (same as extension, but inlined) ────────────────────────────────
+
+const CODEBASE_RESEARCH_PROMPT = `You are a senior software engineer doing a deep-dive investigation of a codebase for an implementation plan.
+
+You have a web search helper for fetching external resources:
+
+  node ${WEB_SEARCH_SCRIPT} fetch "https://some-docs-url.com/page"
+  node ${WEB_SEARCH_SCRIPT} gh-readme owner/repo
+  node ${WEB_SEARCH_SCRIPT} gh-file owner/repo path/to/file.py
+
+You have been given an issue with its full discussion context (including all linked issues, PRs, and comments).
+Your job: exhaustively investigate the codebase to gather every fact that could be relevant.
+
+CRITICAL RULES:
+- For EVERY claim you make, include a citation: file path + line number, or a URL.
+- Do NOT guess or assume. If you're not sure, say "NOT VERIFIED".
+- Read actual code. Trace actual call chains. Check actual tests.
+- Do NOT propose solutions. Only gather facts.
+
+Investigation strategy:
+1. Start from the entry points mentioned in the issue
+2. grep/find to locate all relevant code
+3. Read key files — the actual implementation
+4. Trace imports and dependencies
+5. Find ALL test files for the relevant code
+6. Check docs/ for documentation of the feature area
+7. Look for TODOs, FIXMEs referencing this issue
+
+Output: ## Relevant Code, ## Type System & Interfaces, ## Call Chains, ## Test Coverage, ## Documentation, ## Constraints Found — each with citations.`;
+
+const COMPETITIVE_ANALYSIS_PROMPT = `You are a senior software engineer analyzing how other agentic AI frameworks implement a specific capability.
+
+Web research tools available via bash:
+  node ${WEB_SEARCH_SCRIPT} gh-search-repos "query" --max 10
+  node ${WEB_SEARCH_SCRIPT} gh-search-code "query" --repo owner/repo --max 10
+  node ${WEB_SEARCH_SCRIPT} gh-readme owner/repo
+  node ${WEB_SEARCH_SCRIPT} gh-file owner/repo path/to/file.py
+  node ${WEB_SEARCH_SCRIPT} fetch "https://docs-url.com/page"
+  node ${WEB_SEARCH_SCRIPT} search "query"
+
+Frameworks to investigate: LangGraph (langchain-ai/langgraph), CrewAI (crewAIInc/crewAI), Mastra (mastra-ai/mastra), AutoGen (microsoft/autogen), LlamaIndex (run-llama/llama_index), Semantic Kernel (microsoft/semantic-kernel).
+
+For each: does it support this capability? Fetch actual source code. Show real examples. Cite URLs.
+Mark anything unverified as "UNVERIFIED".
+
+Output: ## Capability Under Analysis, ## Framework Analysis (per framework: Supports?, How, API, Limitations, Sources), ## Key Patterns, ## Recommendations.`;
+
+const PLAN_GENERATION_PROMPT = `You are a senior software engineer writing an implementation plan for a GitHub issue in Pydantic AI.
+
+CRITICAL RULES:
+- EVERY claim must have a citation: file path + line number, GitHub URL, or doc URL
+- No filler. No "this will improve the developer experience." Just facts and steps.
+- Call out what you are NOT sure about
+
+Output: ## Goal, ## Prior Art & Competitive Landscape, ## Approach, ## Implementation Steps (with file paths and code snippets), ## Files to Modify, ## New Files, ## Test Plan, ## Documentation Changes, ## Risks and Pitfalls, ## Open Questions, ## References.`;
+
+const REVIEW_PROMPT = `You are reviewing an implementation plan for Pydantic AI. Find gaps, hallucinated facts, wrong assumptions, missed edge cases. Verify citations. Do not praise — only identify problems.
+
+For each issue: WHAT is wrong, WHERE in the plan, WHY it matters (cite evidence), HOW to fix it.
+
+End with: SATISFIED (minor nits only) or NOT SATISFIED (material issues found).`;
+
+const CONSOLIDATION_PROMPT = `Produce the final consolidated implementation plan from two reviewed plans. Take strongest elements from each. Every claim must have a citation. Zero filler.
+
+Use format: ## Goal, ## Prior Art, ## Approach, ## Implementation Steps, ## Files, ## Tests, ## Docs, ## Risks, ## Open Questions, ## References.`;
+
+// ─── Main Pipeline ───────────────────────────────────────────────────────────
+
+async function main() {
+	log(`Plan debate: issue #${ISSUE_NUMBER} in ${REPO}`);
+	log(`Model A: ${MODEL_A}`);
+	log(`Model B: ${MODEL_B}`);
+	log(`Working directory: ${CWD}`);
+	log("");
+
+	// Phase 1: Issue Graph
+	log("═══ PHASE 1/5: Crawling issue graph ═══");
+	const { root, linked, fullContext } = await crawlIssueGraph(ISSUE_NUMBER);
+	log(`Issue graph: ${1 + linked.length} items`);
+	for (const item of linked) log(`  - ${item.type} #${item.number}: ${item.title}`);
+	log("");
+
+	// Phase 2: Research
+	log("═══ PHASE 2/5: Deep parallel research (4 subagents) ═══");
+	const cap = `${root.title}\n\n${root.body}`;
+
+	const researchResults = await runConcurrent([
+		{ label: `${MODEL_A} — codebase`, model: MODEL_A, task: `${CODEBASE_RESEARCH_PROMPT}\n\n${fullContext}` },
+		{ label: `${MODEL_B} — codebase`, model: MODEL_B, task: `${CODEBASE_RESEARCH_PROMPT}\n\n${fullContext}` },
+		{ label: `${MODEL_A} — competitive`, model: MODEL_A, task: `${COMPETITIVE_ANALYSIS_PROMPT}\n\n## Issue\n\n${cap}\n\n## Full Context\n\n${fullContext}` },
+		{ label: `${MODEL_B} — competitive`, model: MODEL_B, task: `${COMPETITIVE_ANALYSIS_PROMPT}\n\n## Issue\n\n${cap}\n\n## Full Context\n\n${fullContext}` },
+	]);
+
+	const researchA = `## Codebase Research\n\n${researchResults[0].output}\n\n## Competitive Analysis\n\n${researchResults[2].output}`;
+	const researchB = `## Codebase Research\n\n${researchResults[1].output}\n\n## Competitive Analysis\n\n${researchResults[3].output}`;
+	log("");
+
+	// Phase 3: Plans
+	log("═══ PHASE 3/5: Generating independent plans ═══");
+	const [planA, planB] = await Promise.all([
+		llmComplete(MODEL_A, PLAN_GENERATION_PROMPT, `${fullContext}\n\n## Research Findings\n\n${researchA}`),
+		llmComplete(MODEL_B, PLAN_GENERATION_PROMPT, `${fullContext}\n\n## Research Findings\n\n${researchB}`),
+	]);
+	log(`  ${MODEL_A}: ${(planA.length / 1024).toFixed(1)}KB`);
+	log(`  ${MODEL_B}: ${(planB.length / 1024).toFixed(1)}KB`);
+	log("");
+
+	let currentPlanA = planA;
+	let currentPlanB = planB;
+
+	// Phase 4: Debate
+	log("═══ PHASE 4/5: Debate ═══");
+	for (let round = 1; round <= MAX_DEBATE_ROUNDS; round++) {
+		log(`Round ${round}/${MAX_DEBATE_ROUNDS}: cross-reviewing...`);
+
+		const [reviewA, reviewB] = await Promise.all([
+			llmComplete(MODEL_A, REVIEW_PROMPT, `## Issue Graph\n${fullContext}\n\n## Plan Under Review (by ${MODEL_B})\n\n${currentPlanB}\n\n## Your Research\n\n${researchA}`),
+			llmComplete(MODEL_B, REVIEW_PROMPT, `## Issue Graph\n${fullContext}\n\n## Plan Under Review (by ${MODEL_A})\n\n${currentPlanA}\n\n## Your Research\n\n${researchB}`),
+		]);
+
+		const satA = !reviewA.match(/\bnot\s+satisfied\b/gi) && !!reviewA.match(/\bsatisfied\b/gi);
+		const satB = !reviewB.match(/\bnot\s+satisfied\b/gi) && !!reviewB.match(/\bsatisfied\b/gi);
+
+		log(`  ${MODEL_A} ${satA ? "✅ satisfied" : "❌ not satisfied"} | ${MODEL_B} ${satB ? "✅ satisfied" : "❌ not satisfied"}`);
+
+		if (satA && satB) { log("  Both satisfied!"); break; }
+
+		log(`  Revising...`);
+		const [revA, revB] = await Promise.all([
+			llmComplete(MODEL_A, PLAN_GENERATION_PROMPT, `## Your Previous Plan\n\n${currentPlanA}\n\n## Review From ${MODEL_B}\n\n${reviewB}\n\n## Issue Graph\n${fullContext}\n\n## Your Research\n\n${researchA}\n\nRevise addressing the feedback.`),
+			llmComplete(MODEL_B, PLAN_GENERATION_PROMPT, `## Your Previous Plan\n\n${currentPlanB}\n\n## Review From ${MODEL_A}\n\n${reviewA}\n\n## Issue Graph\n${fullContext}\n\n## Your Research\n\n${researchB}\n\nRevise addressing the feedback.`),
+		]);
+		currentPlanA = revA;
+		currentPlanB = revB;
+		log(`  Revised: ${MODEL_A} (${(revA.length / 1024).toFixed(1)}KB) | ${MODEL_B} (${(revB.length / 1024).toFixed(1)}KB)`);
+	}
+	log("");
+
+	// Phase 5: Consolidation
+	log("═══ PHASE 5/5: Consolidating ═══");
+	const consolidated = await llmComplete(
+		MODEL_A, CONSOLIDATION_PROMPT,
+		`## Issue Graph\n${fullContext}\n\n## ${MODEL_A}'s Plan\n\n${currentPlanA}\n\n## ${MODEL_B}'s Plan\n\n${currentPlanB}\n\n## ${MODEL_A}'s Research\n\n${researchA}\n\n## ${MODEL_B}'s Research\n\n${researchB}`,
+	);
+
+	const linkedSummary = linked.length > 0
+		? linked.map((i) => `- ${i.type} #${i.number}: ${i.title} (${i.url})`).join("\n")
+		: "None found.";
+
+	const plan = `# Implementation Plan: Issue #${root.number}
+
+> **${root.title}**
+> ${root.url}
+
+> Generated via dual-model debate (${MODEL_A} + ${MODEL_B})
+> Date: ${new Date().toISOString().split("T")[0]}
+> Issue graph: ${1 + linked.length} items crawled
+
+## Linked Issues & PRs
+
+${linkedSummary}
+
+${consolidated}
+
+---
+
+## Appendix
+
+<details>
+<summary>${MODEL_A}'s Final Plan</summary>
+
+${currentPlanA}
+
+</details>
+
+<details>
+<summary>${MODEL_B}'s Final Plan</summary>
+
+${currentPlanB}
+
+</details>
+
+<details>
+<summary>${MODEL_A}'s Research</summary>
+
+${researchA}
+
+</details>
+
+<details>
+<summary>${MODEL_B}'s Research</summary>
+
+${researchB}
+
+</details>`;
+
+	// Write plan
+	const planPath = path.join(CWD, "PLAN.md");
+	fs.writeFileSync(planPath, plan, "utf-8");
+	log(`Plan written to ${planPath} (${(plan.length / 1024).toFixed(1)}KB)`);
+
+	if (SKIP_PR) {
+		log("Skipping PR creation (--skip-pr)");
+		return;
+	}
+
+	// Create PR
+	log("Creating PR...");
+	const branch = `plan/issue-${ISSUE_NUMBER}`;
+
+	for (const cmd of [
+		`git checkout -b ${branch}`,
+		`git add PLAN.md`,
+		`git commit -m "Add implementation plan for issue #${ISSUE_NUMBER}"`,
+		`git push -u origin ${branch}`,
+	]) {
+		const r = await exec(cmd);
+		if (r.code !== 0) { log(`FAILED: ${cmd}\n${r.stderr}`); process.exit(1); }
+	}
+
+	const prBody = `Implementation plan generated via dual-model debate (${MODEL_A} + ${MODEL_B}).\n\nCloses #${ISSUE_NUMBER}`;
+	const prResult = await exec(
+		`gh pr create --draft --title "Plan: Issue #${ISSUE_NUMBER}" --body "${prBody.replace(/"/g, '\\"')}" --head ${branch} --repo ${REPO}`,
+	);
+	if (prResult.code !== 0) {
+		log(`PR creation failed: ${prResult.stderr}`);
+		process.exit(1);
+	}
+	log(`✅ PR created: ${prResult.stdout.trim()}`);
+}
+
+main().catch((err) => {
+	console.error("Fatal:", err.message);
+	process.exit(1);
+});

--- a/.github/plan-debate/ci-plan-debate.mjs
+++ b/.github/plan-debate/ci-plan-debate.mjs
@@ -36,7 +36,8 @@ function getArg(name) {
 }
 
 const ISSUE_NUMBER = parseInt(getArg("--issue") || process.env.ISSUE_NUMBER || "", 10);
-const REPO = getArg("--repo") || process.env.REPO || "pydantic/pydantic-ai";
+const REPO = getArg("--repo") || process.env.REPO || "pydantic/pydantic-harness";
+const CODE_REPO = getArg("--code-repo") || process.env.CODE_REPO || "pydantic/pydantic-ai";
 const MODEL_A = getArg("--model-a") || process.env.MODEL_A || "anthropic/claude-opus-4-6";
 const MODEL_B = getArg("--model-b") || process.env.MODEL_B || "openai/gpt-4.1";
 const CWD = getArg("--cwd") || process.env.CWD || process.cwd();
@@ -270,7 +271,7 @@ function llmComplete(model, systemPrompt, userMessage) {
 // ─── Prompts (shared with interactive extension) ─────────────────────────────
 
 import {
-	CODEBASE_RESEARCH_PROMPT,
+	getCodebaseResearchPrompt,
 	getCompetitiveAnalysisPrompt,
 	PLAN_GENERATION_PROMPT,
 	REVIEW_PROMPT,
@@ -300,8 +301,8 @@ async function main() {
 	const cap = `${root.title}\n\n${root.body}`;
 
 	const researchResults = await runConcurrent([
-		{ label: `${MODEL_A} — codebase`, model: MODEL_A, task: `${CODEBASE_RESEARCH_PROMPT}\n\n${fullContext}` },
-		{ label: `${MODEL_B} — codebase`, model: MODEL_B, task: `${CODEBASE_RESEARCH_PROMPT}\n\n${fullContext}` },
+		{ label: `${MODEL_A} — codebase`, model: MODEL_A, task: `${getCodebaseResearchPrompt(CODE_REPO)}\n\n${fullContext}` },
+		{ label: `${MODEL_B} — codebase`, model: MODEL_B, task: `${getCodebaseResearchPrompt(CODE_REPO)}\n\n${fullContext}` },
 		{ label: `${MODEL_A} — competitive`, model: MODEL_A, task: `${COMPETITIVE_ANALYSIS_PROMPT}\n\n## Issue\n\n${cap}\n\n## Full Context\n\n${fullContext}` },
 		{ label: `${MODEL_B} — competitive`, model: MODEL_B, task: `${COMPETITIVE_ANALYSIS_PROMPT}\n\n## Issue\n\n${cap}\n\n## Full Context\n\n${fullContext}` },
 	]);

--- a/.github/plan-debate/ci-plan-debate.mjs
+++ b/.github/plan-debate/ci-plan-debate.mjs
@@ -305,12 +305,11 @@ Tools:
   node ${WEB_SEARCH_SCRIPT} gh-search-code "keyword" --repo owner/repo --max 10
   node ${WEB_SEARCH_SCRIPT} gh-file owner/repo path/to/file.py
 
-Frameworks (only these three):
-1. LangGraph — langchain-ai/langgraph (Python, libs/langgraph/langgraph/)
-2. CrewAI — crewAIInc/crewAI (Python, src/crewai/)
-3. AutoGen — microsoft/autogen (Python, autogen/)
+Pick the 3 most relevant frameworks for THIS capability from:
+- LangGraph (langchain-ai/langgraph), CrewAI (crewAIInc/crewAI), AutoGen (microsoft/autogen)
+- Mastra (mastra-ai/mastra), LlamaIndex (run-llama/llama_index), Semantic Kernel (microsoft/semantic-kernel)
 
-For each: search for relevant code, fetch 2-3 source files, read the implementation. Note if they don't support it. Do NOT guess at APIs.
+For each chosen framework: search for relevant code, fetch 2-3 source files, read the implementation. Note if they don't support it. Do NOT guess at APIs.
 
 Output per framework: Supports? Implementation (cite paths). Code snippets. Gaps. Then: common patterns and what Pydantic AI should consider.`;
 

--- a/.github/plan-debate/ci-plan-debate.mjs
+++ b/.github/plan-debate/ci-plan-debate.mjs
@@ -297,21 +297,20 @@ Investigation strategy:
 
 Output: ## Relevant Code, ## Type System & Interfaces, ## Call Chains, ## Test Coverage, ## Documentation, ## Constraints Found — each with citations.`;
 
-const COMPETITIVE_ANALYSIS_PROMPT = `You are researching how competing agent frameworks implement a capability described in a GitHub issue.
-
-Look at SOURCE CODE only. Do not fetch docs pages, blog posts, or tutorials.
+const COMPETITIVE_ANALYSIS_PROMPT = `You are researching how competing agent/LLM frameworks implement a capability described in a GitHub issue.
 
 Tools:
+  node ${WEB_SEARCH_SCRIPT} search "query"
+  node ${WEB_SEARCH_SCRIPT} gh-search-repos "query" --max 10
   node ${WEB_SEARCH_SCRIPT} gh-search-code "keyword" --repo owner/repo --max 10
   node ${WEB_SEARCH_SCRIPT} gh-file owner/repo path/to/file.py
 
-Pick the 3 most relevant frameworks for THIS capability from:
-- LangGraph (langchain-ai/langgraph), CrewAI (crewAIInc/crewAI), AutoGen (microsoft/autogen)
-- Mastra (mastra-ai/mastra), LlamaIndex (run-llama/llama_index), Semantic Kernel (microsoft/semantic-kernel)
+Process:
+1. DISCOVER: Search for frameworks that implement this capability. Use search and gh-search-repos with keywords from the issue.
+2. PICK 3: Choose the 3 most relevant. Explain why.
+3. DEEP DIVE: For each, search their repo, fetch 2-3 source files, read the implementation. Source code only — no docs pages.
 
-For each chosen framework: search for relevant code, fetch 2-3 source files, read the implementation. Note if they don't support it. Do NOT guess at APIs.
-
-Output per framework: Supports? Implementation (cite paths). Code snippets. Gaps. Then: common patterns and what Pydantic AI should consider.`;
+Output: Discovery (what you searched, what you found, why you picked these 3). Per framework: Repo, Supports?, Implementation (cite paths), Code snippets, Gaps. Then: common patterns and what Pydantic AI should consider.`;
 
 const PLAN_GENERATION_PROMPT = `You are a senior software engineer writing an implementation plan for a GitHub issue in Pydantic AI.
 

--- a/.github/plan-debate/ci-plan-debate.mjs
+++ b/.github/plan-debate/ci-plan-debate.mjs
@@ -267,69 +267,17 @@ function llmComplete(model, systemPrompt, userMessage) {
 	});
 }
 
-// ─── Prompts (same as extension, but inlined) ────────────────────────────────
+// ─── Prompts (shared with interactive extension) ─────────────────────────────
 
-const CODEBASE_RESEARCH_PROMPT = `You are a senior software engineer doing a deep-dive investigation of a codebase for an implementation plan.
+import {
+	CODEBASE_RESEARCH_PROMPT,
+	getCompetitiveAnalysisPrompt,
+	PLAN_GENERATION_PROMPT,
+	REVIEW_PROMPT,
+	CONSOLIDATION_PROMPT,
+} from "./prompts.mjs";
 
-You have a web search helper for fetching external resources:
-
-  node ${WEB_SEARCH_SCRIPT} fetch "https://some-docs-url.com/page"
-  node ${WEB_SEARCH_SCRIPT} gh-readme owner/repo
-  node ${WEB_SEARCH_SCRIPT} gh-file owner/repo path/to/file.py
-
-You have been given an issue with its full discussion context (including all linked issues, PRs, and comments).
-Your job: exhaustively investigate the codebase to gather every fact that could be relevant.
-
-CRITICAL RULES:
-- For EVERY claim you make, include a citation: file path + line number, or a URL.
-- Do NOT guess or assume. If you're not sure, say "NOT VERIFIED".
-- Read actual code. Trace actual call chains. Check actual tests.
-- Do NOT propose solutions. Only gather facts.
-
-Investigation strategy:
-1. Start from the entry points mentioned in the issue
-2. grep/find to locate all relevant code
-3. Read key files — the actual implementation
-4. Trace imports and dependencies
-5. Find ALL test files for the relevant code
-6. Check docs/ for documentation of the feature area
-7. Look for TODOs, FIXMEs referencing this issue
-
-Output: ## Relevant Code, ## Type System & Interfaces, ## Call Chains, ## Test Coverage, ## Documentation, ## Constraints Found — each with citations.`;
-
-const COMPETITIVE_ANALYSIS_PROMPT = `You are researching how competing agent/LLM frameworks implement a capability described in a GitHub issue.
-
-Tools:
-  node ${WEB_SEARCH_SCRIPT} search "query"
-  node ${WEB_SEARCH_SCRIPT} gh-search-repos "query" --max 10
-  node ${WEB_SEARCH_SCRIPT} gh-search-code "keyword" --repo owner/repo --max 10
-  node ${WEB_SEARCH_SCRIPT} gh-file owner/repo path/to/file.py
-
-Process:
-1. DISCOVER: Search for frameworks that implement this capability. Use search and gh-search-repos with keywords from the issue.
-2. PICK 3: Choose the 3 most relevant. Explain why.
-3. DEEP DIVE: For each, search their repo, fetch 2-3 source files, read the implementation. Source code only — no docs pages.
-
-Output: Discovery (what you searched, what you found, why you picked these 3). Per framework: Repo, Supports?, Implementation (cite paths), Code snippets, Gaps. Then: common patterns and what Pydantic AI should consider.`;
-
-const PLAN_GENERATION_PROMPT = `You are a senior software engineer writing an implementation plan for a GitHub issue in Pydantic AI.
-
-CRITICAL RULES:
-- EVERY claim must have a citation: file path + line number, GitHub URL, or doc URL
-- No filler. No "this will improve the developer experience." Just facts and steps.
-- Call out what you are NOT sure about
-
-Output: ## Goal, ## Prior Art & Competitive Landscape, ## Approach, ## Implementation Steps (with file paths and code snippets), ## Files to Modify, ## New Files, ## Test Plan, ## Documentation Changes, ## Risks and Pitfalls, ## Open Questions, ## References.`;
-
-const REVIEW_PROMPT = `You are reviewing an implementation plan for Pydantic AI. Find gaps, hallucinated facts, wrong assumptions, missed edge cases. Verify citations. Do not praise — only identify problems.
-
-For each issue: WHAT is wrong, WHERE in the plan, WHY it matters (cite evidence), HOW to fix it.
-
-End with: SATISFIED (minor nits only) or NOT SATISFIED (material issues found).`;
-
-const CONSOLIDATION_PROMPT = `Produce the final consolidated implementation plan from two reviewed plans. Take strongest elements from each. Every claim must have a citation. Zero filler.
-
-Use format: ## Goal, ## Prior Art, ## Approach, ## Implementation Steps, ## Files, ## Tests, ## Docs, ## Risks, ## Open Questions, ## References.`;
+const COMPETITIVE_ANALYSIS_PROMPT = getCompetitiveAnalysisPrompt(WEB_SEARCH_SCRIPT);
 
 // ─── Main Pipeline ───────────────────────────────────────────────────────────
 

--- a/.github/plan-debate/prompts.mjs
+++ b/.github/plan-debate/prompts.mjs
@@ -3,7 +3,10 @@
  * Used by both the interactive PI extension (index.ts) and the CI script (ci-plan-debate.mjs).
  */
 
-export const CODEBASE_RESEARCH_PROMPT = `You are investigating a codebase for an implementation plan. You have an issue with full discussion context.
+export function getCodebaseResearchPrompt(codeRepo) {
+	return `You are investigating the ${codeRepo} codebase for an implementation plan.
+
+The issue you've been given is from a separate planning repo, but the code you are reading and searching is ${codeRepo}. Your tools (read, grep, find, ls) operate on the ${codeRepo} checkout.
 
 Gather every relevant fact. Do NOT propose solutions.
 
@@ -27,6 +30,7 @@ OUTPUT:
 ## Test Coverage — test files, what they cover, gaps
 ## Documentation — docs files, docstrings, discrepancies
 ## Constraints — backward compat, type safety, dependencies (cite sources)`;
+}
 
 export function getCompetitiveAnalysisPrompt(webSearchScript) {
 	return `You are researching how competing agent/LLM frameworks implement a capability described in a GitHub issue.

--- a/.github/plan-debate/prompts.mjs
+++ b/.github/plan-debate/prompts.mjs
@@ -1,0 +1,174 @@
+/**
+ * Shared prompts for the dual-model plan debate pipeline.
+ * Used by both the interactive PI extension (index.ts) and the CI script (ci-plan-debate.mjs).
+ */
+
+export const CODEBASE_RESEARCH_PROMPT = `You are investigating a codebase for an implementation plan. You have an issue with full discussion context.
+
+Gather every relevant fact. Do NOT propose solutions.
+
+RULES:
+- Every claim needs a citation: file path + line number.
+- If unsure, say "NOT VERIFIED". Do not guess.
+- Read actual code. Trace actual call chains. Check actual tests.
+
+STRATEGY:
+1. grep/find to locate relevant code from the issue's entry points
+2. Read key files — the actual implementation, not just headers
+3. Trace imports and dependencies
+4. Find ALL test files for the relevant code
+5. Check docs/ for documentation of the feature area
+6. Look for TODOs/FIXMEs referencing this issue
+
+OUTPUT:
+## Relevant Code — file path, lines, what's there, what imports it
+## Type System — key types/protocols/interfaces with actual code
+## Call Chains — trace execution paths
+## Test Coverage — test files, what they cover, gaps
+## Documentation — docs files, docstrings, discrepancies
+## Constraints — backward compat, type safety, dependencies (cite sources)`;
+
+export function getCompetitiveAnalysisPrompt(webSearchScript) {
+	return `You are researching how competing agent/LLM frameworks implement a capability described in a GitHub issue.
+
+## Tools
+
+  node ${webSearchScript} search "query"                                        # find relevant repos/frameworks
+  node ${webSearchScript} gh-search-repos "query" --max 10                      # search GitHub repos
+  node ${webSearchScript} gh-search-code "keyword" --repo owner/repo --max 10   # search code in a repo
+  node ${webSearchScript} gh-file owner/repo path/to/file.py                    # fetch a source file
+
+## Process
+
+1. DISCOVER: Search for frameworks that implement this capability. Use \`search\` and \`gh-search-repos\` with keywords from the issue. Cast a wide net here.
+2. PICK 3: From what you find, choose the 3 frameworks most likely to have a real implementation. Explain why you picked them.
+3. DEEP DIVE: For each of your 3, search their repo for relevant code, fetch 2-3 source files, read the actual implementation.
+
+Source code only for the deep dive. Do not fetch docs pages or tutorials. Only cite code you actually read.
+
+## Output
+
+### Discovery
+What you searched for and what you found. Why you picked the 3 you did.
+
+### [Framework] (repeat for each of 3)
+- **Repo**: owner/repo
+- **Supports?**: Yes/No/Partial
+- **Implementation**: Classes, methods, signatures (cite file paths)
+- **Code**: Key snippets from actual source
+- **Gaps**: What's missing or limited
+
+### Patterns
+What's common. What Pydantic AI should consider.`;
+}
+
+export const PLAN_GENERATION_PROMPT = `You are a senior software engineer writing an implementation plan for a GitHub issue in Pydantic AI.
+
+You have:
+1. Deep codebase research with specific file paths, line numbers, and code snippets
+2. A full issue graph (the issue itself plus all linked issues, PRs, and their discussions)
+3. Competitive analysis showing how other agentic frameworks handle this capability
+
+CRITICAL RULES:
+- EVERY claim must have a citation: file path + line number, GitHub URL, or doc URL
+- EVERY risk must cite where in the code the risk manifests
+- No filler. No "this will improve the developer experience." Just facts and steps.
+- If you reference how another framework does something, include the URL
+- Call out explicitly what you are NOT sure about
+- Identify things that need human judgment or maintainer input
+- If a linked issue or PR discussion contains a decision by maintainers, cite and respect it
+
+Output format:
+
+## Goal
+One sentence. What the change achieves for users.
+
+## Prior Art & Competitive Landscape
+How other frameworks handle this. For each:
+- Framework name, approach, citation URL
+- What Pydantic AI can learn or should avoid
+
+## Approach
+2-3 paragraphs explaining the technical approach and why this approach over alternatives.
+Cite specific code patterns from the research. Reference maintainer decisions from linked issues/PRs.
+
+## Implementation Steps
+Numbered, ordered steps. Each step MUST specify:
+- Which file(s) to modify or create (with current line ranges)
+- What to change (with code snippet showing the shape of the change)
+- Why this step is needed (cite the issue, a linked discussion, or a code constraint)
+
+## Files to Modify
+| File | Change | Lines Affected | Citation |
+|------|--------|----------------|----------|
+| path/to/file.py | Description | ~L100-150 | Why (link) |
+
+## New Files (if any)
+| File | Purpose | Modeled After |
+|------|---------|---------------|
+| path/to/new.py | Description | Existing pattern at path/to/similar.py |
+
+## Test Plan
+- What tests to add or modify (cite existing test patterns)
+- What scenarios to cover (cite edge cases from linked issues)
+- What testing infrastructure to use (cite existing test helpers)
+
+## Documentation Changes
+- Which doc files to update
+- What to add to docstrings
+
+## Risks and Pitfalls
+For each risk:
+- What could go wrong
+- Where in the code this manifests (file + line)
+- Evidence from linked issues/PRs/other frameworks
+- Mitigation strategy
+
+## Open Questions
+Things that need clarification. For each, cite where the ambiguity arises.
+
+## References
+All URLs, file paths, and sources cited in this plan, collected for easy access.`;
+
+export const REVIEW_PROMPT = `You are a senior software engineer reviewing a proposed implementation plan for Pydantic AI.
+Your job: find gaps, incorrect assumptions, hallucinated facts, and missed edge cases.
+
+CRITICAL: Verify citations. If the plan claims a file contains something, check if that's plausible.
+If the plan cites a framework's behavior, check if the citation URL is real.
+
+For each issue found:
+1. WHAT is wrong or missing
+2. WHERE in the plan it appears
+3. WHY it matters (cite codebase evidence or linked issue discussion)
+4. HOW to fix it (specific suggestion with file paths)
+
+Also verify:
+- Are all file paths and line numbers plausible given the codebase structure?
+- Are there assumptions not backed by code evidence or linked discussions?
+- Does the plan respect decisions made by maintainers in linked issues/PRs?
+- Are backward compatibility issues handled per the version policy?
+- Did the plan consider all relevant competitive framework approaches?
+- Are there simpler alternatives the plan doesn't consider?
+- Are all citations present and plausible?
+
+End with a clear verdict:
+- SATISFIED: The plan is solid. Minor nits only.
+- NOT SATISFIED: Material issues found. List them with citations.`;
+
+export const CONSOLIDATION_PROMPT = `You are producing the final consolidated implementation plan from two reviewed and revised plans for Pydantic AI.
+
+Take the strongest elements of both plans. Where they disagree, pick the approach with stronger code evidence and more citations. Where both have gaps, call them out as open questions.
+
+The output MUST be:
+- Actionable by a developer who has not read either individual plan
+- Self-contained with ALL necessary context
+- EVERY claim backed by a citation (file path + line, GitHub URL, or doc URL)
+- Zero filler. Zero fluff. Every sentence must convey actionable information.
+- Include the competitive analysis section with framework citations
+- Include all references collected from both plans
+
+Writing style: Direct, technical, to the point. Like a senior engineer's design doc.
+Bad: "This comprehensive plan will enable a robust implementation of the feature."
+Good: "Add a \`validate_schema()\` method to \`BaseModel\` (pydantic_ai_slim/pydantic_ai/models/base.py:L45) that runs before \`__init__\`. See LangGraph's equivalent: https://..."
+
+Use the same output format as the individual plans (Goal, Prior Art, Approach, Steps, Files, Tests, Docs, Risks, Open Questions, References).`;

--- a/.github/plan-debate/web-search.mjs
+++ b/.github/plan-debate/web-search.mjs
@@ -91,16 +91,56 @@ function json(obj) { console.log(JSON.stringify(obj, null, 2)); }
 // ─── Commands ─────────────────────────────────────────────────────────────
 
 async function searchWeb() {
-	// GitHub repo search — reliable, no API key needed
-	const result = gh(["search", "repos", query, "--json", "name,url,description,stargazersCount", "--limit", String(max)]);
-	if (result) {
+	const results = [];
+
+	// Strategy 1: Tavily (best for agents, free tier 1000 queries/month)
+	if (process.env.TAVILY_API_KEY && results.length === 0) {
 		try {
-			const repos = JSON.parse(result);
-			json({ query, resultCount: repos.length, results: repos.map((r) => ({ url: r.url, title: r.name, snippet: r.description || "", stars: r.stargazersCount })) });
-			return;
+			const resp = await fetch("https://api.tavily.com/search", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ api_key: process.env.TAVILY_API_KEY, query, max_results: max, search_depth: "basic" }),
+				signal: AbortSignal.timeout(10000),
+			});
+			if (resp.ok) {
+				const data = await resp.json();
+				for (const r of data.results || []) {
+					results.push({ url: r.url, title: r.title || "", snippet: r.content || "", source: "tavily" });
+				}
+			}
 		} catch { /* fall through */ }
 	}
-	json({ query, resultCount: 0, results: [] });
+
+	// Strategy 2: Brave Search (free tier 2000 queries/month)
+	if (process.env.BRAVE_API_KEY && results.length === 0) {
+		try {
+			const params = new URLSearchParams({ q: query, count: String(max) });
+			const resp = await fetch(`https://api.search.brave.com/res/v1/web/search?${params}`, {
+				headers: { "X-Subscription-Token": process.env.BRAVE_API_KEY, Accept: "application/json" },
+				signal: AbortSignal.timeout(10000),
+			});
+			if (resp.ok) {
+				const data = await resp.json();
+				for (const r of data.web?.results || []) {
+					results.push({ url: r.url, title: r.title || "", snippet: r.description || "", source: "brave" });
+				}
+			}
+		} catch { /* fall through */ }
+	}
+
+	// Strategy 3: GitHub repo search (always works, no extra key needed)
+	if (results.length === 0) {
+		const ghResult = gh(["search", "repos", query, "--json", "name,url,description,stargazersCount", "--limit", String(max)]);
+		if (ghResult) {
+			try {
+				for (const r of JSON.parse(ghResult)) {
+					results.push({ url: r.url, title: r.name, snippet: r.description || "", stars: r.stargazersCount, source: "github" });
+				}
+			} catch { /* ignore */ }
+		}
+	}
+
+	json({ query, resultCount: results.length, source: results[0]?.source || "none", results });
 }
 
 async function fetchUrl() {

--- a/.github/plan-debate/web-search.mjs
+++ b/.github/plan-debate/web-search.mjs
@@ -2,20 +2,18 @@
 /**
  * Web search helper for plan-debate subagents.
  *
- * Uses multiple strategies in order of reliability:
- *   1. GitHub search (for code, repos, issues — via gh CLI)
- *   2. Fetch + extract text from URLs (for documentation pages)
- *   3. DuckDuckGo HTML search (for general web queries)
- *
  * Usage:
  *   node web-search.mjs search "langgraph agent tools"
- *   node web-search.mjs search "crewai multi-agent" --max 10
  *   node web-search.mjs fetch "https://docs.example.com/page"
  *   node web-search.mjs gh-search-code "class Agent" --repo langchain-ai/langgraph
  *   node web-search.mjs gh-search-repos "agentic framework"
  *   node web-search.mjs gh-readme langchain-ai/langgraph
+ *   node web-search.mjs gh-file langchain-ai/langgraph path/to/file.py
  */
 
+import { execFileSync } from "node:child_process";
+
+const MAX_CONTENT = 15000;
 const args = process.argv.slice(2);
 const command = args[0];
 
@@ -30,48 +28,54 @@ if (!command) {
 	process.exit(0);
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────
+// ─── Arg Parsing ─────────────────────────────────────────────────────────
 
-function getArg(name) {
+function getFlag(name) {
 	const idx = args.indexOf(name);
 	return idx !== -1 && args[idx + 1] ? args[idx + 1] : null;
 }
 
-function getMax() {
-	return parseInt(getArg("--max") || "10", 10);
+// Extract positional args (skip flags and their values)
+const positional = [];
+for (let i = 1; i < args.length; i++) {
+	if (args[i].startsWith("--")) { i++; } else { positional.push(args[i]); }
+}
+const query = positional.join(" ");
+const max = parseInt(getFlag("--max") || "10", 10);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function gh(ghArgs) {
+	try {
+		return execFileSync("gh", ghArgs, { encoding: "utf-8", timeout: 30000 }).trim();
+	} catch {
+		return "";
+	}
 }
 
-/** Strip HTML tags and decode entities */
+function truncate(text) {
+	return text.length > MAX_CONTENT ? text.slice(0, MAX_CONTENT) + "\n\n[TRUNCATED]" : text;
+}
+
 function stripHtml(html) {
 	return html
 		.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
 		.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
 		.replace(/<nav[^>]*>[\s\S]*?<\/nav>/gi, "")
 		.replace(/<footer[^>]*>[\s\S]*?<\/footer>/gi, "")
-		.replace(/<header[^>]*>[\s\S]*?<\/header>/gi, "")
 		.replace(/<[^>]+>/g, " ")
-		.replace(/&nbsp;/g, " ")
-		.replace(/&amp;/g, "&")
-		.replace(/&lt;/g, "<")
-		.replace(/&gt;/g, ">")
-		.replace(/&quot;/g, '"')
-		.replace(/&#39;/g, "'")
+		.replace(/&nbsp;/g, " ").replace(/&amp;/g, "&").replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#39;/g, "'")
 		.replace(/\s+/g, " ")
 		.trim();
 }
 
-/** Extract meaningful text from HTML, keeping some structure */
-function extractText(html, maxLength = 15000) {
-	// Try to find main content area
+function extractText(html) {
 	const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
 		|| html.match(/<article[^>]*>([\s\S]*?)<\/article>/i)
-		|| html.match(/<div[^>]*class="[^"]*content[^"]*"[^>]*>([\s\S]*?)<\/div>/i)
 		|| html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
 
-	const content = mainMatch ? mainMatch[1] : html;
-
-	// Convert some tags to text markers for structure
-	let text = content
+	let text = (mainMatch ? mainMatch[1] : html)
 		.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, "\n\n## $2\n\n")
 		.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "\n- $1")
 		.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, "\n```\n$1\n```\n")
@@ -79,220 +83,93 @@ function extractText(html, maxLength = 15000) {
 		.replace(/<br\s*\/?>/gi, "\n")
 		.replace(/<p[^>]*>/gi, "\n\n");
 
-	text = stripHtml(text);
-
-	// Collapse multiple newlines
-	text = text.replace(/\n{3,}/g, "\n\n").trim();
-
-	if (text.length > maxLength) {
-		text = text.slice(0, maxLength) + "\n\n[TRUNCATED]";
-	}
-
-	return text;
+	return truncate(stripHtml(text).replace(/\n{3,}/g, "\n\n").trim());
 }
 
-/** Run a shell command and return stdout */
-async function exec(cmd) {
-	const { execSync } = await import("node:child_process");
-	try {
-		return execSync(cmd, { encoding: "utf-8", timeout: 30000, stdio: ["pipe", "pipe", "pipe"] }).trim();
-	} catch {
-		return "";
-	}
-}
+function json(obj) { console.log(JSON.stringify(obj, null, 2)); }
 
 // ─── Commands ─────────────────────────────────────────────────────────────
 
-async function searchWeb(query) {
-	const max = getMax();
-	const results = [];
-
-	// Strategy 1: DuckDuckGo HTML lite
-	try {
-		const params = new URLSearchParams({ q: query, kl: "us-en" });
-		const resp = await fetch(`https://lite.duckduckgo.com/lite/?${params}`, {
-			headers: {
-				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
-			},
-			signal: AbortSignal.timeout(10000),
-		});
-		const html = await resp.text();
-
-		// DDG lite puts results in a table with specific structure
-		// Extract links from the results
-		const linkRegex = /href="(https?:\/\/[^"]+)"[^>]*class="[^"]*result-link/gi;
-		let match;
-		while ((match = linkRegex.exec(html)) !== null && results.length < max) {
-			results.push({ url: decodeURIComponent(match[1]), title: "", snippet: "", source: "duckduckgo" });
-		}
-
-		// Also try extracting from any external links
-		if (results.length === 0) {
-			const anyLinkRegex = /href="(https?:\/\/(?!duckduckgo\.com)[^"]+)"/gi;
-			const seen = new Set();
-			while ((match = anyLinkRegex.exec(html)) !== null && results.length < max) {
-				const url = decodeURIComponent(match[1]);
-				if (!seen.has(url) && !url.includes("duckduckgo.com")) {
-					seen.add(url);
-					results.push({ url, title: "", snippet: "", source: "duckduckgo" });
-				}
-			}
-		}
-	} catch { /* DDG failed, continue */ }
-
-	// Strategy 2: If DDG failed, try GitHub search for the query
-	if (results.length === 0) {
+async function searchWeb() {
+	// GitHub repo search — reliable, no API key needed
+	const result = gh(["search", "repos", query, "--json", "name,url,description,stargazersCount", "--limit", String(max)]);
+	if (result) {
 		try {
-			const ghResult = await exec(`gh search repos "${query.replace(/"/g, '\\"')}" --json name,url,description --limit ${max}`);
-			if (ghResult) {
-				const repos = JSON.parse(ghResult);
-				for (const repo of repos) {
-					results.push({
-						url: repo.url,
-						title: repo.name,
-						snippet: repo.description || "",
-						source: "github-repos",
-					});
-				}
-			}
-		} catch { /* ignore */ }
+			const repos = JSON.parse(result);
+			json({ query, resultCount: repos.length, results: repos.map((r) => ({ url: r.url, title: r.name, snippet: r.description || "", stars: r.stargazersCount })) });
+			return;
+		} catch { /* fall through */ }
 	}
-
-	console.log(JSON.stringify({ query, resultCount: results.length, results }, null, 2));
+	json({ query, resultCount: 0, results: [] });
 }
 
-async function fetchUrl(url) {
+async function fetchUrl() {
+	const url = args[1];
 	try {
 		const resp = await fetch(url, {
-			headers: {
-				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
-				"Accept": "text/html,application/xhtml+xml,text/plain,application/json",
-			},
+			headers: { "User-Agent": "Mozilla/5.0", "Accept": "text/html,application/json,text/plain" },
 			signal: AbortSignal.timeout(15000),
 			redirect: "follow",
 		});
+		if (!resp.ok) { json({ url, error: `HTTP ${resp.status}`, content: "" }); return; }
 
-		if (!resp.ok) {
-			console.log(JSON.stringify({ url, error: `HTTP ${resp.status}`, content: "" }));
-			return;
-		}
-
-		const contentType = resp.headers.get("content-type") || "";
+		const ct = resp.headers.get("content-type") || "";
 		const body = await resp.text();
 
 		let content;
-		if (contentType.includes("json")) {
-			// JSON — pretty print
-			try {
-				content = JSON.stringify(JSON.parse(body), null, 2).slice(0, 15000);
-			} catch {
-				content = body.slice(0, 15000);
-			}
-		} else if (contentType.includes("html")) {
+		if (ct.includes("json")) {
+			try { content = truncate(JSON.stringify(JSON.parse(body), null, 2)); } catch { content = truncate(body); }
+		} else if (ct.includes("html")) {
 			content = extractText(body);
 		} else {
-			// Plain text or other
-			content = body.slice(0, 15000);
+			content = truncate(body);
 		}
-
-		console.log(JSON.stringify({ url, contentType, contentLength: body.length, content }));
+		json({ url, contentLength: body.length, content });
 	} catch (e) {
-		console.log(JSON.stringify({ url, error: e.message, content: "" }));
+		json({ url, error: e.message, content: "" });
 	}
 }
 
-async function ghSearchCode(query) {
-	const repo = getArg("--repo");
-	const max = getMax();
-	if (!repo) {
-		console.log(JSON.stringify({ error: "Missing --repo argument" }));
-		return;
-	}
-	// Use spawn to avoid shell quoting issues
-	const { execFileSync } = await import("node:child_process");
-	try {
-		const result = execFileSync("gh", [
-			"search", "code", query, "--repo", repo,
-			"--json", "path,textMatches", "--limit", String(max),
-		], { encoding: "utf-8", timeout: 30000 });
-		console.log(result.trim() || JSON.stringify({ query, repo, results: [] }));
-	} catch {
-		console.log(JSON.stringify({ query, repo, results: [] }));
-	}
+function ghSearchCode() {
+	const repo = getFlag("--repo");
+	if (!repo) { json({ error: "Missing --repo" }); return; }
+	const result = gh(["search", "code", query, "--repo", repo, "--json", "path,textMatches", "--limit", String(max)]);
+	console.log(result || JSON.stringify({ query, repo, results: [] }));
 }
 
-async function ghSearchRepos(query) {
-	const max = getMax();
-	const { execFileSync } = await import("node:child_process");
-	try {
-		const result = execFileSync("gh", [
-			"search", "repos", query,
-			"--json", "name,url,description,stargazersCount", "--limit", String(max),
-		], { encoding: "utf-8", timeout: 30000 });
-		console.log(result.trim() || JSON.stringify({ query, results: [] }));
-	} catch {
-		console.log(JSON.stringify({ query, results: [] }));
-	}
+function ghSearchRepos() {
+	const result = gh(["search", "repos", query, "--json", "name,url,description,stargazersCount", "--limit", String(max)]);
+	console.log(result || JSON.stringify({ query, results: [] }));
 }
 
-async function ghReadme(repo) {
-	// Fetch README via API, decode from base64
-	const result = await exec(
-		`gh api repos/${repo}/readme --jq '.content' 2>/dev/null | base64 -d`,
-	);
+function ghReadme() {
+	const result = gh(["api", `repos/${args[1]}/readme`, "--jq", ".content"]);
 	if (result) {
-		const truncated = result.length > 15000 ? result.slice(0, 15000) + "\n\n[TRUNCATED]" : result;
-		console.log(JSON.stringify({ repo, content: truncated }));
+		const decoded = Buffer.from(result, "base64").toString("utf-8");
+		json({ repo: args[1], content: truncate(decoded) });
 	} else {
-		console.log(JSON.stringify({ repo, error: "Could not fetch README", content: "" }));
+		json({ repo: args[1], error: "Could not fetch README", content: "" });
 	}
 }
 
-async function ghFile(repo, filePath) {
-	const result = await exec(
-		`gh api repos/${repo}/contents/${filePath} --jq '.content' 2>/dev/null | base64 -d`,
-	);
+function ghFile() {
+	const result = gh(["api", `repos/${args[1]}/contents/${args[2]}`, "--jq", ".content"]);
 	if (result) {
-		const truncated = result.length > 15000 ? result.slice(0, 15000) + "\n\n[TRUNCATED]" : result;
-		console.log(JSON.stringify({ repo, path: filePath, content: truncated }));
+		const decoded = Buffer.from(result, "base64").toString("utf-8");
+		json({ repo: args[1], path: args[2], content: truncate(decoded) });
 	} else {
-		console.log(JSON.stringify({ repo, path: filePath, error: "Could not fetch file", content: "" }));
+		json({ repo: args[1], path: args[2], error: "Could not fetch file", content: "" });
 	}
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────
 
-// Extract query: skip flags and their values
-const queryParts = [];
-for (let i = 1; i < args.length; i++) {
-	if (args[i].startsWith("--")) {
-		i++; // skip flag value too
-	} else {
-		queryParts.push(args[i]);
-	}
-}
-const query = queryParts.join(" ");
-
 switch (command) {
-	case "search":
-		await searchWeb(query);
-		break;
-	case "fetch":
-		await fetchUrl(args[1]);
-		break;
-	case "gh-search-code":
-		await ghSearchCode(query);
-		break;
-	case "gh-search-repos":
-		await ghSearchRepos(query);
-		break;
-	case "gh-readme":
-		await ghReadme(args[1]);
-		break;
-	case "gh-file":
-		await ghFile(args[1], args[2]);
-		break;
-	default:
-		console.log(`Unknown command: ${command}`);
-		process.exit(1);
+	case "search": await searchWeb(); break;
+	case "fetch": await fetchUrl(); break;
+	case "gh-search-code": ghSearchCode(); break;
+	case "gh-search-repos": ghSearchRepos(); break;
+	case "gh-readme": ghReadme(); break;
+	case "gh-file": ghFile(); break;
+	default: console.log(`Unknown command: ${command}`); process.exit(1);
 }

--- a/.github/plan-debate/web-search.mjs
+++ b/.github/plan-debate/web-search.mjs
@@ -1,0 +1,298 @@
+#!/usr/bin/env node
+/**
+ * Web search helper for plan-debate subagents.
+ *
+ * Uses multiple strategies in order of reliability:
+ *   1. GitHub search (for code, repos, issues — via gh CLI)
+ *   2. Fetch + extract text from URLs (for documentation pages)
+ *   3. DuckDuckGo HTML search (for general web queries)
+ *
+ * Usage:
+ *   node web-search.mjs search "langgraph agent tools"
+ *   node web-search.mjs search "crewai multi-agent" --max 10
+ *   node web-search.mjs fetch "https://docs.example.com/page"
+ *   node web-search.mjs gh-search-code "class Agent" --repo langchain-ai/langgraph
+ *   node web-search.mjs gh-search-repos "agentic framework"
+ *   node web-search.mjs gh-readme langchain-ai/langgraph
+ */
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (!command) {
+	console.log(`Usage:
+  node web-search.mjs search <query> [--max N]
+  node web-search.mjs fetch <url>
+  node web-search.mjs gh-search-code <query> --repo <owner/repo> [--max N]
+  node web-search.mjs gh-search-repos <query> [--max N]
+  node web-search.mjs gh-readme <owner/repo>
+  node web-search.mjs gh-file <owner/repo> <path>`);
+	process.exit(0);
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+function getArg(name) {
+	const idx = args.indexOf(name);
+	return idx !== -1 && args[idx + 1] ? args[idx + 1] : null;
+}
+
+function getMax() {
+	return parseInt(getArg("--max") || "10", 10);
+}
+
+/** Strip HTML tags and decode entities */
+function stripHtml(html) {
+	return html
+		.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+		.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "")
+		.replace(/<nav[^>]*>[\s\S]*?<\/nav>/gi, "")
+		.replace(/<footer[^>]*>[\s\S]*?<\/footer>/gi, "")
+		.replace(/<header[^>]*>[\s\S]*?<\/header>/gi, "")
+		.replace(/<[^>]+>/g, " ")
+		.replace(/&nbsp;/g, " ")
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/** Extract meaningful text from HTML, keeping some structure */
+function extractText(html, maxLength = 15000) {
+	// Try to find main content area
+	const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
+		|| html.match(/<article[^>]*>([\s\S]*?)<\/article>/i)
+		|| html.match(/<div[^>]*class="[^"]*content[^"]*"[^>]*>([\s\S]*?)<\/div>/i)
+		|| html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+
+	const content = mainMatch ? mainMatch[1] : html;
+
+	// Convert some tags to text markers for structure
+	let text = content
+		.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, "\n\n## $2\n\n")
+		.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "\n- $1")
+		.replace(/<pre[^>]*>([\s\S]*?)<\/pre>/gi, "\n```\n$1\n```\n")
+		.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, "`$1`")
+		.replace(/<br\s*\/?>/gi, "\n")
+		.replace(/<p[^>]*>/gi, "\n\n");
+
+	text = stripHtml(text);
+
+	// Collapse multiple newlines
+	text = text.replace(/\n{3,}/g, "\n\n").trim();
+
+	if (text.length > maxLength) {
+		text = text.slice(0, maxLength) + "\n\n[TRUNCATED]";
+	}
+
+	return text;
+}
+
+/** Run a shell command and return stdout */
+async function exec(cmd) {
+	const { execSync } = await import("node:child_process");
+	try {
+		return execSync(cmd, { encoding: "utf-8", timeout: 30000, stdio: ["pipe", "pipe", "pipe"] }).trim();
+	} catch {
+		return "";
+	}
+}
+
+// ─── Commands ─────────────────────────────────────────────────────────────
+
+async function searchWeb(query) {
+	const max = getMax();
+	const results = [];
+
+	// Strategy 1: DuckDuckGo HTML lite
+	try {
+		const params = new URLSearchParams({ q: query, kl: "us-en" });
+		const resp = await fetch(`https://lite.duckduckgo.com/lite/?${params}`, {
+			headers: {
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+			},
+			signal: AbortSignal.timeout(10000),
+		});
+		const html = await resp.text();
+
+		// DDG lite puts results in a table with specific structure
+		// Extract links from the results
+		const linkRegex = /href="(https?:\/\/[^"]+)"[^>]*class="[^"]*result-link/gi;
+		let match;
+		while ((match = linkRegex.exec(html)) !== null && results.length < max) {
+			results.push({ url: decodeURIComponent(match[1]), title: "", snippet: "", source: "duckduckgo" });
+		}
+
+		// Also try extracting from any external links
+		if (results.length === 0) {
+			const anyLinkRegex = /href="(https?:\/\/(?!duckduckgo\.com)[^"]+)"/gi;
+			const seen = new Set();
+			while ((match = anyLinkRegex.exec(html)) !== null && results.length < max) {
+				const url = decodeURIComponent(match[1]);
+				if (!seen.has(url) && !url.includes("duckduckgo.com")) {
+					seen.add(url);
+					results.push({ url, title: "", snippet: "", source: "duckduckgo" });
+				}
+			}
+		}
+	} catch { /* DDG failed, continue */ }
+
+	// Strategy 2: If DDG failed, try GitHub search for the query
+	if (results.length === 0) {
+		try {
+			const ghResult = await exec(`gh search repos "${query.replace(/"/g, '\\"')}" --json name,url,description --limit ${max}`);
+			if (ghResult) {
+				const repos = JSON.parse(ghResult);
+				for (const repo of repos) {
+					results.push({
+						url: repo.url,
+						title: repo.name,
+						snippet: repo.description || "",
+						source: "github-repos",
+					});
+				}
+			}
+		} catch { /* ignore */ }
+	}
+
+	console.log(JSON.stringify({ query, resultCount: results.length, results }, null, 2));
+}
+
+async function fetchUrl(url) {
+	try {
+		const resp = await fetch(url, {
+			headers: {
+				"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+				"Accept": "text/html,application/xhtml+xml,text/plain,application/json",
+			},
+			signal: AbortSignal.timeout(15000),
+			redirect: "follow",
+		});
+
+		if (!resp.ok) {
+			console.log(JSON.stringify({ url, error: `HTTP ${resp.status}`, content: "" }));
+			return;
+		}
+
+		const contentType = resp.headers.get("content-type") || "";
+		const body = await resp.text();
+
+		let content;
+		if (contentType.includes("json")) {
+			// JSON — pretty print
+			try {
+				content = JSON.stringify(JSON.parse(body), null, 2).slice(0, 15000);
+			} catch {
+				content = body.slice(0, 15000);
+			}
+		} else if (contentType.includes("html")) {
+			content = extractText(body);
+		} else {
+			// Plain text or other
+			content = body.slice(0, 15000);
+		}
+
+		console.log(JSON.stringify({ url, contentType, contentLength: body.length, content }));
+	} catch (e) {
+		console.log(JSON.stringify({ url, error: e.message, content: "" }));
+	}
+}
+
+async function ghSearchCode(query) {
+	const repo = getArg("--repo");
+	const max = getMax();
+	if (!repo) {
+		console.log(JSON.stringify({ error: "Missing --repo argument" }));
+		return;
+	}
+	// Use spawn to avoid shell quoting issues
+	const { execFileSync } = await import("node:child_process");
+	try {
+		const result = execFileSync("gh", [
+			"search", "code", query, "--repo", repo,
+			"--json", "path,textMatches", "--limit", String(max),
+		], { encoding: "utf-8", timeout: 30000 });
+		console.log(result.trim() || JSON.stringify({ query, repo, results: [] }));
+	} catch {
+		console.log(JSON.stringify({ query, repo, results: [] }));
+	}
+}
+
+async function ghSearchRepos(query) {
+	const max = getMax();
+	const { execFileSync } = await import("node:child_process");
+	try {
+		const result = execFileSync("gh", [
+			"search", "repos", query,
+			"--json", "name,url,description,stargazersCount", "--limit", String(max),
+		], { encoding: "utf-8", timeout: 30000 });
+		console.log(result.trim() || JSON.stringify({ query, results: [] }));
+	} catch {
+		console.log(JSON.stringify({ query, results: [] }));
+	}
+}
+
+async function ghReadme(repo) {
+	// Fetch README via API, decode from base64
+	const result = await exec(
+		`gh api repos/${repo}/readme --jq '.content' 2>/dev/null | base64 -d`,
+	);
+	if (result) {
+		const truncated = result.length > 15000 ? result.slice(0, 15000) + "\n\n[TRUNCATED]" : result;
+		console.log(JSON.stringify({ repo, content: truncated }));
+	} else {
+		console.log(JSON.stringify({ repo, error: "Could not fetch README", content: "" }));
+	}
+}
+
+async function ghFile(repo, filePath) {
+	const result = await exec(
+		`gh api repos/${repo}/contents/${filePath} --jq '.content' 2>/dev/null | base64 -d`,
+	);
+	if (result) {
+		const truncated = result.length > 15000 ? result.slice(0, 15000) + "\n\n[TRUNCATED]" : result;
+		console.log(JSON.stringify({ repo, path: filePath, content: truncated }));
+	} else {
+		console.log(JSON.stringify({ repo, path: filePath, error: "Could not fetch file", content: "" }));
+	}
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────
+
+// Extract query: skip flags and their values
+const queryParts = [];
+for (let i = 1; i < args.length; i++) {
+	if (args[i].startsWith("--")) {
+		i++; // skip flag value too
+	} else {
+		queryParts.push(args[i]);
+	}
+}
+const query = queryParts.join(" ");
+
+switch (command) {
+	case "search":
+		await searchWeb(query);
+		break;
+	case "fetch":
+		await fetchUrl(args[1]);
+		break;
+	case "gh-search-code":
+		await ghSearchCode(query);
+		break;
+	case "gh-search-repos":
+		await ghSearchRepos(query);
+		break;
+	case "gh-readme":
+		await ghReadme(args[1]);
+		break;
+	case "gh-file":
+		await ghFile(args[1], args[2]);
+		break;
+	default:
+		console.log(`Unknown command: ${command}`);
+		process.exit(1);
+}

--- a/.github/workflows/plan-debate.yml
+++ b/.github/workflows/plan-debate.yml
@@ -114,6 +114,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+          BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
         run: |
           node .github/plan-debate/ci-plan-debate.mjs \
             --issue ${{ steps.inputs.outputs.issue }} \

--- a/.github/workflows/plan-debate.yml
+++ b/.github/workflows/plan-debate.yml
@@ -104,7 +104,6 @@ jobs:
             });
 
       - name: Configure git
-        working-directory: pydantic-ai
         run: |
           git config user.name "plan-debate[bot]"
           git config user.email "plan-debate[bot]@users.noreply.github.com"
@@ -117,6 +116,7 @@ jobs:
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
         run: |
+          # CI script researches the pydantic-ai codebase, writes PLAN.md there
           node .github/plan-debate/ci-plan-debate.mjs \
             --issue ${{ steps.inputs.outputs.issue }} \
             --repo ${{ steps.inputs.outputs.repo }} \
@@ -125,29 +125,31 @@ jobs:
             --cwd ${{ github.workspace }}/pydantic-ai \
             --skip-pr
 
-      - name: Create PR on pydantic-ai
-        working-directory: pydantic-ai
+          # Copy PLAN.md to pydantic-harness (where the PR will be created)
+          cp ${{ github.workspace }}/pydantic-ai/PLAN.md ${{ github.workspace }}/PLAN.md
+
+      - name: Create PR on pydantic-harness
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ISSUE_NUM=${{ steps.inputs.outputs.issue }}
+          ISSUE_REPO=${{ steps.inputs.outputs.repo }}
           BRANCH="plan/issue-${ISSUE_NUM}"
 
           git checkout -b "$BRANCH"
           git add PLAN.md
-          git commit -m "Add implementation plan for issue #${ISSUE_NUM}"
+          git commit -m "Plan: ${ISSUE_REPO}#${ISSUE_NUM}"
           git push -u origin "$BRANCH"
 
           gh pr create \
             --draft \
-            --title "Plan: Issue #${ISSUE_NUM}" \
-            --body "Implementation plan generated via dual-model debate (${{ steps.inputs.outputs.model_a }} + ${{ steps.inputs.outputs.model_b }}).
+            --title "Plan: ${ISSUE_REPO}#${ISSUE_NUM}" \
+            --body "Implementation plan for ${ISSUE_REPO}#${ISSUE_NUM}
 
-          Closes #${ISSUE_NUM}
+          Generated via dual-model debate (${{ steps.inputs.outputs.model_a }} + ${{ steps.inputs.outputs.model_b }}).
 
-          _Triggered from [pydantic-harness](https://github.com/pydantic/pydantic-harness)._" \
-            --head "$BRANCH" \
-            --repo ${{ steps.inputs.outputs.repo }}
+          See: https://github.com/${ISSUE_REPO}/issues/${ISSUE_NUM}" \
+            --head "$BRANCH"
 
       - name: Comment on issue (success)
         if: success()
@@ -155,13 +157,14 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const plan = fs.readFileSync('pydantic-ai/PLAN.md', 'utf-8');
+            const plan = fs.readFileSync('PLAN.md', 'utf-8');
             const preview = plan.slice(0, 3000) + (plan.length > 3000 ? '\n\n...[see PR for full plan]' : '');
+            const issueRepo = '${{ steps.inputs.outputs.repo }}'.split('/');
             await github.rest.issues.createComment({
-              owner: 'pydantic',
-              repo: 'pydantic-ai',
+              owner: issueRepo[0],
+              repo: issueRepo[1],
               issue_number: ${{ steps.inputs.outputs.issue }},
-              body: `## 🤖 Plan debate complete\n\nA draft PR has been created with the implementation plan.\n\n<details>\n<summary>Plan preview</summary>\n\n${preview}\n\n</details>`
+              body: `## 🤖 Plan debate complete\n\nA draft PR has been created on [pydantic-harness](https://github.com/pydantic/pydantic-harness) with the implementation plan.\n\n<details>\n<summary>Plan preview</summary>\n\n${preview}\n\n</details>`
             });
 
       - name: Comment on issue (failure)
@@ -169,9 +172,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const issueRepo = '${{ steps.inputs.outputs.repo }}'.split('/');
             await github.rest.issues.createComment({
-              owner: 'pydantic',
-              repo: 'pydantic-ai',
+              owner: issueRepo[0],
+              repo: issueRepo[1],
               issue_number: ${{ steps.inputs.outputs.issue }},
               body: '## ❌ Plan debate failed\n\nSee [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
             });

--- a/.github/workflows/plan-debate.yml
+++ b/.github/workflows/plan-debate.yml
@@ -1,0 +1,175 @@
+# Dual-model plan debate for pydantic-ai issues.
+#
+# Runs in pydantic-harness but researches against pydantic-ai codebase.
+#
+# Triggers:
+#   - Manual dispatch with issue number
+#   - Issue comment "/plan-debate" (on pydantic-harness issues that reference pydantic-ai issues)
+#
+# Required secrets:
+#   ANTHROPIC_API_KEY — for Claude
+#   OPENAI_API_KEY   — for GPT
+
+name: Plan Debate
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "pydantic-ai issue number"
+        required: true
+        type: number
+      model_a:
+        description: "First model (provider/id)"
+        required: false
+        default: "anthropic/claude-opus-4-6"
+        type: string
+      model_b:
+        description: "Second model (provider/id)"
+        required: false
+        default: "openai/gpt-4.1"
+        type: string
+      issue_repo:
+        description: "Repo to fetch issue from"
+        required: false
+        default: "pydantic/pydantic-ai"
+        type: string
+
+  issue_comment:
+    types: [created]
+
+jobs:
+  plan-debate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    # Run on:
+    #   - workflow_dispatch (always)
+    #   - issue comment starting with "/plan-debate <number>"
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/plan-debate'))
+
+    steps:
+      - name: Checkout pydantic-harness (for scripts)
+        uses: actions/checkout@v4
+
+      - name: Checkout pydantic-ai (for codebase research)
+        uses: actions/checkout@v4
+        with:
+          repository: pydantic/pydantic-ai
+          path: pydantic-ai
+          # Uses GITHUB_TOKEN — works for public repos. For private, add a PAT.
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pi
+        run: npm install -g @mariozechner/pi-coding-agent
+
+      - name: Determine inputs
+        id: inputs
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "issue=${{ inputs.issue_number }}" >> $GITHUB_OUTPUT
+            echo "model_a=${{ inputs.model_a }}" >> $GITHUB_OUTPUT
+            echo "model_b=${{ inputs.model_b }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ inputs.issue_repo }}" >> $GITHUB_OUTPUT
+          else
+            # Parse "/plan-debate 1234" or "/plan-debate 1234 --repo owner/repo"
+            COMMENT="${{ github.event.comment.body }}"
+            ISSUE_NUM=$(echo "$COMMENT" | grep -oE '/plan-debate\s+([0-9]+)' | grep -oE '[0-9]+')
+            if [ -z "$ISSUE_NUM" ]; then
+              echo "::error::Could not parse issue number from comment: $COMMENT"
+              exit 1
+            fi
+            echo "issue=$ISSUE_NUM" >> $GITHUB_OUTPUT
+            echo "model_a=anthropic/claude-opus-4-6" >> $GITHUB_OUTPUT
+            echo "model_b=openai/gpt-4.1" >> $GITHUB_OUTPUT
+            echo "repo=pydantic/pydantic-ai" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Acknowledge comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+      - name: Configure git
+        working-directory: pydantic-ai
+        run: |
+          git config user.name "plan-debate[bot]"
+          git config user.email "plan-debate[bot]@users.noreply.github.com"
+
+      - name: Run plan debate
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          node .github/plan-debate/ci-plan-debate.mjs \
+            --issue ${{ steps.inputs.outputs.issue }} \
+            --repo ${{ steps.inputs.outputs.repo }} \
+            --model-a "${{ steps.inputs.outputs.model_a }}" \
+            --model-b "${{ steps.inputs.outputs.model_b }}" \
+            --cwd ${{ github.workspace }}/pydantic-ai \
+            --skip-pr
+
+      - name: Create PR on pydantic-ai
+        working-directory: pydantic-ai
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUM=${{ steps.inputs.outputs.issue }}
+          BRANCH="plan/issue-${ISSUE_NUM}"
+
+          git checkout -b "$BRANCH"
+          git add PLAN.md
+          git commit -m "Add implementation plan for issue #${ISSUE_NUM}"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --draft \
+            --title "Plan: Issue #${ISSUE_NUM}" \
+            --body "Implementation plan generated via dual-model debate (${{ steps.inputs.outputs.model_a }} + ${{ steps.inputs.outputs.model_b }}).
+
+          Closes #${ISSUE_NUM}
+
+          _Triggered from [pydantic-harness](https://github.com/pydantic/pydantic-harness)._" \
+            --head "$BRANCH" \
+            --repo ${{ steps.inputs.outputs.repo }}
+
+      - name: Comment on issue (success)
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('pydantic-ai/PLAN.md', 'utf-8');
+            const preview = plan.slice(0, 3000) + (plan.length > 3000 ? '\n\n...[see PR for full plan]' : '');
+            await github.rest.issues.createComment({
+              owner: 'pydantic',
+              repo: 'pydantic-ai',
+              issue_number: ${{ steps.inputs.outputs.issue }},
+              body: `## 🤖 Plan debate complete\n\nA draft PR has been created with the implementation plan.\n\n<details>\n<summary>Plan preview</summary>\n\n${preview}\n\n</details>`
+            });
+
+      - name: Comment on issue (failure)
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: 'pydantic',
+              repo: 'pydantic-ai',
+              issue_number: ${{ steps.inputs.outputs.issue }},
+              body: '## ❌ Plan debate failed\n\nSee [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
+            });


### PR DESCRIPTION

Adds a GitHub Actions workflow that orchestrates two LLMs (Claude + GPT) to generate deeply-researched implementation plans for pydantic-ai issues.

## What it does

1. **Recursively crawls** the issue graph — follows all `#NNN` references, cross-references, linked PRs, all comments
2. **Spawns 4 parallel research subagents** — both models do independent codebase deep-dives and competitive analysis (LangGraph, CrewAI, Mastra, AutoGen, etc.)
3. **Both models write independent plans** — every claim must cite file paths, line numbers, or URLs
4. **Cross-review debate** — each model reviews the other's plan, up to 2 rounds
5. **Consolidates** into a single plan and opens a draft PR on pydantic-ai

## How to trigger

**Manual dispatch:** Actions tab → Plan Debate → enter pydantic-ai issue number

**Comment:** On any pydantic-harness issue, comment `/plan-debate 1234` (where 1234 is the pydantic-ai issue number)

## Required secrets

- `ANTHROPIC_API_KEY`
- `OPENAI_API_KEY`

## Files

- `.github/workflows/plan-debate.yml` — workflow
- `.github/plan-debate/ci-plan-debate.mjs` — non-interactive pipeline
- `.github/plan-debate/web-search.mjs` — web research helper for competitive analysis