### PR TITLE
ci: clarify fork-PR security posture in compat-test header comment

### DIFF
--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -5,9 +5,16 @@ name: Compat Test
 # verify that pydantic-ai PRs don't break the harness's contract before merge.
 #
 # Security: the called pydantic-ai ref may come from an untrusted fork PR, so
-# this workflow runs without secrets and never grants write permissions. The
-# caller (pydantic-ai's harness-compat workflow) gates fork PRs behind an
-# approval label before invoking this workflow.
+# this workflow runs without secrets and only with `contents: read`. That keeps
+# fork PR exposure equivalent to pydantic-ai's regular `ci.yml` test jobs.
+#
+# **If you add steps that need elevated permissions or secrets** (Anthropic API
+# key, write tokens, deploy creds, anything posting to external services), the
+# caller (pydantic-ai's `harness-compat.yml`) needs to gate fork PRs at the
+# job level so untrusted code can't be triggered with the new privileges. The
+# original `safe-for-ci` label gate was removed once the workflow's scope was
+# stable at `contents: read` — adding it back is the standard pattern if scope
+# grows.
 
 on:
   workflow_call:


### PR DESCRIPTION
## Summary

Companion to pydantic/pydantic-ai's removal of the `safe-for-ci` label gate (PR opened separately). The called workflow runs with `contents: read` only and no secrets, so fork-PR exposure is equivalent to pydantic-ai's regular `ci.yml` test jobs and doesn't need a separate deny-by-default gate.

Header comment now flags the fork-PR consideration for future expanders: if this workflow ever grows steps that need elevated permissions or secrets (Anthropic API key, write tokens, deploy creds, anything posting to external services), the caller needs to gate fork PRs at the job level (e.g. require a `safe-for-ci` label) before merging that change. Documents the pattern for future re-introduction without enforcing the friction now.

No behavioral change — comment-only update.

## Linked Issue

Fixes #

## Checklist

- [ ] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior (N/A — comment-only)
- [x] `make lint && make typecheck && make test` passes locally
- [x] No changes to `pyproject.toml` or `uv.lock`
- [x] Docstrings use single backticks (not RST double backticks)