### PR TITLE
Remove defer_loading fallback from CodeMode sandbox

### DIFF
--- a/pydantic_harness/code_mode/_toolset.py
+++ b/pydantic_harness/code_mode/_toolset.py
@@ -167,9 +167,8 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
     callable from the sandbox at runtime. Non-selected tools remain visible
     to the model as normal tool calls.
 
-    Tools that require deferred execution (kind `external`/`unapproved`) or
-    deferred loading (`defer_loading=True`) cannot be called from inside the
-    sandbox and are dropped with a one-time `UserWarning`.
+    Tools that require deferred execution (kind `external`/`unapproved`) cannot
+    be called from inside the sandbox and are dropped with a one-time `UserWarning`.
     """
 
     tool_selector: ToolSelector[AgentDepsT] = 'all'
@@ -439,10 +438,10 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         hyphens or dots like `get-weather`, `api.call`) are sanitized to
         underscored forms and mapped back to their original names for dispatch.
 
-        Tools requiring deferred execution (kind `external`/`unapproved`) or
-        deferred loading (`defer_loading=True`) cannot run in the sandbox and
-        are excluded from `callable_defs`. Their names are returned in the
-        third element so the caller can promote them back to native tools.
+        Tools requiring deferred execution (kind `external`/`unapproved`) cannot
+        run in the sandbox and are excluded from `callable_defs`. Their names
+        are returned in the third element so the caller can promote them back
+        to native tools.
 
         Returns:
             A tuple of `(callable_defs, sanitized_to_original, native_fallbacks)`
@@ -461,18 +460,6 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
                         f'CodeMode: tool {name!r} requires deferred execution '
                         f'(kind={td.kind!r}) and cannot be called from inside the '
                         f'sandbox; it will be exposed as a native tool instead.',
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                native_fallbacks.add(name)
-                continue
-            if td.defer_loading:
-                if name not in self._warned_deferred:
-                    self._warned_deferred.add(name)
-                    warnings.warn(
-                        f'CodeMode: tool {name!r} uses deferred loading (tool search) '
-                        f'and cannot be pre-registered in the sandbox; it will be '
-                        f'exposed as a native tool instead.',
                         UserWarning,
                         stacklevel=2,
                     )

--- a/tests/_code_mode/test_code_mode.py
+++ b/tests/_code_mode/test_code_mode.py
@@ -660,36 +660,6 @@ class TestCodeMode:
     # Deferred tools
     # ---------------------------------------------------------------------------
 
-    async def test_deferred_loading_tools_promoted_to_native_with_warning(self) -> None:
-        """Tools with `defer_loading=True` are excluded from sandbox but promoted to native; warning fires once."""
-
-        def later() -> str:
-            """A deferred tool."""
-            return 'later'  # pragma: no cover - deferred tools are promoted to native, not sandboxed
-
-        toolset = FunctionToolset[None](tools=[Tool(add), Tool(later, defer_loading=True)])
-        wrapper = CodeMode[None]().get_wrapper_toolset(toolset)
-        assert isinstance(wrapper, CodeModeToolset)
-
-        ctx = build_run_context(None)
-        with pytest.warns(UserWarning, match=r"tool 'later' uses deferred loading"):
-            tools = await wrapper.get_tools(ctx)
-
-        description = tools['run_code'].tool_def.description
-        assert description is not None
-        assert 'async def add' in description
-        assert 'async def later' not in description
-        # Deferred tool is promoted to native — not lost
-        assert 'later' in tools
-
-        # Second `get_tools` call must not warn again — the set is preserved across calls
-        # within the same toolset instance.
-        import warnings as _warnings
-
-        with _warnings.catch_warnings():
-            _warnings.simplefilter('error')
-            await wrapper.get_tools(ctx)
-
     async def test_deferred_execution_tools_promoted_to_native_with_warning(self) -> None:
         """Tools with `kind='external'` (deferred execution) are excluded from sandbox but promoted to native."""
         td_external = ToolDefinition(

--- a/tests/_code_mode/test_code_mode.py
+++ b/tests/_code_mode/test_code_mode.py
@@ -660,6 +660,28 @@ class TestCodeMode:
     # Deferred tools
     # ---------------------------------------------------------------------------
 
+    async def test_deferred_loading_tools_sandboxed(self) -> None:
+        """Tools with `defer_loading=True` (tool search) are sandboxed like normal tools."""
+
+        def later(x: int) -> str:
+            """A deferred-loading tool."""
+            return str(x)
+
+        toolset = FunctionToolset[None](tools=[Tool(add), Tool(later, defer_loading=True)])
+        wrapper = CodeMode[None]().get_wrapper_toolset(toolset)
+        assert isinstance(wrapper, CodeModeToolset)
+
+        ctx = build_run_context(None)
+        tools = await wrapper.get_tools(ctx)
+
+        description = tools['run_code'].tool_def.description
+        assert description is not None
+        # Both tools should appear as sandboxed function signatures
+        assert 'async def add' in description
+        assert 'async def later' in description
+        # The deferred-loading tool should NOT be exposed as a native tool
+        assert 'later' not in tools
+
     async def test_deferred_execution_tools_promoted_to_native_with_warning(self) -> None:
         """Tools with `kind='external'` (deferred execution) are excluded from sandbox but promoted to native."""
         td_external = ToolDefinition(

--- a/tests/_code_mode/test_code_mode.py
+++ b/tests/_code_mode/test_code_mode.py
@@ -665,7 +665,7 @@ class TestCodeMode:
 
         def later(x: int) -> str:
             """A deferred-loading tool."""
-            return str(x)
+            return str(x)  # pragma: no cover - tool body is not invoked in this test
 
         toolset = FunctionToolset[None](tools=[Tool(add), Tool(later, defer_loading=True)])
         wrapper = CodeMode[None]().get_wrapper_toolset(toolset)


### PR DESCRIPTION
## Summary
- Remove the `defer_loading` special-case in `CodeModeToolset._partition_callable_tools` that excluded ToolSearch-based tools from the sandbox and fell them back to native tools
- Tools with `defer_loading=True` are now registered in the sandbox like any other tool, since CodeMode works properly with ToolSearch
- Deferred *execution* fallback (`kind='external'`/`'unapproved'`) remains unchanged

## Test plan
- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes (76 tests)
- [ ] Verify ToolSearch-based tools work correctly inside the CodeMode sandbox end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)