### PR TITLE
Fix protected pattern read-only walkers

### DIFF
--- a/pydantic_ai_harness/filesystem/README.md
+++ b/pydantic_ai_harness/filesystem/README.md
@@ -77,11 +77,12 @@ The three rules apply at two different granularities:
   `create_directory`) gates the operation's target path. You must name a path
   that the patterns permit.
 - **Walkers** (`list_directory`, `search_files`, `find_files`) gate their root
-  by deny/protected patterns, but **not** by `allowed_patterns` -- a directory
-  root like `.` never matches a file pattern such as `src/*.py`, so requiring
-  it to would make every listing fail. Instead, the root is always walked and
-  each **entry** is filtered against all three lists. A directory listing can
-  never surface a path the agent couldn't otherwise read or write.
+  by deny patterns, but **not** by `allowed_patterns` -- a directory root like
+  `.` never matches a file pattern such as `src/*.py`, so requiring it to would
+  make every listing fail. Instead, the root is always walked and each **entry**
+  is filtered against readable access: `allowed_patterns` and `denied_patterns`
+  still apply, while `protected_patterns` remain visible because they only
+  reject writes.
 
 So with `allowed_patterns=['*.py']`, `list_directory('.')` succeeds and shows
 only the `.py` entries; `read_file('notes.md')` is rejected.

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -151,8 +151,9 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         directory isn't required to match `allowed_patterns` itself -- `.` or
         `src` would never match a file pattern like `src/*.py`. The walk's
         entries are still filtered against `allowed_patterns` per-entry via
-        `_is_accessible`. Denied and protected patterns continue to gate the
-        root.
+        `_is_accessible`. Denied patterns continue to gate the root. Protected
+        patterns only block writes, so read-only walkers can still inspect
+        protected paths.
         """
         if write and self._protected_patterns:
             matched = self._first_matching_pattern(path, self._protected_patterns)
@@ -320,7 +321,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         Returns:
             A newline-separated listing with type indicators and sizes.
         """
-        # The listing root is gated by denied/protected patterns but not by
+        # The listing root is gated by denied patterns but not by
         # allowed_patterns: a directory like '.' never matches a file pattern.
         # Entries are filtered per-entry against allowed_patterns below.
         resolved = self._safe_resolve(path, check_allowed=False)
@@ -338,10 +339,9 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             if any(part.startswith('.') for part in rel_path.parts):
                 continue
             rel = str(rel_path)
-            # Apply the same allow/deny/protected filtering used for direct
-            # access so a directory listing can't leak patterns the agent
-            # couldn't otherwise read or write.
-            if not self._is_accessible(rel, write=True):
+            # Apply the readable access filter. Protected paths remain visible
+            # because protected patterns only make them read-only.
+            if not self._is_accessible(rel):
                 continue
             if entry.is_dir():
                 entries.append(f'{rel}/')
@@ -391,10 +391,9 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             if any(part.startswith('.') for part in rel_parts):
                 continue
             rel_str = str(file_path.relative_to(real_root))
-            # Apply the same allow/deny/protected filtering used for direct
-            # access so a recursive search can't read patterns the agent
-            # couldn't otherwise read.
-            if not self._is_accessible(rel_str, write=True):
+            # Apply the readable access filter. Protected paths remain
+            # searchable because protected patterns only make them read-only.
+            if not self._is_accessible(rel_str):
                 continue
             if include_glob and not fnmatch.fnmatch(rel_str, include_glob):
                 continue
@@ -441,10 +440,9 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             if any(part.startswith('.') for part in rel_parts):
                 continue
             rel = str(match.relative_to(real_root))
-            # Apply the same allow/deny/protected filtering used for direct
-            # access so a glob find can't surface patterns the agent
-            # couldn't otherwise see.
-            if not self._is_accessible(rel, write=True):
+            # Apply the readable access filter. Protected paths remain
+            # discoverable because protected patterns only make them read-only.
+            if not self._is_accessible(rel):
                 continue
             suffix = '/' if match.is_dir() else ''
             matches.append(f'{rel}{suffix}')

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -434,23 +434,30 @@ class TestListDirectory:
         result = await toolset.list_directory('empty')
         assert result == '(empty directory)'
 
-    async def test_list_hides_protected_entries(self, fs_root: Path) -> None:
-        # .env is protected by the default toolset fixture; .git is hidden by
-        # the dotfile filter, but a directory that is itself explicitly
-        # protected is also hidden from listings.
+    async def test_list_shows_protected_entries(self, fs_root: Path) -> None:
+        # Protected patterns make entries read-only, not invisible to read-only
+        # walkers. Dotfiles remain hidden by the separate dotfile filter.
         (fs_root / 'visible.txt').write_text('ok\n')
+        (fs_root / 'readonly.txt').write_text('readable\n')
         ts = FileSystemToolset(
             root_dir=fs_root,
             allowed_patterns=[],
             denied_patterns=[],
-            protected_patterns=['.env', '.env.*'],
+            protected_patterns=['readonly.txt'],
             max_read_lines=2000,
             max_search_results=1000,
             max_find_results=1000,
         )
         result = await ts.list_directory('.')
         assert 'visible.txt' in result
-        assert '.env' not in result
+        assert 'readonly.txt' in result
+
+    async def test_list_all_protected_patterns_still_lists_readable_files(self, fs_root: Path) -> None:
+        toolset = FileSystem(root_dir=fs_root, protected_patterns=['*']).get_toolset()
+        assert isinstance(toolset, FileSystemToolset)
+        result = await toolset.list_directory('.')
+        assert 'hello.txt' in result
+        assert result != '(empty directory)'
 
     async def test_list_root_allowed_patterns_filters_entries(self, fs_root: Path) -> None:
         # A file-shaped allowed pattern must not make the root unlistable: '.'
@@ -540,23 +547,23 @@ class TestSearchFiles:
         result = await ts.search_files('findme')
         assert 'truncated at 50 matches' in result
 
-    async def test_search_skips_protected_contents(self, fs_root: Path) -> None:
-        # The .env file has matching content but should be filtered by the
-        # recursive walker before its bytes are read.
+    async def test_search_reads_protected_contents(self, fs_root: Path) -> None:
+        # Protected patterns reject writes, but recursive read-only search can
+        # still read matching non-hidden files.
         (fs_root / 'visible.txt').write_text('SECRET=matchme\n')
-        (fs_root / '.env').write_text('SECRET=matchme\n')
+        (fs_root / 'readonly.txt').write_text('SECRET=matchme\n')
         ts = FileSystemToolset(
             root_dir=fs_root,
             allowed_patterns=[],
             denied_patterns=[],
-            protected_patterns=['.env', '.env.*'],
+            protected_patterns=['readonly.txt'],
             max_read_lines=2000,
             max_search_results=1000,
             max_find_results=1000,
         )
         result = await ts.search_files('matchme')
         assert 'visible.txt' in result
-        assert '.env' not in result
+        assert 'readonly.txt' in result
 
     async def test_search_skips_denied_files(self, fs_root: Path) -> None:
         (fs_root / 'visible.txt').write_text('lookhere\n')
@@ -639,21 +646,21 @@ class TestFindFiles:
         result = await ts.find_files('*.dat')
         assert 'truncated at 5 matches' in result
 
-    async def test_find_hides_protected_entries(self, fs_root: Path) -> None:
+    async def test_find_shows_protected_entries(self, fs_root: Path) -> None:
         (fs_root / 'visible.txt').write_text('ok\n')
-        (fs_root / '.env').write_text('SECRET=abc\n')
+        (fs_root / 'readonly.txt').write_text('SECRET=abc\n')
         ts = FileSystemToolset(
             root_dir=fs_root,
             allowed_patterns=[],
             denied_patterns=[],
-            protected_patterns=['.env', '.env.*'],
+            protected_patterns=['readonly.txt'],
             max_read_lines=2000,
             max_search_results=1000,
             max_find_results=1000,
         )
         result = await ts.find_files('*')
         assert 'visible.txt' in result
-        assert '.env' not in result
+        assert 'readonly.txt' in result
 
     async def test_find_hides_denied_entries(self, fs_root: Path) -> None:
         (fs_root / 'visible.txt').write_text('ok\n')
@@ -1106,7 +1113,7 @@ class TestPatternCanonicalization:
         with pytest.raises(ModelRetry, match='denied'):
             await ts.read_file('config/./secret.txt')
 
-    async def test_root_level_secrets_hidden_from_search(self, fs_root: Path) -> None:
+    async def test_root_level_secrets_readable_but_write_protected(self, fs_root: Path) -> None:
         (fs_root / 'secrets.yaml').write_text('api: PRIVATE KEY material\n')
         ts = FileSystemToolset(
             root_dir=fs_root,
@@ -1117,6 +1124,8 @@ class TestPatternCanonicalization:
             max_search_results=1000,
             max_find_results=1000,
         )
-        # `**/secrets*` must protect a root-level secrets file, not just nested ones.
+        # `**/secrets*` must protect a root-level secrets file for writes, not just nested ones.
+        with pytest.raises(ModelRetry, match='protected'):
+            await ts.write_file('secrets.yaml', 'api: changed\n')
         result = await ts.search_files('PRIVATE KEY')
-        assert 'secrets.yaml' not in result
+        assert 'secrets.yaml' in result


### PR DESCRIPTION
## Summary

Fixes #322

`protected_patterns` are documented as read-only, but filesystem walkers checked
each entry as a write. That made protected files disappear from read-only
operations, and `protected_patterns=["*"]` made `list_directory(".")` return an
empty directory.

## Changes

- Use readable access checks for `list_directory`, `search_files`, and
  `find_files` entries.
- Keep `allowed_patterns`, `denied_patterns`, and dotfile filtering unchanged.
- Keep protected write rejection unchanged for `write_file`, `edit_file`, and
  `create_directory`.
- Update the FileSystem README and regression tests to match the read-only
  protected path semantics.

## Verification

```bash
uv run pytest tests/filesystem/test_filesystem.py -k 'protected or root_level_secrets'
uv run pytest tests/filesystem
make lint
make typecheck
make test
make testcov
git diff --check
```

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)
