### PR TITLE
docs: bump README's pydantic-ai-slim floor to >=1.95.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ uv add "pydantic-ai-harness[codemode]"   # CodeMode (adds the Monty sandbox)
 
 The `code-mode` extra is also supported as an alias.
 
-Requires Python 3.10+ and `pydantic-ai-slim>=1.89.1`.
+Requires Python 3.10+ and `pydantic-ai-slim>=1.95.1`.
 
 ## Quick start
 


### PR DESCRIPTION
Trailing fix from #240/#241: the README still said `pydantic-ai-slim>=1.89.1`, but `pyproject.toml` is at `>=1.95.1` after #241. Same pattern as #237 (the previous README floor bump).