### PR TITLE
chore: stop tracking .agents/settings.local.json

### DIFF
--- a/.agents/settings.local.json
+++ b/.agents/settings.local.json
@@ -1,5 +1,0 @@
-{
-  "permissions": {
-    "allow": []
-  }
-}


### PR DESCRIPTION
`.agents/settings.local.json` is per-developer local config and is already listed in `.gitignore`, but it was still tracked from an earlier commit. This removes it from version control (keeping the local file on disk) so local edits no longer show up as repo changes.

Single-file change; no code impact. Splitting it out so it can land independently of the `ManagedPrompt` capability work.