### PR TITLE
Update package description and authors for launch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,14 @@ build-backend = 'hatchling.build'
 [project]
 name = 'pydantic-harness'
 dynamic = ['version']
-description = 'Agent harness for composable, reusable AI agent capabilities, built on PydanticAI'
+description = 'The batteries for your Pydantic AI agent'
 readme = 'README.md'
 requires-python = '>=3.10'
 license = 'MIT'
 authors = [
-    { name = 'Pydantic Services Inc.' },
+    { name = 'Douwe Maan', email = 'douwe@pydantic.dev' },
+    { name = 'David SF', email = 'david.sanchez@pydantic.dev' },
+    { name = 'Aditya Vardhan', email = 'aditya@pydantic.dev' },
 ]
 classifiers = [
     'Development Status :: 3 - Alpha',


### PR DESCRIPTION
## Summary

- Updates PyPI description from stale "composable, reusable" phrasing to "The batteries for your Pydantic AI agent"
- Replaces generic "Pydantic Services Inc." author with individual maintainers

## Test plan

- [ ] Verify `uv build` succeeds
- [ ] Check PyPI metadata after next tag release

🤖 Generated with [Claude Code](https://claude.com/claude-code)