### PR TITLE
ci: move pydantic-ai checkout outside the harness tree in compat-test

### DIFF
--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -38,13 +38,22 @@ jobs:
           ref: main
           persist-credentials: false
 
+      # Check out pydantic-ai into a workspace subdir, then move it OUTSIDE the
+      # harness tree (`actions/checkout` requires `path:` to live under
+      # `$GITHUB_WORKSPACE`, but tools that walk the harness tree — pyright,
+      # ruff, pytest collection — must not see the pydantic-ai checkout, or
+      # they'll surface thousands of unrelated findings from pydantic-ai's own
+      # `tests/`. `${{ runner.temp }}` lives outside workspace so it's invisible
+      # to those walkers.
       - name: Checkout pydantic-ai @ ${{ inputs.pydantic-ai-ref }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.pydantic-ai-repo }}
           ref: ${{ inputs.pydantic-ai-ref }}
-          path: pydantic-ai
+          path: _pydantic-ai-checkout
           persist-credentials: false
+      - name: Move pydantic-ai outside the harness tree
+        run: mv _pydantic-ai-checkout "${RUNNER_TEMP}/pydantic-ai"
 
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
@@ -60,15 +69,10 @@ jobs:
       - run: uv sync --frozen --all-extras --group lint --group dev
       - run: |
           uv pip install --no-deps \
-            -e ./pydantic-ai/pydantic_ai_slim \
-            -e ./pydantic-ai/pydantic_graph
+            -e "${RUNNER_TEMP}/pydantic-ai/pydantic_ai_slim" \
+            -e "${RUNNER_TEMP}/pydantic-ai/pydantic_graph"
 
       - run: uv run ruff format --check
       - run: uv run ruff check
-      # Scope pyright to harness sources. The pydantic-ai checkout sits at
-      # `./pydantic-ai/` inside the working tree, and pyright's `exclude` in
-      # pyproject.toml doesn't list it (no need to in normal CI — the dir doesn't
-      # exist there). Without scoping, pyright walks into pydantic-ai's own tests
-      # and surfaces thousands of unrelated findings.
-      - run: uv run pyright pydantic_ai_harness tests
+      - run: uv run pyright
       - run: uv run pytest

--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -65,5 +65,10 @@ jobs:
 
       - run: uv run ruff format --check
       - run: uv run ruff check
-      - run: uv run pyright
+      # Scope pyright to harness sources. The pydantic-ai checkout sits at
+      # `./pydantic-ai/` inside the working tree, and pyright's `exclude` in
+      # pyproject.toml doesn't list it (no need to in normal CI — the dir doesn't
+      # exist there). Without scoping, pyright walks into pydantic-ai's own tests
+      # and surfaces thousands of unrelated findings.
+      - run: uv run pyright pydantic_ai_harness tests
       - run: uv run pytest


### PR DESCRIPTION
## Summary

Follow-up from pydantic/pydantic-ai-harness#223. The reusable `compat-test.yml` workflow checks out pydantic-ai into `./pydantic-ai/` inside the harness's working tree, then runs `uv run pyright`. Pyright walks into pydantic-ai's own `tests/typed_agent.py` etc. and emits ~20k unrelated findings, failing the job.

This was caught when pydantic/pydantic-ai#5276 (the calling-side wiring on pydantic-ai's CI) actually exercised the workflow end-to-end for the first time post-merge. Local discovery wasn't possible because the issue only manifests when the workflow runs with a real pydantic-ai checkout placed inside the harness tree.

Fix: check out pydantic-ai to a workspace-relative temp path then `mv` it to `${{ runner.temp }}/pydantic-ai`, which lives outside `$GITHUB_WORKSPACE` and is therefore invisible to anything that walks the harness tree (pyright, ruff, pytest collection, future analyzers). Editable installs of `pydantic_ai_slim` and `pydantic_graph` then point at the temp location.

`actions/checkout` requires `path:` to be under `$GITHUB_WORKSPACE`, so a direct check-out outside is not possible — `mv` is the simplest workaround that preserves `actions/checkout`'s safety features.

What we care about for compat is "is the harness still healthy with this pydantic-ai", not "does pydantic-ai's own typecheck pass" — pydantic-ai has its own typecheck.

## Linked Issue

Fixes #

## Checklist

- [ ] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] No changes to `pyproject.toml` or `uv.lock`
- [x] Docstrings use single backticks (not RST double backticks)