### PR TITLE
Require explicit `CodeMode` final output wrapper

### DIFF
--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -150,6 +150,12 @@ The last expression in the code snippet is automatically captured as the return 
 | With print output | `{"output": "<printed text>", "result": <last expression>}` |
 | Multimodal content (e.g. images) | Returned natively for model processing |
 
+If the captured value is valid for the agent's output schema, `CodeMode` commits it as the final
+output immediately. The `run_code` tool return still appears in message history, but there is no
+extra model turn whose only job is to restate the same value. When printed output is present,
+`CodeMode` validates the `result` value from the `{"output": ..., "result": ...}` wrapper.
+Invalid or intermediate values continue through the normal next-model-turn flow.
+
 ## REPL state
 
 State persists between `run_code` calls within the same agent run -- variables, imports, and function definitions carry over. Pass `restart: true` in the tool call to reset state.

--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -150,11 +150,14 @@ The last expression in the code snippet is automatically captured as the return 
 | With print output | `{"output": "<printed text>", "result": <last expression>}` |
 | Multimodal content (e.g. images) | Returned natively for model processing |
 
-If the captured value is valid for the agent's output schema, `CodeMode` commits it as the final
-output immediately. The `run_code` tool return still appears in message history, but there is no
-extra model turn whose only job is to restate the same value. When printed output is present,
-`CodeMode` validates the `result` value from the `{"output": ..., "result": ...}` wrapper.
-Invalid or intermediate values continue through the normal next-model-turn flow.
+To commit a value as the agent's final output immediately, make the last expression exactly
+`{"final_output": <value>}`. The `run_code` tool return still appears in message history, but
+there is no extra model turn whose only job is to restate the same value. When printed output is
+present, `CodeMode` looks for that exact wrapper in the `result` value from
+`{"output": ..., "result": ...}`.
+
+Ordinary return values, even when they happen to match the agent's output schema, continue through
+the normal next-model-turn flow so the model can inspect them before deciding whether to finish.
 
 ## REPL state
 

--- a/pydantic_ai_harness/code_mode/_capability.py
+++ b/pydantic_ai_harness/code_mode/_capability.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass, field, replace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic import TypeAdapter, ValidationError
 from pydantic_ai import AbstractToolset
 from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
 from pydantic_ai.capabilities._tool_search import ToolSearch as _ToolSearch
-from pydantic_ai.messages import ModelResponse, NativeToolSearchReturnPart, SystemPromptPart
+from pydantic_ai.messages import ModelResponse, NativeToolSearchReturnPart, SystemPromptPart, ToolReturn
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition, ToolSelector
+from pydantic_graph import End
 from typing_extensions import TypedDict
 
 from pydantic_ai_harness.code_mode._toolset import CodeModeMount, CodeModeOS, CodeModeToolset
@@ -26,6 +27,8 @@ _DISCOVERY_ANNOUNCEMENT_PREFIX = (
     'New functions are now available inside `run_code`. Their signatures have been '
     'added to the available-functions catalog in the system prompt'
 )
+_RUN_CODE_TOOL_NAME = 'run_code'
+_NO_FINAL_OUTPUT_CANDIDATE = object()
 
 
 @dataclass
@@ -120,15 +123,14 @@ class CodeMode(AbstractCapability[AgentDepsT]):
     """
 
     _announced_tools: set[str] = field(default_factory=set[str], init=False, repr=False)
+    _final_output_candidate: object = field(default=_NO_FINAL_OUTPUT_CANDIDATE, init=False, repr=False)
 
     def get_ordering(self) -> CapabilityOrdering:
         """CodeMode wraps around ToolSearch so that search_tools stays native."""
         return CapabilityOrdering(position='outermost', wraps=[_ToolSearch])
 
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> CodeMode[AgentDepsT]:
-        """Return a fresh instance so concurrent runs don't share `_announced_tools`."""
-        if not self.dynamic_catalog:
-            return self
+        """Return a fresh instance so concurrent runs don't share hook state."""
         return replace(self)
 
     def get_wrapper_toolset(self, toolset: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT] | None:
@@ -158,9 +160,21 @@ class CodeMode(AbstractCapability[AgentDepsT]):
         (server-side search emits a `NativeToolSearchReturnPart` rather than a regular tool
         execute result).
         """
-        if self.dynamic_catalog and tool_def.tool_kind == 'tool-search':
+        if call.tool_name == _RUN_CODE_TOOL_NAME:
+            self._final_output_candidate = _code_mode_result_candidate(result)
+        elif self.dynamic_catalog and tool_def.tool_kind == 'tool-search':
             self._announce_newly_discovered(ctx, _extract_discovered_names(result))
         return result
+
+    async def after_node_run(self, ctx: RunContext[AgentDepsT], *, node: Any, result: Any) -> Any:
+        """Commit a valid `run_code` result as final output without another model turn."""
+        if self._final_output_candidate is _NO_FINAL_OUTPUT_CANDIDATE or isinstance(result, End):
+            return cast(object, result)
+
+        candidate = self._final_output_candidate
+        self._final_output_candidate = _NO_FINAL_OUTPUT_CANDIDATE
+        committed: object | None = await ctx.output.try_commit_candidate(candidate, result=result)
+        return committed if committed is not None else result
 
     async def after_model_request(
         self,
@@ -204,8 +218,16 @@ class _DiscoveredEntry(TypedDict):
     name: str
 
 
+class _RunCodeResultWrapper(TypedDict):
+    """Structured `run_code` return when stdout is also present."""
+
+    output: object
+    result: object
+
+
 _CATALOG_ADAPTER = TypeAdapter(_DiscoveredCatalog)
 _ENTRY_ADAPTER = TypeAdapter(_DiscoveredEntry)
+_RUN_CODE_RESULT_ADAPTER = TypeAdapter(_RunCodeResultWrapper)
 
 
 def _extract_discovered_names(content: object) -> list[str]:
@@ -227,3 +249,18 @@ def _extract_discovered_names(content: object) -> list[str]:
         except ValidationError:
             continue
     return names
+
+
+def _code_mode_result_candidate(result: object) -> object:
+    """Extract the user-script result from a `run_code` tool result."""
+    candidate: object
+    if isinstance(result, ToolReturn):
+        candidate = cast(object, result.return_value)
+    else:
+        candidate = result
+
+    if isinstance(candidate, dict):
+        candidate_dict = cast(dict[object, object], candidate)
+        if len(candidate_dict) == 2 and 'output' in candidate_dict and 'result' in candidate_dict:
+            return _RUN_CODE_RESULT_ADAPTER.validate_python(candidate_dict)['result']
+    return cast(object, candidate)

--- a/pydantic_ai_harness/code_mode/_capability.py
+++ b/pydantic_ai_harness/code_mode/_capability.py
@@ -28,6 +28,7 @@ _DISCOVERY_ANNOUNCEMENT_PREFIX = (
     'added to the available-functions catalog in the system prompt'
 )
 _RUN_CODE_TOOL_NAME = 'run_code'
+_FINAL_OUTPUT_KEY = 'final_output'
 _NO_FINAL_OUTPUT_CANDIDATE = object()
 
 
@@ -252,7 +253,7 @@ def _extract_discovered_names(content: object) -> list[str]:
 
 
 def _code_mode_result_candidate(result: object) -> object:
-    """Extract the user-script result from a `run_code` tool result."""
+    """Extract an explicit final-output candidate from a `run_code` tool result."""
     candidate: object
     if isinstance(result, ToolReturn):
         candidate = cast(object, result.return_value)
@@ -262,5 +263,11 @@ def _code_mode_result_candidate(result: object) -> object:
     if isinstance(candidate, dict):
         candidate_dict = cast(dict[object, object], candidate)
         if len(candidate_dict) == 2 and 'output' in candidate_dict and 'result' in candidate_dict:
-            return _RUN_CODE_RESULT_ADAPTER.validate_python(candidate_dict)['result']
-    return cast(object, candidate)
+            candidate = _RUN_CODE_RESULT_ADAPTER.validate_python(candidate_dict)['result']
+
+    if isinstance(candidate, dict):
+        candidate_dict = cast(dict[object, object], candidate)
+        if len(candidate_dict) == 1 and _FINAL_OUTPUT_KEY in candidate_dict:
+            return candidate_dict[_FINAL_OUTPUT_KEY]
+
+    return _NO_FINAL_OUTPUT_CANDIDATE

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -129,7 +129,11 @@ The last expression's value is automatically captured as the return value -- you
 structured data. Use `print()` only for supplementary logging or debug output.
 
 Returns the last expression's value directly. If `print()` was also called, returns \
-`{"output": "<printed text>", "result": <last expression>}`.\
+`{"output": "<printed text>", "result": <last expression>}`.
+
+To finish the agent run immediately, make the last expression exactly \
+`{"final_output": <value>}`. CodeMode treats only that exact wrapper as a final output \
+candidate; ordinary return values stay regular `run_code` results for the model to inspect.\
 """
 
 

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -947,8 +947,67 @@ class TestCodeMode:
         # The agent's final output reflects the value flowing through the sandbox.
         assert result.output == 'sum is 10'
 
-    async def test_run_code_result_can_be_committed_as_final_output(self) -> None:
-        """Regression for pydantic/pydantic-ai#6243: commit a valid `run_code` result."""
+    async def test_run_code_plain_result_matching_output_schema_waits_for_model_final_output(self) -> None:
+        """A regular `run_code` return is context for the model, not an implicit final output."""
+        from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, ToolCallPart, ToolReturnPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        class SumOutput(BaseModel):
+            value: int
+
+        model_call_count = 0
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal model_call_count
+            model_call_count += 1
+            if model_call_count == 1:
+                code = 'result = await add(a=4, b=6)\n{"value": result}'
+                return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': code})])
+
+            last_request = messages[-1]
+            assert isinstance(last_request, ModelRequest)
+            run_code_return = next(
+                p for p in last_request.parts if isinstance(p, ToolReturnPart) and p.tool_name == 'run_code'
+            )
+            assert run_code_return.content == {'value': 10}
+            assert info.output_tools is not None
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name=info.output_tools[0].name, args={'value': 11})],
+            )
+
+        agent: Agent[object, SumOutput] = Agent(
+            FunctionModel(model_fn),
+            output_type=SumOutput,
+            capabilities=[CodeMode[object]()],
+        )
+
+        @agent.tool_plain
+        def add(a: int, b: int) -> int:  # pyright: ignore[reportUnusedFunction]
+            """Add two numbers."""
+            return a + b
+
+        result = await agent.run('please add 4 and 6')
+
+        assert model_call_count == 2
+        assert result.output == SumOutput(value=11)
+
+    async def test_run_code_hook_accepts_raw_result_for_final_output_detection(self) -> None:
+        """`CodeMode` accepts raw hook results even though its own toolset returns `ToolReturn`."""
+        cap = CodeMode[object]()
+        raw_result = {'final_output': {'value': 10}}
+
+        result = await cap.after_tool_execute(
+            build_run_context(None),
+            call=ToolCallPart(tool_name='run_code', args={'code': '{}'}),
+            tool_def=ToolDefinition(name='run_code'),
+            args={'code': '{}'},
+            result=raw_result,
+        )
+
+        assert result is raw_result
+
+    async def test_run_code_final_output_wrapper_commits_without_extra_model_turn(self) -> None:
+        """The reserved `final_output` wrapper commits a valid `run_code` result."""
         from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart, ToolReturnPart
         from pydantic_ai.models.function import AgentInfo, FunctionModel
 
@@ -960,7 +1019,7 @@ class TestCodeMode:
         def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             nonlocal model_call_count
             model_call_count += 1
-            code = 'result = await add(a=4, b=6)\nprint(f"add returned {result}")\n{"value": result}'
+            code = 'result = await add(a=4, b=6)\n{"final_output": {"value": result}}'
             return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': code})])
 
         agent: Agent[object, SumOutput] = Agent(
@@ -986,7 +1045,51 @@ class TestCodeMode:
             if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code'
         ]
         assert len(run_code_returns) == 1
-        assert run_code_returns[0].content == {'output': 'add returned 10\n', 'result': {'value': 10}}
+        assert run_code_returns[0].content == {'final_output': {'value': 10}}
+
+    async def test_run_code_final_output_wrapper_with_print_commits_result(self) -> None:
+        """The reserved `final_output` wrapper is honored inside the printed-output `result` value."""
+        from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart, ToolReturnPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        class SumOutput(BaseModel):
+            value: int
+
+        model_call_count = 0
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal model_call_count
+            model_call_count += 1
+            code = 'result = await add(a=4, b=6)\nprint(f"add returned {result}")\n{"final_output": {"value": result}}'
+            return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': code})])
+
+        agent: Agent[object, SumOutput] = Agent(
+            FunctionModel(model_fn),
+            output_type=SumOutput,
+            capabilities=[CodeMode[object]()],
+        )
+
+        @agent.tool_plain
+        def add(a: int, b: int) -> int:  # pyright: ignore[reportUnusedFunction]
+            """Add two numbers."""
+            return a + b
+
+        result = await agent.run('please add 4 and 6')
+
+        assert model_call_count == 1
+        assert result.output == SumOutput(value=10)
+
+        run_code_returns = [
+            part
+            for message in result.all_messages()
+            for part in message.parts
+            if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code'
+        ]
+        assert len(run_code_returns) == 1
+        assert run_code_returns[0].content == {
+            'output': 'add returned 10\n',
+            'result': {'final_output': {'value': 10}},
+        }
 
     async def test_deferred_capability_loader_stays_native_with_tools_all(self) -> None:
         """Regression for the deferred-capability bootstrap (issue #276).

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 import pytest
+from pydantic import BaseModel
 from pydantic_ai import (
     AbstractToolset,
     Agent,
@@ -945,6 +946,47 @@ class TestCodeMode:
 
         # The agent's final output reflects the value flowing through the sandbox.
         assert result.output == 'sum is 10'
+
+    async def test_run_code_result_can_be_committed_as_final_output(self) -> None:
+        """Regression for pydantic/pydantic-ai#6243: commit a valid `run_code` result."""
+        from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart, ToolReturnPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        class SumOutput(BaseModel):
+            value: int
+
+        model_call_count = 0
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal model_call_count
+            model_call_count += 1
+            code = 'result = await add(a=4, b=6)\nprint(f"add returned {result}")\n{"value": result}'
+            return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': code})])
+
+        agent: Agent[object, SumOutput] = Agent(
+            FunctionModel(model_fn),
+            output_type=SumOutput,
+            capabilities=[CodeMode[object]()],
+        )
+
+        @agent.tool_plain
+        def add(a: int, b: int) -> int:  # pyright: ignore[reportUnusedFunction]
+            """Add two numbers."""
+            return a + b
+
+        result = await agent.run('please add 4 and 6')
+
+        assert model_call_count == 1
+        assert result.output == SumOutput(value=10)
+
+        run_code_returns = [
+            part
+            for message in result.all_messages()
+            for part in message.parts
+            if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code'
+        ]
+        assert len(run_code_returns) == 1
+        assert run_code_returns[0].content == {'output': 'add returned 10\n', 'result': {'value': 10}}
 
     async def test_deferred_capability_loader_stays_native_with_tools_all(self) -> None:
         """Regression for the deferred-capability bootstrap (issue #276).
@@ -1900,7 +1942,7 @@ class TestToolSearchIntegration:
             ModelRequest(
                 parts=[
                     ToolSearchReturnPart(
-                        content={'discovered_tools': [{'name': 'later', 'description': 'A deferred-loading tool.'}]},
+                        content={'discovered_tools': [{'name': 'later'}]},
                         tool_call_id='search-1',
                     )
                 ]
@@ -2083,9 +2125,9 @@ class TestDynamicCatalog:
         assert fresh is not cap
         assert fresh._announced_tools == set()  # pyright: ignore[reportPrivateUsage]
 
-    async def test_for_run_returns_self_when_disabled(self) -> None:
+    async def test_for_run_returns_fresh_state_when_dynamic_catalog_disabled(self) -> None:
         cap = CodeMode[object]()
-        assert await cap.for_run(build_run_context(None)) is cap
+        assert await cap.for_run(build_run_context(None)) is not cap
 
     # -- discovery announcement: local search path ------------------------
 
@@ -2186,7 +2228,7 @@ class TestDynamicCatalog:
             parts=[
                 NativeToolSearchReturnPart(
                     tool_name='tool_search',
-                    content={'discovered_tools': [{'name': 'weather', 'description': 'Get the weather.'}]},
+                    content={'discovered_tools': [{'name': 'weather'}]},
                     tool_call_id='c1',
                 )
             ],


### PR DESCRIPTION
## Summary

Wires `CodeMode` to use the new `RunContext.output.try_commit_candidate(...)` API from pydantic/pydantic-ai#6247. When `run_code` produces a value that validates against the agent output schema, `CodeMode` commits it as the final output without requiring an extra model turn.

The normal flow is preserved for intermediate or invalid values, and the `run_code` tool return remains in message history.

## Linked Issue

Fixes pydantic/pydantic-ai#6243

Depends on pydantic/pydantic-ai#6247.

## Validation

- `uv run ruff check pydantic_ai_harness/code_mode/_capability.py tests/code_mode/test_code_mode.py`
- `PATH=/Users/kazmer.nagy-betegh/.nvm/versions/node/v24.14.1/bin:$PATH uv run --group lint --with-editable /Users/kazmer.nagy-betegh/dev/pydantic-ai/pydantic_ai_slim pyright pydantic_ai_harness/code_mode/_capability.py tests/code_mode/test_code_mode.py`
- `uv run --with-editable /Users/kazmer.nagy-betegh/dev/pydantic-ai/pydantic_ai_slim pytest tests/code_mode/test_code_mode.py::TestCodeMode::test_run_code_result_can_be_committed_as_final_output tests/code_mode/test_code_mode.py::TestCodeMode::test_code_mode_via_agent_run_executes_run_code_and_returns_result tests/code_mode/test_code_mode.py::TestDynamicCatalog::test_for_run_returns_fresh_state_when_dynamic_catalog_disabled tests/code_mode/test_code_mode.py::TestToolSearchIntegration::test_tool_search_toolset_discovered_tool_in_run_code tests/code_mode/test_code_mode.py::TestDynamicCatalog::test_announce_on_native_search_return_part`
- `git diff --check`

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (focused checks listed above)
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)
