### PR TITLE
ci: add pydantic-ai v2 beta early-warning job and make code_mode v1/v2 compatible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,48 @@ jobs:
       - run: uv sync --locked --group dev --all-extras
       - run: uv run --no-sync pytest
 
+  # Early-warning signal for the pydantic-ai v2 beta line. The harness targets
+  # the v1 line today (the `>=1.105.0` floor and the lock both resolve to v1),
+  # but that `>=` constraint also admits the v2 prereleases once prerelease
+  # resolution is enabled. This job pins the latest v2 beta so we see v2
+  # breakage as it lands -- e.g. v2 dropped the `calls` argument from
+  # `ToolManager.get_parallel_execution_mode`, which CodeMode still calls with
+  # the v1 signature -- rather than discovering it the day v2 is released.
+  #
+  # Deliberately absent from the `check` gate below: v2 is unreleased and the
+  # harness does not yet claim to support it, so a red result here is expected
+  # and must not block merges. It is a visible signal, not a required check.
+  test-v2-beta:
+    runs-on: ubuntu-latest
+    name: test on pydantic-ai v2 beta
+    timeout-minutes: 20
+    # The whole point of the job is to resolve v2 prereleases; allow them for
+    # every uv invocation in this job rather than threading flags per step.
+    env:
+      UV_PRERELEASE: allow
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          python-version: '3.14'
+          enable-cache: true # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
+          cache-suffix: v2-beta
+
+      # `env -u UV_LOCKED`: same as `test-latest` -- under the workflow-level
+      # `UV_LOCKED=1`, `uv lock` would assert the lockfile is current instead of
+      # applying the upgrade, so this step would fail the moment a newer v2 beta
+      # exists rather than testing it.
+      - run: |
+          env -u UV_LOCKED uv lock \
+            --prerelease allow \
+            --upgrade-package pydantic-ai-slim \
+            --upgrade-package pydantic-graph
+      - run: uv sync --locked --group dev --all-extras
+      - run: uv run --no-sync pytest
+
   coverage:
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,8 +198,8 @@ jobs:
       # would not catch this -- the hang happens after the test body finishes,
       # during interpreter shutdown -- so the cap has to be on the process.
       #
-      # Two instrumentation tests assert pydantic-ai v1's OpenTelemetry attribute
-      # and span names (`gen_ai.usage.*`, span `agent run`). v2 deliberately
+      # Two instrumentation assertions depend on pydantic-ai v1's OpenTelemetry
+      # attribute and span names (`gen_ai.usage.*`, span `agent run`). v2 deliberately
       # renamed these (aggregated-usage attributes, and GenAI-semconv span names
       # such as `invoke_agent {name}`), so they are expected-red on v2 and carry
       # no signal here. Deselect them so this job stays a meaningful early-warning
@@ -209,7 +209,7 @@ jobs:
       - run: |
           timeout -k 30 300 uv run --no-sync pytest \
             --deselect "tests/logfire_variables/test_managed_prompt.py::test_baggage_propagates_to_run_and_child_spans" \
-            --deselect "tests/logfire_variables/test_managed_prompt.py::test_provider_backed_resolution_uses_remote_value_and_label"
+            --deselect "tests/logfire_variables/test_managed_prompt.py::test_provider_backed_resolution_tags_v1_instrumentation_spans"
 
   coverage:
     needs: [test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,7 +188,16 @@ jobs:
             --upgrade-package pydantic-ai-slim \
             --upgrade-package pydantic-graph
       - run: uv sync --locked --group dev --all-extras
-      - run: uv run --no-sync pytest
+      # A v2 break can hang instead of failing cleanly: e.g. an unhandled
+      # exception raised inside a DBOS workflow leaves DBOS's background
+      # (non-daemon) recovery thread alive, so the Python process never exits
+      # and the step would otherwise ride to the 20-minute job timeout. The
+      # `timeout` wrapper caps the step so any such hang fails fast (exit 124)
+      # rather than burning a full runner slot. `-k 30` escalates to SIGKILL if
+      # pytest ignores the initial SIGTERM. A per-test plugin (pytest-timeout)
+      # would not catch this -- the hang happens after the test body finishes,
+      # during interpreter shutdown -- so the cap has to be on the process.
+      - run: timeout -k 30 300 uv run --no-sync pytest
 
   coverage:
     needs: [test]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,19 @@ jobs:
       # pytest ignores the initial SIGTERM. A per-test plugin (pytest-timeout)
       # would not catch this -- the hang happens after the test body finishes,
       # during interpreter shutdown -- so the cap has to be on the process.
-      - run: timeout -k 30 300 uv run --no-sync pytest
+      #
+      # Two instrumentation tests assert pydantic-ai v1's OpenTelemetry attribute
+      # and span names (`gen_ai.usage.*`, span `agent run`). v2 deliberately
+      # renamed these (aggregated-usage attributes, and GenAI-semconv span names
+      # such as `invoke_agent {name}`), so they are expected-red on v2 and carry
+      # no signal here. Deselect them so this job stays a meaningful early-warning
+      # for capability breakage (e.g. code mode) rather than documented
+      # instrumentation drift. If either test is renamed the deselect stops
+      # matching and the job goes red, which is the right prompt to revisit.
+      - run: |
+          timeout -k 30 300 uv run --no-sync pytest \
+            --deselect "tests/logfire_variables/test_managed_prompt.py::test_baggage_propagates_to_run_and_child_spans" \
+            --deselect "tests/logfire_variables/test_managed_prompt.py::test_provider_backed_resolution_uses_remote_value_and_label"
 
   coverage:
     needs: [test]

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -197,6 +197,25 @@ def _sanitize_tool_name(name: str) -> str:
     return sanitized or '_'
 
 
+def _global_mode_is_sequential(get_mode: Callable[..., ParallelExecutionMode]) -> bool:
+    """Whether the run-scoped execution mode forces sandbox tool calls to run sequentially.
+
+    pydantic-ai v1's `get_parallel_execution_mode` took the pending calls list
+    and folded per-tool `sequential` flags into the result; v2 dropped the
+    argument and returns only the run-scoped context-var mode. Passing `[]` in
+    v1 isolated that context var from per-tool flags, which is exactly what the
+    no-arg v2 call returns, so the two are equivalent.
+
+    Inspect the arity rather than catch `TypeError` so a genuine `TypeError`
+    raised inside the method is not swallowed. The `Callable[...]` parameter
+    type erases the bound signature so both call shapes typecheck whichever
+    major's stubs pyright resolves.
+    """
+    if inspect.signature(get_mode).parameters:
+        return get_mode([]) != 'parallel'
+    return get_mode() != 'parallel'
+
+
 @dataclass(kw_only=True)
 class _RunCodeTool(ToolsetTool[AgentDepsT]):
     """ToolsetTool subclass that caches data computed during `get_tools`.
@@ -429,20 +448,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         #   to isolate the context var from per-tool flags.
         # - sequential_tools: per-tool `sequential` flags on ToolDefinition.
         #   These tools are rendered as `def` (sync) and resolved inline.
-        # pydantic-ai v1's `get_parallel_execution_mode` took the pending calls
-        # list; v2 dropped it and reads the run-scoped mode from a context var.
-        # Passing `[]` in v1 isolated that context var from per-tool sequential
-        # flags, which is exactly what the no-arg v2 call returns, so the two
-        # are equivalent. Inspect arity rather than catch TypeError so a genuine
-        # TypeError inside the method is not swallowed.
-        # The `Callable[...]` annotation erases the bound signature so both call
-        # shapes typecheck regardless of which pydantic-ai major's stubs pyright
-        # resolves (v1 requires `calls`, v2 takes none).
-        _get_mode: Callable[..., ParallelExecutionMode] = tool_manager.get_parallel_execution_mode
-        if inspect.signature(_get_mode).parameters:
-            global_sequential = _get_mode([]) != 'parallel'
-        else:
-            global_sequential = _get_mode() != 'parallel'
+        global_sequential = _global_mode_is_sequential(tool_manager.get_parallel_execution_mode)
         sequential_tools = {name for name, td in callable_defs.items() if td.sequential}
 
         # Collect nested tool calls and returns keyed by tool_call_id so they

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import keyword
 import re
 import warnings
@@ -22,7 +23,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     is_multi_modal_content,
 )
-from pydantic_ai.tool_manager import ToolManager
+from pydantic_ai.tool_manager import ParallelExecutionMode, ToolManager
 from pydantic_ai.tools import AgentDepsT, ToolDenied, ToolSelector, matches_tool_selector
 from pydantic_ai.toolsets.abstract import SchemaValidatorProt, ToolsetTool
 
@@ -428,7 +429,20 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         #   to isolate the context var from per-tool flags.
         # - sequential_tools: per-tool `sequential` flags on ToolDefinition.
         #   These tools are rendered as `def` (sync) and resolved inline.
-        global_sequential = tool_manager.get_parallel_execution_mode([]) != 'parallel'
+        # pydantic-ai v1's `get_parallel_execution_mode` took the pending calls
+        # list; v2 dropped it and reads the run-scoped mode from a context var.
+        # Passing `[]` in v1 isolated that context var from per-tool sequential
+        # flags, which is exactly what the no-arg v2 call returns, so the two
+        # are equivalent. Inspect arity rather than catch TypeError so a genuine
+        # TypeError inside the method is not swallowed.
+        # The `Callable[...]` annotation erases the bound signature so both call
+        # shapes typecheck regardless of which pydantic-ai major's stubs pyright
+        # resolves (v1 requires `calls`, v2 takes none).
+        _get_mode: Callable[..., ParallelExecutionMode] = tool_manager.get_parallel_execution_mode
+        if inspect.signature(_get_mode).parameters:
+            global_sequential = _get_mode([]) != 'parallel'
+        else:
+            global_sequential = _get_mode() != 'parallel'
         sequential_tools = {name for name, td in callable_defs.items() if td.sequential}
 
         # Collect nested tool calls and returns keyed by tool_call_id so they

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -20,7 +20,9 @@ from pydantic_ai import (
     ToolDefinition,
 )
 from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.tool_manager import ParallelExecutionMode
 from pydantic_ai.toolsets.abstract import ToolsetTool
 from pydantic_ai.toolsets.function import FunctionToolset
 from pydantic_ai.usage import RunUsage
@@ -33,6 +35,7 @@ from pydantic_ai_harness.code_mode import CodeModeToolset
 from pydantic_ai_harness.code_mode._toolset import (  # pyright: ignore[reportPrivateUsage]
     _SEARCH_TOOLS_MODIFIER,
     _TOOL_SEARCH_ADDENDUM,
+    _global_mode_is_sequential,
     _PrintCapture,
     _sanitize_tool_name,
 )
@@ -2494,3 +2497,32 @@ def _search_tool_def(description: str = 'Search for tools.') -> ToolDefinition:
         description=description,
         parameters_json_schema={'type': 'object', 'properties': {'keywords': {'type': 'string'}}},
     )
+
+
+class TestGlobalModeIsSequential:
+    """`_global_mode_is_sequential` dispatches across pydantic-ai v1 and v2.
+
+    v1's `get_parallel_execution_mode` takes the pending calls list; v2 dropped
+    the argument. The helper inspects arity and calls the matching shape, so
+    both code paths are exercised here regardless of which major is installed.
+    """
+
+    def test_v1_signature_with_calls_argument(self) -> None:
+        def parallel(calls: list[ToolCallPart]) -> ParallelExecutionMode:
+            return 'parallel'
+
+        def sequential(calls: list[ToolCallPart]) -> ParallelExecutionMode:
+            return 'sequential'
+
+        assert _global_mode_is_sequential(parallel) is False
+        assert _global_mode_is_sequential(sequential) is True
+
+    def test_v2_signature_without_arguments(self) -> None:
+        def parallel() -> ParallelExecutionMode:
+            return 'parallel'
+
+        def sequential() -> ParallelExecutionMode:
+            return 'sequential'
+
+        assert _global_mode_is_sequential(parallel) is False
+        assert _global_mode_is_sequential(sequential) is True

--- a/tests/logfire_variables/test_managed_prompt.py
+++ b/tests/logfire_variables/test_managed_prompt.py
@@ -428,8 +428,8 @@ async def test_resolved_property_exposes_active_resolution() -> None:
     assert capability.resolved is None
 
 
-async def test_provider_backed_resolution_uses_remote_value_and_label(capfire: CaptureLogfire) -> None:
-    config = VariablesConfig(
+def _remote_prompt_config() -> VariablesConfig:
+    return VariablesConfig(
         variables={
             'prompt__remote_slug': VariableConfig(
                 name='prompt__remote_slug',
@@ -439,11 +439,11 @@ async def test_provider_backed_resolution_uses_remote_value_and_label(capfire: C
             )
         }
     )
-    with _variables_provider_configured(capfire, config):
-        agent = Agent(
-            TestModel(),
-            capabilities=[ManagedPrompt('remote_slug', default='fallback', label='production'), Instrumentation()],
-        )
+
+
+async def test_provider_backed_resolution_uses_remote_value_and_label(capfire: CaptureLogfire) -> None:
+    with _variables_provider_configured(capfire, _remote_prompt_config()):
+        agent = Agent(TestModel(), capabilities=[ManagedPrompt('remote_slug', default='fallback', label='production')])
 
         result = await agent.run('hello')
 
@@ -455,6 +455,18 @@ async def test_provider_backed_resolution_uses_remote_value_and_label(capfire: C
     assert resolution['attributes']['reason'] == 'resolved'
     assert resolution['attributes']['value'] == '"You are the PRODUCTION prompt."'
     assert resolution['attributes']['label'] == 'production'
+
+
+async def test_provider_backed_resolution_tags_v1_instrumentation_spans(capfire: CaptureLogfire) -> None:
+    with _variables_provider_configured(capfire, _remote_prompt_config()):
+        agent = Agent(
+            TestModel(),
+            capabilities=[ManagedPrompt('remote_slug', default='fallback', label='production'), Instrumentation()],
+        )
+
+        await agent.run('hello')
+
+    spans = capfire.exporter.exported_spans_as_dict()
     # Child spans are tagged with the resolved label via baggage.
     tagged = {s['name'] for s in spans if s['attributes'].get('logfire.variables.prompt__remote_slug') == 'production'}
     assert {'agent run', 'chat test'} <= tagged


### PR DESCRIPTION
## What

Adds a non-blocking `test-v2-beta` CI job that resolves the latest pydantic-ai
v2 prerelease and runs the suite against it, plus the source and test fixes that
job surfaced.

The harness still targets the v1 line. This job is an early-warning signal for
v2 breakage and is deliberately kept out of the `check` gate, so an expected-red
v2 result never blocks a merge.

No dependency edits: the existing `>=1.105.0` floor already admits v2
prereleases once prerelease resolution is enabled, so the job resolves v2 with
`uv lock --prerelease allow --upgrade-package pydantic-ai-slim pydantic-graph`
rather than pinning a specific beta.

## code_mode: v1/v2 compatibility fix

pydantic-ai v2 (#5339) dropped the `calls` argument from
`ToolManager.get_parallel_execution_mode`. code_mode still called it with the v1
signature (`get_parallel_execution_mode([])`), so every code_mode run raised
`TypeError` under v2.

The dispatch now inspects the method arity and calls the matching shape (`([])`
on v1, `()` on v2), extracted into `_global_mode_is_sequential`. The two are
equivalent: v1's `[]` isolated the run-scoped context var from per-tool
`sequential` flags, which is exactly what v2's no-arg call returns. Inspecting
arity rather than catching `TypeError` avoids swallowing a genuine `TypeError`
raised inside the method. A both-arity unit test keeps both branches exercised
whichever major is installed.

## Test changes for the v2 job

- **timeout wrapper:** a v2 `TypeError` raised inside a DBOS workflow leaves
  DBOS's non-daemon recovery thread alive, so the process never exits and the
  step would otherwise ride to the 20-minute job cap. The pytest step is wrapped
  in `timeout -k 30 300` so any such shutdown hang fails fast (exit 124). A
  per-test timeout plugin would not help -- the hang happens during interpreter
  shutdown, after the test body finishes, so the cap has to be on the process.
- **managed-prompt test split:** `test_provider_backed_resolution_uses_remote_value_and_label`
  previously asserted both the resolved value/label (v2-safe) and v1-only
  OpenTelemetry span names in one test. It is split so the value/label
  assertions stay live on v2, and only the v1-only span-name assertions move
  into a new `test_provider_backed_resolution_tags_v1_instrumentation_spans`.
  This preserves real v2 signal instead of deselecting the whole test.
- **deselects:** that new test and `test_baggage_propagates_to_run_and_child_spans`
  assert v1 OpenTelemetry attribute and span names that v2 deliberately renamed
  (aggregated-usage attributes; GenAI-semconv span names such as
  `invoke_agent {name}`). They are deselected only in the v2-beta job so it
  signals real capability breakage, not documented instrumentation drift. If
  either test is renamed the deselect stops matching and the job goes red, which
  is the right prompt to revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
