### PR TITLE
Keep framework control tools (tool search, capability loading) native in CodeMode

### DIFF
--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -261,15 +261,13 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
     callable from the sandbox at runtime. Non-selected tools remain visible
     to the model as normal tool calls.
 
-    Framework control tools with a non-null `tool_kind` stay native, including
-    Tool Search's `search_tools` and capability-loading tools. Legacy
-    `search_tools` definitions without `tool_kind` are also kept native for
-    compatibility. Tools with `defer_loading=True` (Tool Search) are likewise
-    never sandboxed: they stay native pass-through so the deferred-loading
-    contract is honored, and only get folded into `run_code` once they've been
-    discovered (`defer_loading=False`).
-    Tools annotated with `unless_native` likewise stay native so
-    `Model.prepare_request` can drop them when the provider supports the native tool.
+    Some tools always stay native rather than being sandboxed:
+
+    - Framework control tools (`tool_kind` set: tool search, capability loading).
+    - `defer_loading=True` tools, until discovery flips them to `defer_loading=False`.
+    - `unless_native` tools, so `Model.prepare_request` can drop them when the
+      provider supports the native tool.
+
     To keep a Tool Search corpus native even after discovery (e.g. for prompt-cache
     stability), pass a `tool_selector` that excludes tools with `with_native` set.
     """
@@ -361,24 +359,22 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         wrapped_tools = await self.wrapped.get_tools(ctx)
 
         # Split tools into sandboxed vs native based on the selector.
-        # Framework control/discovery tools are kept native so they can manage
-        # capability loading, tool search, and related protocol-level flows.
-        # Keep a name fallback for older/local `search_tools` definitions that
-        # predate `tool_kind`.
         sandboxed_tools: dict[str, ToolsetTool[AgentDepsT]] = {}
         native_tools: dict[str, ToolsetTool[AgentDepsT]] = {}
         for name, tool in wrapped_tools.items():
-            if tool.tool_def.tool_kind is not None or name == _SEARCH_TOOLS_NAME:
+            # Framework control tools (tool search, capability loading) stay native to
+            # drive protocol-level flows. `tool_kind` is the framework's discriminator
+            # for them; pydantic-ai has set it on `search_tools` since 1.95.0.
+            if tool.tool_def.tool_kind is not None:
                 native_tools[name] = tool
             elif tool.tool_def.defer_loading:
-                # Tool Search keeps these out of the model's initial context until discovered.
-                # Stay native pass-through so `ToolSearchToolset`'s `defer_loading` /
-                # `with_native` flags reach `Model.prepare_request` unaltered; once a tool is
-                # discovered it comes back with `defer_loading=False` and is sandboxed from then on.
+                # Stay native so Tool Search's `defer_loading`/`with_native` flags reach
+                # `Model.prepare_request` unaltered. Discovery flips `defer_loading` to
+                # False, and the tool is sandboxed from then on.
                 native_tools[name] = tool
             elif tool.tool_def.unless_native:
-                # Defer to `Model.prepare_request`'s `unless_native` filtering: keep the local
-                # fallback native so it can be dropped when the provider supports the native tool.
+                # Keep the local fallback native so `Model.prepare_request` can drop it
+                # when the provider supports the native tool.
                 native_tools[name] = tool
             elif await matches_tool_selector(self.tool_selector, ctx, tool.tool_def):
                 sandboxed_tools[name] = tool

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -261,9 +261,13 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
     callable from the sandbox at runtime. Non-selected tools remain visible
     to the model as normal tool calls.
 
-    Tools with `defer_loading=True` (Tool Search) are never sandboxed: they stay
-    native pass-through so the deferred-loading contract is honored, and only get
-    folded into `run_code` once they've been discovered (`defer_loading=False`).
+    Framework control tools with a non-null `tool_kind` stay native, including
+    Tool Search's `search_tools` and capability-loading tools. Legacy
+    `search_tools` definitions without `tool_kind` are also kept native for
+    compatibility. Tools with `defer_loading=True` (Tool Search) are likewise
+    never sandboxed: they stay native pass-through so the deferred-loading
+    contract is honored, and only get folded into `run_code` once they've been
+    discovered (`defer_loading=False`).
     Tools annotated with `unless_native` likewise stay native so
     `Model.prepare_request` can drop them when the provider supports the native tool.
     To keep a Tool Search corpus native even after discovery (e.g. for prompt-cache
@@ -357,12 +361,14 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         wrapped_tools = await self.wrapped.get_tools(ctx)
 
         # Split tools into sandboxed vs native based on the selector.
-        # The search_tools tool (from ToolSearchToolset) is always kept native
-        # so the model can discover deferred tools alongside run_code.
+        # Framework control/discovery tools are kept native so they can manage
+        # capability loading, tool search, and related protocol-level flows.
+        # Keep a name fallback for older/local `search_tools` definitions that
+        # predate `tool_kind`.
         sandboxed_tools: dict[str, ToolsetTool[AgentDepsT]] = {}
         native_tools: dict[str, ToolsetTool[AgentDepsT]] = {}
         for name, tool in wrapped_tools.items():
-            if name == _SEARCH_TOOLS_NAME:
+            if tool.tool_def.tool_kind is not None or name == _SEARCH_TOOLS_NAME:
                 native_tools[name] = tool
             elif tool.tool_def.defer_loading:
                 # Tool Search keeps these out of the model's initial context until discovered.

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -991,13 +991,17 @@ class TestCodeMode:
         """Regression for the deferred-capability bootstrap (issue #276).
 
         With `CodeMode(tools='all')` and a deferred capability configured, the
-        framework-managed `load_capability` tool must stay a native call so the model
-        can reveal the capability. Its member tools keep `defer_loading=True`, so they
-        stay hidden until loaded rather than getting folded into `run_code`.
+        framework-managed `load_capability` tool must reach the model as a native call
+        (alongside `run_code`) so the model can reveal the capability. The deferred
+        member tool stays hidden -- it is neither folded into `run_code` nor surfaced as
+        a plain tool until loaded.
+
+        (The native-vs-sandbox split per tool kind is covered directly at the toolset
+        level by `test_framework_tool_kind_tool_not_sandboxed` and
+        `test_tool_search_toolset_deferred_tool_not_in_run_code`; this exercises the
+        end-to-end path through `Agent`.)
         """
         from pydantic_ai.capabilities import Capability
-        from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
 
         capability = Capability[None](
             id='demo',
@@ -1010,29 +1014,23 @@ class TestCodeMode:
         def demo_tool() -> str:  # pyright: ignore[reportUnusedFunction]
             return 'ok'
 
-        seen: dict[str, list[AgentInfo]] = {'infos': []}
-
-        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
-            seen['infos'].append(info)
-            return ModelResponse(parts=[TextPart('done')])
-
+        model = TestModel(call_tools=[])
         agent: Agent[None, str] = Agent(
-            FunctionModel(model_fn),
+            model,
             capabilities=[capability, CodeMode[None](tools='all')],
         )
         await agent.run('inspect tools')
 
-        info = seen['infos'][0]
-        by_name = {td.name: td for td in info.function_tools}
+        assert model.last_model_request_parameters is not None
+        by_name = {td.name: td for td in model.last_model_request_parameters.function_tools}
 
         # The bootstrap tool is a native call alongside `run_code`, not buried in the sandbox.
         assert 'load_capability' in by_name
         assert 'run_code' in by_name
 
-        # The deferred member tool stays native pass-through with its `defer_loading`
-        # flag intact, so `Model.prepare_request` keeps it hidden until it's loaded --
-        # it is not folded into the `run_code` catalog.
-        assert by_name['demo_tool'].defer_loading is True
+        # The deferred member tool stays hidden until loaded: not folded into `run_code`
+        # and not surfaced as a plain native tool.
+        assert 'demo_tool' not in by_name
         run_code_desc = by_name['run_code'].description or ''
         assert 'demo_tool' not in run_code_desc
         assert 'load_capability' not in run_code_desc
@@ -2140,7 +2138,7 @@ class TestDynamicCatalog:
         await cap.after_tool_execute(
             ctx,
             call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c1'),
-            tool_def=_search_tool_def_with_kind(),
+            tool_def=_search_tool_def(),
             args={},
             result={'discovered_tools': [{'name': 'weather', 'description': '...'}]},
         )
@@ -2162,7 +2160,7 @@ class TestDynamicCatalog:
         await cap.after_tool_execute(
             ctx,
             call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c1'),
-            tool_def=_search_tool_def_with_kind(),
+            tool_def=_search_tool_def(),
             args={},
             result={'discovered_tools': [{'name': 'weather'}]},
         )
@@ -2176,7 +2174,7 @@ class TestDynamicCatalog:
         await cap.after_tool_execute(
             ctx,
             call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c1'),
-            tool_def=_search_tool_def_with_kind(),
+            tool_def=_search_tool_def(),
             args={},
             result={'discovered_tools': []},
         )
@@ -2209,7 +2207,7 @@ class TestDynamicCatalog:
             await cap.after_tool_execute(
                 ctx,
                 call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id=cid),
-                tool_def=_search_tool_def_with_kind(),
+                tool_def=_search_tool_def(),
                 args={},
                 result=result,
             )
@@ -2408,11 +2406,6 @@ class TestDynamicCatalog:
         assert result.output == 'got 7'
 
 
-def _search_tool_def_with_kind(name: str = 'search_tools') -> ToolDefinition:
-    """A `search_tools` ToolDefinition carrying `tool_kind='tool-search'` (the announcement trigger)."""
-    return ToolDefinition(name=name, description='', parameters_json_schema={}, tool_kind='tool-search')
-
-
 def _unused_os_callback(fn: OsFunction, args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
     """An `os` callback for tests that only assert description/forwarding, never run code."""
     return NOT_HANDLED  # pragma: no cover - never invoked by these tests
@@ -2606,13 +2599,18 @@ class TestCodeModeOSAccess:
 
 
 def _search_tool_def(description: str = 'Search for tools.') -> ToolDefinition:
-    """Create a ToolDefinition mimicking the search_tools tool from ToolSearchToolset."""
+    """Create a ToolDefinition mimicking the search_tools tool from ToolSearchToolset.
+
+    Carries `tool_kind='tool-search'`, matching what pydantic-ai emits (since 1.95.0);
+    CodeMode routes it native off `tool_kind`, not its name.
+    """
     from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME
 
     return ToolDefinition(
         name=_SEARCH_TOOLS_NAME,
         description=description,
         parameters_json_schema={'type': 'object', 'properties': {'keywords': {'type': 'string'}}},
+        tool_kind='tool-search',
     )
 
 

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -760,6 +760,32 @@ class TestCodeMode:
         assert 'async def later' in description
         assert 'later' not in tools
 
+    async def test_framework_tool_kind_tool_not_sandboxed(self) -> None:
+        """Framework control tools with `tool_kind` stay native even when CodeMode wraps all user tools."""
+        td_loader = ToolDefinition(
+            name='load_capability',
+            description='Load a deferred capability.',
+            parameters_json_schema={
+                'type': 'object',
+                'properties': {'capability_id': {'type': 'string'}},
+                'required': ['capability_id'],
+            },
+            return_schema={'type': 'string'},
+            tool_kind='capability-load',
+        )
+        static = _StaticToolset([_make_address_tool_def('get_user', 'Get a user.', 'street'), td_loader])
+        wrapper = CodeMode[None]().get_wrapper_toolset(static)
+        assert isinstance(wrapper, CodeModeToolset)
+
+        tools = await wrapper.get_tools(build_run_context(None))
+
+        description = tools['run_code'].tool_def.description
+        assert description is not None
+        assert 'async def get_user' in description
+        assert 'load_capability' not in description
+        assert 'load_capability' in tools
+        assert tools['load_capability'].tool_def.tool_kind == 'capability-load'
+
     async def test_unless_native_tool_not_sandboxed(self) -> None:
         """Tools annotated with `unless_native` stay native so `Model.prepare_request` can filter them."""
         td_fallback = ToolDefinition(

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -1012,7 +1012,7 @@ class TestCodeMode:
 
         @capability.tool_plain
         def demo_tool() -> str:  # pyright: ignore[reportUnusedFunction]
-            return 'ok'
+            return 'ok'  # pragma: no cover - deferred tool stays hidden, body is not invoked
 
         model = TestModel(call_tools=[])
         agent: Agent[None, str] = Agent(

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -987,6 +987,56 @@ class TestCodeMode:
         # The agent's final output reflects the value flowing through the sandbox.
         assert result.output == 'sum is 10'
 
+    async def test_deferred_capability_loader_stays_native_with_tools_all(self) -> None:
+        """Regression for the deferred-capability bootstrap (issue #276).
+
+        With `CodeMode(tools='all')` and a deferred capability configured, the
+        framework-managed `load_capability` tool must stay a native call so the model
+        can reveal the capability. Its member tools keep `defer_loading=True`, so they
+        stay hidden until loaded rather than getting folded into `run_code`.
+        """
+        from pydantic_ai.capabilities import Capability
+        from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        capability = Capability[None](
+            id='demo',
+            description='Demo deferred capability.',
+            instructions='Use demo_tool.',
+            defer_loading=True,
+        )
+
+        @capability.tool_plain
+        def demo_tool() -> str:  # pyright: ignore[reportUnusedFunction]
+            return 'ok'
+
+        seen: dict[str, list[AgentInfo]] = {'infos': []}
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            seen['infos'].append(info)
+            return ModelResponse(parts=[TextPart('done')])
+
+        agent: Agent[None, str] = Agent(
+            FunctionModel(model_fn),
+            capabilities=[capability, CodeMode[None](tools='all')],
+        )
+        await agent.run('inspect tools')
+
+        info = seen['infos'][0]
+        by_name = {td.name: td for td in info.function_tools}
+
+        # The bootstrap tool is a native call alongside `run_code`, not buried in the sandbox.
+        assert 'load_capability' in by_name
+        assert 'run_code' in by_name
+
+        # The deferred member tool stays native pass-through with its `defer_loading`
+        # flag intact, so `Model.prepare_request` keeps it hidden until it's loaded --
+        # it is not folded into the `run_code` catalog.
+        assert by_name['demo_tool'].defer_loading is True
+        run_code_desc = by_name['run_code'].description or ''
+        assert 'demo_tool' not in run_code_desc
+        assert 'load_capability' not in run_code_desc
+
     # ---------------------------------------------------------------------------
     # Capability registration
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`CodeMode(tools='all')` now keeps framework control tools native instead of folding them into `run_code`. A tool is treated as a framework control tool when its `ToolDefinition` carries a `tool_kind` (`tool-search` or `capability-load`).

Without this, the deferred-capability bootstrap breaks: `load_capability` (`tool_kind='capability-load'`) was being sandboxed into `run_code`, removing the native loader the model needs to reveal deferred capabilities. The same applies to Tool Search's `search_tools` (`tool_kind='tool-search'`). Normal user tools are still sandboxed as before.

Routing keys purely off `tool_kind`. The previous `name == 'search_tools'` fallback is removed: pydantic-ai has set `tool_kind` on `search_tools` since 1.95.0, and this package floors at `pydantic-ai-slim>=1.105.0`, so the fallback was unreachable in any supported install.

## Changes

- Route tools with a non-null `ToolDefinition.tool_kind` native before `CodeMode` applies its sandbox selector.
- Remove the redundant `search_tools` name fallback (covered by `tool_kind` given the `>=1.105.0` floor).
- Add regression tests: `load_capability` (`tool_kind='capability-load'`) stays native, and the deferred-capability bootstrap stays native end-to-end through `Agent`.

## Linked Issue

Fixes #276

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)

## Verification

```bash
uv run pytest tests/code_mode/test_code_mode.py -q
make lint && make typecheck && make testcov
```
