### PR TITLE
[codex] Explain code mode metadata selection

### DIFF
--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -109,6 +109,19 @@ CodeMode(tools=lambda ctx, td: td.with_native is None)
 
 ### Metadata-based selection
 
+Use metadata when the decision should travel with a tool or toolset, rather than
+with one `CodeMode` instance. This is useful for shared toolsets: the toolset
+author can tag the tools that are safe and useful to call from generated code,
+and each agent can opt into that tag with `CodeMode(tools={...})`.
+
+`CodeMode(tools={'code_mode': True})` uses the standard Pydantic AI
+`ToolSelector` metadata form. A tool is sandboxed when its
+`ToolDefinition.metadata` contains all of the selector's key-value pairs. Extra
+metadata on the tool is fine, and nested dictionaries are matched by deep
+inclusion.
+
+The common pattern is to tag an entire toolset with `.with_metadata(...)`:
+
 ```python
 from pydantic_ai import Agent
 from pydantic_ai.toolsets import FunctionToolset
@@ -122,6 +135,10 @@ agent = Agent(
     capabilities=[CodeMode(tools={'code_mode': True})],
 )
 ```
+
+Here `search` and `fetch` are removed from the model-facing tool list and
+become callable functions inside `run_code`. Tools without
+`metadata['code_mode'] == True` stay visible as regular tool calls.
 
 ## Return values
 


### PR DESCRIPTION
## Summary

Clarifies the `CodeMode` README section on metadata-based tool selection.

## Details

- Explains when metadata-based selection is useful for shared toolsets.
- Documents that `CodeMode(tools={...})` uses the standard Pydantic AI `ToolSelector` metadata matching behavior.
- Makes the example outcome explicit: tagged tools move into `run_code`; untagged tools remain regular model-facing tools.

## Validation

- `git diff --check -- pydantic_ai_harness/code_mode/README.md`
- Pre-commit docs hooks during commit (`codespell`, whitespace/end-of-file checks)