### PR TITLE
docs: stale-PR re-eval, experimental-export, and background-coder review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,9 @@ Before implementing or reviewing a capability change:
    signatures when needed. Do not assume a contributor's local checkout layout.
 5. Use `pydantic_ai_harness.code_mode` as the exemplar for capability shape,
    docs, tests, and public exports until another capability becomes a better
-   example.
+   example. `code_mode` is a released top-level capability; new capabilities
+   start under `pydantic_ai_harness.experimental` (see
+   `agent_docs/capability-authoring.md`, "Experimental Vs Released Exports").
 
 ## Capabilities API reference
 

--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -31,6 +31,19 @@ Each capability package should normally have:
 The root `pydantic_ai_harness/__init__.py` should re-export stable public
 capabilities. Keep implementation helpers private unless users need them.
 
+### Experimental Vs Released Exports
+
+New capabilities land under `pydantic_ai_harness/experimental/`. Each
+experimental package calls `warn_experimental('<name>')` in its `__init__.py` so
+importing it emits `HarnessExperimentalWarning`. Anything under `experimental`
+may change or be removed in any release, without a deprecation period.
+
+Promote a capability to a top-level package and a top-level re-export in
+`pydantic_ai_harness/__init__.py` only when its API is stable.
+
+Already-released top-level exports (`CodeMode`, `FileSystem`, `ManagedPrompt`,
+`Shell`) are public API. Do not move, rename, or break them.
+
 ## API Design
 
 - Prefer a small dataclass capability with typed fields.

--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -41,8 +41,11 @@ may change or be removed in any release, without a deprecation period.
 Promote a capability to a top-level package and a top-level re-export in
 `pydantic_ai_harness/__init__.py` only when its API is stable.
 
-Already-released top-level exports (`CodeMode`, `FileSystem`, `ManagedPrompt`,
-`Shell`) are public API. Do not move, rename, or break them.
+Top-level exports in `pydantic_ai_harness/__init__.py` are the intended public
+surface. Once an export has shipped in a published release it is a
+backward-compatibility commitment: do not move, rename, or break it. (`CodeMode`
+is a shipped, released example.) Do not relocate an already-top-level capability
+into `experimental`.
 
 ## API Design
 

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -4,10 +4,7 @@ Use this before opening a PR or reviewing a capability change.
 
 ## Product Fit
 
-- The capability has a clear user or dogfooding need. pydanty, our background CLI
-  coding agent, is a reference consumer: for capabilities a long-running
-  background coder uses, weigh prompt-cache stability, token cost, and
-  reliability, not just feature correctness.
+- The capability has a clear user or dogfooding need.
 - The behavior belongs in harness, not Pydantic AI core.
 - The public API is small and named around user concepts.
 - The capability composes with relevant existing capabilities.

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -4,7 +4,10 @@ Use this before opening a PR or reviewing a capability change.
 
 ## Product Fit
 
-- The capability has a clear user or dogfooding need.
+- The capability has a clear user or dogfooding need. pydanty, our background CLI
+  coding agent, is a reference consumer: for capabilities a long-running
+  background coder uses, weigh prompt-cache stability, token cost, and
+  reliability, not just feature correctness.
 - The behavior belongs in harness, not Pydantic AI core.
 - The public API is small and named around user concepts.
 - The capability composes with relevant existing capabilities.
@@ -19,6 +22,21 @@ Use this before opening a PR or reviewing a capability change.
   runtime behavior.
 - Capability ordering is justified when present.
 - Dependency changes were made through `uv` and have a clear reason.
+
+## Stale Or Pre-Merge PRs
+
+Run these checks when adopting, rebasing, or re-reviewing a PR that was opened
+well before now, or that was built against unreleased Pydantic AI changes.
+
+- Temporary `[tool.uv.sources]` pins to a branch or git ref are removed once the
+  upstream change they waited on has landed in a released `pydantic-ai-slim`.
+- Each upstream Pydantic AI PR or branch the change rode on has merged. Link the
+  upstream PR and its merge state.
+- The touched surface has not drifted: re-check the capability, hook, and toolset
+  signatures it depends on against current main, not against the state at fork
+  time.
+- Behavior the PR worked around because a primitive was missing is reconsidered
+  if that primitive now exists in core.
 
 ## Tests
 


### PR DESCRIPTION
Closes gaps in the AICA-facing review/authoring guides that surfaced while adopting a months-old PR (#243, the CodeMode `dynamic_catalog` adoption). Docs-only; no code or behavior changes.

### Gaps

1. **No re-evaluation discipline for a stale / pre-merge PR.** #243 was built against unreleased pyai branches and pinned `pydantic-ai-slim` to a `background-tools` branch via `[tool.uv.sources]`. Both upstream changes have since merged, so the pin is removable -- but nothing told an adopting agent to check that. Added a "Stale Or Pre-Merge PRs" section to `agent_docs/review-checklist.md`.
2. **The `experimental` export convention was undocumented.** `pydantic_ai_harness/experimental/` is where new capabilities land (each emitting `HarnessExperimentalWarning`), while released top-level exports (`CodeMode`, `FileSystem`, `ManagedPrompt`, `Shell`) must not be moved/broken. The documented exemplar (`code_mode`) is itself top-level, which steers new-capability authors the wrong way. Added "Experimental Vs Released Exports" to `agent_docs/capability-authoring.md` and a one-line pointer in the `AGENTS.md` AICA preflight.
3. **No reference-consumer lens.** The checklist named "dogfooding need" but no concrete consumer or the cache/cost/reliability tradeoffs a long-running background coder cares about. Extended the "Product Fit" bullet to name pydanty as the reference consumer.

All three extend files AICAs already read via the `AGENTS.md` -> `agent_docs/index.md` routing. `CLAUDE.md` is a symlink to `AGENTS.md`, so the preflight edit reaches Claude automatically.