### PR TITLE
Fix list-value recursion and over-aggressive env redaction in SecretMasking

### DIFF
--- a/src/pydantic_harness/secret_masking.py
+++ b/src/pydantic_harness/secret_masking.py
@@ -98,8 +98,45 @@ def _mask_dict_values(
             result[key] = _mask_dict_values(
                 cast(dict[str, Any], value), patterns, replacement, partial=partial, visible_chars=visible_chars
             )
+        elif isinstance(value, list):
+            result[key] = _mask_list_values(
+                cast('list[Any]', value), patterns, replacement, partial=partial, visible_chars=visible_chars
+            )
         else:
             result[key] = value
+    return result
+
+
+def _mask_list_values(
+    items: list[Any],
+    patterns: dict[str, re.Pattern[str]],
+    replacement: str,
+    *,
+    partial: bool = False,
+    visible_chars: int = 4,
+) -> list[Any]:
+    """Recursively scrub secret patterns from string items in a list."""
+    result: list[Any] = []
+    for item in items:
+        if isinstance(item, str):
+            if partial:
+                result.append(_partial_mask_text(item, patterns, visible_chars))
+            else:
+                result.append(_mask_text(item, patterns, replacement))
+        elif isinstance(item, dict):
+            result.append(
+                _mask_dict_values(
+                    cast(dict[str, Any], item), patterns, replacement, partial=partial, visible_chars=visible_chars
+                )
+            )
+        elif isinstance(item, list):
+            result.append(
+                _mask_list_values(
+                    cast('list[Any]', item), patterns, replacement, partial=partial, visible_chars=visible_chars
+                )
+            )
+        else:
+            result.append(item)
     return result
 
 

--- a/src/pydantic_harness/secret_masking.py
+++ b/src/pydantic_harness/secret_masking.py
@@ -46,7 +46,9 @@ _PRIVATE_KEY_PATTERNS: dict[str, re.Pattern[str]] = {
 }
 
 _ENV_FILE_PATTERNS: dict[str, re.Pattern[str]] = {
-    'env_key_value': re.compile(r'(?m)^[A-Z][A-Z0-9_]+=.+$'),
+    'env_key_value': re.compile(
+        r'(?m)^[A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|AUTH|CERT|CREDENTIAL)[A-Z0-9_]*=.+$'
+    ),
 }
 
 _BUILTIN_CATEGORIES: dict[str, dict[str, re.Pattern[str]]] = {

--- a/tests/test_secret_masking.py
+++ b/tests/test_secret_masking.py
@@ -206,6 +206,16 @@ class TestMaskDictValues:
         result = _mask_dict_values(d, _ALL_BUILTIN_PATTERNS, '[REDACTED]')
         assert result['outer']['inner_key'] == '[REDACTED]'
 
+    def test_mask_list_values(self):
+        d = {
+            'headers': ['Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test', 'safe-header'],
+            'configs': [{'token': 'sk-abc123def456ghi789jkl012mno'}],
+        }
+        result = _mask_dict_values(d, _ALL_BUILTIN_PATTERNS, '[REDACTED]')
+        assert 'eyJ' not in result['headers'][0]
+        assert result['headers'][1] == 'safe-header'
+        assert result['configs'][0]['token'] == '[REDACTED]'
+
     def test_non_string_values_unchanged(self):
         d: dict[str, Any] = {'count': 42, 'flag': True, 'items': [1, 2]}
         result = _mask_dict_values(d, _ALL_BUILTIN_PATTERNS, '[REDACTED]')

--- a/tests/test_secret_masking.py
+++ b/tests/test_secret_masking.py
@@ -149,9 +149,12 @@ class TestMaskText:
     # --- .env content detection ---
 
     def test_env_key_value_single_line(self):
+        """DATABASE_URL isn't a sensitive *name*, but the credentials in its value still get
+        caught by the connection_strings category, so the variable name can stay visible."""
         text = 'DATABASE_URL=postgres://user:pass@localhost/db'
         result = _mask_text(text, _ALL_BUILTIN_PATTERNS, '[REDACTED]')
-        assert 'DATABASE_URL=' not in result
+        assert 'user:pass' not in result
+        assert 'DATABASE_URL=' in result
 
     def test_env_key_value_multiline(self):
         text = 'API_KEY=some_secret_value\nDB_PASSWORD=hunter2\nDEBUG=true'
@@ -163,6 +166,13 @@ class TestMaskText:
         """Lowercase variable names are not typical .env format and should not match."""
         patterns = _BUILTIN_CATEGORIES['env_file']
         text = 'lowercase_var=value'
+        result = _mask_text(text, patterns, '[REDACTED]')
+        assert result == text
+
+    def test_env_key_value_ignores_non_sensitive_names(self):
+        """Ordinary system env vars with no security-relevant name should survive untouched."""
+        patterns = _BUILTIN_CATEGORIES['env_file']
+        text = 'PATH=/usr/local/bin:/usr/bin\nHOME=/root\nDEBUG=true\nNODE_ENV=production'
         result = _mask_text(text, patterns, '[REDACTED]')
         assert result == text
 


### PR DESCRIPTION
## Summary

Two bugs flagged by automated review on #172 but never addressed since the PR
went stale:

1. `_mask_dict_values` only recursed into `str` and `dict` values — list
   arguments (e.g. header arrays, batches of config dicts) passed through
   `before_tool_execute` completely unmasked. Added `_mask_list_values` for
   mutual recursion, plus a test proving the leak.

2. `env_key_value`'s pattern (`^[A-Z][A-Z0-9_]+=.+$`) matched any
   UPPER_CASE=value line, redacting harmless output like `PATH=`, `HOME=`,
   `DEBUG=true` along with real secrets. Restricted it to names containing
   KEY/TOKEN/SECRET/PASSWORD/AUTH/CERT/CREDENTIAL.

Both changes are covered by new tests; full suite + ruff + pyright pass.

## Linked Issue

Relates to #78 (the tracking issue this PR is built toward). This PR doesn't
close #78 on its own — it fixes review feedback already left on #172, which
is what implements #78.

## Checklist

- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] No changes to `pyproject.toml` or `uv.lock`
- [x] Docstrings use single backticks