### PR TITLE
docs: align README code-mode extra name with pyproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ uv add pydantic-ai-harness
 Extras for specific capabilities:
 
 ```bash
-uv add "pydantic-ai-harness[codemode]"   # CodeMode (adds the Monty sandbox)
+uv add "pydantic-ai-harness[code-mode]"   # CodeMode (adds the Monty sandbox)
 uv add "pydantic-ai-harness[logfire]"     # ManagedPrompt (Logfire-managed prompts)
 ```
 
-The `code-mode` extra is also supported as an alias.
+The `codemode` extra is also supported as an alias.
 
 Requires Python 3.10+ and `pydantic-ai-slim>=1.95.1`.
 


### PR DESCRIPTION
## What

Swap the `code-mode` / `codemode` extra names in the README install section so they match `pyproject.toml`:

- The snippet showed `[codemode]` as the primary extra and called `[code-mode]` "also supported as an alias".
- `pyproject.toml` defines `code-mode` **first** (the canonical extra) and `codemode` **second** with a comment that it's a duplicate alias (extras metadata has no native alias syntax).
- The Quick start (and the internal `pydantic-ai-harness[code-mode]` reference) already use `[code-mode]`.

So the README now lists `[code-mode]` as primary and `[codemode]` as the alias, consistent with the package metadata and the rest of the README.

```diff
-uv add "pydantic-ai-harness[codemode]"   # CodeMode (adds the Monty sandbox)
+uv add "pydantic-ai-harness[code-mode]"   # CodeMode (adds the Monty sandbox)
 ...
-The `code-mode` extra is also supported as an alias.
+The `codemode` extra is also supported as an alias.
```

Docs-only; the README example tests still pass. No `pyproject.toml` / `uv.lock` changes.

## How this was produced

This is our first change authored by the **coding harness** (the integration agent built from `FileSystem` + `Shell` + `Planning` on the `claude/coding-harness` branch), driven by a live model. Given the prompt "find a concrete, correct-to-fix issue in the README and verify it against the codebase," the agent listed the repo, read the README and `pyproject.toml`, searched for the extra names, identified the primary/alias inversion, and made the edit. A human reviewed the diff and verified the claim against `pyproject.toml` before opening this PR.
