### PR TITLE
feat(subagents): configurable delegate-tool retries

### DIFF
--- a/pydantic_ai_harness/experimental/subagents/README.md
+++ b/pydantic_ai_harness/experimental/subagents/README.md
@@ -98,7 +98,7 @@ orchestrator = Agent(
 
 A *soft outcome* returns a steering message to the parent as a normal tool result, so its model reads the message and decides what to do next (rather than immediately re-delegating, which a `ModelRetry` invites). A timeout, a reached `usage_limits` budget, and an exhausted `max_calls` budget are always soft. When `on_failure` is set, the message it carries replaces the built-in default for these outcomes.
 
-A sub-agent run that fails with a *soft model error* (`ModelRetry`, `UnexpectedModelBehavior`, e.g. it exhausted its own retries) is, by default, converted into a `ModelRetry` for the parent -- so the parent's model sees `Sub-agent '<name>' failed: ...` and can react. Set `on_failure` for that delegate to make its failures soft instead: the child error returns the `on_failure` message as a normal tool result.
+A sub-agent run that fails with a *soft model error* (`ModelRetry`, `UnexpectedModelBehavior`, e.g. it exhausted its own retries) is, by default, converted into a `ModelRetry` for the parent -- so the parent's model sees `Sub-agent '<name>' failed: ...` and can react by re-delegating. The delegate tool defaults to `tool_retries=2`, so the parent aborts only after that many consecutive delegate failures; the counter resets after any successful delegation. Raise `tool_retries` to tolerate a flakier sub-agent, or set `None` to inherit the parent agent's default tool retries. Set `on_failure` for a delegate to make its failures soft instead: the child error returns the `on_failure` message as a normal tool result.
 
 Hard errors propagate to stop the whole run. A `UsageLimitExceeded` from a child that has *no* per-delegate `usage_limits` (so it shares the parent's accounting) means the whole tree is out of budget and propagates; a child reaching its *own* `usage_limits` is soft, as above.
 
@@ -190,6 +190,7 @@ SubAgents(
     shared_capabilities=(),# capabilities applied to every sub-agent run
     event_stream_handler=None,  # forwarded to each sub-agent run to stream its events
     tool_name='delegate_task',
+    tool_retries=2,        # extra delegate-tool attempts after a sub-agent error before aborting (None inherits the agent default)
 )
 ```
 

--- a/pydantic_ai_harness/experimental/subagents/_capability.py
+++ b/pydantic_ai_harness/experimental/subagents/_capability.py
@@ -130,6 +130,13 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     tool_name: str = 'delegate_task'
     """Name of the delegate tool exposed to the model."""
 
+    tool_retries: int | None = None
+    """How many times the model may retry the delegate tool after a sub-agent
+    run errors (e.g. the sub-agent exhausts its own output retries). `None` (the
+    default) inherits the parent agent's default tool retries. Set it (e.g. 2-3)
+    so a flaky sub-agent failure lets the parent re-delegate with a corrected
+    task instead of crashing the parent run on the first sub-agent error."""
+
     _by_name: dict[str, SubAgent[AgentDepsT]] = field(
         default_factory=dict[str, 'SubAgent[AgentDepsT]'], init=False, repr=False, compare=False
     )
@@ -262,6 +269,7 @@ class SubAgents(AbstractCapability[AgentDepsT]):
             shared_capabilities=self.shared_capabilities,
             event_stream_handler=self.event_stream_handler,
             tool_name=self.tool_name,
+            tool_retries=self.tool_retries,
             call_counts=self._call_counts,
         )
 

--- a/pydantic_ai_harness/experimental/subagents/_capability.py
+++ b/pydantic_ai_harness/experimental/subagents/_capability.py
@@ -130,12 +130,15 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     tool_name: str = 'delegate_task'
     """Name of the delegate tool exposed to the model."""
 
-    tool_retries: int | None = None
-    """How many times the model may retry the delegate tool after a sub-agent
-    run errors (e.g. the sub-agent exhausts its own output retries). `None` (the
-    default) inherits the parent agent's default tool retries. Set it (e.g. 2-3)
-    so a flaky sub-agent failure lets the parent re-delegate with a corrected
-    task instead of crashing the parent run on the first sub-agent error."""
+    tool_retries: int | None = 2
+    """Retries for the delegate tool -- how many extra attempts it gets after a
+    sub-agent error before the parent run aborts. A sub-agent failure (e.g. it
+    exhausts its own output retries) surfaces to the parent as a tool retry it
+    can react to by re-delegating with a corrected task. The retry counter
+    resets after any successful delegation, so this bounds consecutive failures,
+    not total ones. Defaults to `2` (pydantic-ai's per-tool default is `1`) so a
+    repeated flaky sub-agent does not abort the parent run on its first repeat;
+    set `None` to inherit the parent agent's default tool retries instead."""
 
     _by_name: dict[str, SubAgent[AgentDepsT]] = field(
         default_factory=dict[str, 'SubAgent[AgentDepsT]'], init=False, repr=False, compare=False

--- a/pydantic_ai_harness/experimental/subagents/_toolset.py
+++ b/pydantic_ai_harness/experimental/subagents/_toolset.py
@@ -107,6 +107,7 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
         shared_capabilities: Sequence[AgentCapability[AgentDepsT]],
         event_stream_handler: EventStreamHandler[AgentDepsT] | None,
         tool_name: str,
+        tool_retries: int | None,
         call_counts: dict[str, dict[str, int]],
     ) -> None:
         super().__init__()
@@ -119,7 +120,7 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
         # Run-scoped delegation counts, keyed by run_id then sub-agent name.
         # Shared with the capability, which clears each run's entry in wrap_run.
         self._call_counts = call_counts
-        self.add_function(self.delegate_task, name=tool_name)
+        self.add_function(self.delegate_task, name=tool_name, retries=tool_retries)
 
     def _inherited_toolsets(self, ctx: RunContext[AgentDepsT]) -> list[AbstractToolset[AgentDepsT]] | None:
         """The parent agent's own toolsets, excluding capability-contributed ones.

--- a/tests/experimental/subagents/test_subagents.py
+++ b/tests/experimental/subagents/test_subagents.py
@@ -167,9 +167,15 @@ class TestToolset:
         assert isinstance(toolset, SubAgentToolset)
         assert 'run_agent' in toolset.tools
 
-    def test_tool_retries_default_inherits(self) -> None:
+    def test_tool_retries_default_is_resilient(self) -> None:
         agent = Agent(TestModel(), name='x')
         toolset = SubAgents(agents=[SubAgent(agent)]).get_toolset()
+        assert isinstance(toolset, SubAgentToolset)
+        assert toolset.tools['delegate_task'].max_retries == 2
+
+    def test_tool_retries_none_inherits_agent_default(self) -> None:
+        agent = Agent(TestModel(), name='x')
+        toolset = SubAgents(agents=[SubAgent(agent)], tool_retries=None).get_toolset()
         assert isinstance(toolset, SubAgentToolset)
         assert toolset.tools['delegate_task'].max_retries is None
 

--- a/tests/experimental/subagents/test_subagents.py
+++ b/tests/experimental/subagents/test_subagents.py
@@ -167,6 +167,18 @@ class TestToolset:
         assert isinstance(toolset, SubAgentToolset)
         assert 'run_agent' in toolset.tools
 
+    def test_tool_retries_default_inherits(self) -> None:
+        agent = Agent(TestModel(), name='x')
+        toolset = SubAgents(agents=[SubAgent(agent)]).get_toolset()
+        assert isinstance(toolset, SubAgentToolset)
+        assert toolset.tools['delegate_task'].max_retries is None
+
+    def test_tool_retries_configures_delegate_tool(self) -> None:
+        agent = Agent(TestModel(), name='x')
+        toolset = SubAgents(agents=[SubAgent(agent)], tool_retries=3).get_toolset()
+        assert isinstance(toolset, SubAgentToolset)
+        assert toolset.tools['delegate_task'].max_retries == 3
+
 
 class TestDelegation:
     async def test_delegates_and_returns_output(self) -> None:
@@ -289,6 +301,7 @@ class TestDelegation:
             shared_capabilities=[],
             event_stream_handler=None,
             tool_name='delegate_task',
+            tool_retries=1,
             call_counts={},
         )
         parent: Agent[object, str] = Agent(_delegate_then_finish('worker'), toolsets=[toolset])


### PR DESCRIPTION
## Why
A sub-agent that errors (commonly: it exhausts its own output retries) surfaces
to the parent as a `ModelRetry` on the `delegate_task` tool. That tool inherits
the pydantic-ai per-tool default of `retries=1`, so the parent gets only one
re-delegation before a second consecutive failure aborts the whole run with
`UnexpectedModelBehavior`. The retry counter resets after any successful
delegation, so this only bites a sub-agent that fails repeatedly in a row -- but
when it does, a flaky delegate can take down a multi-agent orchestrator built on
`SubAgents`.

## What
Add a `tool_retries: int | None = 2` field on `SubAgents`, threaded to
`SubAgentToolset` and applied via `add_function(..., retries=tool_retries)`.

- Defaults to `2` (vs pydantic-ai's per-tool default of `1`), so the parent
  tolerates a repeated flaky sub-agent and re-delegates with a corrected task
  instead of aborting on the first repeat. `subagents` is experimental, so a
  more resilient default is preferable to shipping the crash behind an opt-in.
- Set a higher value for a flakier sub-agent, or `None` to inherit the parent
  agent's default tool retries (the previous behavior).
- `SubAgent.on_failure` remains the other lever: it makes a delegate's failures
  soft (returns its message as a normal tool result) rather than retrying.

## Tests
- `test_tool_retries_default_is_resilient` (default -> tool `max_retries == 2`)
- `test_tool_retries_none_inherits_agent_default` (None -> `max_retries is None`)
- `test_tool_retries_configures_delegate_tool` (3 -> `max_retries == 3`)
- `make lint && make typecheck && make testcov` all green (100% branch coverage held).
