### PR TITLE
docs: link the new per-capability pages in core's Capabilities section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Before implementing or reviewing a capability change:
 1. Read `agent_docs/index.md`.
 2. Read the linked `agent_docs/` guide for the task.
 3. Read the public Pydantic AI docs for every integration point you touch:
-   - capabilities: <https://pydantic.dev/docs/ai/core-concepts/capabilities/>
+   - capabilities: <https://pydantic.dev/docs/ai/capabilities/overview/>
    - hooks: <https://pydantic.dev/docs/ai/core-concepts/hooks/>
    - toolsets: <https://pydantic.dev/docs/ai/tools-toolsets/toolsets/>
    - advanced tools: <https://pydantic.dev/docs/ai/tools-toolsets/tools-advanced/>
@@ -55,7 +55,7 @@ Before implementing or reviewing a capability change:
 
 When implementing a new capability, reference these docs:
 
-- <https://pydantic.dev/docs/ai/core-concepts/capabilities/> -- main capabilities documentation, usage patterns, built-in capabilities
+- <https://pydantic.dev/docs/ai/capabilities/overview/> -- main capabilities documentation, usage patterns, built-in capabilities
 - <https://pydantic.dev/docs/ai/core-concepts/hooks/> -- lifecycle hooks reference, hook ordering, all hook categories
 - <https://pydantic.dev/docs/ai/guides/extensibility/> -- publishing capabilities as packages, spec serialization
 - <https://pydantic.dev/docs/ai/tools-toolsets/toolsets/> -- toolset abstraction, building tools for capabilities

--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -36,7 +36,7 @@ Pydantic AI toolsets.
 
 ## Pydantic AI References
 
-- Capabilities: <https://pydantic.dev/docs/ai/core-concepts/capabilities/>
+- Capabilities: <https://pydantic.dev/docs/ai/capabilities/overview/>
 - Hooks: <https://pydantic.dev/docs/ai/core-concepts/hooks/>
 - Toolsets: <https://pydantic.dev/docs/ai/tools-toolsets/toolsets/>
 - Advanced tools: <https://pydantic.dev/docs/ai/tools-toolsets/tools-advanced/>

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -243,4 +243,4 @@ Source: [`pydantic_ai_harness/experimental/acp/`](https://github.com/pydantic/py
 - [Agent Client Protocol](https://agentclientprotocol.com) -- protocol specification
 - [Zed external agents](https://zed.dev/docs/ai/external-agents) -- editor-side configuration
 - [Human-in-the-loop tool approval](/ai/tools-toolsets/deferred-tools/#human-in-the-loop-tool-approval) (Pydantic AI)
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -330,7 +330,7 @@ capabilities:
 
 - [Tool use via code](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic)
 - [Code mode in production](https://blog.cloudflare.com/code-mode/) (Cloudflare)
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
 
 ## API reference
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -105,7 +105,7 @@ RepoContext(
 
 ## Further reading
 
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
 - [Pydantic AI hooks](/ai/core-concepts/hooks/)
 
 ## API reference

--- a/docs/dynamic-workflow.md
+++ b/docs/dynamic-workflow.md
@@ -206,7 +206,7 @@ DynamicWorkflow(
 )
 ```
 
-`defer_loading=True` needs a stable `id`. See [on-demand capabilities](/ai/core-concepts/capabilities/#on-demand-capabilities) for the full picture.
+`defer_loading=True` needs a stable `id`. See [on-demand capabilities](/ai/capabilities/on-demand/) for the full picture.
 
 ## What runs in the sandbox
 
@@ -262,4 +262,4 @@ Source: [`pydantic_ai_harness/dynamic_workflow/`](https://github.com/pydantic/py
 - [Code Mode](code-mode.md) -- the same sandbox, calling the agent's own tools instead of sub-agents.
 - [Subagents](subagents.md) -- one-delegation-per-tool-call sub-agents, without the scripted choreography.
 - [Rewriting Bun in Rust](https://bun.com/blog/bun-in-rust) (Bun) -- the same pattern at scale, via Claude Code's dynamic workflows.
-- [Capabilities](/ai/core-concepts/capabilities/) and [on-demand capabilities](/ai/core-concepts/capabilities/#on-demand-capabilities).
+- [Capabilities](/ai/capabilities/overview/) and [on-demand capabilities](/ai/capabilities/on-demand/).

--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -179,7 +179,7 @@ Pass `custom_capability_types` so the spec loader knows how to instantiate
 
 ## Further reading
 
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
 - [Toolsets](/ai/tools-toolsets/toolsets/)
 - [the capabilities overview](index.md)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,22 +7,22 @@ description: The official capability library for Pydantic AI -- pick-and-choose 
 
 **The batteries for your [Pydantic AI](/ai/) agent.**
 
-Pydantic AI's [capabilities](/ai/core-concepts/capabilities/) and [hooks](/ai/core-concepts/hooks/) API is how you give an agent its harness -- bundles of tools, lifecycle hooks, instructions, and model settings that extend what the agent can do without any framework changes.
+Pydantic AI's [capabilities](/ai/capabilities/overview/) and [hooks](/ai/core-concepts/hooks/) API is how you give an agent its harness -- bundles of tools, lifecycle hooks, instructions, and model settings that extend what the agent can do without any framework changes.
 
-**Pydantic AI Harness** is the official capability library for Pydantic AI, maintained by the [Pydantic AI](https://github.com/pydantic/pydantic-ai) team. Pydantic AI core ships the capabilities that require model or framework support, plus the ones fundamental to every agent -- [web search](/ai/core-concepts/capabilities/#provider-adaptive-tools), [tool search](/ai/tools-toolsets/deferred-tools/), [thinking](/ai/core-concepts/capabilities/#thinking). Everything else lives here: standalone building blocks you pick and choose to turn your agent into a coding agent, a research assistant, or anything else. This is also where new capabilities start -- as they stabilize and prove themselves broadly essential, they can graduate into core.
+**Pydantic AI Harness** is the official capability library for Pydantic AI, maintained by the [Pydantic AI](https://github.com/pydantic/pydantic-ai) team. Pydantic AI core ships the capabilities that require model or framework support, plus the ones fundamental to every agent -- [web search](/ai/capabilities/web-search/), [tool search](/ai/capabilities/tool-search/), [thinking](/ai/capabilities/thinking/). Everything else lives here: standalone building blocks you pick and choose to turn your agent into a coding agent, a research assistant, or anything else. This is also where new capabilities start -- as they stabilize and prove themselves broadly essential, they can graduate into core.
 
 ## What goes where?
 
 Pydantic AI core ships the agent loop, model providers, the capabilities/hooks abstraction, and two kinds of capabilities:
 
-- **Capabilities that require model or framework support** -- anything backed by provider native tools (like [image generation](/ai/core-concepts/capabilities/#provider-adaptive-tools)), provider-specific APIs (like compaction via the OpenAI or Anthropic APIs), or deep agent graph integration. These go hand-in-hand with model class code and need to ship together.
-- **Capabilities that are fundamental to the agent experience** -- things nearly every agent benefits from, like [web search](/ai/core-concepts/capabilities/#provider-adaptive-tools), [tool search](/ai/tools-toolsets/deferred-tools/), and [thinking](/ai/core-concepts/capabilities/#thinking). These feel like qualities of the agent itself, not accessories.
+- **Capabilities that require model or framework support** -- anything backed by provider native tools (like [image generation](/ai/capabilities/image-generation/)), provider-specific APIs (like [compaction](/ai/capabilities/compaction/) via the OpenAI or Anthropic APIs), or deep agent graph integration (like [tool search](/ai/capabilities/tool-search/) and [on-demand loading](/ai/capabilities/on-demand/)). These go hand-in-hand with model class code and need to ship together.
+- **Capabilities that are fundamental to the agent experience** -- things nearly every agent benefits from, like [web search](/ai/capabilities/web-search/), [web fetch](/ai/capabilities/web-fetch/), [thinking](/ai/capabilities/thinking/), and [MCP](/ai/capabilities/mcp/). These feel like qualities of the agent itself, not accessories. See [built-in capabilities](/ai/capabilities/overview/#built-in-capabilities) for the full list.
 
 **Pydantic AI Harness** is where everything else lives: standalone capabilities that make specific categories of agents powerful, or that are still finding their final shape. Context management, memory, guardrails, file system access, code execution, multi-agent orchestration -- these are the building blocks you pick and choose based on what your agent needs to do.
 
 The harness is also where new capabilities *start*. It ships as a separate package so capabilities can iterate faster without the strict backward-compatibility requirements of core. As a capability stabilizes and proves itself broadly essential, it can graduate into core -- [code mode](code-mode.md) is an early candidate.
 
-Many capabilities benefit from a "fall up" pattern: they typically start as a local implementation that works with every model, then gain provider-native support that uses the provider's built-in API when available -- auto-switching between the two. This is how [web search](/ai/core-concepts/capabilities/#provider-adaptive-tools), [web fetch](/ai/core-concepts/capabilities/#provider-adaptive-tools), and [image generation](/ai/core-concepts/capabilities/#provider-adaptive-tools) already work in core, and the same approach is coming for skills, code mode, and context compaction.
+Many capabilities benefit from a "fall up" pattern: they typically start as a local implementation that works with every model, then gain provider-native support that uses the provider's built-in API when available -- auto-switching between the two. This is how [web search](/ai/capabilities/web-search/), [web fetch](/ai/capabilities/web-fetch/), and [image generation](/ai/capabilities/image-generation/) already work in core, and the same approach is coming for skills, code mode, and context compaction.
 
 ## Installation
 
@@ -107,7 +107,7 @@ practices and warning of a "normalization of deviance" as engineers stop reviewi
 
 ## Capabilities
 
-Each capability is a self-contained battery you drop into an agent's `capabilities=[...]` list. They compose with each other and with Pydantic AI's [built-in capabilities](/ai/core-concepts/capabilities/).
+Each capability is a self-contained battery you drop into an agent's `capabilities=[...]` list. They compose with each other and with Pydantic AI's [built-in capabilities](/ai/capabilities/overview/).
 
 | Capability | What it does | Extra |
 |---|---|---|
@@ -133,7 +133,7 @@ Most capabilities are stable within the [version policy](#version-policy) below.
 
 ## Build your own
 
-[Capabilities](/ai/core-concepts/capabilities/#building-custom-capabilities) are the primary extension point for Pydantic AI. Any of the capabilities in this library can serve as a reference for building your own.
+[Capabilities](/ai/capabilities/custom/) are the primary extension point for Pydantic AI. Any of the capabilities in this library can serve as a reference for building your own.
 
 Publishing as a standalone package? Use the `pydantic-ai-<name>` naming convention -- see [Publishing capability packages](/ai/guides/extensibility/#publishing-capability-packages).
 
@@ -143,7 +143,7 @@ Pydantic AI Harness uses **0.x versioning** to signal that APIs are still stabil
 
 ## Pydantic AI references
 
-- [Capabilities](/ai/core-concepts/capabilities/) -- what capabilities are, built-in capabilities, building your own
+- [Capabilities](/ai/capabilities/overview/) -- what capabilities are, built-in capabilities, building your own
 - [Hooks](/ai/core-concepts/hooks/) -- lifecycle hooks reference, ordering, error handling
 - [Extensibility](/ai/guides/extensibility/) -- publishing packages, third-party ecosystem
 - [Toolsets](/ai/tools-toolsets/toolsets/) -- building tools for capabilities

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -217,7 +217,7 @@ Memory records do not carry source citations or verified provenance. If an appli
 ## API reference
 
 - [`pydantic_ai_harness.memory` source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/memory/)
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
 - [Pydantic AI hooks](/ai/core-concepts/hooks/)
 
 The public module exports `Memory`, `MemoryToolset`, the bundled stores, the store protocols, mutation and search result models, and conflict exceptions. Import them from `pydantic_ai_harness.memory`.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -133,7 +133,7 @@ capabilities:
 
 ## Further reading
 
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
 - [Hooks](/ai/core-concepts/hooks/) -- `wrap_model_request` is the ephemeral injection point used here
 - [Anthropic prompt caching](https://docs.claude.com/en/docs/build-with-claude/prompt-caching)
 - [Code Mode](code-mode.md) -- another prompt-cache-aware harness capability

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -19,7 +19,7 @@ Agents frequently need to run a build, a test suite, a linter, or a quick
 killing runaway processes, and cleaning up background jobs at the end of a run --
 is fiddly boilerplate that every agent reinvents.
 
-`Shell` bundles that plumbing into a single [capability](/ai/core-concepts/capabilities/):
+`Shell` bundles that plumbing into a single [capability](/ai/capabilities/overview/):
 configurable allow/deny lists, output truncation tuned to keep the useful tail,
 optional sticky working directory, environment control that can keep host
 secrets out of spawned commands, and automatic cleanup of background processes
@@ -247,7 +247,7 @@ Pass `custom_capability_types` so the spec loader knows how to instantiate
 
 ## Further reading
 
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
 - [Toolsets](/ai/tools-toolsets/toolsets/)
 
 ## API reference

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -215,7 +215,7 @@ SubAgent(
 
 ## Further reading
 
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
 - [Multi-agent applications](/ai/guides/multi-agent-applications/)
 
 ## API reference

--- a/pydantic_ai_harness/dynamic_workflow/README.md
+++ b/pydantic_ai_harness/dynamic_workflow/README.md
@@ -455,7 +455,7 @@ DynamicWorkflow(
 ```
 
 `defer_loading=True` needs a stable `id`. See
-[on-demand capabilities](https://pydantic.dev/docs/ai/core-concepts/capabilities/#on-demand-capabilities)
+[on-demand capabilities](https://pydantic.dev/docs/ai/capabilities/on-demand/)
 for the full picture.
 
 ## What runs in the sandbox
@@ -532,6 +532,6 @@ WorkflowAgent(
   (Anthropic), the orchestration patterns a script can express.
 - [Rewriting Bun in Rust](https://bun.com/blog/bun-in-rust) (Bun), the same pattern at scale: Jarred
   Sumner's port of Bun from Zig to Rust with Claude Code dynamic workflows.
-- [Capabilities](https://pydantic.dev/docs/ai/core-concepts/capabilities/) and
-  [on-demand capabilities](https://pydantic.dev/docs/ai/core-concepts/capabilities/#on-demand-capabilities).
+- [Capabilities](https://pydantic.dev/docs/ai/capabilities/overview/) and
+  [on-demand capabilities](https://pydantic.dev/docs/ai/capabilities/on-demand/).
 - [Monty](https://github.com/pydantic/monty), the sandbox.

--- a/pydantic_ai_harness/memory/README.md
+++ b/pydantic_ai_harness/memory/README.md
@@ -212,7 +212,7 @@ Memory records do not carry source citations or verified provenance. If an appli
 ## API reference
 
 - [`pydantic_ai_harness.memory` source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/memory/)
-- [Pydantic AI capabilities](https://pydantic.dev/docs/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](https://pydantic.dev/docs/ai/capabilities/overview/)
 - [Pydantic AI hooks](https://pydantic.dev/docs/ai/core-concepts/hooks/)
 
 The public module exports `Memory`, `MemoryToolset`, the bundled stores, the store protocols, mutation and search result models, and conflict exceptions. Import them from `pydantic_ai_harness.memory`.


### PR DESCRIPTION
Companion to pydantic/pydantic-ai#6621, which promotes Capabilities to a top-level docs section at `/ai/capabilities/` with a page per built-in capability.

## What

- Remap all `/ai/core-concepts/capabilities/` links (docs, package READMEs, AGENTS.md, agent_docs) to the new `/ai/capabilities/` pages, pointing at per-capability pages where one exists (`thinking/`, `on-demand/`, `custom/`, etc.)
- **"What goes where?"** on the overview now names and links the core built-ins explicitly:
  - first category: [image generation], [compaction], [tool search], [on-demand loading]
  - second category: [web search], [web fetch], [thinking], [MCP], plus a pointer to the full built-in list on the Capabilities overview
- The intro paragraph and "fall up" section link the per-capability pages directly instead of a shared anchor

## ⚠️ Merge sequencing

**Merge together with (or after) the pydantic-ai release containing pydantic/pydantic-ai#6621** — the `/ai/capabilities/` URLs only exist on pydantic.dev once that release is synced (see also pydantic/unified-docs#82).
