### PR TITLE
Remove stale Claude-only AICA attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,4 +155,3 @@ need.
 - Always link sources for any claims made during research
 - Run `make lint && make typecheck && make test` before every commit
 - Commit messages should summarize the "why", not the "what"
-- All GitHub comments must start with "Claude here: "


### PR DESCRIPTION
This pull request was posted by Codex Desktop on behalf of David.

Removes the repository-specific instruction that forced every AICA to open GitHub comments with “Claude here”. The global CE policy now owns attribution and resolves the active harness and model through the deterministic aica-identity helper.

Existing generated AGENTS.override.md files should be refreshed with ph-config after this lands.