### PR TITLE
Bump vcrpy to 8.2.1 to fix YAML deserialization RCE

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1854,15 +1854,15 @@ wheels = [
 
 [[package]]
 name = "vcrpy"
-version = "8.1.1"
+version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyyaml" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/07/bcfd5ebd7cb308026ab78a353e091bd699593358be49197d39d004e5ad83/vcrpy-8.1.1.tar.gz", hash = "sha256:58e3053e33b423f3594031cb758c3f4d1df931307f1e67928e30cf352df7709f", size = 85770, upload-time = "2026-01-04T19:22:03.886Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/db/08183b845b0040bb877dad2bd7e4e0976fc232bb3476d7ee369c6c4f8b5a/vcrpy-8.2.1.tar.gz", hash = "sha256:d73a6e4eb6dae8148e659764b7a00e68cc51ba29ba9e6a85e1f0790ad96b97df", size = 90511, upload-time = "2026-06-16T13:20:52.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/d7/f79b05a5d728f8786876a7d75dfb0c5cae27e428081b2d60152fb52f155f/vcrpy-8.1.1-py3-none-any.whl", hash = "sha256:2d16f31ad56493efb6165182dd99767207031b0da3f68b18f975545ede8ac4b9", size = 42445, upload-time = "2026-01-04T19:22:02.532Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7c/0e812ab83f5289404c674f3461ba783250b967d34b5ab034d361236ec042/vcrpy-8.2.1-py3-none-any.whl", hash = "sha256:7ce58c9e2792b246f79d6f4b3e9660676cc6f853be17e1547305b4437ab1ff85", size = 44925, upload-time = "2026-06-16T13:20:51.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the locked `vcrpy` from 8.1.1 to 8.2.1 (`uv.lock` only).

`vcrpy < 8.2.1` deserializes YAML cassette files with PyYAML's unsafe loader, so a crafted cassette can execute arbitrary code the moment it is loaded -- e.g. when a test suite loads a fixture in CI. 8.2.1 switches to `SafeLoader`. Resolves Dependabot alert GHSA-rpj2-4hq8-938g (high, CVSS 7.8).

## Linked Issue

Fixes #301

## Checklist

- [x] Linked issue exists and is referenced above
- [ ] Tests added/updated for new behavior -- N/A, dependency bump only
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] Changes to `uv.lock` are intentional and tracked by the linked issue (security bump)
- [x] Docstrings use single backticks (not RST double backticks) -- N/A