### PR TITLE
docs(agents): discourage private-helper imports in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,6 +138,14 @@ need.
 - Prefer tests through `Agent(..., capabilities=[...])` when that is the public
   behavior. Use direct `Toolset`/`RunContext` tests for lower-level lifecycle,
   schema, retry, or wrapper behavior that is hard to isolate through `Agent`.
+- Don't import private (`_`-prefixed) helpers into tests. Exercise them through
+  the capability's public surface so tests survive internal refactors: drive the
+  behavior through `Agent(..., capabilities=[...])`, or import the public class
+  re-exported from the capability package's `__init__.py` (e.g.
+  `from pydantic_ai_harness.filesystem import FileSystemToolset`, not
+  `from pydantic_ai_harness.filesystem._toolset import _content_hash`). When a
+  branch is only reachable by calling a private helper directly, mark it
+  `# pragma: no cover` rather than reaching into the helper from a test.
 
 ## Contributing rules for AICAs
 


### PR DESCRIPTION
Adds one testing convention to `AGENTS.md` (which `CLAUDE.md` symlinks to), modeled on pydantic/platform#25340.

That PR added two conventions: avoid `typing.cast`/`typing.Any`, and don't import private (`_`-prefixed) functions into tests. The first is already covered by this repo's Coding standards (`no Any types`, `no typecasting … use type narrowing instead`), so this PR ports only the second.

The rule is rephrased entirely in harness terms -- it does not reference any platform primitives (FastAPI/HTTPX, ARQ tasks, DAOs). Instead it points at the public surface this repo actually exposes:

- drive behavior through `Agent(..., capabilities=[...])`
- import the public class re-exported from the capability package's `__init__.py` (e.g. `from pydantic_ai_harness.filesystem import FileSystemToolset`, not `…filesystem._toolset import _content_hash`)
- mark branches no entrypoint can reach with `# pragma: no cover` rather than reaching into the private helper

It sits alongside the existing `Agent` vs direct `Toolset`/`RunContext` testing bullet and follows the repo writing style.

Docs-only.

## AI Disclaimer

This PR was developed with the assistance of Claude. I've reviewed and verified the changes.