### PR TITLE
Add pydantic-harness deprecation shim

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - '**'
+      - 'v*'
   pull_request: {}
 
 env:

--- a/.github/workflows/release-shim.yml
+++ b/.github/workflows/release-shim.yml
@@ -1,0 +1,33 @@
+name: Release pydantic-harness shim
+
+on:
+  push:
+    tags:
+      - 'pydantic-harness-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          python-version: '3.14'
+          enable-cache: false
+
+      - run: uv build
+        working-directory: legacy/pydantic-harness
+
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          packages-dir: legacy/pydantic-harness/dist

--- a/legacy/pydantic-harness/README.md
+++ b/legacy/pydantic-harness/README.md
@@ -1,0 +1,25 @@
+# pydantic-harness (deprecated)
+
+This package has been renamed to **[pydantic-ai-harness](https://github.com/pydantic/pydantic-ai-harness)** to align with the Pydantic AI family naming convention (`pydantic-ai`, `pydantic-ai-slim`, `pydantic-ai-harness`).
+
+## Migration
+
+```bash
+uv remove pydantic-harness
+uv add pydantic-ai-harness
+```
+
+Update your imports:
+
+```diff
+- from pydantic_harness import CodeMode
++ from pydantic_ai_harness import CodeMode
+```
+
+## About this shim
+
+This `pydantic-harness==0.1.1` release is a compatibility shim that depends on `pydantic-ai-harness>=0.1.1,<0.2` and re-exports its public API. Existing code keeps working, but importing `pydantic_harness` emits a `DeprecationWarning`.
+
+When `pydantic-ai-harness==0.2.0` ships, this shim will stop resolving — `pip install pydantic-harness` will fail and users will be forced to migrate.
+
+This is the final release of the `pydantic-harness` package name.

--- a/legacy/pydantic-harness/pydantic_harness/__init__.py
+++ b/legacy/pydantic-harness/pydantic_harness/__init__.py
@@ -1,0 +1,28 @@
+"""Deprecated: pydantic-harness has been renamed to pydantic-ai-harness."""
+
+import warnings
+from typing import TYPE_CHECKING
+
+warnings.warn(
+    'pydantic-harness has been renamed to pydantic-ai-harness. '
+    'Please update your dependencies and imports:\n'
+    '    uv remove pydantic-harness\n'
+    '    uv add pydantic-ai-harness\n'
+    'Then change `from pydantic_harness import ...` to `from pydantic_ai_harness import ...`. '
+    'This shim re-exports from pydantic-ai-harness 0.1.x and will stop resolving with 0.2.0.',
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+if TYPE_CHECKING:
+    from pydantic_ai_harness import CodeMode
+
+__all__ = ['CodeMode']
+
+
+def __getattr__(name: str) -> object:
+    if name == 'CodeMode':
+        from pydantic_ai_harness import CodeMode
+
+        return CodeMode
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/legacy/pydantic-harness/pydantic_harness/code_mode/__init__.py
+++ b/legacy/pydantic-harness/pydantic_harness/code_mode/__init__.py
@@ -1,0 +1,5 @@
+"""Deprecated submodule: re-exports from pydantic_ai_harness.code_mode."""
+
+from pydantic_ai_harness.code_mode import CodeMode, CodeModeToolset
+
+__all__ = ['CodeMode', 'CodeModeToolset']

--- a/legacy/pydantic-harness/pyproject.toml
+++ b/legacy/pydantic-harness/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ['hatchling']
+build-backend = 'hatchling.build'
+
+[project]
+name = 'pydantic-harness'
+version = '0.1.1'
+description = 'Deprecated: renamed to pydantic-ai-harness'
+readme = 'README.md'
+requires-python = '>=3.10'
+license = 'MIT'
+authors = [
+    { name = 'Douwe Maan', email = 'douwe@pydantic.dev' },
+    { name = 'David SF', email = 'david.sanchez@pydantic.dev' },
+    { name = 'Aditya Vardhan', email = 'aditya@pydantic.dev' },
+]
+classifiers = [
+    'Development Status :: 7 - Inactive',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
+    'Topic :: Software Development :: Libraries',
+    'Typing :: Typed',
+]
+dependencies = [
+    'pydantic-ai-harness>=0.1.1,<0.2',
+]
+
+[project.urls]
+Homepage = 'https://github.com/pydantic/pydantic-ai-harness'
+Source = 'https://github.com/pydantic/pydantic-ai-harness'
+Issues = 'https://github.com/pydantic/pydantic-ai-harness/issues'
+
+[tool.hatch.build.targets.wheel]
+packages = ['pydantic_harness']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ packages = ['pydantic_ai_harness']
 [tool.ruff]
 line-length = 120
 target-version = 'py310'
-exclude = ['template']
+exclude = ['template', 'legacy']
 
 [tool.ruff.lint]
 extend-select = ['Q', 'RUF100', 'C90', 'UP', 'I', 'D', 'TID251']
@@ -102,7 +102,7 @@ quote-style = 'single'
 [tool.pyright]
 pythonVersion = '3.10'
 typeCheckingMode = 'strict'
-exclude = ['template', '.venv']
+exclude = ['template', '.venv', 'legacy']
 executionEnvironments = [
     { root = 'tests', reportPrivateUsage = false },
 ]


### PR DESCRIPTION
## Summary

Creates a compatibility shim so users with \`pydantic-harness\` installed can keep running during the rename to \`pydantic-ai-harness\`.

### What's in \`legacy/pydantic-harness/\`

- **\`pyproject.toml\`** — hardcoded \`version = '0.1.1'\`, depends on \`pydantic-ai-harness>=0.1.1,<0.2\`. Development Status :: 7 - Inactive.
- **\`pydantic_harness/__init__.py\`** — emits \`DeprecationWarning\` on import and lazily re-exports \`CodeMode\` via \`__getattr__\` (mirrors the upstream pattern so \`pydantic-monty\` stays optional).
- **\`pydantic_harness/code_mode/__init__.py\`** — re-exports \`CodeMode\`, \`CodeModeToolset\` from \`pydantic_ai_harness.code_mode\`.
- **\`README.md\`** — migration instructions.

Verified locally: all three import patterns work, and \`pydantic_harness.CodeMode is pydantic_ai_harness.CodeMode\` returns \`True\`.

### Release workflow

- **New**: \`.github/workflows/release-shim.yml\` triggers on \`pydantic-harness-v*\` tags, builds from \`legacy/pydantic-harness/\`, publishes to PyPI via trusted publishing.
- **Updated**: \`.github/workflows/main.yml\` tag filter narrowed from \`'**'\` to \`'v*'\` so shim tags don't trigger the main package release.

### Release flow

1. Merge this PR
2. Tag \`v0.1.1\` on main → existing \`main.yml\` publishes \`pydantic-ai-harness==0.1.1\` to PyPI
3. Tag \`pydantic-harness-v0.1.1\` → new \`release-shim.yml\` publishes \`pydantic-harness==0.1.1\` to PyPI

### Forcing function at 0.2.0

The shim's \`<0.2\` upper bound means when \`pydantic-ai-harness==0.2.0\` ships, \`pip install pydantic-harness\` will fail to resolve. Users will be forced to migrate. A follow-up cleanup PR will delete \`legacy/pydantic-harness/\` before \`v0.2.0\` ships.

## Test plan

- [x] \`uv build\` in \`legacy/pydantic-harness/\` produces \`pydantic_harness-0.1.1-py3-none-any.whl\`
- [x] Installing the shim with local \`pydantic-ai-harness\` triggers \`DeprecationWarning\` on import
- [x] \`import pydantic_harness\` succeeds without \`pydantic-monty\` (lazy loading)
- [x] \`pydantic_harness.CodeMode\` proxies to \`pydantic_ai_harness.CodeMode\` (identity check passes)
- [x] \`from pydantic_harness.code_mode import CodeMode, CodeModeToolset\` works
- [x] Main package \`make lint\`, \`make typecheck\`, \`make test\` still pass (77 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)