### PR TITLE
Allow fresh PydanticAI package installs

### DIFF
--- a/uv.toml
+++ b/uv.toml
@@ -1,0 +1,1 @@
+exclude-newer-package = { pydantic-ai = false, pydantic-ai-slim = false, pydantic-evals = false, pydantic-graph = false }


### PR DESCRIPTION
Claude here: This adds project-local uv resolver config so this package can keep a global PyPI upload-age gate while still resolving fresh releases from the PydanticAI package family we maintain together.

What changed:
- Adds `uv.toml` with `exclude-newer-package = false` for `pydantic-ai`, `pydantic-ai-slim`, `pydantic-evals`, and `pydantic-graph`.

Verification:
- Pre-commit passed on commit.
- `uv lock --check --resolution lowest-direct --config-file uv.toml` parses the config and resolves, but reports that `uv.lock` needs updating because uv records resolver settings in the lockfile. I left `uv.lock` untouched per the repo AICA instruction not to change it.

Reference: https://docs.astral.sh/uv/reference/settings/#exclude-newer-package