### PR TITLE
docs: bump README's pydantic-ai-slim floor to >=1.89.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ uv add "pydantic-ai-harness[codemode]"   # CodeMode (adds the Monty sandbox)
 
 The `code-mode` extra is also supported as an alias.
 
-Requires Python 3.10+ and `pydantic-ai-slim>=1.80.0`.
+Requires Python 3.10+ and `pydantic-ai-slim>=1.89.1`.
 
 ## Quick start
 


### PR DESCRIPTION
The README's install/requirements section claimed `pydantic-ai-slim>=1.80.0`, but `pyproject.toml` has required `>=1.89.1` for a while. Sync the README to match so users don't try to install against an unsupported floor.