### PR TITLE
fix(code_mode): filter `prefer_builtin` tools out of sandboxing

### DIFF
--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -213,6 +213,10 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         for name, tool in wrapped_tools.items():
             if name == _SEARCH_TOOLS_NAME:
                 native_tools[name] = tool
+            elif tool.tool_def.prefer_builtin:
+                # Defer to `Model.prepare_request`'s `prefer_builtin` filtering: keep the local
+                # fallback native so it can be dropped when the provider supports the builtin.
+                native_tools[name] = tool
             elif await matches_tool_selector(self.tool_selector, ctx, tool.tool_def):
                 sandboxed_tools[name] = tool
             else:

--- a/tests/_code_mode/test_code_mode.py
+++ b/tests/_code_mode/test_code_mode.py
@@ -688,6 +688,71 @@ class TestCodeMode:
         # The deferred-loading tool should NOT be exposed as a native tool
         assert 'later' not in tools
 
+    async def test_prefer_builtin_tool_not_sandboxed(self) -> None:
+        """Tools annotated with `prefer_builtin` stay native so `Model.prepare_request` can filter them."""
+        td_fallback = ToolDefinition(
+            name='duckduckgo_search',
+            description='DDG fallback.',
+            parameters_json_schema={'type': 'object', 'properties': {'q': {'type': 'string'}}, 'required': ['q']},
+            return_schema={'type': 'string'},
+            prefer_builtin='web_search',
+        )
+        static = _StaticToolset([_make_address_tool_def('get_user', 'Get a user.', 'street'), td_fallback])
+        wrapper = CodeMode[None]().get_wrapper_toolset(static)
+        assert isinstance(wrapper, CodeModeToolset)
+
+        ctx = build_run_context(None)
+        tools = await wrapper.get_tools(ctx)
+
+        description = tools['run_code'].tool_def.description
+        assert description is not None
+        # Other tools are sandboxed as usual.
+        assert 'async def get_user' in description
+        # The prefer_builtin tool's signature must NOT appear inside run_code's description.
+        assert 'duckduckgo_search' not in description
+
+    async def test_prefer_builtin_tool_exposed_as_native(self) -> None:
+        """`prefer_builtin` tools remain in the toolset's native tools so `Model.prepare_request` can drop them when the provider supports the builtin."""
+        td_fallback = ToolDefinition(
+            name='duckduckgo_search',
+            description='DDG fallback.',
+            parameters_json_schema={'type': 'object', 'properties': {'q': {'type': 'string'}}, 'required': ['q']},
+            return_schema={'type': 'string'},
+            prefer_builtin='web_search',
+        )
+        static = _StaticToolset([td_fallback])
+        wrapper = CodeMode[None]().get_wrapper_toolset(static)
+        assert isinstance(wrapper, CodeModeToolset)
+
+        ctx = build_run_context(None)
+        tools = await wrapper.get_tools(ctx)
+
+        # The fallback tool is exposed as a native tool, with its prefer_builtin annotation
+        # preserved so Model.prepare_request can filter it when the builtin is supported.
+        assert 'duckduckgo_search' in tools
+        assert tools['duckduckgo_search'].tool_def.prefer_builtin == 'web_search'
+
+    async def test_no_prefer_builtin_tool_is_sandboxed(self) -> None:
+        """Tools without a `prefer_builtin` annotation are sandboxed as usual (confirms the guard only diverts truthy values)."""
+        td_plain = ToolDefinition(
+            name='duckduckgo_search',
+            description='DDG (no fallback annotation).',
+            parameters_json_schema={'type': 'object', 'properties': {'q': {'type': 'string'}}, 'required': ['q']},
+            return_schema={'type': 'string'},
+        )
+        static = _StaticToolset([td_plain])
+        wrapper = CodeMode[None]().get_wrapper_toolset(static)
+        assert isinstance(wrapper, CodeModeToolset)
+
+        ctx = build_run_context(None)
+        tools = await wrapper.get_tools(ctx)
+
+        description = tools['run_code'].tool_def.description
+        assert description is not None
+        # Without prefer_builtin, the tool is sandboxed normally.
+        assert 'async def duckduckgo_search' in description
+        assert 'duckduckgo_search' not in tools
+
     async def test_deferred_execution_tools_sandboxed(self) -> None:
         """Tools with `kind='external'`/`'unapproved'` are sandboxed like any other tool; resolution happens via a `HandleDeferredToolCalls` capability."""
         td_external = ToolDefinition(


### PR DESCRIPTION
Claude here: filing the Tier-1 fix from #233.

## Summary

`CodeModeToolset.get_tools` was sandboxing local-fallback tools annotated with `prefer_builtin`, rendering their signatures inside `run_code.description` before `Model.prepare_request`'s `prefer_builtin` filter could drop them when the provider supports the matching builtin. This collapsed `BuiltinOrLocalTool`'s fallback semantics into a split tool surface (e.g. Anthropic's builtin `web_search` at top level *and* `duckduckgo_search` inside `run_code`). The fix mirrors the existing `_SEARCH_TOOLS_NAME` guard: `prefer_builtin`-annotated tools stay native so the prepare-request layer can do its job.

Tradeoff: on providers that don't support the builtin, the local fallback stays on the wire as a top-level native tool rather than being sandboxed inside `run_code`. Users who want it sandboxed can pass `WebSearch(builtin=False)` (drops the annotation), which is symmetric with the existing `MCP(url, builtin=False)` pattern.

## Linked Issue

Closes #233.

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes (extras `temporal`, `dbos` installed locally)
- [x] `make test` passes (79 passed, 2 skipped)
- [x] `_toolset.py` and `test_code_mode.py` retain 100% line+branch coverage
- [x] New tests:
  - `test_prefer_builtin_tool_not_sandboxed` — signature is NOT in `run_code.description`
  - `test_prefer_builtin_tool_exposed_as_native` — tool is in `get_tools()` with annotation preserved so `Model.prepare_request` can filter it
  - `test_no_prefer_builtin_tool_is_sandboxed` — confirms guard only diverts truthy values

## Notes

- Same shape as #232 (different annotation); can ship independently of pydantic-ai #5143 since `prefer_builtin` is already on main.
- No changes to `pyproject.toml` or `uv.lock`.