### PR TITLE
Add opt-in `CodeMode(allow_final_output=True)` with a sandbox `final_output()` function

### DIFF
--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -150,6 +150,38 @@ The last expression in the code snippet is automatically captured as the return 
 | With print output | `{"output": "<printed text>", "result": <last expression>}` |
 | Multimodal content (e.g. images) | Returned natively for model processing |
 
+## Committing the final output
+
+By default a `run_code` return flows back to the model, which decides what to do next -- a
+schema-matching return is never committed as the agent's output on its own. Set
+`allow_final_output=True` to let a script end the run itself:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import CodeMode
+
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[CodeMode(allow_final_output=True)])
+```
+
+This exposes a `final_output(value)` function inside the sandbox. Calling it commits `value` as
+the agent's final output and ends the run with no further model turn. The `run_code` call still
+returns normally and stays in message history, and code after `final_output(...)` keeps running:
+
+```python
+report = build_report(await gather_data())
+final_output(report)
+```
+
+`value` must already match the agent's output type. It is passed through the agent's
+[output validators](https://ai.pydantic.dev/output/#output-validator-functions) (the same ones a
+model-produced output runs through), but it is **not** coerced to the declared type, so committing
+a value of the wrong shape is your responsibility. Coerce it in code (or in an output validator)
+before committing.
+
+The function is opt-in per capability: with the default `allow_final_output=False` it is absent
+from the sandbox, and a script that calls `final_output` fails as an undefined function. Most
+code-mode agents should leave it off so a script cannot finish the run.
+
 ## REPL state
 
 State persists between `run_code` calls within the same agent run -- variables, imports, and function definitions carry over. Pass `restart: true` in the tool call to reset state.
@@ -250,6 +282,7 @@ Code runs inside [Monty](https://github.com/pydantic/monty), a sandboxed Python 
 CodeMode(
     tools: ToolSelector = 'all',        # 'all', list[str], callable, or dict
     max_retries: int = 3,               # retries on sandbox execution errors
+    allow_final_output: bool = False,   # expose final_output(value) to end the run from a script
     os_access: CodeModeOS | None = None,   # host handler for env vars, clock, and file I/O
     mount: CodeModeMount | None = None,    # host directories to share with the sandbox
 )

--- a/pydantic_ai_harness/code_mode/_capability.py
+++ b/pydantic_ai_harness/code_mode/_capability.py
@@ -10,14 +10,23 @@ from pydantic import TypeAdapter, ValidationError
 from pydantic_ai import AbstractToolset
 from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
 from pydantic_ai.capabilities._tool_search import ToolSearch as _ToolSearch
+from pydantic_ai.exceptions import StopRun
 from pydantic_ai.messages import ModelResponse, NativeToolSearchReturnPart, SystemPromptPart
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition, ToolSelector
+from pydantic_graph import End
 from typing_extensions import TypedDict
 
-from pydantic_ai_harness.code_mode._toolset import CodeModeMount, CodeModeOS, CodeModeToolset
+from pydantic_ai_harness.code_mode._toolset import (
+    _FINAL_OUTPUT_METADATA_KEY,  # pyright: ignore[reportPrivateUsage]
+    _RUN_CODE_TOOL_NAME,  # pyright: ignore[reportPrivateUsage]
+    CodeModeMount,
+    CodeModeOS,
+    CodeModeToolset,
+    _FinalOutput,  # pyright: ignore[reportPrivateUsage]  -- shared within the code_mode package
+)
 
 if TYPE_CHECKING:
-    from pydantic_ai.capabilities.abstract import ValidatedToolArgs
+    from pydantic_ai.capabilities.abstract import AgentNode, NodeResult, ValidatedToolArgs
     from pydantic_ai.messages import ToolCallPart
     from pydantic_ai.models import ModelRequestContext
 
@@ -119,15 +128,38 @@ class CodeMode(AbstractCapability[AgentDepsT]):
     keeps the system prompt shorter and is the better choice.
     """
 
+    allow_final_output: bool = False
+    """Let sandboxed `run_code` scripts commit the agent's final output directly.
+
+    When `True`, a `final_output(value)` function is exposed inside the sandbox. Calling it
+    records `value` and, once the `run_code` call returns, `CodeMode` ends the run with that
+    value as the output -- no extra model turn -- while the `run_code` tool return stays in
+    message history. The value is passed through the agent's output validators but is **not**
+    coerced to the declared output type, so it must already match it.
+
+    Off by default: most code-mode agents should not be able to finish the run from a script.
+    A schema-matching `run_code` return is never committed implicitly; committing is always an
+    explicit `final_output(...)` call.
+    """
+
     _announced_tools: set[str] = field(default_factory=set[str], init=False, repr=False)
+
+    # The value a `run_code` script committed via `final_output()` this run, or None. Recorded in
+    # `after_tool_execute` and consumed in `after_node_run` to end the run. A fresh instance per
+    # run (see `for_run`) keeps concurrent runs from sharing it.
+    _final_output_candidate: _FinalOutput | None = field(default=None, init=False, repr=False)
 
     def get_ordering(self) -> CapabilityOrdering:
         """CodeMode wraps around ToolSearch so that search_tools stays native."""
         return CapabilityOrdering(position='outermost', wraps=[_ToolSearch])
 
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> CodeMode[AgentDepsT]:
-        """Return a fresh instance so concurrent runs don't share `_announced_tools`."""
-        if not self.dynamic_catalog:
+        """Return a fresh instance so concurrent runs don't share per-run state.
+
+        Needed when `dynamic_catalog` tracks `_announced_tools` or `allow_final_output` tracks
+        `_final_output_candidate`; otherwise the shared instance is safe to reuse.
+        """
+        if not (self.dynamic_catalog or self.allow_final_output):
             return self
         return replace(self)
 
@@ -138,6 +170,7 @@ class CodeMode(AbstractCapability[AgentDepsT]):
             tool_selector=self.tools,
             max_retries=self.max_retries,
             dynamic_catalog=self.dynamic_catalog,
+            allow_final_output=self.allow_final_output,
             os_access=self.os_access,
             mount=self.mount,
         )
@@ -151,15 +184,48 @@ class CodeMode(AbstractCapability[AgentDepsT]):
         args: ValidatedToolArgs,
         result: Any,
     ) -> Any:
-        """Announce newly-discovered tools from a local `search_tools` return.
+        """Announce discovered tools and record a `run_code` final-output commit.
 
-        Only active with `dynamic_catalog=True`. The native-search path is handled by
-        [`after_model_request`][pydantic_ai_harness.CodeMode.after_model_request] instead
-        (server-side search emits a `NativeToolSearchReturnPart` rather than a regular tool
-        execute result).
+        Two concerns share this hook:
+
+        - With `dynamic_catalog=True`, announce newly-discovered tools from a local
+          `search_tools` return. The native-search path is handled by
+          [`after_model_request`][pydantic_ai_harness.CodeMode.after_model_request] instead
+          (server-side search emits a `NativeToolSearchReturnPart` rather than a regular tool
+          execute result).
+        - With `allow_final_output=True`, read back a value the `run_code` script committed via
+          `final_output()`. The value rides on the `ToolReturn` metadata; recording it here lets
+          [`after_node_run`][pydantic_ai_harness.CodeMode.after_node_run] end the run once the
+          `run_code` return is in message history. The result is returned unchanged.
         """
         if self.dynamic_catalog and tool_def.tool_kind == 'tool-search':
             self._announce_newly_discovered(ctx, _extract_discovered_names(result))
+        if self.allow_final_output and call.tool_name == _RUN_CODE_TOOL_NAME:
+            # `run_code` always returns a `ToolReturn`; the committed value (if any) rides on its
+            # metadata as a `_FinalOutput`. Reading `.metadata` off `result` (typed `Any`) avoids
+            # narrowing `result` itself, keeping the pass-through `return result` fully typed.
+            marker: object = result.metadata.get(_FINAL_OUTPUT_METADATA_KEY)
+            if isinstance(marker, _FinalOutput):
+                self._final_output_candidate = marker
+        return result
+
+    async def after_node_run(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        node: AgentNode[AgentDepsT],
+        result: NodeResult[AgentDepsT],
+    ) -> NodeResult[AgentDepsT]:
+        """End the run with a value committed via `final_output()`, once tool returns are recorded.
+
+        Only active with `allow_final_output=True`. When a `run_code` script committed a value
+        this run and the node didn't already end the run, raise
+        [`StopRun`][pydantic_ai.exceptions.StopRun]: Pydantic AI runs the value through the
+        agent's output validators, preserves the pending `run_code` tool return in message
+        history, and finishes without another model request. Otherwise the result is unchanged.
+        """
+        if self._final_output_candidate is not None and not isinstance(result, End):
+            raise StopRun(self._final_output_candidate.value)
         return result
 
     async def after_model_request(

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -68,6 +68,20 @@ CodeModeOS = AbstractOS | CodeModeOSCallback
 CodeModeMount = MountDir | list[MountDir]
 
 
+@dataclass(frozen=True)
+class _FinalOutput:
+    """Wraps a value committed via `final_output()` inside the sandbox.
+
+    The wrapper keeps a committed `None` distinguishable from "nothing committed":
+    a bare `None` sentinel means no `final_output()` call happened, while
+    `_FinalOutput(None)` means the script committed `None` as the run's output.
+    It travels on the `run_code` `ToolReturn` metadata to the `CodeMode` capability,
+    which reads it back to end the run via `StopRun`.
+    """
+
+    value: Any
+
+
 class _RunCodeArguments(TypedDict):
     code: Annotated[str, Field(description='The Python code to execute in the sandbox.')]
     restart: NotRequired[
@@ -180,6 +194,31 @@ _TOOL_SEARCH_ADDENDUM = (
     f' that will become callable in subsequent `run_code` invocations.'
 )
 
+# Synthetic function injected into the sandbox when `CodeMode(allow_final_output=True)`.
+# Exposed across three surfaces the toolset derives from `callable_defs`: the rendered
+# catalog, the type-check stubs, and the runtime dispatch.
+_FINAL_OUTPUT_NAME = 'final_output'
+# Key under which the committed `_FinalOutput` is carried on the `run_code` `ToolReturn`
+# metadata, from which `CodeMode.after_tool_execute` reads it back.
+_FINAL_OUTPUT_METADATA_KEY = 'final_output'
+_FINAL_OUTPUT_DESCRIPTION = (
+    "Commit `value` as the agent's final output and end the run without another model turn. "
+    'The value must already match the agent output type: it is checked by the output validators '
+    'but not coerced, so pass a value of the correct type. The `run_code` call still returns '
+    'normally and stays in message history, and code after this call keeps running. '
+    'Returns `value` unchanged.'
+)
+
+
+def _final_output_block(body: str) -> str:
+    """Render the synthetic `final_output` definition shared by the catalog and type-check stubs.
+
+    `body` is the placeholder statement (`...` for the model-facing catalog,
+    `raise NotImplementedError()` for the type-check stub).
+    """
+    return f'def {_FINAL_OUTPUT_NAME}(value: Any) -> Any:\n    """{_FINAL_OUTPUT_DESCRIPTION}"""\n    {body}'
+
+
 _INVALID_IDENT_CHARS = re.compile(r'[^a-zA-Z0-9_]')
 
 
@@ -281,9 +320,22 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
     so Tool Search discoveries don't bust the tool-definitions cache prefix.
     """
 
+    allow_final_output: bool = False
+    """Expose a synthetic `final_output(value)` function inside the sandbox.
+
+    When `True`, sandboxed scripts can commit `value` as the agent's final output; the
+    committed value rides back on the `run_code` `ToolReturn` metadata for `CodeMode` to
+    end the run. When `False` (default), the function is absent from every surface.
+    """
+
     # init=False so `replace()` in `for_run` produces a fresh instance with _repl=None,
     # giving each agent run isolated REPL state. Lazy-initialized on first call_tool.
     _repl: MontyRepl | None = field(default=None, init=False, repr=False)
+
+    # The value committed by a `final_output()` call during the current `call_tool`, or None
+    # if the script didn't call it. Reset at the start of every `call_tool`; safe as per-call
+    # instance state because `run_code` is `sequential=True` (no concurrent calls share it).
+    _pending_final_output: _FinalOutput | None = field(default=None, init=False, repr=False)
 
     # Catalog string stashed during `get_tools` (when `dynamic_catalog`) and read back by
     # `get_instructions` in the same step. Empty when there's nothing to surface.
@@ -368,9 +420,11 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         has_mount = self.mount is not None
         if self.dynamic_catalog:
             description = _base_description(has_os=has_os, has_mount=has_mount)
-            self._last_catalog = self._render_catalog(callable_defs)
+            self._last_catalog = self._render_catalog(callable_defs, include_final_output=self.allow_final_output)
         else:
-            description = self._build_description(callable_defs, has_os=has_os, has_mount=has_mount)
+            description = self._build_description(
+                callable_defs, has_os=has_os, has_mount=has_mount, include_final_output=self.allow_final_output
+            )
             self._last_catalog = ''
 
         if _RUN_CODE_TOOL_NAME in native_tools:
@@ -420,6 +474,10 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
 
         code = tool_args['code']
         restart = tool_args.get('restart', False)
+
+        # Reset the per-call final-output sentinel. Safe as instance state: `run_code` is
+        # `sequential=True`, so no other `call_tool` runs concurrently against this instance.
+        self._pending_final_output = None
 
         # Clear the REPL on restart so that if type checking fails, the
         # next retry still gets fresh_repl=True and is type-checked again.
@@ -518,13 +576,25 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             # Serialize to JSON-compatible form so Monty receives only plain data.
             return _TOOL_RETURN_CONTENT_TA.dump_python(result)
 
+        # Record a `final_output(value)` call, if enabled. `run_code` is sequential, so
+        # writing to instance state here is safe. The callback is `None` when the feature
+        # is off, which leaves `final_output` undefined in the sandbox (calling it errors
+        # as an unknown function).
+        on_final_output: Callable[[Any], None] | None = None
+        if self.allow_final_output:
+
+            def record_final_output(value: Any) -> None:
+                self._pending_final_output = _FinalOutput(value)
+
+            on_final_output = record_final_output
+
         # Static type checking on fresh REPL sessions (first call or after
         # restart). Skipped on subsequent calls because accumulated REPL state
         # (variables from prior snippets) is invisible to the stateless checker.
         # Runs before REPL creation so that if this raises ModelRetry, the REPL
         # stays None and the next retry still gets type-checked.
         if fresh_repl and callable_defs:
-            self._type_check(code, callable_defs=callable_defs)
+            self._type_check(code, callable_defs=callable_defs, include_final_output=self.allow_final_output)
 
         # Create the REPL after type checking passes.
         if fresh_repl:
@@ -544,6 +614,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
                 global_sequential=global_sequential,
                 os_access=self.os_access,
                 mount=self.mount,
+                on_final_output=on_final_output,
             )
         except MontySyntaxError as e:
             raise ModelRetry(f'Syntax error in code:\n{_prepend_prints(e.display(), capture)}') from e
@@ -584,10 +655,13 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         else:
             return_value = {'output': printed, 'result': result}
 
-        return ToolReturn(
-            return_value=return_value,
-            metadata={'code_mode': True, 'tool_calls': nested_calls, 'tool_returns': nested_returns},
-        )
+        metadata: dict[str, Any] = {'code_mode': True, 'tool_calls': nested_calls, 'tool_returns': nested_returns}
+        # Surface a committed final output for `CodeMode.after_tool_execute` to read back.
+        # The `_FinalOutput` wrapper keeps a committed `None` distinct from "nothing committed".
+        if self._pending_final_output is not None:
+            metadata[_FINAL_OUTPUT_METADATA_KEY] = self._pending_final_output
+
+        return ToolReturn(return_value=return_value, metadata=metadata)
 
     def _partition_callable_tools(
         self, wrapped_tools: dict[str, ToolsetTool[AgentDepsT]]
@@ -641,24 +715,29 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         return callable_defs, sanitized_to_original
 
     @staticmethod
-    def _build_description(callable_defs: dict[str, ToolDefinition], *, has_os: bool, has_mount: bool) -> str:
+    def _build_description(
+        callable_defs: dict[str, ToolDefinition], *, has_os: bool, has_mount: bool, include_final_output: bool = False
+    ) -> str:
         """Render the `run_code` description: base prose + TypedDicts + function signatures."""
         base = _base_description(has_os=has_os, has_mount=has_mount)
-        catalog = CodeModeToolset._render_catalog(callable_defs)
+        catalog = CodeModeToolset._render_catalog(callable_defs, include_final_output=include_final_output)
         if not catalog:
             return base
         return base + '\n\n' + catalog
 
     @staticmethod
-    def _render_catalog(callable_defs: dict[str, ToolDefinition]) -> str:
-        """Render the functions-header + TypedDict + function-signature blocks, or `''` if no defs.
+    def _render_catalog(callable_defs: dict[str, ToolDefinition], *, include_final_output: bool = False) -> str:
+        """Render the functions-header + TypedDict + function-signature blocks, or `''` if empty.
 
         Excludes the `run_code` base prose; the catalog is the discovery-driven portion that's
         cache-hostile when carried in `run_code.description`. Used by `_build_description`
         (default static-description path) and by `get_instructions` (the `dynamic_catalog`
         path, which moves it into instructions instead).
+
+        When `include_final_output` is set, the synthetic `final_output(value)` function is
+        appended so the model sees it alongside the sandboxed tools.
         """
-        if not callable_defs:
+        if not callable_defs and not include_final_output:
             return ''
 
         sigs, conflicting = _get_sigs_and_conflicting(callable_defs)
@@ -667,8 +746,11 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             td.render_signature('...', is_async=not td.sequential, conflicting_type_names=conflicting)
             for td in callable_defs.values()
         ]
+        if include_final_output:
+            function_blocks.append(_final_output_block('...'))
 
-        has_sync = any(td.sequential for td in callable_defs.values())
+        # `final_output` is synchronous (called without `await`), so it counts toward `has_sync`.
+        has_sync = any(td.sequential for td in callable_defs.values()) or include_final_output
         has_async = any(not td.sequential for td in callable_defs.values())
         sections = [_functions_header(has_sync=has_sync, has_async=has_async)]
         if type_blocks:
@@ -677,7 +759,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         return '\n\n'.join(sections)
 
     @staticmethod
-    def _build_type_check_stubs(callable_defs: dict[str, ToolDefinition]) -> str:
+    def _build_type_check_stubs(callable_defs: dict[str, ToolDefinition], *, include_final_output: bool = False) -> str:
         """Build Python stubs for Monty's static type checker."""
         sigs, conflicting = _get_sigs_and_conflicting(callable_defs)
         parts = ['import asyncio\nfrom typing import Any, TypedDict, NotRequired, Literal']
@@ -689,10 +771,12 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             )
             for td in callable_defs.values()
         )
+        if include_final_output:
+            parts.append(_final_output_block('raise NotImplementedError()'))
         return '\n\n'.join(parts)
 
     @staticmethod
-    def _type_check(code: str, *, callable_defs: dict[str, ToolDefinition]) -> None:
+    def _type_check(code: str, *, callable_defs: dict[str, ToolDefinition], include_final_output: bool = False) -> None:
         """Type-check a code snippet against tool signatures before execution.
 
         Uses Monty's stateless type checker with function stubs. Only sound
@@ -701,7 +785,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         Raises:
             ModelRetry: If the code has type errors or syntax errors.
         """
-        stubs = CodeModeToolset._build_type_check_stubs(callable_defs)
+        stubs = CodeModeToolset._build_type_check_stubs(callable_defs, include_final_output=include_final_output)
         try:
             Monty(code, type_check=True, type_check_stubs=stubs)
         except MontyTypingError as e:
@@ -731,6 +815,7 @@ async def _execution_loop(
     global_sequential: bool,
     os_access: CodeModeOS | None,
     mount: CodeModeMount | None,
+    on_final_output: Callable[[Any], None] | None = None,
 ) -> MontyComplete:
     """Drive the Monty REPL via the synchronous snapshot API until completion.
 
@@ -773,6 +858,7 @@ async def _execution_loop(
                     pre_resolved=pre_resolved,
                     os_access=os_access,
                     mount=mount,
+                    on_final_output=on_final_output,
                 )
             else:
                 monty_state = await _resolve_future_snapshot(
@@ -805,9 +891,17 @@ async def _handle_function_snapshot(
     pre_resolved: dict[int, ExternalResult],
     os_access: CodeModeOS | None,
     mount: CodeModeMount | None,
+    on_final_output: Callable[[Any], None] | None = None,
 ) -> FunctionSnapshot | FutureSnapshot | NameLookupSnapshot | MontyComplete:
     """Handle a single FunctionSnapshot from the Monty execution loop."""
     fn_name = snapshot.function_name
+
+    if on_final_output is not None and fn_name == _FINAL_OUTPUT_NAME:
+        # Synthetic `final_output(value)`: capture the value and hand it straight back so the
+        # script continues. The commit itself happens after `run_code` returns, in `CodeMode`.
+        value = snapshot.args[0] if snapshot.args else snapshot.kwargs['value']
+        on_final_output(value)
+        return snapshot.resume({'return_value': value}, os=os_access, mount=mount)
 
     if fn_name not in callable_defs:
         return snapshot.resume({'exception': NameError(f'Unknown function: {fn_name}')}, os=os_access, mount=mount)

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -2600,3 +2600,191 @@ class TestGlobalModeIsSequential:
 
         assert _global_mode_is_sequential(parallel) is False
         assert _global_mode_is_sequential(sequential) is True
+
+
+class TestFinalOutput:
+    """`CodeMode(allow_final_output=True)` lets a `run_code` script commit the final output.
+
+    These use a hand-driven `FunctionModel` rather than a recorded provider call because the
+    behavior under test is control-flow and message-history shaped: how many model turns run,
+    which value ends the run, and that the `run_code` tool return stays in history. A VCR
+    cassette pins request/response bytes, not those invariants.
+    """
+
+    async def test_final_output_commits_value_in_single_turn(self) -> None:
+        """A positional `final_output(value)` ends the run in one model turn, keeping the return.
+
+        FunctionModel/non-VCR: asserts the model is called exactly once (no second turn) and the
+        `run_code` `ToolReturnPart` survives in history -- neither is visible in recorded bytes.
+        """
+        from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        turns = 0
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal turns
+            turns += 1
+            if turns == 1:
+                code = "greeting = await greet(name='Ada')\nfinal_output(greeting)"
+                return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': code})])
+            return ModelResponse(parts=[TextPart('second turn should not run')])  # pragma: no cover
+
+        agent: Agent[object, str] = Agent(
+            FunctionModel(model_fn), capabilities=[CodeMode[object](allow_final_output=True)]
+        )
+
+        @agent.tool_plain
+        def greet(name: str) -> str:  # pyright: ignore[reportUnusedFunction]
+            """Greet someone."""
+            return f'Hello, {name}!'
+
+        result = await agent.run('greet Ada')
+
+        assert turns == 1
+        assert result.output == 'Hello, Ada!'
+
+        run_code_returns = [
+            part
+            for message in result.all_messages()
+            for part in message.parts
+            if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code'
+        ]
+        assert len(run_code_returns) == 1
+
+    async def test_final_output_commits_structured_output_through_validators(self) -> None:
+        """A keyword `final_output(value=...)` commits a structured value, run through validators.
+
+        FunctionModel/non-VCR: pins that the `@agent.output_validator` runs on the committed
+        value (which `StopRun` validates but does not coerce) in a single turn.
+        """
+        from pydantic import BaseModel
+        from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        class Weather(BaseModel):
+            city: str
+            temp_c: int
+
+        turns = 0
+        validated: list[object] = []
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal turns
+            turns += 1
+            if turns == 1:
+                code = "final_output(value={'city': 'Paris', 'temp_c': 20})"
+                return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': code})])
+            return ModelResponse(parts=[TextPart('second turn should not run')])  # pragma: no cover
+
+        agent: Agent[object, Weather] = Agent(
+            FunctionModel(model_fn),
+            output_type=Weather,
+            capabilities=[CodeMode[object](allow_final_output=True)],
+        )
+
+        @agent.output_validator
+        def finalize(data: Weather) -> Weather:  # pyright: ignore[reportUnusedFunction]
+            validated.append(data)
+            # `StopRun` does not coerce, so `data` is the raw dict the sandbox committed; the app
+            # coerces it here to demonstrate validators run and can shape the final output.
+            return Weather.model_validate(data)
+
+        result = await agent.run('weather in Paris')
+
+        assert turns == 1
+        assert validated == [{'city': 'Paris', 'temp_c': 20}]
+        assert result.output == Weather(city='Paris', temp_c=20)
+
+    async def test_enabled_but_no_commit_flows_to_second_turn(self) -> None:
+        """With the feature on, a `run_code` return that never calls `final_output` does not commit.
+
+        FunctionModel/non-VCR: asserts the model is called twice -- proving a schema-shaped return
+        is never auto-committed; committing is only ever an explicit `final_output(...)` call.
+        """
+        from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        turns = 0
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal turns
+            turns += 1
+            if turns == 1:
+                return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': 'await add(a=1, b=2)'})])
+            last_request = messages[-1]
+            assert isinstance(last_request, ModelRequest)
+            return ModelResponse(parts=[TextPart('done')])
+
+        agent: Agent[object, str] = Agent(
+            FunctionModel(model_fn), capabilities=[CodeMode[object](allow_final_output=True)]
+        )
+
+        @agent.tool_plain
+        def add(a: int, b: int) -> int:  # pyright: ignore[reportUnusedFunction]
+            """Add two numbers."""
+            return a + b
+
+        result = await agent.run('add 1 and 2')
+
+        assert turns == 2
+        assert result.output == 'done'
+
+    async def test_disabled_plain_return_flows_to_second_turn(self) -> None:
+        """By default (`allow_final_output=False`) `run_code` never ends the run.
+
+        FunctionModel/non-VCR: asserts the model is called twice, matching pre-feature behavior.
+        """
+        from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        turns = 0
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal turns
+            turns += 1
+            if turns == 1:
+                return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': 'await add(a=1, b=2)'})])
+            last_request = messages[-1]
+            assert isinstance(last_request, ModelRequest)
+            return ModelResponse(parts=[TextPart('done')])
+
+        agent: Agent[object, str] = Agent(FunctionModel(model_fn), capabilities=[CodeMode[object]()])
+
+        @agent.tool_plain
+        def add(a: int, b: int) -> int:  # pyright: ignore[reportUnusedFunction]
+            """Add two numbers."""
+            return a + b
+
+        result = await agent.run('add 1 and 2')
+
+        assert turns == 2
+        assert result.output == 'done'
+
+    async def test_final_output_in_catalog_only_when_enabled(self) -> None:
+        """`final_output` shows up in the `run_code` description only when the feature is on."""
+        toolset = _build_function_toolset(add)
+
+        enabled = CodeMode[object](allow_final_output=True).get_wrapper_toolset(toolset)
+        disabled = CodeMode[object]().get_wrapper_toolset(toolset)
+        assert isinstance(enabled, CodeModeToolset)
+        assert isinstance(disabled, CodeModeToolset)
+
+        enabled_desc = (await enabled.get_tools(build_run_context(None)))['run_code'].tool_def.description
+        disabled_desc = (await disabled.get_tools(build_run_context(None)))['run_code'].tool_def.description
+        assert enabled_desc is not None and disabled_desc is not None
+
+        assert 'def final_output(value: Any) -> Any' in enabled_desc
+        assert 'final output' in enabled_desc
+        assert 'final_output' not in disabled_desc
+
+    async def test_final_output_call_errors_when_disabled(self) -> None:
+        """Calling `final_output` with the feature off fails: it is not defined in the sandbox."""
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(add))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+
+        with pytest.raises(ModelRetry) as exc_info:
+            await wrapper.call_tool('run_code', {'code': 'final_output(1)'}, ctx, tools['run_code'])
+        assert 'final_output' in str(exc_info.value)


### PR DESCRIPTION
## Summary

Opt-in way for a `run_code` script to commit the agent's final output directly, ending the run with no extra model turn while the `run_code` return stays in message history.

This is an **alternative** to #319, built on a new, minimal pydantic-ai primitive (`StopRun`, pydantic/pydantic-ai#6257) instead of the `RunContext.output` / candidate-matching surface in pydantic/pydantic-ai#6247. Posting both so we can compare shapes; let's pick a direction on the call.

### What it does

`CodeMode(allow_final_output=True)` exposes a synthetic `final_output(value)` function inside the sandbox:

```python
agent = Agent(model, capabilities=[CodeMode(allow_final_output=True)])
# model emits run_code:
#   result = fetch_order("A-123")
#   final_output({"order_id": result.id, "status": result.status})
# -> run ends with that dict as result.output, in ONE model turn; the run_code
#    ToolReturn stays in history; no second turn to restate the value.
```

Mechanics: `final_output(x)` records `x` (via the `run_code` `ToolReturn` metadata) → `CodeMode.after_tool_execute` reads it → `CodeMode.after_node_run` raises `StopRun(x)`. pydantic-ai runs `x` through the agent's output validators, preserves the pending `run_code` tool return in history, and ends the run.

### Deliberately explicit and opt-in

- **Off by default.** Most code-mode agents should not be able to finish the run from a script.
- **No implicit schema-matching.** A `run_code` return that happens to match the output schema is *never* auto-committed (unlike the original #319 direction). Committing is always an explicit `final_output(...)` call. This avoids the "an agent with `output_type=str`/`list` silently swallows tool returns" failure mode.

### Depends on

pydantic/pydantic-ai#6257 (`StopRun`). Not yet released, so CI here (which runs against released pydantic-ai) will fail on the import until that lands; tested locally against an editable checkout.

## Big open questions (for discussion, deliberately not resolved here)

These are the "is this too coupled / what's the right shape" questions:

1. **Single `final_output(value)` vs. exposing the real output tools.** In tool-output mode the agent has one output tool per union member, but CodeMode currently doesn't expose *any* output tools to the sandbox. Should CodeMode instead surface those as explicit per-type functions (e.g. `Weather(...)`, `Error(...)`) so the model constructs a typed output directly, rather than a single generic `final_output(value)`? That needs `prepare_output_tools` + per-member schema rendering, and it couples CodeMode more tightly to pydantic-ai's output machinery. And should it do so even under structured/native output mode, where there are no model-facing output tools at all?
2. **Coercion.** `StopRun` runs output *validators* but does not coerce `value` to the declared output type (see the pydantic-ai #6257 discussion). Since Monty has no classes, a script can only commit plain data, so today an output validator has to do the `Model.model_validate(...)`. Do we want CodeMode (or `StopRun`) to coerce?
3. **Script-halting semantics.** `final_output()` currently records and lets the script keep running (committed after `run_code` returns). Should it instead halt the script immediately, like a `return`?

## Known rough edge

`final_output()` called with **no argument** on a non-fresh REPL (a second `run_code` call, where static type-checking is skipped) currently raises `KeyError` from dispatch. On fresh REPLs the type-check stub makes `value` required, so a correctly-behaving model can't hit it — but it's a sharp edge if we want a friendlier error. Left as-is pending the direction above.

## Linked Issue

Fixes pydantic/pydantic-ai#6243

## Checklist

- [ ] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (typecheck/test run against an editable pydantic-ai with `StopRun`; released pydantic-ai lacks it)
- [x] No changes to `pyproject.toml` or `uv.lock`
- [x] Docstrings use single backticks (not RST double backticks)
