### PR TITLE
Fix: apply tool_timeout cumulatively across run_code execution

### DIFF
--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
 from typing import Annotated, Any
 
+import anyio
 from pydantic import Field, TypeAdapter
 from pydantic_ai import AbstractToolset, RunContext, ToolDefinition, WrapperToolset
 from pydantic_ai.exceptions import ApprovalRequired, CallDeferred, ModelRetry, UserError
@@ -541,16 +542,29 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
 
         capture = PrintCapture()
 
+        tool_timeout = ctx.agent._tool_timeout if ctx.agent is not None else None  # pyright: ignore[reportPrivateUsage]
+
         try:
             monty_state = self._repl.feed_start(code, print_callback=capture, os=self.os_access, mount=self.mount)
-            completed = await MontyExecutor(
+            executor = MontyExecutor(
                 dispatch=dispatch_tool_call,
                 valid_names=callable_defs,
                 sequential_names=sequential_tools,
                 global_sequential=global_sequential,
                 os_access=self.os_access,
                 mount=self.mount,
-            ).run(monty_state)
+            )
+            if tool_timeout is not None:
+                with anyio.move_on_after(tool_timeout) as cancel_scope:
+                    completed = await executor.run(monty_state)
+                if cancel_scope.cancelled_caught:
+                    self._repl = None
+                    raise ModelRetry(
+                        f'run_code exceeded the cumulative tool timeout of {tool_timeout}s. '
+                        'The session was reset. Simplify the code or reduce the number of tool calls.'
+                    )
+            else:
+                completed = await executor.run(monty_state)
         except MontySyntaxError as e:
             raise ModelRetry(f'Syntax error in code:\n{capture.prepend_to(e.display())}') from e
         except MontyTypingError as e:  # pragma: no cover -- MontyRepl.feed_start doesn't raise this
@@ -580,7 +594,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
                 'each gathered call its own invocation. Revise the code and try again.'
             ) from e
 
-        result = completed.output
+        result = completed.output  # pyright: ignore[reportPossiblyUnboundVariable]
         printed = capture.joined
 
         # Validate result to reconstruct multimodal types (e.g. BinaryContent from

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -321,6 +321,31 @@ class TestCodeMode:
         with pytest.raises(ModelRetry, match='not allowed'):
             await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
 
+    async def test_run_code_cumulative_tool_timeout(self) -> None:
+        """tool_timeout applies to the total run_code execution, not per individual tool call."""
+        import asyncio
+
+        async def slow_tool(x: int) -> int:
+            """A tool that sleeps briefly before returning."""
+            await asyncio.sleep(0.2)
+            return x
+
+        agent = Agent(TestModel(), tool_timeout=0.3)  
+        toolset = _build_function_toolset(slow_tool)
+        wrapper = CodeMode[object]().get_wrapper_toolset(toolset)
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        ctx.agent = agent
+        tools = await wrapper.get_tools(ctx)
+
+        code = (
+            'import asyncio\n'
+            'await slow_tool(x=1)\n'
+            'await slow_tool(x=2)\n'
+        )
+        with pytest.raises(ModelRetry, match='cumulative tool timeout'):
+            await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+
     async def test_run_code_renders_no_arg_tool_signature(self) -> None:
         """A no-argument tool renders as `async def name() -> ...` (without `(*, ...)`).
 


### PR DESCRIPTION
Previously tool_timeout was applied per individual sandboxed tool call via the agent's ToolManager, meaning an agent calling a slow tool N times in a loop could exceed the timeout N times over.

This fix wraps the entire MontyExecutor.run() call with anyio.move_on_after(tool_timeout), so the cumulative wall-clock time of a single run_code invocation is bounded. If the timeout is exceeded, the REPL state is reset (matching the existing sandbox panic behaviour) and ModelRetry is raised with a clear message.

Fixes #308 (https://github.com/pydantic/pydantic-ai-harness/issues/308)

Previously tool_timeout was applied per individual sandboxed tool call inside run_code via the agent's ToolManager. An agent calling a slow tool N times in a loop could exceed the timeout N*budget times over.

This wraps the entire MontyExecutor.run() call with anyio.move_on_after(tool_timeout), bounding the cumulative wall-clock time of a single run_code invocation. On timeout the REPL state is reset (matching existing sandbox panic behaviour) and ModelRetry is raised with a clear message.

Changes:
- pydantic_ai_harness/code_mode/_toolset.py: fix
- tests/code_mode/test_code_mode.py: new test demonstrating two sequential 0.2s tool calls correctly exceeding a 0.3s cumulative budget


## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)
