### PR TITLE
Fix `search_files` return description parsing

### DIFF
--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -363,7 +363,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             include_glob: If provided, only search files matching this glob (e.g. '*.py').
 
         Returns:
-            Matching lines formatted as file:line_number:text.
+            str: Matching lines formatted as file:line_number:text.
         """
         # See list_directory: the search root isn't gated by allowed_patterns;
         # matched files are filtered per-entry below.

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -1050,6 +1050,17 @@ class TestFileSystemCapability:
         toolset = fs.get_toolset()
         assert isinstance(toolset, FileSystemToolset)
 
+    def test_search_files_description_has_string_return_type(self) -> None:
+        description = FileSystem().get_toolset().tools['search_files'].description
+
+        assert description == (
+            '<summary>Search file contents using a regular expression.</summary>\n'
+            '<returns>\n'
+            '<type>str</type>\n'
+            '<description>Matching lines formatted as file:line_number:text.</description>\n'
+            '</returns>'
+        )
+
     def test_protected_defaults(self) -> None:
         fs = FileSystem()
         assert '.git/*' in fs.protected_patterns


### PR DESCRIPTION
## Summary

- Declare the `search_files` docstring return as `str` so its literal output format stays in the description.
- Add regression coverage for the generated tool description.

## Linked Issue

Closes #360

## Validation

- `make lint`
- `make typecheck`
- `make test`
- `make testcov`

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] No changes to `pyproject.toml` or `uv.lock`
- [x] Docstrings use single backticks