### PR TITLE
feat: add optional ripgrep backend for FileSystem search

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Extras for specific capabilities:
 ```bash
 uv add "pydantic-ai-harness[codemode]"   # CodeMode (adds the Monty sandbox)
 uv add "pydantic-ai-harness[logfire]"     # ManagedPrompt (Logfire-managed prompts)
+uv add "pydantic-ai-harness[ripgrep]"     # FileSystem ripgrep-backed search (adds the rg binary)
 ```
 
 The `code-mode` extra is also supported as an alias.

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -4,7 +4,8 @@ Mutation testing complements the 100% branch-coverage requirement: coverage
 proves every line and branch runs, mutation testing proves the assertions
 actually pin the behavior down.
 
-Covers `pydantic_ai_harness/filesystem/_toolset.py` and
+Covers `pydantic_ai_harness/filesystem/_toolset.py`,
+`pydantic_ai_harness/filesystem/_ripgrep.py`, and
 `pydantic_ai_harness/shell/_toolset.py`.
 
 Run with [mutmut](https://mutmut.readthedocs.io/) v3 via `scripts/run-mutmut.sh`,
@@ -35,6 +36,10 @@ survivor; the recurring equivalent-mutant categories in this codebase are:
   can't be triggered in the test environment.
 - **`CancelScope(shield=True)` flips** — require an outer cancellation during
   the near-instant cleanup window.
+- **ripgrep-path breaks masked by the fallback** — `search_files` falls back to
+  the pure-Python backend whenever ripgrep fails, so a mutation that only breaks
+  the `rg` invocation produces identical output via the fallback. The `rg`
+  command is pinned directly by `TestRipgrepProtocol` in `tests/filesystem/`.
 
 Anything outside these categories should be treated as a real gap and killed
 with a new test.

--- a/pydantic_ai_harness/filesystem/README.md
+++ b/pydantic_ai_harness/filesystem/README.md
@@ -101,10 +101,53 @@ FileSystem(
     max_read_lines=2000,           # cap for a single read_file
     max_search_results=1000,       # cap for search_files
     max_find_results=1000,         # cap for find_files
+    use_ripgrep=None,              # None=auto, True=require, False=pure-Python
 )
 ```
 
 The integer limits must be positive; they are validated at construction.
+
+## ripgrep-backed search (optional)
+
+`search_files` has two backends: a pure-Python walker (always available, the
+default, and the behavioral reference) and a ripgrep backend that shells out to
+the `rg` binary, which is typically faster on large trees. Install the optional
+extra to enable it (it pulls in a bundled `rg`; a system `rg` on `PATH` also
+works):
+
+```bash
+uv add "pydantic-ai-harness[ripgrep]"
+```
+
+`use_ripgrep` selects the backend:
+
+| Value | Behavior |
+|---|---|
+| `None` (default) | Use ripgrep if an `rg` binary is on `PATH`, otherwise pure Python. |
+| `True` | Require ripgrep; raise at construction if it is unavailable. |
+| `False` | Always use pure Python. |
+
+Both backends are confined to `root_dir` and apply the same filters, so for a
+given pattern they return the same results for text files:
+
+- ripgrep runs with `root_dir` as its working directory on a target inside the
+  root and does not follow symlinks; each result's path is containment-checked
+  again before the file is read.
+- The dotfile, allow/deny/protected, and `include_glob` filters run on ripgrep's
+  results just as on the pure-Python walk, and `--no-ignore` stops ripgrep from
+  honoring `.gitignore` (which the pure-Python walk also ignores), so both walk
+  the same files.
+
+The one difference is binary detection: the pure-Python walker samples the first
+8 KB of a file for a NUL byte, while ripgrep scans the whole file. A file with a
+NUL byte beyond the first 8 KB is therefore searched by the pure-Python backend
+but skipped by ripgrep.
+
+Only `search_files` uses ripgrep. The pattern is validated with Python's `re`
+first, so an invalid regex is rejected the same way in both backends. Matching
+then uses ripgrep's regex engine, which differs from `re` for some constructs
+(for example, lookaround needs a PCRE2-enabled `rg`); when ripgrep rejects a
+pattern that `re` accepts, the search falls back to pure Python.
 
 ## Agent spec (YAML/JSON)
 

--- a/pydantic_ai_harness/filesystem/_capability.py
+++ b/pydantic_ai_harness/filesystem/_capability.py
@@ -56,6 +56,17 @@ class FileSystem(AbstractCapability[AgentDepsT]):
     max_find_results: int = 1000
     """Maximum number of matches returned by `find_files`."""
 
+    use_ripgrep: bool | None = None
+    """Backend for `search_files` content search.
+
+    `None` (default) auto-detects: ripgrep is used when an `rg` binary is on
+    `PATH` (via the `ripgrep` extra or a system install), otherwise a pure-Python
+    search runs. `True` forces ripgrep and raises if it is unavailable; `False`
+    always uses the pure-Python search. Both backends are confined to `root_dir`
+    and return the same results for text files (they differ only on binary
+    detection for files with a NUL byte past the first 8 KB; see the README).
+    """
+
     def __post_init__(self) -> None:
         # Runtime validation: dataclass field annotations are advisory, not enforced.
         # A config-driven caller could pass a string that would otherwise propagate.
@@ -78,4 +89,5 @@ class FileSystem(AbstractCapability[AgentDepsT]):
             max_read_lines=self.max_read_lines,
             max_search_results=self.max_search_results,
             max_find_results=self.max_find_results,
+            use_ripgrep=self.use_ripgrep,
         )

--- a/pydantic_ai_harness/filesystem/_ripgrep.py
+++ b/pydantic_ai_harness/filesystem/_ripgrep.py
@@ -1,0 +1,95 @@
+"""Optional ripgrep-backed content search for the filesystem toolset.
+
+When an `rg` binary is on `PATH`, the toolset can delegate `search_files` to
+ripgrep, which is much faster than the pure-Python walker on large trees.
+ripgrep is confined to the root: it runs with the root as its working directory,
+searches a target inside it, and never follows symlinks. The toolset re-checks
+containment and applies its own dotfile / allow / deny / protected / include_glob
+filters to every result, so both backends produce the same output.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Annotated, Literal
+
+from anyio import run_process
+from pydantic import BaseModel, Field, TypeAdapter
+
+
+class RipgrepError(RuntimeError):
+    """ripgrep failed to run a search (e.g. a pattern its engine rejects).
+
+    The toolset catches this and falls back to the pure-Python search, so the
+    backend choice never changes results.
+    """
+
+
+def ripgrep_available() -> bool:
+    """Whether an `rg` binary is available on `PATH`."""
+    return shutil.which('rg') is not None
+
+
+def resolve_ripgrep_enabled(use_ripgrep: bool | None) -> bool:
+    """Decide whether the ripgrep backend is active.
+
+    `None` auto-detects via `ripgrep_available`; `True` requires it and raises if
+    it is missing; `False` disables it.
+    """
+    if use_ripgrep is False:
+        return False
+    available = ripgrep_available()
+    if use_ripgrep and not available:
+        raise RuntimeError(
+            "use_ripgrep=True but no 'rg' binary was found on PATH. Install the "
+            "'ripgrep' extra (pydantic-ai-harness[ripgrep]) or ripgrep itself."
+        )
+    return available
+
+
+class _RgText(BaseModel):
+    text: str
+
+
+class _RgMatchData(BaseModel):
+    path: _RgText
+    line_number: int
+
+
+class _RgMatch(BaseModel):
+    type: Literal['match']
+    data: _RgMatchData
+
+
+class _RgEvent(BaseModel):
+    """Any non-match event (begin, end, summary, context); fields are ignored."""
+
+    type: str
+
+
+# ripgrep emits one JSON object per line; only `match` events carry results.
+_RG_ROW: TypeAdapter[_RgMatch | _RgEvent] = TypeAdapter(
+    Annotated[_RgMatch | _RgEvent, Field(union_mode='left_to_right')]
+)
+
+
+async def ripgrep_file_matches(*, root: Path, target: Path, pattern: str) -> list[tuple[Path, list[int]]]:
+    """Return `(path_relative_to_root, line_numbers)` for each file with matches.
+
+    `--no-ignore` matches the pure-Python walker, which ignores `.gitignore`;
+    hidden files stay skipped by ripgrep's defaults. `--sort=path` gives the same
+    deterministic ordering as the fallback's `sorted(...)`. Exit code 1 means no
+    matches; anything other than 0 or 1 means ripgrep itself failed.
+    """
+    command = ['rg', '--json', '--no-ignore', '--sort=path', '-e', pattern, '--', str(target)]
+    process = await run_process(command, cwd=root, check=False)
+    if process.returncode not in (0, 1):
+        raise RipgrepError(process.stderr.decode('utf-8', errors='replace').strip())
+
+    matches: dict[Path, list[int]] = {}
+    for line in process.stdout.splitlines():
+        row = _RG_ROW.validate_json(line)
+        if isinstance(row, _RgMatch):
+            matches.setdefault(Path(row.data.path.text), []).append(row.data.line_number)
+    return list(matches.items())

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -7,7 +7,7 @@ import functools
 import hashlib
 import os
 import re
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Iterator, Sequence
 from pathlib import Path
 from typing import Concatenate, ParamSpec
 
@@ -15,7 +15,12 @@ from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import FunctionToolset
 
+from pydantic_ai_harness.filesystem._ripgrep import RipgrepError, resolve_ripgrep_enabled, ripgrep_file_matches
+
 _P = ParamSpec('_P')
+
+# A file's search hits: its path and the (line_number, line_text) pairs that matched.
+_FileMatches = tuple[str, list[tuple[int, str]]]
 
 # Errors that mean "the model asked for something the tool couldn't do" — a
 # missing file, a denied path, a stale edit. pyai only feeds `ModelRetry` back
@@ -94,6 +99,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         max_read_lines: int,
         max_search_results: int,
         max_find_results: int,
+        use_ripgrep: bool | None = None,
     ) -> None:
         super().__init__()
         self._root = root_dir.resolve()
@@ -104,6 +110,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         self._max_read_lines = max_read_lines
         self._max_search_results = max_search_results
         self._max_find_results = max_find_results
+        self._use_ripgrep = resolve_ripgrep_enabled(use_ripgrep)
 
         self.add_function(self.read_file, name='read_file')
         self.add_function(self.write_file, name='write_file')
@@ -373,30 +380,40 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         except re.error as e:
             raise ValueError(f'Invalid regex pattern: {e}') from e
 
+        # The regex is compiled with Python's engine above so an invalid pattern
+        # is rejected the same way regardless of backend. ripgrep then re-matches
+        # with its own engine; a pattern it rejects but Python accepts (e.g.
+        # lookaround) falls back below, so the backend choice never changes output.
+        if self._use_ripgrep:
+            try:
+                return self._format_matches(await self._ripgrep_matches(resolved, pattern, include_glob))
+            except RipgrepError:
+                pass
+        return self._format_matches(self._python_matches(resolved, compiled, include_glob))
+
+    def _format_matches(self, per_file: Iterable[_FileMatches]) -> str:
+        """Render and truncate match groups: the shared output of both backends."""
         results: list[str] = []
+        for rel_str, line_matches in per_file:
+            results.extend(f'{rel_str}:{line_num}:{line}' for line_num, line in line_matches)
+            if len(results) >= self._max_search_results:
+                results.append(f'[... truncated at {self._max_search_results} matches]')
+                break
+        return '\n'.join(results) if results else 'No matches found.'
 
-        if resolved.is_file():
-            files = [resolved]
-        else:
-            files = sorted(resolved.rglob('*'))
-
-        real_root = Path(os.path.realpath(self._root))
+    def _python_matches(
+        self, resolved: Path, compiled: re.Pattern[str], include_glob: str | None
+    ) -> Iterator[_FileMatches]:
+        """Walk the tree in Python, yielding matches per file: the reference backend."""
+        files = [resolved] if resolved.is_file() else sorted(resolved.rglob('*'))
         for file_path in files:
             if not file_path.is_file():
                 continue
             try:
-                rel_parts = file_path.relative_to(real_root).parts
+                rel_str = str(file_path.relative_to(self._real_root))
             except ValueError:  # pragma: no cover
                 continue
-            if any(part.startswith('.') for part in rel_parts):
-                continue
-            rel_str = str(file_path.relative_to(real_root))
-            # Apply the same allow/deny/protected filtering used for direct
-            # access so a recursive search can't read patterns the agent
-            # couldn't otherwise read.
-            if not self._is_accessible(rel_str, write=True):
-                continue
-            if include_glob and not fnmatch.fnmatch(rel_str, include_glob):
+            if not self._is_searchable_entry(rel_str, include_glob):
                 continue
             try:
                 raw = file_path.read_bytes()
@@ -405,14 +422,49 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             if _is_binary(raw):
                 continue
             text = raw.decode('utf-8', errors='replace')
-            for line_num, line in enumerate(text.splitlines(), start=1):
-                if compiled.search(line):
-                    results.append(f'{rel_str}:{line_num}:{line}')
-            if len(results) >= self._max_search_results:
-                results.append(f'[... truncated at {self._max_search_results} matches]')
-                break
+            line_matches = [(n, line) for n, line in enumerate(text.splitlines(), start=1) if compiled.search(line)]
+            if line_matches:
+                yield rel_str, line_matches
 
-        return '\n'.join(results) if results else 'No matches found.'
+    async def _ripgrep_matches(self, resolved: Path, pattern: str, include_glob: str | None) -> list[_FileMatches]:
+        """Delegate matching to ripgrep, returning matches per file.
+
+        ripgrep finds the files and line numbers (skipping binaries itself); each
+        result is run through the same filters as `_python_matches`, and the line
+        text is re-read via the containment-checked `_resolve_path` so the output
+        matches the fallback.
+        """
+        target = resolved.relative_to(self._real_root)
+        groups: list[_FileMatches] = []
+        for rel_path, line_numbers in await ripgrep_file_matches(root=self._real_root, target=target, pattern=pattern):
+            rel_str = str(rel_path)
+            if not self._is_searchable_entry(rel_str, include_glob):
+                continue
+            try:
+                text = self._resolve_path(rel_str).read_text(encoding='utf-8', errors='replace')
+            except OSError:  # pragma: no cover  # file vanished between the search and the read
+                continue
+            # read_text translates CRLF/CR to LF, so splitting on '\n' matches
+            # ripgrep's line numbering with no trailing carriage returns. A line
+            # past EOF means a concurrent write shrank the file after ripgrep
+            # scanned it; drop it rather than crash.
+            lines = text.split('\n')
+            groups.append((rel_str, [(n, lines[n - 1]) for n in line_numbers if n <= len(lines)]))
+        return groups
+
+    def _is_searchable_entry(self, rel_str: str, include_glob: str | None) -> bool:
+        """Shared per-file filter for both search backends.
+
+        Skips dotfiles, applies allow/deny/protected patterns (so a search can't
+        read what direct access couldn't), and honors `include_glob`.
+        """
+        if any(part.startswith('.') for part in Path(rel_str).parts):
+            return False
+        if not self._is_accessible(rel_str, write=True):
+            return False
+        if include_glob and not fnmatch.fnmatch(rel_str, include_glob):
+            return False
+        return True
 
     @_recoverable
     async def find_files(self, pattern: str, *, path: str = '.') -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ logfire = [
     'logfire>=4.31.0',
     'pydantic-ai-slim[spec]>=1.95.1',
 ]
+ripgrep = [
+    'ripgrep>=15.1.0',
+]
 
 [project.urls]
 Homepage = 'https://github.com/pydantic/pydantic-ai-harness'
@@ -154,6 +157,7 @@ exclude_lines = [
 [tool.mutmut]
 paths_to_mutate = [
     'pydantic_ai_harness/filesystem/_toolset.py',
+    'pydantic_ai_harness/filesystem/_ripgrep.py',
     'pydantic_ai_harness/shell/_toolset.py',
 ]
 tests_dir = ['tests/filesystem/', 'tests/shell/']

--- a/tests/filesystem/test_ripgrep.py
+++ b/tests/filesystem/test_ripgrep.py
@@ -1,0 +1,294 @@
+"""Tests for the optional ripgrep backend of the FileSystem capability.
+
+These exercise both the detection/resolution logic (which runs everywhere, via
+monkeypatching) and the ripgrep search path itself (which is skipped when the
+`ripgrep` extra or the `rg` binary is unavailable). The pure-Python fallback is
+covered both here (via `use_ripgrep=False`) and by `test_filesystem.py`.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+
+from pydantic_ai_harness.filesystem import FileSystem
+from pydantic_ai_harness.filesystem import _ripgrep as rg
+from pydantic_ai_harness.filesystem._toolset import FileSystemToolset
+
+requires_ripgrep = pytest.mark.skipif(
+    not rg.ripgrep_available(),
+    reason="ripgrep backend unavailable (install the 'ripgrep' extra and an 'rg' binary)",
+)
+
+
+def _toolset(
+    root: Path,
+    *,
+    use_ripgrep: bool,
+    allowed_patterns: Sequence[str] = (),
+    denied_patterns: Sequence[str] = (),
+    max_search_results: int = 1000,
+) -> FileSystemToolset[None]:
+    return FileSystemToolset(
+        root_dir=root,
+        allowed_patterns=allowed_patterns,
+        denied_patterns=denied_patterns,
+        protected_patterns=(),
+        max_read_lines=2000,
+        max_search_results=max_search_results,
+        max_find_results=1000,
+        use_ripgrep=use_ripgrep,
+    )
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A small tree shared by the backend-parity tests."""
+    (tmp_path / 'hello.txt').write_text('Hello, world!\nfindme here\n')
+    (tmp_path / 'multi.txt').write_text('line1\nline2\nline3\nfindme\n')
+    (tmp_path / 'pkg').mkdir()
+    (tmp_path / 'pkg' / 'mod.py').write_text('def go():\n    findme = 1\n    return findme\n')
+    (tmp_path / 'pkg' / 'notes.md').write_text('# notes\nfindme in markdown\n')
+    (tmp_path / '.hidden').write_text('findme secret\n')
+    (tmp_path / 'binary.bin').write_bytes(b'findme\x00\x01\x02')
+    return tmp_path
+
+
+def _set_available(monkeypatch: pytest.MonkeyPatch, available: bool) -> None:
+    def fake_available() -> bool:
+        return available
+
+    monkeypatch.setattr(rg, 'ripgrep_available', fake_available)
+
+
+class TestDetection:
+    def test_available_requires_binary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def no_binary(cmd: str) -> str | None:
+            return None
+
+        monkeypatch.setattr(shutil, 'which', no_binary)
+        assert rg.ripgrep_available() is False
+
+    def test_available_when_binary_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def has_binary(cmd: str) -> str | None:
+            return '/usr/bin/rg'
+
+        monkeypatch.setattr(shutil, 'which', has_binary)
+        assert rg.ripgrep_available() is True
+
+    def test_resolve_false_disables(self) -> None:
+        assert rg.resolve_ripgrep_enabled(False) is False
+
+    def test_resolve_none_follows_availability(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_available(monkeypatch, True)
+        assert rg.resolve_ripgrep_enabled(None) is True
+        _set_available(monkeypatch, False)
+        assert rg.resolve_ripgrep_enabled(None) is False
+
+    def test_resolve_true_when_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _set_available(monkeypatch, True)
+        assert rg.resolve_ripgrep_enabled(True) is True
+
+    def test_resolve_true_unavailable_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Pin both halves of the message: the problem and the actionable fix.
+        _set_available(monkeypatch, False)
+        with pytest.raises(RuntimeError, match=r"no 'rg' binary.+Install the 'ripgrep' extra"):
+            rg.resolve_ripgrep_enabled(True)
+
+
+class TestCapabilityWiring:
+    def test_default_is_none(self) -> None:
+        assert FileSystem[None]().use_ripgrep is None
+
+    def test_forwards_to_toolset(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The capability must forward use_ripgrep to the toolset: forcing the
+        # backend on while it is unavailable surfaces through get_toolset().
+        _set_available(monkeypatch, False)
+        with pytest.raises(RuntimeError, match="no 'rg' binary"):
+            FileSystem[None](root_dir=tmp_path, use_ripgrep=True).get_toolset()
+
+
+class _FakeProcess:
+    def __init__(self, returncode: int, stdout: bytes = b'', stderr: bytes = b'') -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TestRipgrepProtocol:
+    """Pin the `rg` invocation and JSON/exit-code handling directly.
+
+    The behavioral tests run real ripgrep, but the toolset falls back to pure
+    Python whenever ripgrep fails, which would mask a broken `rg` command or
+    parser. Faking the subprocess is the pragmatic boundary to assert the
+    protocol the fallback otherwise hides.
+    """
+
+    async def test_builds_expected_command(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        captured: dict[str, object] = {}
+
+        async def fake(command: list[str], *, cwd: Path, check: bool) -> _FakeProcess:
+            captured.update(command=command, cwd=cwd, check=check)
+            return _FakeProcess(1)
+
+        monkeypatch.setattr(rg, 'run_process', fake)
+        result = await rg.ripgrep_file_matches(root=tmp_path, target=Path('sub'), pattern='foo')
+        assert result == []
+        assert captured['command'] == ['rg', '--json', '--no-ignore', '--sort=path', '-e', 'foo', '--', 'sub']
+        assert captured['cwd'] == tmp_path
+        assert captured['check'] is False
+
+    async def test_parses_match_events(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        stdout = (
+            b'{"type":"begin","data":{"path":{"text":"a.txt"}}}\n'
+            b'{"type":"match","data":{"path":{"text":"a.txt"},"line_number":2}}\n'
+            b'{"type":"match","data":{"path":{"text":"a.txt"},"line_number":5}}\n'
+            b'{"type":"end","data":{"path":{"text":"a.txt"}}}\n'
+            b'{"type":"summary","data":{}}\n'
+        )
+
+        async def fake(command: list[str], *, cwd: Path, check: bool) -> _FakeProcess:
+            return _FakeProcess(0, stdout=stdout)
+
+        monkeypatch.setattr(rg, 'run_process', fake)
+        result = await rg.ripgrep_file_matches(root=tmp_path, target=Path('.'), pattern='x')
+        assert result == [(Path('a.txt'), [2, 5])]
+
+    async def test_raises_on_failure_with_stderr(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        # Invalid bytes also exercise the stderr decode's error handling.
+        async def fake(command: list[str], *, cwd: Path, check: bool) -> _FakeProcess:
+            return _FakeProcess(2, stderr=b'\xff regex parse error: boom')
+
+        monkeypatch.setattr(rg, 'run_process', fake)
+        with pytest.raises(rg.RipgrepError, match='regex parse error: boom'):
+            await rg.ripgrep_file_matches(root=tmp_path, target=Path('.'), pattern='(')
+
+    async def test_line_past_eof_is_dropped(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        # A file shrinking between ripgrep's scan and the re-read must not crash.
+        (tmp_path / 'f.txt').write_text('only one line\n')
+        _set_available(monkeypatch, True)
+
+        async def fake_matches(*, root: Path, target: Path, pattern: str) -> list[tuple[Path, list[int]]]:
+            return [(Path('f.txt'), [1, 99])]
+
+        monkeypatch.setattr('pydantic_ai_harness.filesystem._toolset.ripgrep_file_matches', fake_matches)
+        result = await _toolset(tmp_path, use_ripgrep=True).search_files('one')
+        assert result == 'f.txt:1:only one line'
+
+
+@requires_ripgrep
+class TestRipgrepBackend:
+    """ripgrep-specific behavior; equivalence to the fallback is in TestBackendParity."""
+
+    async def test_output_format(self, tree: Path) -> None:
+        result = await _toolset(tree, use_ripgrep=True).search_files('findme', path='multi.txt')
+        assert result == 'multi.txt:4:findme'
+
+    async def test_access_patterns_filter_results(self, tree: Path) -> None:
+        result = await _toolset(tree, use_ripgrep=True, denied_patterns=['*.md']).search_files('findme')
+        assert 'mod.py' in result
+        assert 'notes.md' not in result
+
+    async def test_truncation(self, tmp_path: Path) -> None:
+        for i in range(20):
+            (tmp_path / f'm{i}.txt').write_text('findme\n' * 50)
+        result = await _toolset(tmp_path, use_ripgrep=True, max_search_results=30).search_files('findme')
+        assert 'truncated at 30 matches' in result
+
+    async def test_unsupported_pattern_falls_back(self, tree: Path) -> None:
+        # A lookahead is valid for Python `re` but rejected by ripgrep's default
+        # engine, so the toolset must fall back instead of failing or differing.
+        rg_result = await _toolset(tree, use_ripgrep=True).search_files('(?=findme)')
+        py_result = await _toolset(tree, use_ripgrep=False).search_files('(?=findme)')
+        assert rg_result == py_result
+        assert 'findme' in rg_result
+
+
+@requires_ripgrep
+class TestBackendParity:
+    """The ripgrep path must produce the same output as the pure-Python path."""
+
+    @pytest.mark.parametrize('pattern', ['findme', r'line\d', 'def ', 'world'])
+    async def test_same_output(self, tree: Path, pattern: str) -> None:
+        rg_result = await _toolset(tree, use_ripgrep=True).search_files(pattern)
+        py_result = await _toolset(tree, use_ripgrep=False).search_files(pattern)
+        assert rg_result == py_result
+
+    async def test_same_output_with_include_glob(self, tree: Path) -> None:
+        rg_result = await _toolset(tree, use_ripgrep=True).search_files('findme', include_glob='*.py')
+        py_result = await _toolset(tree, use_ripgrep=False).search_files('findme', include_glob='*.py')
+        assert rg_result == py_result
+
+    async def test_same_output_in_subdir(self, tree: Path) -> None:
+        rg_result = await _toolset(tree, use_ripgrep=True).search_files('findme', path='pkg')
+        py_result = await _toolset(tree, use_ripgrep=False).search_files('findme', path='pkg')
+        assert rg_result == py_result
+
+    async def test_same_output_with_crlf(self, tmp_path: Path) -> None:
+        (tmp_path / 'win.txt').write_bytes(b'alpha\r\nfindme\r\nbeta\r\n')
+        rg_result = await _toolset(tmp_path, use_ripgrep=True).search_files('findme')
+        py_result = await _toolset(tmp_path, use_ripgrep=False).search_files('findme')
+        assert rg_result == py_result == 'win.txt:2:findme'
+
+    async def test_binary_detection_differs_past_8kb(self, tmp_path: Path) -> None:
+        # Documented limitation: the pure-Python walker samples the first 8 KB for
+        # a NUL byte while ripgrep scans the whole file, so they differ on a file
+        # whose only NUL byte is past 8 KB.
+        (tmp_path / 'big.txt').write_bytes((b'findme\n' * 1300) + b'\x00' + b'findme\n')
+        rg_result = await _toolset(tmp_path, use_ripgrep=True).search_files('findme')
+        py_result = await _toolset(tmp_path, use_ripgrep=False).search_files('findme')
+        assert rg_result == 'No matches found.'  # ripgrep treats it as binary
+        assert 'big.txt:1:findme' in py_result  # pure Python searches it
+
+
+class TestFallbackPath:
+    """Force the pure-Python backend so it is covered even where ripgrep exists."""
+
+    async def test_fallback_basic(self, tree: Path) -> None:
+        result = await _toolset(tree, use_ripgrep=False).search_files('findme')
+        assert 'hello.txt:2:findme here' in result
+
+    async def test_fallback_skips_hidden_and_binary(self, tree: Path) -> None:
+        result = await _toolset(tree, use_ripgrep=False).search_files('findme')
+        assert '.hidden' not in result
+        assert 'binary.bin' not in result
+
+    async def test_fallback_single_file(self, tree: Path) -> None:
+        result = await _toolset(tree, use_ripgrep=False).search_files('findme', path='multi.txt')
+        assert result == 'multi.txt:4:findme'
+
+    async def test_fallback_truncation(self, tmp_path: Path) -> None:
+        for i in range(20):
+            (tmp_path / f'm{i}.txt').write_text('findme\n' * 50)
+        result = await _toolset(tmp_path, use_ripgrep=False, max_search_results=30).search_files('findme')
+        assert 'truncated at 30 matches' in result
+
+    async def test_fallback_no_matches_message(self, tree: Path) -> None:
+        assert await _toolset(tree, use_ripgrep=False).search_files('ZZZNOPE') == 'No matches found.'
+
+    async def test_fallback_truncates_at_exactly_the_limit(self, tmp_path: Path) -> None:
+        # Truncation triggers when results reach the limit, not only past it.
+        (tmp_path / 'f.txt').write_text('findme\n' * 5)
+        result = await _toolset(tmp_path, use_ripgrep=False, max_search_results=5).search_files('findme')
+        assert 'truncated at 5 matches' in result
+
+
+@pytest.mark.parametrize('use_ripgrep', [False, pytest.param(True, marks=requires_ripgrep)])
+class TestWalkDoesNotStopOnSkip:
+    """A skipped entry sorting before a wanted match must not halt the walk."""
+
+    async def test_skipped_entry_before_match(self, tmp_path: Path, use_ripgrep: bool) -> None:
+        # These all sort before 'zzz.txt': a directory (not a file), a binary
+        # file, and a denied file. None may turn the per-entry skip into a stop.
+        (tmp_path / 'aaa_dir').mkdir()
+        (tmp_path / 'aab.bin').write_bytes(b'findme\x00\x01')
+        (tmp_path / 'aac_skip.txt').write_text('findme\n')
+        (tmp_path / 'zzz.txt').write_text('findme\n')
+        ts = _toolset(tmp_path, use_ripgrep=use_ripgrep, denied_patterns=['aac_skip.txt'])
+        result = await ts.search_files('findme')
+        assert 'zzz.txt' in result
+        assert 'aac_skip.txt' not in result
+        assert 'aab.bin' not in result

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,14 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+
+[options.exclude-newer-package]
+pydantic-ai-slim = false
+pydantic-graph = false
+pydantic-ai = false
+pydantic-evals = false
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -995,6 +1003,9 @@ logfire = [
     { name = "logfire" },
     { name = "pydantic-ai-slim", extra = ["spec"] },
 ]
+ripgrep = [
+    { name = "ripgrep" },
+]
 temporal = [
     { name = "pydantic-ai-slim", extra = ["temporal"] },
 ]
@@ -1026,8 +1037,9 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["temporal"], marker = "extra == 'temporal'" },
     { name = "pydantic-monty", marker = "extra == 'code-mode'", specifier = ">=0.0.16" },
     { name = "pydantic-monty", marker = "extra == 'codemode'", specifier = ">=0.0.16" },
+    { name = "ripgrep", marker = "extra == 'ripgrep'", specifier = ">=15.1.0" },
 ]
-provides-extras = ["code-mode", "codemode", "dbos", "logfire", "temporal"]
+provides-extras = ["code-mode", "codemode", "dbos", "logfire", "ripgrep", "temporal"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1500,6 +1512,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ripgrep"
+version = "15.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/18/0740869cfcee3b9671d601aec90541cc68e342794cecf02c6eec7ee12f19/ripgrep-15.1.0.tar.gz", hash = "sha256:3b4793859cd25c57ffd894b59ba9155636616b4084a1c12d0b9e819c16931ebf", size = 488918, upload-time = "2026-05-24T04:02:30.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/42/994bb17dc45399f60bc850c9ea295b9638eb7abee9ec26cc386a2ebc264d/ripgrep-15.1.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3f99a068cea48d10ffc6b3c43bef37b684e1ba449d4ae57b0f96c4521f8d923f", size = 2072593, upload-time = "2026-05-24T04:02:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5c/951baee5033a25e9b79df51b378276fd0b3a88c7aba9665d50178e9738c1/ripgrep-15.1.0-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:9b9bbd02a7f2c3e88882f9a9df416da8e272957071ba8ab59a7a7f06813643cf", size = 7817112, upload-time = "2026-05-24T04:02:28.625Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an optional ripgrep backend to `FileSystem.search_files`. When an `rg` binary is available (new `ripgrep` extra, or a system `rg`) content search delegates to ripgrep; otherwise the pure-Python walker runs — it stays the default and the behavioral reference.

- New `use_ripgrep` field: `None` auto-detects, `True` requires (raises if `rg` is missing), `False` forces pure Python.
- Both backends are confined to `root_dir`, apply the same dotfile / allow / deny / protected / `include_glob` filters, and share one formatter, so they return the same results for text files. ripgrep runs rooted, never follows symlinks, uses `--no-ignore` for parity, and each result is containment-checked before re-read.
- ripgrep runs via `anyio.run_process` (asyncio + trio) and its JSON is parsed with typed Pydantic models. A pattern ripgrep rejects but `re` accepts (e.g. lookaround) transparently falls back to pure Python.
- Only `search_files` uses ripgrep; the public surface is one field, the backend module is private.

**Known limitation:** binary detection differs — the pure-Python walker samples the first 8 KB for a NUL byte, ripgrep scans the whole file — so a file with a NUL past 8 KB is searched by pure Python but skipped by ripgrep (documented + tested; aligning them would change existing behavior).

## Validation

`make lint && make typecheck && make test` green; **100% branch coverage**, verified on slim (→ fallback) and `--all-extras`. Parity + behavior tests run real `rg`; protocol tests fake the subprocess to pin the command/JSON/exit-code handling the fallback would otherwise mask. Mutation-tested (`_ripgrep.py` + new `_toolset.py` functions in `[tool.mutmut]`). Adds a `ripgrep` extra (the `rg` binary) — `pyproject.toml` / `uv.lock` touched deliberately.

https://claude.ai/code/session_01A7oqgLJMQzovutMdywz2qk