### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @dsfaccini @DouweM @samuelcolvin @dmontagu @adtyavrdhn @Kludex


### PR DESCRIPTION
The wildcard `* @everyone` rule was auto-requesting reviews from all team members on every PR. Removing it to reduce noise.