### PR TITLE
fix(shell): use platform-appropriate process termination on Windows

### DIFF
--- a/pydantic_ai_harness/shell/README.md
+++ b/pydantic_ai_harness/shell/README.md
@@ -116,9 +116,12 @@ explicitly when you replace the environment.
 
 `start_command` writes stdout/stderr to temp files and returns a short ID. Use
 `check_command(id)` to poll and `stop_command(id)` to terminate and collect
-final output. Processes are launched in their own session (`start_new_session`)
-so the whole process group can be signalled -- `SIGTERM`, escalating to
-`SIGKILL` after a grace period.
+final output. On POSIX, processes are launched in their own session
+(`start_new_session`) so the whole process group can be signalled -- `SIGTERM`,
+escalating to `SIGKILL` after a grace period. On Windows, where process groups
+and these signals don't exist, the direct child is terminated via
+`TerminateProcess` with the same grace-period escalation; grandchildren it
+spawned are not reaped.
 
 On run end, the toolset's `__aexit__` terminates every still-running background
 process and deletes its temp files. The agent runtime enters toolsets via an

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import signal
 import subprocess
+import sys
 import tempfile
 import uuid
 from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -257,7 +258,33 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
             self._cwd = candidate
 
     async def _kill_process_group(self, proc: anyio.abc.Process) -> None:
-        """SIGTERM the process group, escalating to SIGKILL after the grace period."""
+        """Terminate the spawned command, escalating to a hard kill after the grace period.
+
+        On POSIX the whole process group is signalled (SIGTERM, then SIGKILL):
+        the process is launched with `start_new_session=True`, so grandchildren
+        that would otherwise survive and keep the output pipes open die with it.
+        On Windows `os.killpg`, `os.getpgid` and `signal.SIGKILL` do not exist
+        (the lookup raises `AttributeError`) and `start_new_session` is ignored,
+        so fall back to `Process.terminate()`/`Process.kill()`, which map to
+        `TerminateProcess` and only affect the direct child.
+        """
+        if sys.platform == 'win32':
+            try:
+                proc.terminate()
+            except OSError:
+                return
+
+            with anyio.move_on_after(_KILL_GRACE_PERIOD):
+                await proc.wait()
+                return
+
+            # Still alive after grace period -- hard kill
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            return
+
         pid = proc.pid
         try:
             os.killpg(os.getpgid(pid), signal.SIGTERM)

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -1271,6 +1271,87 @@ class TestKillProcessGroupEdgeCases:
         assert call_count == 2
 
 
+class TestKillProcessGroupWindows:
+    """The Windows kill path (`os.killpg`/`os.getpgid`/`signal.SIGKILL` do not exist there)."""
+
+    def _toolset(self, tmp_path: Path) -> ShellToolset:
+        return ShellToolset(
+            cwd=tmp_path,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=5.0,
+            max_output_chars=50_000,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+
+    async def test_graceful_exit_skips_kill(self, tmp_path: Path) -> None:
+        """When the process exits within the grace period, kill() is not called."""
+        ts = self._toolset(tmp_path)
+        proc = MagicMock()
+
+        async def exit_immediately() -> None:
+            return
+
+        proc.wait = exit_immediately
+
+        with patch('sys.platform', 'win32'):
+            await ts._kill_process_group(proc)
+
+        proc.terminate.assert_called_once_with()
+        proc.kill.assert_not_called()
+
+    async def test_terminate_raises_os_error(self, tmp_path: Path) -> None:
+        """When terminate() raises OSError (process already gone), method returns early."""
+        ts = self._toolset(tmp_path)
+        proc = MagicMock()
+        proc.terminate.side_effect = OSError
+
+        with patch('sys.platform', 'win32'):
+            await ts._kill_process_group(proc)
+
+        proc.kill.assert_not_called()
+
+    async def test_kill_escalation(self, tmp_path: Path) -> None:
+        """When the process outlives the grace period, kill() is called."""
+        ts = self._toolset(tmp_path)
+        proc = MagicMock()
+
+        async def never_return() -> None:
+            await anyio.sleep(999)
+
+        proc.wait = never_return
+
+        with (
+            patch('sys.platform', 'win32'),
+            patch('pydantic_ai_harness.shell._toolset._KILL_GRACE_PERIOD', 0.01),
+        ):
+            await ts._kill_process_group(proc)
+
+        proc.terminate.assert_called_once_with()
+        proc.kill.assert_called_once_with()
+
+    async def test_kill_raises_os_error(self, tmp_path: Path) -> None:
+        """When kill() raises OSError (process exited between terminate and kill)."""
+        ts = self._toolset(tmp_path)
+        proc = MagicMock()
+        proc.kill.side_effect = OSError
+
+        async def never_return() -> None:
+            await anyio.sleep(999)
+
+        proc.wait = never_return
+
+        with (
+            patch('sys.platform', 'win32'),
+            patch('pydantic_ai_harness.shell._toolset._KILL_GRACE_PERIOD', 0.01),
+        ):
+            await ts._kill_process_group(proc)
+
+        proc.kill.assert_called_once_with()
+
+
 class TestDrainWithTimeoutEdgeCases:
     async def test_stdout_closed_resource_error(self, tmp_path: Path) -> None:
         """ClosedResourceError on stdout is caught silently after yielding data."""


### PR DESCRIPTION
## Summary

Fixes #349.

`ShellToolset._kill_process_group` called `os.killpg(os.getpgid(pid), signal.SIGTERM/SIGKILL)` unconditionally. None of these names exist on Windows (per typeshed they are guarded by `sys.platform != 'win32'`), so the attribute lookup raises `AttributeError` on the command/review timeout path. The surrounding handlers catch `OSError` subclasses only, so the exception propagates and aborts the agent run instead of terminating the timed-out process.

## Changes

- `_kill_process_group` now branches on `sys.platform`:
  - POSIX: unchanged process-group signalling (SIGTERM, grace period, SIGKILL).
  - Windows: `anyio.abc.Process.terminate()` / `.kill()` (both map to `TerminateProcess`) with the same grace-period escalation.
- Shell README documents the Windows behavior, including that grandchild processes are not reaped there (no process-group equivalent without `CREATE_NEW_PROCESS_GROUP`, which `anyio.open_process` does not expose).
- Four tests for the Windows branch, mirroring the existing `TestKillProcessGroupEdgeCases` pattern (`patch('sys.platform', 'win32')` + mocked process), keeping branch coverage at 100%.

Notes on scope:

- `start_new_session=True` needs no guard: CPython's Windows `_execute_child` receives it as `unused_start_new_session`, so process launch already works there.
- The issue also mentions `experimental/macroscope/_toolset.py`, which is not on `main` (it lives in #350); that PR could reuse the same pattern once merged.
- No `AttributeError` belt-and-suspenders catch: with the platform branch the POSIX-only names can no longer be reached on Windows.

## Testing

- [x] `make lint`, `make typecheck` (pyright strict), `make testcov` all pass locally (macOS); coverage stays at 100% branch.
- [ ] Not verified on a real Windows machine; the Windows branch is exercised via mocks. CI has no Windows job (as noted in the issue).

*This PR was prepared with AI assistance (Claude Code), reviewed and submitted by me.*