### PR TITLE
Fix `ClearToolResults` corrupting typed `ToolReturnPart` subclasses (`ToolSearchReturnPart`)

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -122,6 +122,8 @@ TieredCompaction(
 
 Tool outputs typically dominate an agent's context, and the agent can usually re-run a tool if it needs the data again. `ClearToolResults` replaces the content of the oldest tool *results* with a short placeholder while keeping the most recent `keep_pairs` tool-call / tool-return pairs intact. The tool calls stay paired with their now-blanked results, so the history stays valid.
 
+Framework-typed tool results -- core's `search_tools` and `load_capability` returns -- are left intact (a small token floor), because their structured content is re-parsed on later requests and rewriting it via `dataclasses.replace` would bypass validation and corrupt the part.
+
 ```python
 from pydantic_ai import Agent
 from pydantic_ai_harness.compaction import ClearToolResults

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -104,7 +104,9 @@ turn even when it falls outside the window, so the agent does not lose the origi
 
 `ClearToolResults` keeps the last `keep_pairs` intact. Set `clear_tool_inputs=True` to also blank the
 arguments of the cleared calls, and `exclude_tools` to a set of tool names whose results are never
-cleared.
+cleared. Framework-typed tool results -- core's `search_tools` and `load_capability` returns -- are
+left intact (a small token floor), because their structured content is re-parsed on later requests and
+rewriting it via `dataclasses.replace` would bypass validation and corrupt the part.
 
 ## `LimitWarner` thresholds
 

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -387,8 +387,13 @@ def rebuild_with_cleared(
             request_parts: list[ModelRequestPart] = []
             changed = False
             for part in msg.parts:
+                # Exact type, not `isinstance`: typed `ToolReturnPart` subclasses such as
+                # `ToolSearchReturnPart` carry structured `TypedDict` content that core re-parses
+                # (and trusts to be valid) on every request -- see `parse_discovered_tools`. Blanking
+                # it to a string both breaks that invariant (crash next request) and discards
+                # discovery state, so only untyped tool results are cleared.
                 if (
-                    isinstance(part, ToolReturnPart)
+                    type(part) is ToolReturnPart
                     and part.tool_call_id in clear_return_ids
                     and str(part.content) != placeholder
                 ):

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -2061,11 +2061,11 @@ class TestPublicPath:
 
         def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             step = sum(isinstance(m, ModelResponse) for m in messages)
-            if step < 2:
+            if step == 0:  # discover the deferred tool
                 args = {'queries': ['hidden']}
-                return ModelResponse(
-                    parts=[ToolCallPart(tool_name='search_tools', args=args, tool_call_id=f'ts{step}')]
-                )
+                return ModelResponse(parts=[ToolCallPart(tool_name='search_tools', args=args, tool_call_id='ts0')])
+            if step == 1:  # call it, forcing the request that re-reads the (cleared) search result
+                return ModelResponse(parts=[ToolCallPart(tool_name='hidden_gem', args={'x': 1}, tool_call_id='hg1')])
             return ModelResponse(parts=[TextPart(content='done')])
 
         agent = Agent(

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -2045,6 +2045,47 @@ class TestPublicPath:
         result = await agent.run('hello')
         assert result.output is not None
 
+    @pytest.mark.anyio
+    async def test_clear_does_not_break_tool_search_on_next_request(self):
+        # Regression for #380 through the real agent graph. Core re-reads a
+        # `ToolSearchReturnPart`'s structured content on every request via
+        # `parse_discovered_tools`; blanking it to a string used to crash the *next*
+        # request. Drive a multi-request run (search -> clear fires -> another request)
+        # and assert it completes with discovery intact.
+        from pydantic_ai import Agent, Tool
+        from pydantic_ai.capabilities import ToolSearch
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        def hidden_gem(x: int) -> int:
+            return x + 1
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            step = sum(isinstance(m, ModelResponse) for m in messages)
+            if step < 2:
+                args = {'queries': ['hidden']}
+                return ModelResponse(
+                    parts=[ToolCallPart(tool_name='search_tools', args=args, tool_call_id=f'ts{step}')]
+                )
+            return ModelResponse(parts=[TextPart(content='done')])
+
+        agent = Agent(
+            FunctionModel(model_fn),
+            tools=[Tool(hidden_gem, defer_loading=True)],
+            capabilities=[ToolSearch(), ClearToolResults(max_messages=1, keep_pairs=0)],
+        )
+        result = await agent.run('go')
+
+        assert result.output == 'done'
+        messages = result.all_messages()
+        search_returns = [
+            p for m in messages if isinstance(m, ModelRequest) for p in m.parts if isinstance(p, ToolSearchReturnPart)
+        ]
+        # The typed search return kept its concrete type and structured (dict) content.
+        assert search_returns
+        assert all(isinstance(p.content, dict) for p in search_returns)
+        # Core still recovers the discovered tool -- the read that crashed in #380.
+        assert parse_discovered_tools(messages) == {'hidden_gem'}
+
 
 # ---------------------------------------------------------------------------
 # Remaining branch coverage — defensive paths in shared helpers

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -16,10 +16,13 @@ from pydantic_ai.messages import (
     TextPart,
     ToolCallPart,
     ToolReturnPart,
+    ToolSearchReturnContent,
+    ToolSearchReturnPart,
     UserPromptPart,
 )
 from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets._tool_search import parse_discovered_tools
 from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness.compaction import (
@@ -1580,6 +1583,36 @@ class TestClearToolResults:
         twice = await cap.compact(once, ctx)
         assert _return_contents(twice) == ['[tool result cleared]']
         assert _call_args(twice) == ['{}']
+
+    @pytest.mark.anyio
+    async def test_preserves_typed_tool_search_return(self):
+        # `ToolSearchReturnPart` subclasses `ToolReturnPart` but carries structured content that
+        # core's `parse_discovered_tools` re-reads on the next request. Blanking it to a string
+        # crashed that reader; clearing must skip typed subclasses and touch only plain results.
+        cap = ClearToolResults(max_messages=1, keep_pairs=0)
+        search_content: ToolSearchReturnContent = {'discovered_tools': [{'name': 'alpha'}, {'name': 'beta'}]}
+        messages: list[ModelMessage] = [
+            _tool_call('fn', 'u1'),
+            _tool_return('fn', 'u1', 'plain result'),
+            ModelResponse(parts=[ToolCallPart(tool_name='search_tools', args='{}', tool_call_id='ts1')]),
+            ModelRequest(parts=[ToolSearchReturnPart(content=search_content, tool_call_id='ts1')]),
+        ]
+        result = await cap.before_model_request(_make_ctx(), _make_request_context(messages))
+
+        returns = {
+            p.tool_call_id: p
+            for m in result.messages
+            if isinstance(m, ModelRequest)
+            for p in m.parts
+            if isinstance(p, ToolReturnPart)
+        }
+        # Plain result blanked, typed search return kept intact (concrete type + structured content).
+        assert type(returns['u1']) is ToolReturnPart
+        assert returns['u1'].content == cap.placeholder
+        assert type(returns['ts1']) is ToolSearchReturnPart
+        assert returns['ts1'].content == search_content
+        # The real next-request regression: core still recovers the discovered names.
+        assert parse_discovered_tools(result.messages) == {'alpha', 'beta'}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

## Summary

`ClearToolResults` blanks old tool results in place. `rebuild_with_cleared` selected
them with `isinstance(part, ToolReturnPart)`, which also matches typed subclasses such
as `ToolSearchReturnPart` (core's `search_tools` return). `dataclasses.replace` preserves
the concrete class, so blanking the content produced a `ToolSearchReturnPart` whose
structured `TypedDict` content was now a plain placeholder string.

Core's `parse_discovered_tools` trusts that content shape (docstring: "No defensive
isinstance walks needed") and re-reads it on every request via `content['discovered_tools']`.
Once the corrupted history is written back into run state, the run's next request raises
`TypeError: string indices must be integers`.

The fix narrows the request-side clearing predicate to an exact type check
(`type(part) is ToolReturnPart`), so typed subclasses are skipped rather than blanked.
They carry discovery state core re-reads each request and reclaim little, so skipping
them is both correct and near-free. The response-side `ToolCallPart` args-clearing branch
is unchanged (its placeholder is type-valid there). A code comment guards against a future
revert to `isinstance`.

## Linked Issue

Fixes #380

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)
