### PR TITLE
Emit a span when compaction happens

### DIFF
--- a/pydantic_ai_harness/experimental/compaction/README.md
+++ b/pydantic_ai_harness/experimental/compaction/README.md
@@ -186,17 +186,20 @@ emits a single span for the whole escalation rather than one per tier, because i
 `compact` directly. Without instrumentation the tracer is a no-op, so the span adds no overhead.
 
 The span name is the static `compact_messages`; the strategy is an attribute, not part of the name,
-to keep span cardinality low. Attributes (all `int` or `str`):
+to keep span cardinality low. Attributes:
 
 | Attribute | Type | Meaning |
 |---|---|---|
+| `gen_ai.conversation.compacted` | bool | Always `true`; the OpenTelemetry GenAI convention's flag for a compacted context |
 | `compaction.strategy` | str | Strategy class name (e.g. `SlidingWindow`, `SummarizingCompaction`) |
 | `compaction.messages_before` | int | Message count before compaction |
 | `compaction.messages_after` | int | Message count after compaction |
 | `compaction.tokens_before` | int | Estimated token count before compaction |
 | `compaction.tokens_after` | int | Estimated token count after compaction |
 
-Token counts use the strategy's `tokenizer` when set, otherwise the ~4-chars-per-token heuristic.
+`gen_ai.conversation.compacted` is the GenAI semantic convention's flag; the rest is
+harness-specific. Token counts use the strategy's `tokenizer` when set, otherwise the
+~4-chars-per-token heuristic.
 Raw message content is not recorded.
 
 ## Out of scope

--- a/pydantic_ai_harness/experimental/compaction/README.md
+++ b/pydantic_ai_harness/experimental/compaction/README.md
@@ -176,6 +176,29 @@ def my_file_key(call: ToolCallPart) -> str | None:
     return args.get('path') if isinstance(args, dict) else None
 ```
 
+## Tracing
+
+When core instrumentation is active (the `Instrumentation` capability, `agent.instrument`, or
+`Agent.instrument_all()`), each strategy emits a `compact_messages` span on the run's tracer the
+moment it actually compacts -- that is, in `before_model_request`, once the strategy's threshold is
+exceeded (`ClampOversizedMessages` emits only when a part is actually clamped). `TieredCompaction`
+emits a single span for the whole escalation rather than one per tier, because it drives each tier's
+`compact` directly. Without instrumentation the tracer is a no-op, so the span adds no overhead.
+
+The span name is the static `compact_messages`; the strategy is an attribute, not part of the name,
+to keep span cardinality low. Attributes (all `int` or `str`):
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `compaction.strategy` | str | Strategy class name (e.g. `SlidingWindow`, `SummarizingCompaction`) |
+| `compaction.messages_before` | int | Message count before compaction |
+| `compaction.messages_after` | int | Message count after compaction |
+| `compaction.tokens_before` | int | Estimated token count before compaction |
+| `compaction.tokens_after` | int | Estimated token count after compaction |
+
+Token counts use the strategy's `tokenizer` when set, otherwise the ~4-chars-per-token heuristic.
+Raw message content is not recorded.
+
 ## Out of scope
 
 These strategies compress or drop context *inside* the window. Moving large tool outputs *out* of the

--- a/pydantic_ai_harness/experimental/compaction/_clamp_oversized_messages.py
+++ b/pydantic_ai_harness/experimental/compaction/_clamp_oversized_messages.py
@@ -121,20 +121,6 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
             return True
         return False
 
-    def _would_clamp(self, messages: list[ModelMessage]) -> bool:
-        """Return True if at least one part would be clamped, so a span is only emitted then."""
-        for msg in messages:
-            if not isinstance(msg, ModelResponse):
-                continue
-            for part in msg.parts:
-                if isinstance(part, TextPart):
-                    if self._clamp(part.content) is not None:
-                        return True
-                elif isinstance(part, ToolCallPart) and self.clamp_tool_call_args:
-                    if self._clamp(part.args_as_json_str()) is not None:
-                        return True
-        return False
-
     def _clamp(self, text: str) -> str | None:
         """Return the head/tail-clamped form of *text*, or ``None`` if it would not shrink."""
         if not self._is_oversized(text):
@@ -185,8 +171,6 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
     ) -> ModelRequestContext:
         """Clamp any oversized response part before the request is sent."""
         messages: list[ModelMessage] = list(request_context.messages)
-        if not self._would_clamp(messages):
-            return request_context
         request_context.messages = await compact_with_span(
             ctx,
             strategy='ClampOversizedMessages',

--- a/pydantic_ai_harness/experimental/compaction/_clamp_oversized_messages.py
+++ b/pydantic_ai_harness/experimental/compaction/_clamp_oversized_messages.py
@@ -17,7 +17,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.tools import RunContext
 
-from pydantic_ai_harness.experimental.compaction._shared import estimate_text_tokens
+from pydantic_ai_harness.experimental.compaction._shared import compact_with_span, estimate_text_tokens
 
 if TYPE_CHECKING:
     from pydantic_ai.models import ModelRequestContext
@@ -121,6 +121,20 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
             return True
         return False
 
+    def _would_clamp(self, messages: list[ModelMessage]) -> bool:
+        """Return True if at least one part would be clamped, so a span is only emitted then."""
+        for msg in messages:
+            if not isinstance(msg, ModelResponse):
+                continue
+            for part in msg.parts:
+                if isinstance(part, TextPart):
+                    if self._clamp(part.content) is not None:
+                        return True
+                elif isinstance(part, ToolCallPart) and self.clamp_tool_call_args:
+                    if self._clamp(part.args_as_json_str()) is not None:
+                        return True
+        return False
+
     def _clamp(self, text: str) -> str | None:
         """Return the head/tail-clamped form of *text*, or ``None`` if it would not shrink."""
         if not self._is_oversized(text):
@@ -170,5 +184,14 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
     ) -> ModelRequestContext:
         """Clamp any oversized response part before the request is sent."""
-        request_context.messages = await self.compact(list(request_context.messages), ctx)
+        messages: list[ModelMessage] = list(request_context.messages)
+        if not self._would_clamp(messages):
+            return request_context
+        request_context.messages = await compact_with_span(
+            ctx,
+            'ClampOversizedMessages',
+            messages,
+            lambda: self.compact(messages, ctx),
+            self.tokenizer,
+        )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_clamp_oversized_messages.py
+++ b/pydantic_ai_harness/experimental/compaction/_clamp_oversized_messages.py
@@ -189,9 +189,9 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
             return request_context
         request_context.messages = await compact_with_span(
             ctx,
-            'ClampOversizedMessages',
-            messages,
-            lambda: self.compact(messages, ctx),
-            self.tokenizer,
+            strategy='ClampOversizedMessages',
+            messages=messages,
+            compact=lambda: self.compact(messages, ctx),
+            tokenizer=self.tokenizer,
         )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_clear_tool_results.py
+++ b/pydantic_ai_harness/experimental/compaction/_clear_tool_results.py
@@ -134,9 +134,9 @@ class ClearToolResults(AbstractCapability[AgentDepsT]):
             return request_context
         request_context.messages = await compact_with_span(
             ctx,
-            'ClearToolResults',
-            messages,
-            lambda: self.compact(messages, ctx),
-            self.tokenizer,
+            strategy='ClearToolResults',
+            messages=messages,
+            compact=lambda: self.compact(messages, ctx),
+            tokenizer=self.tokenizer,
         )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_clear_tool_results.py
+++ b/pydantic_ai_harness/experimental/compaction/_clear_tool_results.py
@@ -12,6 +12,7 @@ from pydantic_ai.messages import ModelMessage
 from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness.experimental.compaction._shared import (
+    compact_with_span,
     estimate_token_count,
     exceeds,
     iter_tool_pairs,
@@ -131,5 +132,11 @@ class ClearToolResults(AbstractCapability[AgentDepsT]):
         messages: list[ModelMessage] = list(request_context.messages)
         if not exceeds(messages, self.max_messages, self.max_tokens, self.tokenizer):
             return request_context
-        request_context.messages = await self.compact(messages, ctx)
+        request_context.messages = await compact_with_span(
+            ctx,
+            'ClearToolResults',
+            messages,
+            lambda: self.compact(messages, ctx),
+            self.tokenizer,
+        )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_deduplicate_file_reads.py
+++ b/pydantic_ai_harness/experimental/compaction/_deduplicate_file_reads.py
@@ -11,7 +11,12 @@ from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.messages import ModelMessage, ToolCallPart
 from pydantic_ai.tools import RunContext
 
-from pydantic_ai_harness.experimental.compaction._shared import exceeds, iter_tool_pairs, rebuild_with_cleared
+from pydantic_ai_harness.experimental.compaction._shared import (
+    compact_with_span,
+    exceeds,
+    iter_tool_pairs,
+    rebuild_with_cleared,
+)
 
 if TYPE_CHECKING:
     from pydantic_ai.models import ModelRequestContext
@@ -107,5 +112,11 @@ class DeduplicateFileReads(AbstractCapability[AgentDepsT]):
         if self.max_messages is not None or self.max_tokens is not None:
             if not exceeds(messages, self.max_messages, self.max_tokens, self.tokenizer):
                 return request_context
-        request_context.messages = await self.compact(messages, ctx)
+        request_context.messages = await compact_with_span(
+            ctx,
+            'DeduplicateFileReads',
+            messages,
+            lambda: self.compact(messages, ctx),
+            self.tokenizer,
+        )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_deduplicate_file_reads.py
+++ b/pydantic_ai_harness/experimental/compaction/_deduplicate_file_reads.py
@@ -114,9 +114,9 @@ class DeduplicateFileReads(AbstractCapability[AgentDepsT]):
                 return request_context
         request_context.messages = await compact_with_span(
             ctx,
-            'DeduplicateFileReads',
-            messages,
-            lambda: self.compact(messages, ctx),
-            self.tokenizer,
+            strategy='DeduplicateFileReads',
+            messages=messages,
+            compact=lambda: self.compact(messages, ctx),
+            tokenizer=self.tokenizer,
         )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_shared.py
+++ b/pydantic_ai_harness/experimental/compaction/_shared.py
@@ -125,7 +125,9 @@ def _history_changed(before: list[ModelMessage], after: list[ModelMessage]) -> b
     The same list object, or an equal-length list that compares equal element-wise, counts as
     unchanged; anything else is a change.
     """
-    return before is not after or before != after
+    # `!=` short-circuits on identity element-wise, so this also covers `before is after`; an
+    # unequal length already implies an unequal list, so a separate length check is redundant.
+    return before != after
 
 
 async def compact_with_span(

--- a/pydantic_ai_harness/experimental/compaction/_shared.py
+++ b/pydantic_ai_harness/experimental/compaction/_shared.py
@@ -6,7 +6,7 @@ preservation, and in-place tool-result clearing -- anything used by more than on
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from typing import Protocol
 
@@ -108,6 +108,49 @@ def exceeds(
     if max_tokens is not None and estimate_token_count(messages, tokenizer) > max_tokens:
         return True
     return False
+
+
+# ---------------------------------------------------------------------------
+# Tracing
+# ---------------------------------------------------------------------------
+
+_SPAN_NAME = 'compact_messages'
+"""Static, low-cardinality span name emitted whenever a strategy compacts. The strategy name
+goes in the `compaction.strategy` attribute rather than the span name to keep cardinality low."""
+
+
+async def compact_with_span(
+    ctx: RunContext[AgentDepsT],
+    strategy: str,
+    messages: list[ModelMessage],
+    compact: Callable[[], Awaitable[list[ModelMessage]]],
+    tokenizer: Callable[[str], int] | None = None,
+) -> list[ModelMessage]:
+    """Run *compact* inside a `compact_messages` span recording before/after metrics.
+
+    The span is emitted on `ctx.tracer`, which is a no-op tracer unless core's instrumentation
+    is active, so this adds no overhead to a non-instrumented run.
+
+    Args:
+        ctx: Run context whose `tracer` the span is started on.
+        strategy: Strategy name recorded in the `compaction.strategy` attribute.
+        messages: The pre-compaction messages, measured for the `*_before` attributes.
+        compact: Zero-argument async callable returning the compacted message list.
+        tokenizer: Optional tokenizer for the `compaction.tokens_*` estimates. When `None`,
+            uses the same ~4 characters-per-token heuristic as `estimate_token_count`.
+    """
+    with ctx.tracer.start_as_current_span(_SPAN_NAME) as span:
+        compacted = await compact()
+        span.set_attributes(
+            {
+                'compaction.strategy': strategy,
+                'compaction.messages_before': len(messages),
+                'compaction.messages_after': len(compacted),
+                'compaction.tokens_before': estimate_token_count(messages, tokenizer),
+                'compaction.tokens_after': estimate_token_count(compacted, tokenizer),
+            }
+        )
+        return compacted
 
 
 # ---------------------------------------------------------------------------

--- a/pydantic_ai_harness/experimental/compaction/_shared.py
+++ b/pydantic_ai_harness/experimental/compaction/_shared.py
@@ -119,6 +119,15 @@ _SPAN_NAME = 'compact_messages'
 goes in the `compaction.strategy` attribute rather than the span name to keep cardinality low."""
 
 
+def _history_changed(before: list[ModelMessage], after: list[ModelMessage]) -> bool:
+    """Return True if *after* differs from *before*.
+
+    The same list object, or an equal-length list that compares equal element-wise, counts as
+    unchanged; anything else is a change.
+    """
+    return before is not after and (len(before) != len(after) or before != after)
+
+
 async def compact_with_span(
     ctx: RunContext[AgentDepsT],
     strategy: str,
@@ -126,10 +135,12 @@ async def compact_with_span(
     compact: Callable[[], Awaitable[list[ModelMessage]]],
     tokenizer: Callable[[str], int] | None = None,
 ) -> list[ModelMessage]:
-    """Run *compact* inside a `compact_messages` span recording before/after metrics.
+    """Run *compact* and emit a `compact_messages` span when it changes the history.
 
-    The span is emitted on `ctx.tracer`, which is a no-op tracer unless core's instrumentation
-    is active, so this adds no overhead to a non-instrumented run.
+    *compact* runs before the span so a no-op compaction (a trigger fired but the history is
+    returned unchanged) emits nothing. The span is started on `ctx.tracer`, which is a no-op
+    tracer unless core's instrumentation is active, so this adds no overhead to a
+    non-instrumented run; the before/after attributes are only computed when the span records.
 
     Args:
         ctx: Run context whose `tracer` the span is started on.
@@ -139,18 +150,21 @@ async def compact_with_span(
         tokenizer: Optional tokenizer for the `compaction.tokens_*` estimates. When `None`,
             uses the same ~4 characters-per-token heuristic as `estimate_token_count`.
     """
-    with ctx.tracer.start_as_current_span(_SPAN_NAME) as span:
-        compacted = await compact()
-        span.set_attributes(
-            {
-                'compaction.strategy': strategy,
-                'compaction.messages_before': len(messages),
-                'compaction.messages_after': len(compacted),
-                'compaction.tokens_before': estimate_token_count(messages, tokenizer),
-                'compaction.tokens_after': estimate_token_count(compacted, tokenizer),
-            }
-        )
+    compacted = await compact()
+    if not _history_changed(messages, compacted):
         return compacted
+    with ctx.tracer.start_as_current_span(_SPAN_NAME) as span:
+        if span.is_recording():
+            span.set_attributes(
+                {
+                    'compaction.strategy': strategy,
+                    'compaction.messages_before': len(messages),
+                    'compaction.messages_after': len(compacted),
+                    'compaction.tokens_before': estimate_token_count(messages, tokenizer),
+                    'compaction.tokens_after': estimate_token_count(compacted, tokenizer),
+                }
+            )
+    return compacted
 
 
 # ---------------------------------------------------------------------------

--- a/pydantic_ai_harness/experimental/compaction/_shared.py
+++ b/pydantic_ai_harness/experimental/compaction/_shared.py
@@ -153,7 +153,7 @@ async def compact_with_span(
     """
     compacted = await compact()
     if not _history_changed(messages, compacted):
-        return compacted
+        return messages
     with ctx.tracer.start_as_current_span(_SPAN_NAME) as span:
         if span.is_recording():
             span.set_attributes(

--- a/pydantic_ai_harness/experimental/compaction/_shared.py
+++ b/pydantic_ai_harness/experimental/compaction/_shared.py
@@ -160,6 +160,8 @@ async def compact_with_span(
         if span.is_recording():
             span.set_attributes(
                 {
+                    # GenAI semconv flag; the convention says set `true` only, never `false`.
+                    'gen_ai.conversation.compacted': True,
                     'compaction.strategy': strategy,
                     'compaction.messages_before': len(messages),
                     'compaction.messages_after': len(compacted),

--- a/pydantic_ai_harness/experimental/compaction/_shared.py
+++ b/pydantic_ai_harness/experimental/compaction/_shared.py
@@ -125,7 +125,7 @@ def _history_changed(before: list[ModelMessage], after: list[ModelMessage]) -> b
     The same list object, or an equal-length list that compares equal element-wise, counts as
     unchanged; anything else is a change.
     """
-    return before is not after and (len(before) != len(after) or before != after)
+    return before is not after or before != after
 
 
 async def compact_with_span(

--- a/pydantic_ai_harness/experimental/compaction/_shared.py
+++ b/pydantic_ai_harness/experimental/compaction/_shared.py
@@ -130,6 +130,7 @@ def _history_changed(before: list[ModelMessage], after: list[ModelMessage]) -> b
 
 async def compact_with_span(
     ctx: RunContext[AgentDepsT],
+    *,
     strategy: str,
     messages: list[ModelMessage],
     compact: Callable[[], Awaitable[list[ModelMessage]]],

--- a/pydantic_ai_harness/experimental/compaction/_sliding_window.py
+++ b/pydantic_ai_harness/experimental/compaction/_sliding_window.py
@@ -12,6 +12,7 @@ from pydantic_ai.messages import ModelMessage
 from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness.experimental.compaction._shared import (
+    compact_with_span,
     exceeds,
     find_safe_cutoff,
     find_token_cutoff,
@@ -112,5 +113,11 @@ class SlidingWindow(AbstractCapability[AgentDepsT]):
         messages: list[ModelMessage] = list(request_context.messages)
         if not exceeds(messages, self.max_messages, self.max_tokens, self.tokenizer):
             return request_context
-        request_context.messages = await self.compact(messages, ctx)
+        request_context.messages = await compact_with_span(
+            ctx,
+            'SlidingWindow',
+            messages,
+            lambda: self.compact(messages, ctx),
+            self.tokenizer,
+        )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_sliding_window.py
+++ b/pydantic_ai_harness/experimental/compaction/_sliding_window.py
@@ -115,9 +115,9 @@ class SlidingWindow(AbstractCapability[AgentDepsT]):
             return request_context
         request_context.messages = await compact_with_span(
             ctx,
-            'SlidingWindow',
-            messages,
-            lambda: self.compact(messages, ctx),
-            self.tokenizer,
+            strategy='SlidingWindow',
+            messages=messages,
+            compact=lambda: self.compact(messages, ctx),
+            tokenizer=self.tokenizer,
         )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/experimental/compaction/_summarizing_compaction.py
@@ -21,6 +21,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness.experimental.compaction._shared import (
+    compact_with_span,
     exceeds,
     find_first_user_message,
     find_safe_cutoff,
@@ -259,7 +260,13 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
         messages: list[ModelMessage] = list(request_context.messages)
         if not exceeds(messages, self.max_messages, self.max_tokens, self.tokenizer):
             return request_context
-        request_context.messages = await self.compact(messages, ctx)
+        request_context.messages = await compact_with_span(
+            ctx,
+            'SummarizingCompaction',
+            messages,
+            lambda: self.compact(messages, ctx),
+            self.tokenizer,
+        )
         return request_context
 
     async def _summarize(

--- a/pydantic_ai_harness/experimental/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/experimental/compaction/_summarizing_compaction.py
@@ -262,10 +262,10 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
             return request_context
         request_context.messages = await compact_with_span(
             ctx,
-            'SummarizingCompaction',
-            messages,
-            lambda: self.compact(messages, ctx),
-            self.tokenizer,
+            strategy='SummarizingCompaction',
+            messages=messages,
+            compact=lambda: self.compact(messages, ctx),
+            tokenizer=self.tokenizer,
         )
         return request_context
 

--- a/pydantic_ai_harness/experimental/compaction/_tiered_compaction.py
+++ b/pydantic_ai_harness/experimental/compaction/_tiered_compaction.py
@@ -11,7 +11,11 @@ from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.messages import ModelMessage
 from pydantic_ai.tools import RunContext
 
-from pydantic_ai_harness.experimental.compaction._shared import CompactionStrategy, estimate_token_count
+from pydantic_ai_harness.experimental.compaction._shared import (
+    CompactionStrategy,
+    compact_with_span,
+    estimate_token_count,
+)
 
 if TYPE_CHECKING:
     from pydantic_ai.models import ModelRequestContext
@@ -91,5 +95,11 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
         messages: list[ModelMessage] = list(request_context.messages)
         if estimate_token_count(messages, self.tokenizer) <= self.target_tokens:
             return request_context
-        request_context.messages = await self.compact(messages, ctx)
+        request_context.messages = await compact_with_span(
+            ctx,
+            'TieredCompaction',
+            messages,
+            lambda: self.compact(messages, ctx),
+            self.tokenizer,
+        )
         return request_context

--- a/pydantic_ai_harness/experimental/compaction/_tiered_compaction.py
+++ b/pydantic_ai_harness/experimental/compaction/_tiered_compaction.py
@@ -97,9 +97,9 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
             return request_context
         request_context.messages = await compact_with_span(
             ctx,
-            'TieredCompaction',
-            messages,
-            lambda: self.compact(messages, ctx),
-            self.tokenizer,
+            strategy='TieredCompaction',
+            messages=messages,
+            compact=lambda: self.compact(messages, ctx),
+            tokenizer=self.tokenizer,
         )
         return request_context

--- a/tests/experimental/compaction/test_compaction.py
+++ b/tests/experimental/compaction/test_compaction.py
@@ -2140,6 +2140,7 @@ class TestCompactionSpan:
         # reporting integers.
         assert len(spans) == 1
         attrs = spans[0]['attributes']
+        assert attrs['gen_ai.conversation.compacted'] is True
         assert attrs['compaction.strategy'] == 'SlidingWindow'
         assert attrs['compaction.messages_before'] > attrs['compaction.messages_after']
         assert attrs['compaction.tokens_before'] > attrs['compaction.tokens_after']
@@ -2359,6 +2360,7 @@ class TestCompactWithSpan:
         spans = _compact_spans(capfire)
         assert len(spans) == 1
         attrs = spans[0]['attributes']
+        assert attrs['gen_ai.conversation.compacted'] is True
         assert attrs['compaction.strategy'] == 'Strat'
         assert attrs['compaction.messages_before'] == 2
         assert attrs['compaction.messages_after'] == 1

--- a/tests/experimental/compaction/test_compaction.py
+++ b/tests/experimental/compaction/test_compaction.py
@@ -2318,7 +2318,7 @@ class TestCompactWithSpan:
         async def _compact() -> list[ModelMessage]:
             return messages
 
-        result = await compact_with_span(_make_ctx(), 'Strat', messages, _compact)
+        result = await compact_with_span(_make_ctx(), strategy='Strat', messages=messages, compact=_compact)
         assert result is messages
 
     @pytest.mark.anyio
@@ -2330,7 +2330,7 @@ class TestCompactWithSpan:
         async def _compact() -> list[ModelMessage]:
             return after
 
-        result = await compact_with_span(_make_ctx_with_tracer(), 'Strat', before, _compact)
+        result = await compact_with_span(_make_ctx_with_tracer(), strategy='Strat', messages=before, compact=_compact)
         assert result is after
 
         spans = _compact_spans(capfire)
@@ -2355,6 +2355,8 @@ class TestCompactWithSpan:
         async def _compact() -> list[ModelMessage]:
             return after
 
-        result = await compact_with_span(_make_ctx(), 'Strat', before, _compact, _tokenizer)
+        result = await compact_with_span(
+            _make_ctx(), strategy='Strat', messages=before, compact=_compact, tokenizer=_tokenizer
+        )
         assert result is after
         assert called is False

--- a/tests/experimental/compaction/test_compaction.py
+++ b/tests/experimental/compaction/test_compaction.py
@@ -18,7 +18,8 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness.experimental.compaction import (
@@ -72,16 +73,12 @@ def _make_ctx(
 ) -> Any:
     """Build a minimal RunContext-like object for testing hooks."""
 
-    @dataclasses.dataclass
-    class _FakeModel:
-        model_id: str = 'test-model'
-
     usage = RunUsage(requests=requests, input_tokens=input_tokens, output_tokens=output_tokens)
 
     @dataclasses.dataclass
     class _FakeCtx:
         usage: RunUsage
-        model: Any = dataclasses.field(default_factory=_FakeModel)
+        model: Model = dataclasses.field(default_factory=TestModel)
         deps: None = None
         tracer: Tracer = dataclasses.field(default_factory=NoOpTracer)
 

--- a/tests/experimental/compaction/test_compaction.py
+++ b/tests/experimental/compaction/test_compaction.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from opentelemetry.trace import NoOpTracer
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -49,6 +50,13 @@ from pydantic_ai_harness.experimental.compaction._summarizing_compaction import 
     _format_messages,
 )
 
+try:
+    from logfire.testing import CaptureLogfire
+
+    logfire_installed = True
+except ImportError:  # pragma: no cover
+    logfire_installed = False
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -73,6 +81,7 @@ def _make_ctx(
         usage: RunUsage
         model: Any = dataclasses.field(default_factory=_FakeModel)
         deps: None = None
+        tracer: Any = dataclasses.field(default_factory=NoOpTracer)
 
     return _FakeCtx(usage=usage)
 
@@ -2075,3 +2084,162 @@ class TestSummarizingCompactionPreserveBranches:
             1 for m in result.messages if isinstance(m, ModelRequest) for p in m.parts if isinstance(p, UserPromptPart)
         )
         assert user_count == 1
+
+
+# ---------------------------------------------------------------------------
+# OTel / Logfire instrumentation: the `compact_messages` span
+# ---------------------------------------------------------------------------
+
+
+def _compact_spans(capfire: CaptureLogfire) -> list[dict[str, Any]]:
+    """Return only the `compact_messages` spans, which this package controls.
+
+    Core's own instrumentation span and attribute names have changed across pydantic-ai
+    versions, so the assertions here stay on the spans and attributes this package emits.
+    """
+    return [s for s in capfire.exporter.exported_spans_as_dict() if s['name'] == 'compact_messages']
+
+
+def _make_ctx_with_tracer() -> Any:
+    """A fake RunContext whose `tracer` exports to the active `CaptureLogfire` provider.
+
+    The `capfire` fixture configures the global OTel provider, so a tracer fetched from it
+    captures the `compact_messages` span without needing a full instrumented `Agent` run.
+    """
+    from opentelemetry.trace import get_tracer
+
+    ctx = _make_ctx()
+    ctx.tracer = get_tracer('test')
+    return ctx
+
+
+@pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+class TestCompactionSpan:
+    @pytest.fixture
+    def anyio_backend(self) -> str:
+        # A full agent.run only needs the asyncio backend; trio hits a TestModel
+        # event-loop quirk in core unrelated to compaction.
+        return 'asyncio'
+
+    @pytest.mark.anyio
+    async def test_span_emitted_when_threshold_exceeded(self, capfire: CaptureLogfire) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.instrumented import InstrumentationSettings
+        from pydantic_ai.models.test import TestModel
+
+        agent: Agent[None, str] = Agent(
+            TestModel(),
+            capabilities=[SlidingWindow(max_tokens=1, keep_messages=1)],
+        )
+        agent.instrument = InstrumentationSettings()
+        await agent.run('a reasonably long prompt that exceeds one token')
+
+        spans = _compact_spans(capfire)
+        assert len(spans) >= 1
+        attrs = spans[0]['attributes']
+        assert attrs['compaction.strategy'] == 'SlidingWindow'
+        assert isinstance(attrs['compaction.messages_before'], int)
+        assert isinstance(attrs['compaction.messages_after'], int)
+        assert isinstance(attrs['compaction.tokens_before'], int)
+        assert isinstance(attrs['compaction.tokens_after'], int)
+
+    @pytest.mark.anyio
+    async def test_no_span_when_threshold_not_exceeded(self, capfire: CaptureLogfire) -> None:
+        from pydantic_ai import Agent
+        from pydantic_ai.models.instrumented import InstrumentationSettings
+        from pydantic_ai.models.test import TestModel
+
+        agent: Agent[None, str] = Agent(
+            TestModel(),
+            capabilities=[SlidingWindow(max_tokens=1_000_000, keep_messages=1)],
+        )
+        agent.instrument = InstrumentationSettings()
+        await agent.run('short prompt')
+
+        assert _compact_spans(capfire) == []
+
+    @pytest.mark.anyio
+    async def test_summarizing_compaction_emits_span(self, capfire: CaptureLogfire) -> None:
+        comp = SummarizingCompaction(model='test:m', max_messages=2, keep_messages=1, incremental=False)
+        messages: list[ModelMessage] = [_user('first'), _assistant('a'), _user('b'), _assistant('c')]
+        rc = _make_request_context(messages)
+        ctx = _make_ctx_with_tracer()
+
+        mock_result = AsyncMock()
+        mock_result.output = 'Summary.'
+        with patch('pydantic_ai.Agent') as MockAgent:
+            mock_agent_instance = AsyncMock()
+            mock_agent_instance.run.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+            await comp.before_model_request(ctx, rc)
+
+        spans = _compact_spans(capfire)
+        assert len(spans) == 1
+        assert spans[0]['attributes']['compaction.strategy'] == 'SummarizingCompaction'
+
+    @pytest.mark.anyio
+    async def test_clamp_emits_span_only_when_a_part_is_clamped(self, capfire: CaptureLogfire) -> None:
+        comp = ClampOversizedMessages(max_part_chars=4, keep_head_chars=1, keep_tail_chars=1)
+
+        not_oversized: list[ModelMessage] = [_assistant('ab')]
+        await comp.before_model_request(_make_ctx_with_tracer(), _make_request_context(not_oversized))
+        assert _compact_spans(capfire) == []
+
+        oversized: list[ModelMessage] = [_assistant('a' * 50)]
+        await comp.before_model_request(_make_ctx_with_tracer(), _make_request_context(oversized))
+        spans = _compact_spans(capfire)
+        assert len(spans) == 1
+        assert spans[0]['attributes']['compaction.strategy'] == 'ClampOversizedMessages'
+
+    @pytest.mark.anyio
+    async def test_clamp_emits_span_for_oversized_tool_call_args(self, capfire: CaptureLogfire) -> None:
+        comp = ClampOversizedMessages(max_part_chars=4, keep_head_chars=1, keep_tail_chars=1, clamp_tool_call_args=True)
+        messages: list[ModelMessage] = [
+            ModelResponse(parts=[ToolCallPart(tool_name='fn', args={'q': 'x' * 50}, tool_call_id='tc1')])
+        ]
+        await comp.before_model_request(_make_ctx_with_tracer(), _make_request_context(messages))
+
+        spans = _compact_spans(capfire)
+        assert len(spans) == 1
+        assert spans[0]['attributes']['compaction.strategy'] == 'ClampOversizedMessages'
+
+    @pytest.mark.anyio
+    async def test_clamp_no_span_for_non_oversized_or_skipped_parts(self, capfire: CaptureLogfire) -> None:
+        from pydantic_ai.messages import ThinkingPart
+
+        comp = ClampOversizedMessages(max_part_chars=1_000, clamp_tool_call_args=True)
+        # A small tool call (not oversized) and a thinking part (not a clamp target) both
+        # leave `_would_clamp` falling through without emitting a span.
+        messages: list[ModelMessage] = [
+            ModelResponse(
+                parts=[
+                    ToolCallPart(tool_name='fn', args={'q': 'x'}, tool_call_id='tc1'),
+                    ThinkingPart(content='thinking'),
+                ]
+            )
+        ]
+        await comp.before_model_request(_make_ctx_with_tracer(), _make_request_context(messages))
+
+        assert _compact_spans(capfire) == []
+
+    @pytest.mark.anyio
+    async def test_tiered_emits_single_span_not_one_per_tier(self, capfire: CaptureLogfire) -> None:
+        comp: TieredCompaction[None] = TieredCompaction(
+            tiers=[
+                ClearToolResults(max_tokens=1, keep_pairs=0),
+                SlidingWindow(max_tokens=1, keep_messages=1),
+            ],
+            target_tokens=1,
+        )
+        messages: list[ModelMessage] = [
+            _user('first'),
+            _tool_call('fn', 'tc1'),
+            _tool_return('fn', 'tc1', 'a long tool result that takes up space'),
+            _assistant('done'),
+        ]
+        await comp.before_model_request(_make_ctx_with_tracer(), _make_request_context(messages))
+
+        spans = _compact_spans(capfire)
+        # The orchestrator drives each tier's `compact` directly, so only one span is emitted.
+        assert len(spans) == 1
+        assert spans[0]['attributes']['compaction.strategy'] == 'TieredCompaction'

--- a/tests/experimental/compaction/test_compaction.py
+++ b/tests/experimental/compaction/test_compaction.py
@@ -7,7 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from opentelemetry.trace import NoOpTracer
+from opentelemetry.trace import NoOpTracer, Tracer
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -83,7 +83,7 @@ def _make_ctx(
         usage: RunUsage
         model: Any = dataclasses.field(default_factory=_FakeModel)
         deps: None = None
-        tracer: Any = dataclasses.field(default_factory=NoOpTracer)
+        tracer: Tracer = dataclasses.field(default_factory=NoOpTracer)
 
     return _FakeCtx(usage=usage)
 

--- a/tests/experimental/compaction/test_compaction.py
+++ b/tests/experimental/compaction/test_compaction.py
@@ -2138,13 +2138,14 @@ class TestCompactionSpan:
         await agent.run('a reasonably long prompt that exceeds one token', message_history=history)
 
         spans = _compact_spans(capfire)
-        assert len(spans) >= 1
+        # Exactly one compaction runs (TestModel makes a single request); `== 1` also guards against
+        # double-emission, and the `>` checks assert the window actually shrank rather than just
+        # reporting integers.
+        assert len(spans) == 1
         attrs = spans[0]['attributes']
         assert attrs['compaction.strategy'] == 'SlidingWindow'
-        assert isinstance(attrs['compaction.messages_before'], int)
-        assert isinstance(attrs['compaction.messages_after'], int)
-        assert isinstance(attrs['compaction.tokens_before'], int)
-        assert isinstance(attrs['compaction.tokens_after'], int)
+        assert attrs['compaction.messages_before'] > attrs['compaction.messages_after']
+        assert attrs['compaction.tokens_before'] > attrs['compaction.tokens_after']
 
     @pytest.mark.anyio
     async def test_no_span_when_threshold_not_exceeded(self, capfire: CaptureLogfire) -> None:
@@ -2211,8 +2212,6 @@ class TestCompactionSpan:
         from pydantic_ai.messages import ThinkingPart
 
         comp = ClampOversizedMessages(max_part_chars=1_000, clamp_tool_call_args=True)
-        # A small tool call (not oversized) and a thinking part (not a clamp target) both
-        # leave `_would_clamp` falling through without emitting a span.
         messages: list[ModelMessage] = [
             ModelResponse(
                 parts=[
@@ -2277,6 +2276,23 @@ class TestCompactionSpan:
         assert len(spans) == 1
         assert spans[0]['attributes']['compaction.strategy'] == 'DeduplicateFileReads'
 
+    @pytest.mark.anyio
+    async def test_clear_tool_results_emits_span(self, capfire: CaptureLogfire) -> None:
+        # ClearToolResults is otherwise only exercised inside TieredCompaction, which reports the
+        # orchestrator's name -- so this is the only check on its own `strategy` literal.
+        comp = ClearToolResults(max_tokens=1, keep_pairs=0)
+        messages: list[ModelMessage] = [
+            _user('first'),
+            _tool_call('fn', 'tc1'),
+            _tool_return('fn', 'tc1', 'a long tool result that takes up space'),
+            _assistant('done'),
+        ]
+        await comp.before_model_request(_make_ctx_with_tracer(), _make_request_context(messages))
+
+        spans = _compact_spans(capfire)
+        assert len(spans) == 1
+        assert spans[0]['attributes']['compaction.strategy'] == 'ClearToolResults'
+
 
 # ---------------------------------------------------------------------------
 # compact_with_span helper internals
@@ -2324,13 +2340,23 @@ class TestCompactWithSpan:
     @pytest.mark.anyio
     @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
     async def test_recording_span_sets_attributes(self, capfire: CaptureLogfire) -> None:
-        before: list[ModelMessage] = [_user('a'), _user('b')]
-        after: list[ModelMessage] = [_user('a')]
+        # Distinct text lengths plus a character-counting tokenizer pin the exact attribute values.
+        # A before/after swap, computing both token counts from one list, or ignoring the strategy
+        # tokenizer would each change a number this test checks.
+        before: list[ModelMessage] = [_user('aaaa'), _user('bb')]
+        after: list[ModelMessage] = [_user('aaaa')]
+        seen: list[str] = []
+
+        def _tokenizer(text: str) -> int:
+            seen.append(text)
+            return len(text)
 
         async def _compact() -> list[ModelMessage]:
             return after
 
-        result = await compact_with_span(_make_ctx_with_tracer(), strategy='Strat', messages=before, compact=_compact)
+        result = await compact_with_span(
+            _make_ctx_with_tracer(), strategy='Strat', messages=before, compact=_compact, tokenizer=_tokenizer
+        )
         assert result is after
 
         spans = _compact_spans(capfire)
@@ -2339,6 +2365,11 @@ class TestCompactWithSpan:
         assert attrs['compaction.strategy'] == 'Strat'
         assert attrs['compaction.messages_before'] == 2
         assert attrs['compaction.messages_after'] == 1
+        # tokenizer counts characters: before = len('aaaa') + len('bb') = 6, after = len('aaaa') = 4.
+        assert attrs['compaction.tokens_before'] == 6
+        assert attrs['compaction.tokens_after'] == 4
+        assert attrs['compaction.tokens_before'] > attrs['compaction.tokens_after']
+        assert seen  # the strategy tokenizer reached the span attributes, not the default heuristic
 
     @pytest.mark.anyio
     async def test_non_recording_tracer_skips_attributes(self):

--- a/tests/experimental/compaction/test_compaction.py
+++ b/tests/experimental/compaction/test_compaction.py
@@ -36,7 +36,9 @@ from pydantic_ai_harness.experimental.compaction._clamp_oversized_messages impor
     _CLAMP_MARKER,
 )
 from pydantic_ai_harness.experimental.compaction._shared import (
+    _history_changed,
     _is_safe_cutoff,
+    compact_with_span,
     find_first_user_message,
     find_safe_cutoff,
     find_token_cutoff,
@@ -2132,7 +2134,8 @@ class TestCompactionSpan:
             capabilities=[SlidingWindow(max_tokens=1, keep_messages=1)],
         )
         agent.instrument = InstrumentationSettings()
-        await agent.run('a reasonably long prompt that exceeds one token')
+        history: list[ModelMessage] = [_user('first'), _assistant('a'), _user('second'), _assistant('b')]
+        await agent.run('a reasonably long prompt that exceeds one token', message_history=history)
 
         spans = _compact_spans(capfire)
         assert len(spans) >= 1
@@ -2243,3 +2246,115 @@ class TestCompactionSpan:
         # The orchestrator drives each tier's `compact` directly, so only one span is emitted.
         assert len(spans) == 1
         assert spans[0]['attributes']['compaction.strategy'] == 'TieredCompaction'
+
+    @pytest.mark.anyio
+    async def test_no_span_when_compaction_is_noop(self, capfire: CaptureLogfire) -> None:
+        # DeduplicateFileReads has no threshold, so its trigger always fires, but with no
+        # superseded reads `compact` returns the history unchanged and no span should be emitted.
+        comp = DeduplicateFileReads(file_key=_file_key)
+        messages: list[ModelMessage] = [
+            _read_call('tc1', 'a.py'),
+            _read_return('tc1', 'a body'),
+            _read_call('tc2', 'b.py'),
+            _read_return('tc2', 'b body'),
+        ]
+        await comp.before_model_request(_make_ctx_with_tracer(), _make_request_context(messages))
+
+        assert _compact_spans(capfire) == []
+
+    @pytest.mark.anyio
+    async def test_span_emitted_when_dedup_changes_history(self, capfire: CaptureLogfire) -> None:
+        comp = DeduplicateFileReads(file_key=_file_key)
+        messages: list[ModelMessage] = [
+            _read_call('tc1', 'a.py'),
+            _read_return('tc1', 'first'),
+            _read_call('tc2', 'a.py'),
+            _read_return('tc2', 'second'),
+        ]
+        await comp.before_model_request(_make_ctx_with_tracer(), _make_request_context(messages))
+
+        spans = _compact_spans(capfire)
+        assert len(spans) == 1
+        assert spans[0]['attributes']['compaction.strategy'] == 'DeduplicateFileReads'
+
+
+# ---------------------------------------------------------------------------
+# compact_with_span helper internals
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryChanged:
+    def test_same_object_is_unchanged(self):
+        msgs: list[ModelMessage] = [_user('a')]
+        assert _history_changed(msgs, msgs) is False
+
+    def test_different_length_is_changed(self):
+        before: list[ModelMessage] = [_user('a')]
+        after: list[ModelMessage] = [_user('a'), _user('b')]
+        assert _history_changed(before, after) is True
+
+    def test_same_length_equal_is_unchanged(self):
+        # Distinct list objects holding equal elements compares unchanged. A shared message
+        # object avoids the per-message timestamp that would otherwise break equality.
+        shared = _user('a')
+        before: list[ModelMessage] = [shared]
+        after: list[ModelMessage] = [shared]
+        assert before is not after
+        assert _history_changed(before, after) is False
+
+    def test_same_length_unequal_is_changed(self):
+        before: list[ModelMessage] = [_user('a')]
+        after: list[ModelMessage] = [_user('b')]
+        assert _history_changed(before, after) is True
+
+
+class TestCompactWithSpan:
+    @pytest.mark.anyio
+    async def test_no_op_returns_without_starting_span(self):
+        # A NoOpTracer would never record anyway; this guards that `compact` runs and the
+        # unchanged result is returned without attempting to start a span.
+        messages: list[ModelMessage] = [_user('a')]
+
+        async def _compact() -> list[ModelMessage]:
+            return messages
+
+        result = await compact_with_span(_make_ctx(), 'Strat', messages, _compact)
+        assert result is messages
+
+    @pytest.mark.anyio
+    @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
+    async def test_recording_span_sets_attributes(self, capfire: CaptureLogfire) -> None:
+        before: list[ModelMessage] = [_user('a'), _user('b')]
+        after: list[ModelMessage] = [_user('a')]
+
+        async def _compact() -> list[ModelMessage]:
+            return after
+
+        result = await compact_with_span(_make_ctx_with_tracer(), 'Strat', before, _compact)
+        assert result is after
+
+        spans = _compact_spans(capfire)
+        assert len(spans) == 1
+        attrs = spans[0]['attributes']
+        assert attrs['compaction.strategy'] == 'Strat'
+        assert attrs['compaction.messages_before'] == 2
+        assert attrs['compaction.messages_after'] == 1
+
+    @pytest.mark.anyio
+    async def test_non_recording_tracer_skips_attributes(self):
+        # A no-op tracer returns a non-recording span, so attribute computation is skipped.
+        before: list[ModelMessage] = [_user('a'), _user('b')]
+        after: list[ModelMessage] = [_user('a')]
+        called = False
+
+        def _tokenizer(_text: str) -> int:  # pragma: no cover - asserted never called
+            nonlocal called
+            called = True
+            return 1
+
+        async def _compact() -> list[ModelMessage]:
+            return after
+
+        result = await compact_with_span(_make_ctx(), 'Strat', before, _compact, _tokenizer)
+        assert result is after
+        assert called is False


### PR DESCRIPTION
## Summary

The compaction strategies in `pydantic_ai_harness/experimental/compaction/` now emit an OpenTelemetry span named `compact_messages` whenever compaction runs.

The span carries these attributes:

- `compaction.strategy` -- the strategy that ran
- `compaction.messages_before` -- message count before compaction
- `compaction.messages_after` -- message count after compaction
- `compaction.tokens_before` -- token count before compaction
- `compaction.tokens_after` -- token count after compaction

When instrumentation is disabled the span emission is a no-op, so there is no behavior change for callers that do not configure tracing.

Tests cover the new span and its attributes at 100% branch coverage. The compaction README gains a "Tracing" subsection documenting the span name and attributes.

Slack thread: https://pydantic.slack.com/archives/C081LUCJ4KX/p1782749877395839?thread_ts=1782718531.844739&cid=C081LUCJ4KX

## Linked Issue

Fixes #

## Checklist

- [ ] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)

---
_Generated by [Claude Code](https://claude.ai/code/session_015kRjwKq2AmcuWZcDfJ4WHs)_