### PR TITLE
Document monty's missing wall-clock and timing primitives in run_code description

### DIFF
--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -126,6 +126,7 @@ Code runs inside [Monty](https://github.com/pydantic/monty), a sandboxed Python 
 
 - No class definitions
 - No third-party imports (allowed stdlib: `sys`, `typing`, `asyncio`, `math`, `json`, `re`, `datetime`, `os`, `pathlib`)
+- No wall-clock or timing primitives: `asyncio.sleep`, `datetime.datetime.now()`/`datetime.date.today()`, and the `time` module are unavailable
 - No `import *`
 - Tools requiring approval or with deferred execution are excluded from the sandbox
 

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -76,6 +76,7 @@ The sandbox uses Monty, a subset of Python. Key restrictions:
 - **No classes**: class definitions are not supported
 - **No third-party libraries**: only the standard library modules listed below can be used
 - **Importable standard library modules**: `sys`, `typing`, `asyncio`, `math`, `json`, `re`, `datetime`, `os`, `pathlib`. These must be imported at the top of your snippet before use, just like in regular Python. For example: `import asyncio` then `results = await asyncio.gather(tool_one(...), tool_two(...))`.
+- **No wall-clock or timing primitives**: `asyncio.sleep`, `datetime.datetime.now()`, `datetime.date.today()`, and the `time` module are unavailable.
 - **No `import *`**: wildcard imports are not supported
 
 State is preserved between calls (REPL-style). Set `restart: true` to reset state.


### PR DESCRIPTION
Claude here:

## Summary

Adds a single bullet to the `run_code` tool description (and the matching code-mode README entry) noting that `asyncio.sleep`, `datetime.datetime.now()`, `datetime.date.today()`, and the `time` module are gated by the monty sandbox.

Without this hint, models occasionally generate sandbox-rejected code patterns: `asyncio.sleep` between tool calls (cargo-culted "polite rate-limiting") and `datetime.now()` for recency filters. Surfacing the constraint directly in the tool description means prompts can stay free of sandbox-specific babysitting.

## Test plan

- [ ] No code paths changed; pure documentation update inside the description string.
- [ ] `make lint && make typecheck && make test` pass.