### PR TITLE
Fix ShellToolset process-kill crash on Windows

### DIFF
--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import signal
 import subprocess
+import sys
 import tempfile
 import uuid
 from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -257,7 +258,20 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
             self._cwd = candidate
 
     async def _kill_process_group(self, proc: anyio.abc.Process) -> None:
-        """SIGTERM the process group, escalating to SIGKILL after the grace period."""
+        """SIGTERM the process group, escalating to SIGKILL after the grace period.
+
+        Windows has no process-group signal API (`os.killpg`/`os.getpgid`/`signal.SIGKILL`
+        don't exist there), so on Windows we fall back to `proc.kill()`, which anyio maps to
+        `TerminateProcess()`. That only stops the spawned process itself, not any children it
+        started -- there's no cheap Windows equivalent of a POSIX process-group kill.
+        """
+        if sys.platform == 'win32':
+            try:
+                proc.kill()
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+            return
+
         pid = proc.pid
         try:
             os.killpg(os.getpgid(pid), signal.SIGTERM)

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -1270,6 +1270,46 @@ class TestKillProcessGroupEdgeCases:
 
         assert call_count == 2
 
+    async def test_windows_uses_proc_kill_not_killpg(self, tmp_path: Path) -> None:
+        """On Windows there's no process-group signal API; must kill via proc.kill() instead."""
+        ts = ShellToolset(
+            cwd=tmp_path,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=5.0,
+            max_output_chars=50_000,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        proc = MagicMock()
+        proc.pid = 99999
+
+        with patch('sys.platform', 'win32'):
+            await ts._kill_process_group(proc)
+
+        proc.kill.assert_called_once()
+
+    async def test_windows_kill_raises_process_lookup_error(self, tmp_path: Path) -> None:
+        """On Windows, killing a process that already exited must not raise."""
+        ts = ShellToolset(
+            cwd=tmp_path,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=5.0,
+            max_output_chars=50_000,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        proc = MagicMock()
+        proc.pid = 99999
+        proc.kill.side_effect = ProcessLookupError
+
+        with patch('sys.platform', 'win32'):
+            await ts._kill_process_group(proc)
+        # No exception raised, method returned after catching it
+
 
 class TestDrainWithTimeoutEdgeCases:
     async def test_stdout_closed_resource_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `_kill_process_group` used POSIX-only `os.killpg`/`os.getpgid`/`signal.SIGKILL` to stop background and timed-out shell commands. These don't exist on Windows, so the call raised `AttributeError` instead of stopping the process -- crashing the caller (`stop_command`, `run_command`'s timeout path, and `__aexit__` cleanup) and leaking the real subprocess, since the crash happens before any signal is ever sent.
- On Windows, fall back to `proc.kill()` (anyio maps this to `TerminateProcess()`), guarded against an already-exited process the same way the POSIX path already was -- testing surfaced an uncaught `ProcessLookupError` here too, when stopping a process that had already finished.

## Known limitation
Unlike POSIX process-group kill, `proc.kill()` on Windows only stops the spawned process itself, not any children it started -- there's no cheap Windows equivalent of a process-group kill. A full fix would need Windows Job Objects, which is a materially bigger change than this crash fix. Documented in the updated docstring.

## Testing
Added two tests covering the Windows path: `proc.kill()` is called instead of `os.killpg`, and the already-exited-process race is handled without raising. Full `tests/shell/test_shell.py` suite + `ruff` + `pyright` pass on the changed files.
