### PR TITLE
Align `CodeMode` `final_output` with `StopRun` output processing

### DIFF
--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -172,11 +172,12 @@ report = build_report(await gather_data())
 final_output(report)
 ```
 
-`value` must already match the agent's output type. It is passed through the agent's
-[output validators](https://ai.pydantic.dev/output/#output-validator-functions) (the same ones a
-model-produced output runs through), but it is **not** coerced to the declared type, so committing
-a value of the wrong shape is your responsibility. Coerce it in code (or in an output validator)
-before committing.
+`value` is treated as the semantic final-output value: Pydantic AI validates and coerces it against
+the agent's declared output type, then runs output hooks, output functions, and
+[output validators](https://ai.pydantic.dev/output/#output-validator-functions). For example,
+`final_output({"answer": "42"})` can produce a `BaseModel` output with `answer: int`. If validation
+or a hook rejects the value, the run raises that error because there is no further model turn to
+retry against.
 
 The function is opt-in per capability: with the default `allow_final_output=False` it is absent
 from the sandbox, and a script that calls `final_output` fails as an undefined function. Most

--- a/pydantic_ai_harness/code_mode/_capability.py
+++ b/pydantic_ai_harness/code_mode/_capability.py
@@ -134,8 +134,9 @@ class CodeMode(AbstractCapability[AgentDepsT]):
     When `True`, a `final_output(value)` function is exposed inside the sandbox. Calling it
     records `value` and, once the `run_code` call returns, `CodeMode` ends the run with that
     value as the output -- no extra model turn -- while the `run_code` tool return stays in
-    message history. The value is passed through the agent's output validators but is **not**
-    coerced to the declared output type, so it must already match it.
+    message history. Pydantic AI treats the value as the semantic final-output value, validates
+    and coerces it against the agent's declared output type, then runs output hooks, output
+    functions, and output validators.
 
     Off by default: most code-mode agents should not be able to finish the run from a script.
     A schema-matching `run_code` return is never committed implicitly; committing is always an
@@ -221,7 +222,7 @@ class CodeMode(AbstractCapability[AgentDepsT]):
         Only active with `allow_final_output=True`. When a `run_code` script committed a value
         this run and the node didn't already end the run, raise
         [`StopRun`][pydantic_ai.exceptions.StopRun]: Pydantic AI runs the value through the
-        agent's output validators, preserves the pending `run_code` tool return in message
+        normal final-output pipeline, preserves the pending `run_code` tool return in message
         history, and finishes without another model request. Otherwise the result is unchanged.
         """
         if self._final_output_candidate is not None and not isinstance(result, End):

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -899,7 +899,34 @@ async def _handle_function_snapshot(
     if on_final_output is not None and fn_name == _FINAL_OUTPUT_NAME:
         # Synthetic `final_output(value)`: capture the value and hand it straight back so the
         # script continues. The commit itself happens after `run_code` returns, in `CodeMode`.
-        value = snapshot.args[0] if snapshot.args else snapshot.kwargs['value']
+        if len(snapshot.args) > 1:
+            return snapshot.resume(
+                {'exception': TypeError('final_output() takes exactly one argument')}, os=os_access, mount=mount
+            )
+        if snapshot.args and snapshot.kwargs:
+            return snapshot.resume(
+                {'exception': TypeError("final_output() got multiple values for argument 'value'")},
+                os=os_access,
+                mount=mount,
+            )
+        if snapshot.args:
+            value = snapshot.args[0]
+        elif 'value' in snapshot.kwargs:
+            unexpected = set(snapshot.kwargs) - {'value'}
+            if unexpected:
+                keyword = next(iter(unexpected))
+                return snapshot.resume(
+                    {'exception': TypeError(f'final_output() got an unexpected keyword argument {keyword!r}')},
+                    os=os_access,
+                    mount=mount,
+                )
+            value = snapshot.kwargs['value']
+        else:
+            return snapshot.resume(
+                {'exception': TypeError("final_output() missing required argument 'value'")},
+                os=os_access,
+                mount=mount,
+            )
         on_final_output(value)
         return snapshot.resume({'return_value': value}, os=os_access, mount=mount)
 

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -203,18 +203,60 @@ _FINAL_OUTPUT_NAME = 'final_output'
 _FINAL_OUTPUT_METADATA_KEY = 'final_output'
 _FINAL_OUTPUT_DESCRIPTION = (
     "Commit `value` as the agent's final output and end the run without another model turn. "
-    'The value must already match the agent output type: it is checked by the output validators '
-    'but not coerced, so pass a value of the correct type. The `run_code` call still returns '
-    'normally and stays in message history, and code after this call keeps running. '
+    'Pydantic AI validates and coerces the value against the agent output type, then runs output '
+    'hooks, output functions, and output validators. The `run_code` call still returns normally '
+    'and stays in message history, and code after this call keeps running. '
     'Returns `value` unchanged.'
 )
 
 
-def _final_output_block(body: str) -> str:
-    """Render the synthetic `final_output` definition shared by the catalog and type-check stubs.
+def _final_output_tool_def(ctx: RunContext[AgentDepsT]) -> ToolDefinition:
+    """Build the synthetic `final_output(value)` definition advertised inside the sandbox.
 
-    `body` is the placeholder statement (`...` for the model-facing catalog,
-    `raise NotImplementedError()` for the type-check stub).
+    `RunContext` exposes `ctx.agent.output_json_schema()`, but not the current run's resolved
+    output schema. That means this reflects the agent's configured output type and can fall back
+    to `Any` for contexts without an agent; it will not see per-call `agent.run(..., output_type=...)`
+    overrides until core exposes that schema on the public run context.
+    """
+    output_schema: dict[str, Any] = {}
+    if ctx.agent is not None:
+        output_schema = ctx.agent.output_json_schema()
+
+    value_schema = dict(output_schema)
+    defs = value_schema.pop('$defs', None)
+    parameters_json_schema: dict[str, Any] = {
+        'type': 'object',
+        'properties': {'value': value_schema},
+        'required': ['value'],
+        'additionalProperties': False,
+    }
+    if defs is not None:
+        parameters_json_schema['$defs'] = defs
+
+    return ToolDefinition(
+        name=_FINAL_OUTPUT_NAME,
+        description=_FINAL_OUTPUT_DESCRIPTION,
+        parameters_json_schema=parameters_json_schema,
+        return_schema=output_schema,
+        sequential=True,
+    )
+
+
+def _render_final_output_signature(
+    final_output_tool_def: ToolDefinition, body: str, *, conflicting_type_names: frozenset[str] = frozenset()
+) -> str:
+    """Render `final_output(value)` with the agent output type and positional-call shape."""
+    rendered = final_output_tool_def.render_signature(
+        body, is_async=False, conflicting_type_names=conflicting_type_names
+    )
+    return rendered.replace(f'def {_FINAL_OUTPUT_NAME}(*, value:', f'def {_FINAL_OUTPUT_NAME}(value:', 1)
+
+
+def _final_output_type_check_stub(body: str) -> str:
+    """Render the permissive type-check stub for `final_output(value)`.
+
+    The model-facing catalog advertises the agent output type, but the static checker
+    stays permissive so Pydantic AI remains the validation and coercion boundary.
     """
     return f'def {_FINAL_OUTPUT_NAME}(value: Any) -> Any:\n    """{_FINAL_OUTPUT_DESCRIPTION}"""\n    {body}'
 
@@ -410,6 +452,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
                 native_tools[name] = tool
 
         callable_defs, sanitized_to_original = self._partition_callable_tools(sandboxed_tools)
+        final_output_tool_def = _final_output_tool_def(ctx) if self.allow_final_output else None
 
         # `dynamic_catalog` keeps the catalog out of `run_code.description` (cache-stable
         # tool-defs block) and surfaces it via `get_instructions` instead. Stash it for the
@@ -420,10 +463,10 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         has_mount = self.mount is not None
         if self.dynamic_catalog:
             description = _base_description(has_os=has_os, has_mount=has_mount)
-            self._last_catalog = self._render_catalog(callable_defs, include_final_output=self.allow_final_output)
+            self._last_catalog = self._render_catalog(callable_defs, final_output_tool_def=final_output_tool_def)
         else:
             description = self._build_description(
-                callable_defs, has_os=has_os, has_mount=has_mount, include_final_output=self.allow_final_output
+                callable_defs, has_os=has_os, has_mount=has_mount, final_output_tool_def=final_output_tool_def
             )
             self._last_catalog = ''
 
@@ -593,8 +636,9 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         # (variables from prior snippets) is invisible to the stateless checker.
         # Runs before REPL creation so that if this raises ModelRetry, the REPL
         # stays None and the next retry still gets type-checked.
-        if fresh_repl and callable_defs:
-            self._type_check(code, callable_defs=callable_defs, include_final_output=self.allow_final_output)
+        final_output_tool_def = _final_output_tool_def(ctx) if self.allow_final_output else None
+        if fresh_repl and (callable_defs or final_output_tool_def is not None):
+            self._type_check(code, callable_defs=callable_defs, final_output_tool_def=final_output_tool_def)
 
         # Create the REPL after type checking passes.
         if fresh_repl:
@@ -716,17 +760,23 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
 
     @staticmethod
     def _build_description(
-        callable_defs: dict[str, ToolDefinition], *, has_os: bool, has_mount: bool, include_final_output: bool = False
+        callable_defs: dict[str, ToolDefinition],
+        *,
+        has_os: bool,
+        has_mount: bool,
+        final_output_tool_def: ToolDefinition | None = None,
     ) -> str:
         """Render the `run_code` description: base prose + TypedDicts + function signatures."""
         base = _base_description(has_os=has_os, has_mount=has_mount)
-        catalog = CodeModeToolset._render_catalog(callable_defs, include_final_output=include_final_output)
+        catalog = CodeModeToolset._render_catalog(callable_defs, final_output_tool_def=final_output_tool_def)
         if not catalog:
             return base
         return base + '\n\n' + catalog
 
     @staticmethod
-    def _render_catalog(callable_defs: dict[str, ToolDefinition], *, include_final_output: bool = False) -> str:
+    def _render_catalog(
+        callable_defs: dict[str, ToolDefinition], *, final_output_tool_def: ToolDefinition | None = None
+    ) -> str:
         """Render the functions-header + TypedDict + function-signature blocks, or `''` if empty.
 
         Excludes the `run_code` base prose; the catalog is the discovery-driven portion that's
@@ -734,23 +784,30 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         (default static-description path) and by `get_instructions` (the `dynamic_catalog`
         path, which moves it into instructions instead).
 
-        When `include_final_output` is set, the synthetic `final_output(value)` function is
-        appended so the model sees it alongside the sandboxed tools.
+        When `final_output_tool_def` is set, the synthetic `final_output(value)` function is
+        appended so the model sees it alongside the sandboxed tools, typed from the agent output
+        schema when the current run context exposes one.
         """
-        if not callable_defs and not include_final_output:
+        if not callable_defs and final_output_tool_def is None:
             return ''
 
-        sigs, conflicting = _get_sigs_and_conflicting(callable_defs)
+        type_defs = callable_defs
+        if final_output_tool_def is not None:
+            type_defs = {**callable_defs, _FINAL_OUTPUT_NAME: final_output_tool_def}
+
+        sigs, conflicting = _get_sigs_and_conflicting(type_defs)
         type_blocks = FunctionSignature.render_type_definitions(sigs, conflicting)
         function_blocks = [
             td.render_signature('...', is_async=not td.sequential, conflicting_type_names=conflicting)
             for td in callable_defs.values()
         ]
-        if include_final_output:
-            function_blocks.append(_final_output_block('...'))
+        if final_output_tool_def is not None:
+            function_blocks.append(
+                _render_final_output_signature(final_output_tool_def, '...', conflicting_type_names=conflicting)
+            )
 
         # `final_output` is synchronous (called without `await`), so it counts toward `has_sync`.
-        has_sync = any(td.sequential for td in callable_defs.values()) or include_final_output
+        has_sync = any(td.sequential for td in callable_defs.values()) or final_output_tool_def is not None
         has_async = any(not td.sequential for td in callable_defs.values())
         sections = [_functions_header(has_sync=has_sync, has_async=has_async)]
         if type_blocks:
@@ -759,7 +816,9 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         return '\n\n'.join(sections)
 
     @staticmethod
-    def _build_type_check_stubs(callable_defs: dict[str, ToolDefinition], *, include_final_output: bool = False) -> str:
+    def _build_type_check_stubs(
+        callable_defs: dict[str, ToolDefinition], *, final_output_tool_def: ToolDefinition | None = None
+    ) -> str:
         """Build Python stubs for Monty's static type checker."""
         sigs, conflicting = _get_sigs_and_conflicting(callable_defs)
         parts = ['import asyncio\nfrom typing import Any, TypedDict, NotRequired, Literal']
@@ -771,12 +830,17 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             )
             for td in callable_defs.values()
         )
-        if include_final_output:
-            parts.append(_final_output_block('raise NotImplementedError()'))
+        if final_output_tool_def is not None:
+            parts.append(_final_output_type_check_stub('raise NotImplementedError()'))
         return '\n\n'.join(parts)
 
     @staticmethod
-    def _type_check(code: str, *, callable_defs: dict[str, ToolDefinition], include_final_output: bool = False) -> None:
+    def _type_check(
+        code: str,
+        *,
+        callable_defs: dict[str, ToolDefinition],
+        final_output_tool_def: ToolDefinition | None = None,
+    ) -> None:
         """Type-check a code snippet against tool signatures before execution.
 
         Uses Monty's stateless type checker with function stubs. Only sound
@@ -785,7 +849,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         Raises:
             ModelRetry: If the code has type errors or syntax errors.
         """
-        stubs = CodeModeToolset._build_type_check_stubs(callable_defs, include_final_output=include_final_output)
+        stubs = CodeModeToolset._build_type_check_stubs(callable_defs, final_output_tool_def=final_output_tool_def)
         try:
             Monty(code, type_check=True, type_check_stubs=stubs)
         except MontyTypingError as e:

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -2807,6 +2807,26 @@ class TestFinalOutput:
         assert 'final output' in enabled_desc
         assert 'final_output' not in disabled_desc
 
+    async def test_final_output_catalog_uses_agent_output_type(self) -> None:
+        """`final_output` advertises the agent output type when a run context provides one."""
+        from pydantic import BaseModel
+
+        class Weather(BaseModel):
+            city: str
+            temp_c: int
+
+        wrapper = CodeMode[object](allow_final_output=True).get_wrapper_toolset(_build_function_toolset(add))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = build_run_context(None)
+        ctx.agent = Agent(TestModel(), output_type=Weather)
+
+        description = (await wrapper.get_tools(ctx))['run_code'].tool_def.description
+
+        assert description is not None
+        assert 'class Weather(TypedDict):' in description
+        assert 'temp_c: int' in description
+        assert 'def final_output(value: Weather) -> Weather' in description
+
     async def test_final_output_call_errors_when_disabled(self) -> None:
         """Calling `final_output` with the feature off fails: it is not defined in the sandbox."""
         wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(add))

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -1900,7 +1900,7 @@ class TestToolSearchIntegration:
             ModelRequest(
                 parts=[
                     ToolSearchReturnPart(
-                        content={'discovered_tools': [{'name': 'later', 'description': 'A deferred-loading tool.'}]},
+                        content={'discovered_tools': [{'name': 'later'}]},
                         tool_call_id='search-1',
                     )
                 ]
@@ -2186,7 +2186,7 @@ class TestDynamicCatalog:
             parts=[
                 NativeToolSearchReturnPart(
                     tool_name='tool_search',
-                    content={'discovered_tools': [{'name': 'weather', 'description': 'Get the weather.'}]},
+                    content={'discovered_tools': [{'name': 'weather'}]},
                     tool_call_id='c1',
                 )
             ],
@@ -2653,10 +2653,10 @@ class TestFinalOutput:
         assert len(run_code_returns) == 1
 
     async def test_final_output_commits_structured_output_through_validators(self) -> None:
-        """A keyword `final_output(value=...)` commits a structured value, run through validators.
+        """A keyword `final_output(value=...)` commits a structured value through core output handling.
 
-        FunctionModel/non-VCR: pins that the `@agent.output_validator` runs on the committed
-        value (which `StopRun` validates but does not coerce) in a single turn.
+        FunctionModel/non-VCR: pins that `StopRun` coerces the committed value against the
+        declared output type before `@agent.output_validator` runs, all in a single turn.
         """
         from pydantic import BaseModel
         from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
@@ -2673,7 +2673,7 @@ class TestFinalOutput:
             nonlocal turns
             turns += 1
             if turns == 1:
-                code = "final_output(value={'city': 'Paris', 'temp_c': 20})"
+                code = "final_output(value={'city': 'Paris', 'temp_c': '20'})"
                 return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': code})])
             return ModelResponse(parts=[TextPart('second turn should not run')])  # pragma: no cover
 
@@ -2686,15 +2686,44 @@ class TestFinalOutput:
         @agent.output_validator
         def finalize(data: Weather) -> Weather:  # pyright: ignore[reportUnusedFunction]
             validated.append(data)
-            # `StopRun` does not coerce, so `data` is the raw dict the sandbox committed; the app
-            # coerces it here to demonstrate validators run and can shape the final output.
-            return Weather.model_validate(data)
+            return Weather(city=data.city, temp_c=data.temp_c + 1)
 
         result = await agent.run('weather in Paris')
 
         assert turns == 1
-        assert validated == [{'city': 'Paris', 'temp_c': 20}]
-        assert result.output == Weather(city='Paris', temp_c=20)
+        assert validated == [Weather(city='Paris', temp_c=20)]
+        assert result.output == Weather(city='Paris', temp_c=21)
+
+    async def test_final_output_validation_error_propagates(self) -> None:
+        """Invalid committed output raises validation errors instead of retrying the model."""
+        from pydantic import BaseModel, ValidationError
+        from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        class Weather(BaseModel):
+            city: str
+            temp_c: int
+
+        turns = 0
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            nonlocal turns
+            turns += 1
+            if turns == 1:
+                code = "final_output(value={'city': 'Paris', 'temp_c': 'warm'})"
+                return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': code})])
+            return ModelResponse(parts=[TextPart('second turn should not run')])  # pragma: no cover
+
+        agent: Agent[object, Weather] = Agent(
+            FunctionModel(model_fn),
+            output_type=Weather,
+            capabilities=[CodeMode[object](allow_final_output=True)],
+        )
+
+        with pytest.raises(ValidationError):
+            await agent.run('weather in Paris')
+
+        assert turns == 1
 
     async def test_enabled_but_no_commit_flows_to_second_turn(self) -> None:
         """With the feature on, a `run_code` return that never calls `final_output` does not commit.
@@ -2788,3 +2817,16 @@ class TestFinalOutput:
         with pytest.raises(ModelRetry) as exc_info:
             await wrapper.call_tool('run_code', {'code': 'final_output(1)'}, ctx, tools['run_code'])
         assert 'final_output' in str(exc_info.value)
+
+    async def test_final_output_call_without_value_errors_on_persistent_repl(self) -> None:
+        """A malformed `final_output()` call becomes a retryable code error after type checking is skipped."""
+        wrapper = CodeMode[object](allow_final_output=True).get_wrapper_toolset(_build_function_toolset(add))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+
+        await wrapper.call_tool('run_code', {'code': 'x = 1'}, ctx, tools['run_code'])
+
+        with pytest.raises(ModelRetry) as exc_info:
+            await wrapper.call_tool('run_code', {'code': 'final_output()'}, ctx, tools['run_code'])
+        assert "missing required argument 'value'" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Stacked on #323 and depends on pydantic/pydantic-ai#6321. This keeps the upstream shape clean: sandbox code calls `final_output(payload)`, harness carries that intent in metadata, and Pydantic AI validates/coerces `payload` through the normal `StopRun` output pipeline.

Changes in this follow-up:

- update `CodeMode(allow_final_output=True)` docs and tests now that `StopRun` validates/coerces semantic output values
- add a runtime guard so `final_output()` without a value becomes a retryable sandbox error on persisted REPL calls
- update stale tool-search test fixtures for the newer core `ToolSearchReturnContent` shape

## Linked Issue

Refs pydantic/pydantic-ai#6243
Depends on pydantic/pydantic-ai#6321
Stacked on #323

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (focused checks below)
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)

Focused checks run with the local pydantic-ai#6321 overlay:

- `PYTHONPATH=/Users/kazmer.nagy-betegh/dev/pydantic-ai/pydantic_graph:/Users/kazmer.nagy-betegh/dev/pydantic-ai/pydantic_ai_slim UV_CACHE_DIR=/tmp/uv-cache uv run pytest -p no:cacheprovider tests/code_mode/test_code_mode.py -k "final_output or tool_search_toolset_discovered_tool_in_run_code or announce_on_native_search_return_part"`
- `PYTHONPATH=/Users/kazmer.nagy-betegh/dev/pydantic-ai/pydantic_graph:/Users/kazmer.nagy-betegh/dev/pydantic-ai/pydantic_ai_slim UV_CACHE_DIR=/tmp/uv-cache uv run pyright pydantic_ai_harness/code_mode/_capability.py pydantic_ai_harness/code_mode/_toolset.py tests/code_mode/test_code_mode.py`
- `RUFF_CACHE_DIR=/tmp/ruff-cache UV_CACHE_DIR=/tmp/uv-cache uv run ruff check pydantic_ai_harness/code_mode/_capability.py pydantic_ai_harness/code_mode/_toolset.py tests/code_mode/test_code_mode.py pydantic_ai_harness/code_mode/README.md`
- `RUFF_CACHE_DIR=/tmp/ruff-cache UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check pydantic_ai_harness/code_mode/_capability.py pydantic_ai_harness/code_mode/_toolset.py tests/code_mode/test_code_mode.py`