### PR TITLE
Add `TrimRetryHistory` for output-validation retries

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -5,7 +5,7 @@ description: A menu of strategies -- clear, dedupe, trim, or summarize -- for ke
 
 # Compaction
 
-Compaction is a menu of strategies for keeping an agent's conversation history within a model's context window. Most are Pydantic AI `Capability` classes that edit the message history just before each request goes out. `FallbackCompaction` is instead a composing `CompactionStrategy` used through `TieredCompaction` or `compact_now`; it has no request trigger of its own. The edits **persist** into the run's message history, so a trim, clear, or summary carries forward to later steps -- it is not recomputed from the full history every turn.
+Compaction is a menu of strategies for keeping an agent's conversation history within a model's context window. Most are Pydantic AI `Capability` classes that edit message history before a request. `FallbackCompaction` is instead a composing `CompactionStrategy` used through `TieredCompaction` or `compact_now`; it has no request trigger of its own. Most edits **persist** into the run history, so a trim, clear, or summary carries forward to later steps. `TrimRetryHistory` is the exception: it wraps each model call with a request-local message list without changing the source run history.
 
 All strategies preserve tool-call / tool-return **pairing**. Core does not validate this, and a provider rejects an orphaned pair, so the pairing guarantee is what makes these safe to drop into an agent. The zero-LLM strategies never call a model; only `SummarizingCompaction` (and `TieredCompaction` when it escalates that far) spends tokens.
 
@@ -27,6 +27,7 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 | `SlidingWindowCompaction` | zero-LLM | Drops the oldest whole messages down to a tail | You only need the recent turns and can discard old context entirely |
 | `ClearToolResults` | zero-LLM | Blanks the content of old tool *results* in place, keeping the last `keep_pairs` | Tool outputs dominate context and can be re-fetched on demand (the cheap first tier) |
 | `DeduplicateFileReads` | zero-LLM | Blanks every file read superseded by a newer read of the same file | The agent re-reads files and only the latest version matters |
+| `TrimRetryHistory` | zero-LLM | Keeps only the newest output-validation retry pair in the model-facing request | Repeated invalid outputs bloat retry requests, but the source run history must stay intact |
 | `SummarizingCompaction` | one LLM call | Summarizes older messages into a structured summary, keeping the recent tail | Old context still matters but must be compressed; use behind the cheap tiers |
 | `TieredCompaction` | escalates | Runs cheap passes first, summarizes only if still over `target_tokens` | You want a sensible default: spend the expensive summary only when needed |
 | `FallbackCompaction` | depends on chain | Tries the next strategy when one raises | Summarization can fail and deterministic truncation must keep the run alive |
@@ -35,7 +36,7 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 
 ## Triggers
 
-Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`. Token counts anchor on the provider-reported usage of the most recent model response when one is available. That provider usage includes the instructions, tool definitions, and `FilePart` payloads sent in the anchored request; only the messages added since are estimated. The suffix after the anchor, or a history with no usage anchor, uses `tokenizer` or a ~4-chars-per-token heuristic and cannot see `FilePart` payloads. Pending tool schemas newly revealed for the request are conservatively estimated by the implementation. `DeduplicateFileReads` runs on every request when no trigger is set (it is cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` / `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` / `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a large total.
+Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`. Token counts anchor on the provider-reported usage of the most recent model response when one is available. That provider usage includes the instructions, tool definitions, and `FilePart` payloads sent in the anchored request; only the messages added since are estimated. The suffix after the anchor, or a history with no usage anchor, uses `tokenizer` or a ~4-chars-per-token heuristic and cannot see `FilePart` payloads. Pending tool schemas newly revealed for the request are conservatively estimated by the implementation. `DeduplicateFileReads` runs on every request when no trigger is set (it is cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` / `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` / `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a large total. `TrimRetryHistory` has no size trigger; it acts only when repeated trailing output-validation retry pairs are present.
 
 ### `max_fraction`: one setting for every model
 
@@ -166,6 +167,22 @@ history = await compact_now(
 `focus` steers strategies that write prose -- `SummarizingCompaction`, via the exported `SupportsFocus` protocol's `with_focus` -- and is passed over by the ones that drop or blank content by rule, since they have nothing to steer. `TieredCompaction` is focusable when any of its tiers is, so a focus reaches the summarizing tier rather than stopping at the wrapper.
 
 A compaction that changes the history emits the same `compact_messages` span the in-run path emits, so an instrumented application sees one shape however compaction was triggered. Pass `tracer=` to record it; without one the span goes to a no-op tracer.
+
+## `TrimRetryHistory`: keep the latest correction pair
+
+Output-validation failures append the rejected response and validation feedback before the next model request. `TrimRetryHistory` preserves the legitimate conversation prefix and the newest response/feedback pair while removing older output-validation retry pairs from the model-facing request.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import TrimRetryHistory
+
+agent = Agent(
+    'openai:gpt-5.6-luna',
+    capabilities=[TrimRetryHistory()],
+)
+```
+
+At the model-call boundary, the capability replaces the request-local `ModelRequestContext.messages` list passed to the model handler. The persisted source run history remains unchanged. Only output-validation retry pairs are trimmed; function-tool retry history is left untouched.
 
 ## The recommended default: `TieredCompaction`
 
@@ -467,6 +484,8 @@ The recommended default is `TieredCompaction`; the other strategies below can be
 ::: pydantic_ai_harness.compaction.ClearToolResults
 
 ::: pydantic_ai_harness.compaction.DeduplicateFileReads
+
+::: pydantic_ai_harness.compaction.TrimRetryHistory
 
 ::: pydantic_ai_harness.compaction.SlidingWindowCompaction
 

--- a/pydantic_ai_harness/__init__.py
+++ b/pydantic_ai_harness/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
         SlidingWindowCompaction,
         SummarizingCompaction,
         TieredCompaction,
+        TrimRetryHistory,
         WarnNearLimits,
     )
     from .conversation_search import ConversationSearch
@@ -107,6 +108,7 @@ __all__ = [
     'SummarizingCompaction',
     'SystemReminders',
     'TieredCompaction',
+    'TrimRetryHistory',
     'ToolGuardrail',
     'ToolOutputLimits',
     'WarnNearLimits',
@@ -151,6 +153,7 @@ _CAPABILITY_EXPORTS = {
     'SummarizingCompaction': 'compaction',
     'SystemReminders': 'system_reminders',
     'TieredCompaction': 'compaction',
+    'TrimRetryHistory': 'compaction',
     'ToolGuardrail': 'guardrails',
     'ToolOutputLimits': 'tool_output_limits',
     'WarnNearLimits': 'compaction',

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -1,11 +1,11 @@
 # Compaction
 
 A menu of strategies for keeping an agent's conversation history within a model's context
-window. Most are Pydantic AI `Capability` classes that edit the message history just before each
-request goes out. `FallbackCompaction` is instead a composing `CompactionStrategy` used through
-`TieredCompaction` or `compact_now`; it has no request trigger of its own. Edits **persist** into the
-run's message history, so a trim, clear, or summary carries forward to later steps (it is not
-recomputed from the full history every turn).
+window. Most are Pydantic AI `Capability` classes that edit message history before a request.
+`FallbackCompaction` is instead a composing `CompactionStrategy` used through `TieredCompaction`
+or `compact_now`; it has no request trigger of its own. Most edits **persist** into the run history,
+so a trim, clear, or summary carries forward to later steps. `TrimRetryHistory` is the exception:
+it wraps each model call with a request-local message list without changing the source run history.
 
 All strategies preserve tool-call / tool-return **pairing** -- core does not validate this, and a
 provider rejects an orphaned pair. The zero-LLM strategies never call a model.
@@ -24,6 +24,7 @@ alternative: they work with every model and keep the compaction logic (and its c
 | `SlidingWindowCompaction` | zero-LLM | Drops the oldest whole messages down to a tail | You only need the recent turns and can discard old context entirely |
 | `ClearToolResults` | zero-LLM | Blanks the content of old tool *results* in place, keeping the last `keep_pairs` | Tool outputs dominate context and can be re-fetched on demand (the cheap first tier) |
 | `DeduplicateFileReads` | zero-LLM | Blanks every file read superseded by a newer read of the same file | The agent re-reads files and only the latest version matters |
+| `TrimRetryHistory` | zero-LLM | Keeps only the newest output-validation retry pair in the model-facing request | Repeated invalid outputs bloat retry requests, but the source run history must stay intact |
 | `SummarizingCompaction` | one LLM call | Summarizes older messages into a structured summary, keeping the recent tail | Old context still matters but must be compressed; use behind the cheap tiers |
 | `TieredCompaction` | escalates | Runs cheap passes first, summarizes only if still over `target_tokens` | You want a sensible default: spend the expensive summary only when needed |
 | `FallbackCompaction` | depends on chain | Tries the next strategy when one raises | Summarization can fail and deterministic truncation must keep the run alive |
@@ -45,7 +46,8 @@ estimated by the implementation. `DeduplicateFileReads` runs on every request wh
 cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` /
 `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` /
 `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a
-large total.
+large total. `TrimRetryHistory` has no size trigger; it acts only when repeated trailing
+output-validation retry pairs are present.
 
 ### `max_fraction`: one setting for every model
 
@@ -262,6 +264,28 @@ fallback = FallbackCompaction(
 The strategies' trigger fields are not consulted when a composing strategy calls `compact`
 directly. Put `fallback` inside `TieredCompaction` to give the chain a context trigger, or pass it
 to `compact_now` for manual compaction.
+
+## `TrimRetryHistory`: keep the latest correction pair
+
+Output-validation failures append the rejected response and validation feedback before the next
+model request. `TrimRetryHistory` preserves the legitimate conversation prefix and the newest
+response/feedback pair while removing older output-validation retry pairs from the model-facing
+request.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import TrimRetryHistory
+
+agent = Agent(
+    'openai:gpt-5.6-luna',
+    capabilities=[TrimRetryHistory()],
+)
+```
+
+At the model-call boundary, the capability replaces the request-local
+`ModelRequestContext.messages` list passed to the model handler. The persisted source run history
+remains unchanged. Only output-validation retry pairs are trimmed; function-tool retry history is
+left untouched.
 
 ## `ClampOversizedMessages`: surviving a runaway generation
 

--- a/pydantic_ai_harness/compaction/__init__.py
+++ b/pydantic_ai_harness/compaction/__init__.py
@@ -26,6 +26,7 @@ from pydantic_ai_harness.compaction._shared import (
 from pydantic_ai_harness.compaction._sliding_window_compaction import SlidingWindowCompaction
 from pydantic_ai_harness.compaction._summarizing_compaction import SummarizingCompaction
 from pydantic_ai_harness.compaction._tiered_compaction import TieredCompaction
+from pydantic_ai_harness.compaction._trim_retry_history import TrimRetryHistory
 from pydantic_ai_harness.compaction._warn_near_limits import WarningKind, WarnNearLimits
 
 __all__ = [
@@ -42,6 +43,7 @@ __all__ = [
     'SupportsFocus',
     'TieredCompaction',
     'TranscriptHandleProvider',
+    'TrimRetryHistory',
     'WarnNearLimits',
     'WarningKind',
     'compact_now',

--- a/pydantic_ai_harness/compaction/_trim_retry_history.py
+++ b/pydantic_ai_harness/compaction/_trim_retry_history.py
@@ -1,0 +1,82 @@
+"""`TrimRetryHistory` -- compact repeated output-validation retry context."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
+
+from pydantic_ai._run_context import AgentDepsT
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, RetryPromptPart
+from pydantic_ai.tools import RunContext
+
+if TYPE_CHECKING:
+    from pydantic_ai.capabilities.abstract import WrapModelRequestHandler
+    from pydantic_ai.models import ModelRequestContext
+
+
+@dataclass
+class TrimRetryHistory(AbstractCapability[AgentDepsT]):
+    """Keep only the newest output-validation retry pair in a retry request.
+
+    Output validation retries append the rejected response and validation feedback to the
+    conversation. When validation fails more than once, earlier rejected response/feedback
+    pairs add context without helping the model correct its latest answer. This capability
+    presents the model handler with a request-local list containing the original task and the
+    latest pair only, without changing the persisted run history.
+
+    Tool retries are unaffected because their retry prompts name the tool that failed.
+    """
+
+    async def wrap_model_request(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        request_context: ModelRequestContext,
+        handler: WrapModelRequestHandler,
+    ) -> ModelResponse:
+        """Trim repeated output-validation retry pairs only for the model call."""
+        messages = request_context.messages
+        first_pair = _first_output_retry_pair(messages, _output_tool_names(request_context))
+        if first_pair is None or first_pair == len(messages) - 2:
+            return await handler(request_context)
+
+        compacted = [*messages[:first_pair], *messages[-2:]]
+        return await handler(replace(request_context, messages=compacted))
+
+
+def _first_output_retry_pair(messages: list[ModelMessage], output_tool_names: set[str]) -> int | None:
+    """Find the first pair in a trailing sequence of output-validation retries."""
+    if (
+        len(messages) < 2
+        or not isinstance(messages[-2], ModelResponse)
+        or not _is_output_retry_request(messages[-1], output_tool_names)
+    ):
+        return None
+
+    first_pair = len(messages) - 2
+    while first_pair >= 2:
+        previous_pair = first_pair - 2
+        if not isinstance(messages[previous_pair], ModelResponse) or not _is_output_retry_request(
+            messages[previous_pair + 1], output_tool_names
+        ):
+            break
+        first_pair = previous_pair
+    return first_pair
+
+
+def _output_tool_names(request_context: ModelRequestContext) -> set[str]:
+    """Return the output-tool names registered for this model request."""
+    return {tool.name for tool in request_context.model_request_parameters.output_tools}
+
+
+def _is_output_retry_request(message: ModelMessage, output_tool_names: set[str]) -> bool:
+    """Return whether a request contains only output-validation retry feedback."""
+    return (
+        isinstance(message, ModelRequest)
+        and bool(message.parts)
+        and all(
+            isinstance(part, RetryPromptPart) and (part.tool_name is None or part.tool_name in output_tool_names)
+            for part in message.parts
+        )
+    )

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -9,15 +9,16 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from opentelemetry.trace import NoOpTracer, Tracer
-from pydantic_ai import Agent
+from pydantic_ai import Agent, ToolDefinition, capture_run_messages
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.exceptions import ModelAPIError
+from pydantic_ai.exceptions import ModelAPIError, ModelRetry
 from pydantic_ai.messages import (
     LoadCapabilityCallPart,
     ModelMessage,
     ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
+    RetryPromptPart,
     SystemPromptPart,
     TextContent,
     TextPart,
@@ -45,6 +46,7 @@ from pydantic_ai_harness.compaction import (
     SummarizingCompaction,
     TieredCompaction,
     TranscriptHandleProvider,
+    TrimRetryHistory,
     WarnNearLimits,
     estimate_context_tokens,
     estimate_token_count,
@@ -110,7 +112,9 @@ def _make_ctx(
     return _FakeCtx(usage=usage)
 
 
-def _make_request_context(messages: list[ModelMessage], model: Model | None = None) -> ModelRequestContext:
+def _make_request_context(
+    messages: list[ModelMessage], model: Model | None = None, output_tool_name: str | None = None
+) -> ModelRequestContext:
     """Build a ModelRequestContext wrapping the given messages.
 
     *model* is the model the request would be sent to. Pass the context's own model to
@@ -126,7 +130,9 @@ def _make_request_context(messages: list[ModelMessage], model: Model | None = No
         model=model if model is not None else _FakeModel(),  # type: ignore[arg-type]
         messages=messages,
         model_settings=None,
-        model_request_parameters=ModelRequestParameters(),
+        model_request_parameters=ModelRequestParameters(
+            output_tools=[] if output_tool_name is None else [ToolDefinition(name=output_tool_name)]
+        ),
     )
 
 
@@ -144,6 +150,214 @@ def _tool_call(tool_name: str, call_id: str) -> ModelResponse:
 
 def _tool_return(tool_name: str, call_id: str, content: str = 'ok') -> ModelRequest:
     return ModelRequest(parts=[ToolReturnPart(tool_name=tool_name, content=content, tool_call_id=call_id)])
+
+
+def _output_retry(feedback: str) -> ModelRequest:
+    return ModelRequest(parts=[RetryPromptPart(content=feedback)])
+
+
+async def _run_trim_retry_history(
+    capability: TrimRetryHistory[Any], request_context: ModelRequestContext
+) -> tuple[list[ModelMessage], ModelResponse]:
+    """Run the model wrapper and return the messages received by its handler."""
+    seen_messages: list[ModelMessage] | None = None
+
+    async def handler(context: ModelRequestContext) -> ModelResponse:
+        nonlocal seen_messages
+        seen_messages = context.messages
+        return ModelResponse(parts=[TextPart(content='ok')])
+
+    response = await capability.wrap_model_request(_make_ctx(), request_context=request_context, handler=handler)
+    assert seen_messages is not None
+    return seen_messages, response
+
+
+def _text_and_retry_contents(messages: list[ModelMessage]) -> list[str]:
+    """Return assistant text and string retry feedback in history order."""
+    contents: list[str] = []
+    for message in messages:
+        for part in message.parts:
+            if isinstance(part, TextPart):
+                contents.append(part.content)
+            elif isinstance(part, RetryPromptPart) and isinstance(part.content, str):
+                contents.append(part.content)
+    return contents
+
+
+class TestTrimRetryHistory:
+    @pytest.mark.anyio
+    async def test_keeps_original_context_and_newest_retry_pair(self):
+        task = ModelRequest(parts=[SystemPromptPart(content='system'), UserPromptPart(content='task')])
+        invalid_one = _assistant('invalid-one')
+        retry_one = _output_retry('feedback-one')
+        invalid_two = _assistant('invalid-two')
+        retry_two = _output_retry('feedback-two')
+        invalid_three = _assistant('invalid-three')
+        retry_three = _output_retry('feedback-three')
+        messages: list[ModelMessage] = [
+            task,
+            invalid_one,
+            retry_one,
+            invalid_two,
+            retry_two,
+            invalid_three,
+            retry_three,
+        ]
+        request_context = _make_request_context(messages)
+
+        sent_messages, response = await _run_trim_retry_history(TrimRetryHistory(), request_context)
+
+        assert response.parts == [TextPart(content='ok')]
+        assert sent_messages == [task, invalid_three, retry_three]
+        assert request_context.messages is messages
+        assert sent_messages is not messages
+        assert messages == [task, invalid_one, retry_one, invalid_two, retry_two, invalid_three, retry_three]
+
+    @pytest.mark.anyio
+    async def test_compacts_configured_output_tool_retries(self):
+        task = _user('task')
+        old_response = ModelResponse(parts=[ToolCallPart('result', {'value': 'old'}, tool_call_id='old-call')])
+        old_retry = ModelRequest(
+            parts=[RetryPromptPart(content='old feedback', tool_name='result', tool_call_id='old-call')]
+        )
+        newest_response = ModelResponse(parts=[ToolCallPart('result', {'value': 'new'}, tool_call_id='new-call')])
+        newest_retry = ModelRequest(
+            parts=[RetryPromptPart(content='new feedback', tool_name='result', tool_call_id='new-call')]
+        )
+        messages: list[ModelMessage] = [task, old_response, old_retry, newest_response, newest_retry]
+        request_context = _make_request_context(messages, output_tool_name='result')
+
+        sent_messages, _ = await _run_trim_retry_history(TrimRetryHistory(), request_context)
+
+        assert sent_messages == [task, newest_response, newest_retry]
+        assert sent_messages[1] is newest_response
+        assert sent_messages[2] is newest_retry
+        assert request_context.messages is messages
+        assert sent_messages is not messages
+        assert messages == [task, old_response, old_retry, newest_response, newest_retry]
+
+    @pytest.mark.anyio
+    async def test_leaves_tool_retry_request_unchanged(self):
+        messages: list[ModelMessage] = [
+            _user('task'),
+            _tool_call('lookup', 'tool-call'),
+            ModelRequest(parts=[RetryPromptPart(content='retry tool', tool_name='lookup')]),
+        ]
+        request_context = _make_request_context(messages, output_tool_name='result')
+
+        sent_messages, _ = await _run_trim_retry_history(TrimRetryHistory(), request_context)
+
+        assert sent_messages is messages
+        assert request_context.messages is messages
+
+    @pytest.mark.anyio
+    async def test_leaves_single_output_retry_pair_unchanged(self):
+        messages: list[ModelMessage] = [_user('task'), _assistant('invalid'), _output_retry('feedback')]
+        request_context = _make_request_context(messages)
+
+        sent_messages, _ = await _run_trim_retry_history(TrimRetryHistory(), request_context)
+
+        assert sent_messages is messages
+        assert request_context.messages is messages
+
+    @pytest.mark.anyio
+    async def test_keeps_legitimate_history_before_retry_sequence(self):
+        task = _user('task')
+        prior_response = _assistant('prior-response')
+        follow_up = _user('follow-up')
+        newest_response = _assistant('newest-invalid')
+        newest_retry = _output_retry('newest-feedback')
+        messages: list[ModelMessage] = [
+            task,
+            prior_response,
+            follow_up,
+            _assistant('old-invalid'),
+            _output_retry('old-feedback'),
+            newest_response,
+            newest_retry,
+        ]
+        request_context = _make_request_context(messages)
+
+        sent_messages, _ = await _run_trim_retry_history(TrimRetryHistory(), request_context)
+
+        assert sent_messages == [task, prior_response, follow_up, newest_response, newest_retry]
+
+    @pytest.mark.anyio
+    async def test_leaves_ordinary_follow_up_request_unchanged(self):
+        messages: list[ModelMessage] = [_assistant('prior-response'), _user('follow-up')]
+        request_context = _make_request_context(messages)
+
+        sent_messages, _ = await _run_trim_retry_history(TrimRetryHistory(), request_context)
+
+        assert sent_messages is messages
+        assert request_context.messages is messages
+
+    @pytest.mark.anyio
+    async def test_same_instance_is_stateless_across_requests(self):
+        capability = TrimRetryHistory()
+        task = _user('task')
+
+        for label in ('first', 'second'):
+            newest = _assistant(f'{label}-newest')
+            messages: list[ModelMessage] = [
+                task,
+                _assistant(f'{label}-old'),
+                _output_retry(f'{label}-old-feedback'),
+                newest,
+                _output_retry(f'{label}-newest-feedback'),
+            ]
+            sent_messages, _ = await _run_trim_retry_history(capability, _make_request_context(messages))
+            assert sent_messages == [task, newest, messages[-1]]
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
+    async def test_agent_trims_requests_without_losing_run_history(self, anyio_backend: str):
+        assert anyio_backend == 'asyncio'
+        model_requests: list[list[ModelMessage]] = []
+
+        def model_function(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            model_requests.append(list(messages))
+            attempt = len(model_requests)
+            content = 'valid' if attempt == 3 else f'invalid-{attempt}'
+            return ModelResponse(parts=[TextPart(content=content)])
+
+        agent: Agent[None, str] = Agent(
+            FunctionModel(model_function),
+            capabilities=[TrimRetryHistory()],
+            output_type=str,
+            retries=2,
+        )
+        validation_attempt = 0
+
+        @agent.output_validator
+        def require_valid(value: str) -> str:
+            nonlocal validation_attempt
+            validation_attempt += 1
+            if validation_attempt < 3:
+                raise ModelRetry(f'feedback-{validation_attempt}')
+            return value
+
+        with capture_run_messages() as captured_messages:
+            result = await agent.run('task')
+
+        assert result.output == 'valid'
+        assert [len(messages) for messages in model_requests] == [1, 3, 3]
+        assert [_text_and_retry_contents(messages) for messages in model_requests] == [
+            [],
+            ['invalid-1', 'feedback-1'],
+            ['invalid-2', 'feedback-2'],
+        ]
+
+        complete_history = result.all_messages()
+        assert captured_messages == complete_history
+        assert len(complete_history) == 6
+        assert _text_and_retry_contents(complete_history) == [
+            'invalid-1',
+            'feedback-1',
+            'invalid-2',
+            'feedback-2',
+            'valid',
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -935,6 +1149,7 @@ class TestExports:
             'SummarizingCompaction',
             'TieredCompaction',
             'FallbackCompaction',
+            'TrimRetryHistory',
         ]
         for name in names:
             assert hasattr(compaction, name)


### PR DESCRIPTION
## Summary

- add an opt-in `TrimRetryHistory` capability for repeated output-validation retries
- keep the full legitimate conversation prefix and the newest invalid-output/validation-feedback pair while removing older failed pairs
- trim only the request-local model message view through `wrap_model_request`, preserving the complete persistent run history
- leave ordinary requests and function-tool validation retries unchanged while handling both text and structured output-tool validation retries

Historical old-head evaluation measured the serialized fourth request falling from `131,643` to `49,550` bytes, a `62.36%` reduction, with final-output, retry-count, structured-output, multi-turn, function-tool, reuse, immutability, and public Agent lifecycle checks. That evaluator is identity-bound to the prior head and is terminal `EVAL_V1_DRAFT_NO_GO`; it was not replayed on the current head and is not presented as fresh qualification evidence.

## Linked Issue

Fixes #365

## Validation

- focused `TrimRetryHistory` lifecycle/export tests: `16 passed`
- compaction suite: `598 passed`
- documentation/export checks: `746 passed, 18 skipped`
- full suite: `5,427 passed, 62 skipped`
- Ruff formatting and lint: clean
- targeted and full Pyright: `0 errors` on the exact current dependency lock
- rebased onto current `main@35e875e`; clean current-base replay with no conflicts or same-file drift
- historical retained retry-history result: `131643 -> 49550` serialized bytes (`62.36%` reduction); no fresh evaluator replay on this head

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] Repository lint, type checking, and tests pass locally
- [x] No changes to `pyproject.toml` or `uv.lock`
- [x] Docstrings use single backticks