### PR TITLE
Add .macroscope/ignore.md to skip mechanical files in review

### DIFF
--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -1,14 +1,161 @@
 # Repository-wide Macroscope ignore (code review + any check-run agents).
 #
-# One glob per line; `#` starts a comment; `**` spans directories. Files listed
-# here are dropped from the billed review diff, so Macroscope does not spend
-# credits reviewing recorded or mechanical files that no human reads.
+# A custom ignore file REPLACES Macroscope's built-in defaults, so this copies
+# their default "base" patterns verbatim to preserve them, then adds this repo's
+# own recorded files on top. https://docs.macroscope.com/
+#
+# Macroscope's default *test-file* patterns are deliberately NOT copied here: we
+# want Macroscope to review test code. Recorded cassettes and binary fixtures
+# under tests/ stay ignored via the base binary/data patterns plus the explicit
+# cassettes rule below, so only real test *code* is reviewed.
 
-# Lock files: uv.lock diffs are large and mechanical on dependency updates.
+# ---- Macroscope default base patterns (copied to preserve them) ----
+**/.git/**
+**/__pycache__/**
+**/.pytest_cache/**
+**/.mypy_cache/**
+**/.ruff_cache/**
+**/venv/**
+**/.venv/**
+**/node_modules/**
+**/site-packages/**
+**/.pnpm-store/**
+**/__Snapshots__/**
+**/__snapshots__/**
+**/.agents/skills/**
+**/.claude/skills/**
+**/.github/skills/**
+**/bower_components/**
+**/jspm_packages/**
+**/.next/**
+**/.svelte-kit/**
+**/vendor/**
+**/_vendor/**
+**/third_party/**
+**/Pods/**
+**/.bundle/**
+build/**
+env/**
+ENV/**
+**/target/**
+**/generated/**
+**/intermediates/**
+**/generated_sources/**
+**/generated-sources/**
+**/generated-src/**
+**/src/main/generated/**
+**/*.min.js
+**/*.min.css
+**/*_pb.d.ts
+**/*_pb.js
+**/*.pb.go
+**/*_pb2.py
+**/*_pb2_grpc.py
+**/*_pb2.pyi
+**/*.grpc.swift
+**/*.pb.swift
+**/*.sql.go
+**/*.designer.cs
+**/*.g.dart
+**/*.pb.dart
+**/*_pb.rb
+**/go.mod
+**/package.json
+**/*.pbxproj
+**/*.xcstrings
+**/*.strings
+**/*.properties
+**/pom.xml
+**/Package.swift
+**/bun.lock
+**/.eslintrc
+**/.eslintignore
+**/go.sum
+**/package-lock.json
+**/pnpm-lock.yaml
+**/yarn.lock
+**/Package.resolved
+**/*.jpg
+**/*.jpeg
+**/*.png
+**/*.gif
+**/*.svg
+**/*.ico
+**/*.webp
+**/*.bmp
+**/*.tiff
+**/*.woff
+**/*.woff2
+**/*.ttf
+**/*.eot
+**/*.otf
+**/*.mp3
+**/*.mp4
+**/*.wav
+**/*.avi
+**/*.mov
+**/*.mkv
+**/*.flac
+**/*.ogg
+**/*.srt
+**/*.zip
+**/*.tar
+**/*.gz
+**/*.rar
+**/*.7z
+**/*.bz2
+**/*.pdf
+**/*.doc
+**/*.docx
+**/*.xls
+**/*.xlsx
+**/*.ppt
+**/*.pptx
+**/*.db
+**/*.sqlite
+**/*.sqlite3
+**/*.parquet
+**/*.avro
+**/*.arrow
+**/*.npy
+**/*.pkl
+**/*.jsonl
+**/*.onnx
+**/*.tflite
+**/*.h5
+**/*.safetensors
+**/*.exe
+**/*.dll
+**/*.so
+**/*.dylib
+**/*.bin
+**/*.pyc
+**/*.class
+**/*.o
+**/*.a
+**/*.wasm
+**/*.cer
+**/*.pem
+**/*.p12
+**/*.stringsdict
+**/*.snap
+**/*.adoc
+**/*.arb
 **/*.lock
+**/*.po
+**/*.fbx
+**/*.log
+**/*.xib
+**/*.meta
+**/*.kml
+**/*.prefab
+**/*.eml
+**/*.csv
+**/*.grpc.reflection
+**/*.js.map
 
-# Recorded VCR cassettes (regenerated, not hand-reviewed).
+# ---- This repo: recorded files the defaults do not cover ----
+
+# Recorded VCR cassettes (under tests/; kept ignored now that test code is
+# reviewed).
 **/cassettes/**
-
-# Documentation images (binary, not reviewable as a diff).
-docs/images/**

--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -1,0 +1,14 @@
+# Repository-wide Macroscope ignore (code review + any check-run agents).
+#
+# One glob per line; `#` starts a comment; `**` spans directories. Files listed
+# here are dropped from the billed review diff, so Macroscope does not spend
+# credits reviewing recorded or mechanical files that no human reads.
+
+# Lock files: uv.lock diffs are large and mechanical on dependency updates.
+**/*.lock
+
+# Recorded VCR cassettes (regenerated, not hand-reviewed).
+**/cassettes/**
+
+# Documentation images (binary, not reviewable as a diff).
+docs/images/**


### PR DESCRIPTION
Adds a repository-wide Macroscope ignore list so the AI code review does not spend credits on mechanical files that no human reads.

Macroscope's managed review is billed per KB of diff reviewed:

- **`**/*.lock`** — `uv.lock` produces large mechanical diffs on dependency bumps.
- **`**/cassettes/**`** — recorded VCR cassettes (regenerated, not hand-reviewed).
- **`docs/images/**`** — binary images (not reviewable as a diff).

Ignored files are dropped from the reviewed/billed diff. No effect on CI or the files on disk.