### PR TITLE
Migrate FileSystem read_file oMigrate FileSystem read_file offset to 1-indexed before 1.0ffset to 1-indexed

### DIFF
--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -50,7 +50,7 @@ the root you give it.
 
 | Tool | Purpose |
 |---|---|
-| `read_file` | Read a text file with line numbers and a content hash. Binary files are detected and not dumped. Supports `offset`/`limit` paging. |
+| `read_file` | Read a text file with line numbers and a content hash. Binary files are detected and not dumped. Supports `offset`/`limit` paging; `offset` is 1-indexed, matching `grep -n`, editors, and stack traces (`offset=0` is rejected -- omit `offset` or use `offset=1` to start from the first line). |
 | `write_file` | Create or overwrite a file. Optional `expected_hash` rejects stale writes (optimistic concurrency). |
 | `edit_file` | Exact-string replacement; `old_text` must match exactly once. Optional `expected_hash`. |
 | `list_directory` | List a directory's entries with type indicators and sizes. |

--- a/pydantic_ai_harness/filesystem/README.md
+++ b/pydantic_ai_harness/filesystem/README.md
@@ -35,7 +35,7 @@ print(result.output)
 
 | Tool | Purpose |
 |---|---|
-| `read_file` | Read a text file with line numbers and a content hash. Binary files are detected and not dumped. Supports `offset`/`limit` paging. |
+| `read_file` | Read a text file with line numbers and a content hash. Binary files are detected and not dumped. Supports `offset`/`limit` paging; `offset` is 1-indexed, matching `grep -n`, editors, and stack traces (`offset=0` is rejected -- omit `offset` or use `offset=1` to start from the first line). |
 | `write_file` | Create or overwrite a file. Optional `expected_hash` rejects stale writes (optimistic concurrency). |
 | `edit_file` | Exact-string replacement; `old_text` must match exactly once. Optional `expected_hash`. |
 | `list_directory` | List a directory's entries with type indicators and sizes. |

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -39,25 +39,37 @@ def _recoverable(
     return wrapper
 
 
-def _format_lines(lines: Sequence[str], offset: int, limit: int) -> str:
-    """Format pre-split lines with line numbers and continuation hint."""
+def _format_lines(lines: Sequence[str], offset: int | None, limit: int) -> str:
+    """Format pre-split lines with line numbers and continuation hint.
+
+    `offset` is a 1-indexed line number (matching `grep -n`, editors, and stack
+    traces), or `None` to start from the first line.
+    """
     total = len(lines)
 
     if total == 0:
         return '(empty file)\n'
 
-    if offset >= total:
+    if offset is not None and offset < 1:
+        raise ValueError(
+            f'offset must be >= 1: line numbers are 1-indexed (previously 0-indexed), matching '
+            f'grep -n, editors, and stack traces. Use offset=1, or omit it, to start from the '
+            f'beginning. Got offset={offset}.'
+        )
+
+    start = offset - 1 if offset is not None else 0
+    if start >= total:
         raise ValueError(f'Offset {offset} exceeds file length ({total} lines).')
 
-    selected = lines[offset : offset + limit]
-    numbered = [f'{i:>6}\t{line}' for i, line in enumerate(selected, start=offset + 1)]
+    selected = lines[start : start + limit]
+    numbered = [f'{i:>6}\t{line}' for i, line in enumerate(selected, start=start + 1)]
     result = ''.join(numbered)
     if not result.endswith('\n'):
         result += '\n'
 
-    remaining = total - (offset + len(selected))
+    remaining = total - (start + len(selected))
     if remaining > 0:
-        next_offset = offset + len(selected)
+        next_offset = start + len(selected) + 1
         result += f'... ({remaining} more lines. Use offset={next_offset} to continue reading.)\n'
 
     return result
@@ -202,12 +214,13 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         return resolved
 
     @_recoverable
-    async def read_file(self, path: str, *, offset: int = 0, limit: int | None = None) -> str:
+    async def read_file(self, path: str, *, offset: int | None = None, limit: int | None = None) -> str:
         """Read a text file with line numbers.
 
         Args:
             path: File path relative to the root directory.
-            offset: Zero-based line offset to start reading from.
+            offset: 1-indexed line number to start reading from (matching `grep -n`,
+                editors, and stack traces). Omit to start from the first line.
             limit: Maximum number of lines to return (default: 2000).
 
         Returns:

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -47,9 +47,6 @@ def _format_lines(lines: Sequence[str], offset: int | None, limit: int) -> str:
     """
     total = len(lines)
 
-    if total == 0:
-        return '(empty file)\n'
-
     if offset is not None and offset < 1:
         raise ValueError(
             f'offset must be >= 1: line numbers are 1-indexed (previously 0-indexed), matching '
@@ -59,6 +56,8 @@ def _format_lines(lines: Sequence[str], offset: int | None, limit: int) -> str:
 
     start = offset - 1 if offset is not None else 0
     if start >= total:
+        if total == 0:
+            return '(empty file)\n'
         raise ValueError(f'Offset {offset} exceeds file length ({total} lines).')
 
     selected = lines[start : start + limit]

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -16,17 +16,18 @@ from pydantic_ai_harness.filesystem._toolset import FileSystemToolset, _content_
 class TestFormatLines:
     def test_basic_formatting(self) -> None:
         text = 'line1\nline2\nline3\n'
-        result = _format_lines(text.splitlines(keepends=True), 0, 10)
+        result = _format_lines(text.splitlines(keepends=True), 1, 10)
         assert '     1\tline1\n' in result
         assert '     2\tline2\n' in result
         assert '     3\tline3\n' in result
 
     def test_offset(self) -> None:
+        """offset is 1-indexed: offset=2 starts at the second line ('b')."""
         text = 'a\nb\nc\nd\ne\n'
         result = _format_lines(text.splitlines(keepends=True), 2, 2)
+        assert '     2\tb\n' in result
         assert '     3\tc\n' in result
-        assert '     4\td\n' in result
-        assert '... (1 more lines. Use offset=4 to continue reading.)' in result
+        assert '... (2 more lines. Use offset=4 to continue reading.)' in result
 
     def test_offset_exceeds_length(self) -> None:
         text = 'a\nb\n'
@@ -39,13 +40,13 @@ class TestFormatLines:
 
     def test_no_trailing_newline(self) -> None:
         text = 'no newline'
-        result = _format_lines(text.splitlines(keepends=True), 0, 10)
+        result = _format_lines(text.splitlines(keepends=True), 1, 10)
         assert result.endswith('\n')
 
     def test_continuation_hint(self) -> None:
         text = '\n'.join(f'line{i}' for i in range(10))
-        result = _format_lines(text.splitlines(keepends=True), 0, 3)
-        assert '... (7 more lines. Use offset=3 to continue reading.)' in result
+        result = _format_lines(text.splitlines(keepends=True), 1, 3)
+        assert '... (7 more lines. Use offset=4 to continue reading.)' in result
 
 
 class TestIsBinary:
@@ -298,7 +299,9 @@ class TestReadFile:
         assert '1 lines' in result
 
     async def test_read_with_offset(self, toolset: FileSystemToolset[None]) -> None:
+        """offset is 1-indexed: offset=2 starts at the second line, not the third."""
         result = await toolset.read_file('multi.txt', offset=2)
+        assert 'line2' in result
         assert 'line3' in result
         assert 'line1' not in result
 
@@ -307,6 +310,17 @@ class TestReadFile:
         assert 'line1' in result
         assert 'line2' in result
         assert '... (3 more lines' in result
+
+    async def test_read_offset_zero_rejected(self, toolset: FileSystemToolset[None]) -> None:
+        """offset=0 was the old zero-based default; it must fail loudly, not silently shift."""
+        with pytest.raises(ModelRetry, match='1-indexed'):
+            await toolset.read_file('multi.txt', offset=0)
+
+    async def test_read_offset_one_matches_default(self, toolset: FileSystemToolset[None]) -> None:
+        """offset=1 (first line, explicit) is the same window as the default (None)."""
+        explicit = await toolset.read_file('multi.txt', offset=1)
+        default = await toolset.read_file('multi.txt')
+        assert explicit == default
 
     async def test_read_directory_raises(self, toolset: FileSystemToolset[None]) -> None:
         with pytest.raises(ModelRetry, match='is a directory'):
@@ -742,35 +756,35 @@ class TestFileInfo:
 class TestMutationKillers:
     async def test_format_lines_offset_equals_total(self) -> None:
         text = 'a\nb\n'  # 2 lines
-        with pytest.raises(ValueError, match='Offset 2 exceeds file length'):
-            _format_lines(text.splitlines(keepends=True), 2, 10)
+        with pytest.raises(ValueError, match='Offset 3 exceeds file length'):
+            _format_lines(text.splitlines(keepends=True), 3, 10)
 
     async def test_format_lines_exact_fit_no_continuation(self) -> None:
         text = 'a\nb\nc\n'  # 3 lines
-        result = _format_lines(text.splitlines(keepends=True), 0, 3)
+        result = _format_lines(text.splitlines(keepends=True), 1, 3)
         assert '... (' not in result
         assert 'more lines' not in result
 
     async def test_format_lines_exact_fit_from_offset(self) -> None:
         text = 'a\nb\nc\n'  # 3 lines
-        result = _format_lines(text.splitlines(keepends=True), 1, 2)  # lines 2-3, 0 remaining
+        result = _format_lines(text.splitlines(keepends=True), 2, 2)  # lines 2-3, 0 remaining
         assert '... (' not in result
         assert 'more lines' not in result
 
     async def test_format_lines_one_line_remaining(self) -> None:
         text = 'a\nb\nc\n'  # 3 lines
-        result = _format_lines(text.splitlines(keepends=True), 0, 2)
-        assert '... (1 more lines. Use offset=2 to continue reading.)' in result
+        result = _format_lines(text.splitlines(keepends=True), 1, 2)
+        assert '... (1 more lines. Use offset=3 to continue reading.)' in result
 
     async def test_format_lines_line_number_starts_at_one(self) -> None:
         text = 'first\nsecond\n'
-        result = _format_lines(text.splitlines(keepends=True), 0, 10)
+        result = _format_lines(text.splitlines(keepends=True), 1, 10)
         assert '     1\tfirst\n' in result
         assert '     0\t' not in result
 
     async def test_format_lines_offset_line_numbering(self) -> None:
         text = 'a\nb\nc\n'
-        result = _format_lines(text.splitlines(keepends=True), 1, 2)
+        result = _format_lines(text.splitlines(keepends=True), 2, 2)
         assert '     2\tb\n' in result
         assert '     3\tc\n' in result
 
@@ -887,13 +901,13 @@ class TestMutationKillers:
     async def test_format_lines_join_separator(self) -> None:
         """Verify the result doesn't contain garbage between lines."""
         text = 'a\nb\nc\n'
-        result = _format_lines(text.splitlines(keepends=True), 0, 3)
+        result = _format_lines(text.splitlines(keepends=True), 1, 3)
         # Lines should be directly adjacent (no separator between them)
         assert '     1\ta\n     2\tb\n     3\tc\n' in result
 
     async def test_format_lines_no_trailing_newline_preserves_content(self) -> None:
         text = 'no newline'
-        result = _format_lines(text.splitlines(keepends=True), 0, 10)
+        result = _format_lines(text.splitlines(keepends=True), 1, 10)
         # The content must still be present
         assert 'no newline' in result
         assert result.endswith('\n')
@@ -952,7 +966,7 @@ class TestMutationKillers:
     def test_format_lines_no_double_trailing_newline(self) -> None:
         """Text that already ends with newline must NOT get a second one appended."""
         text = 'hello\n'
-        result = _format_lines(text.splitlines(keepends=True), 0, 10)
+        result = _format_lines(text.splitlines(keepends=True), 1, 10)
         # Exact match: no trailing double newline
         assert result == '     1\thello\n'
 

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -35,8 +35,13 @@ class TestFormatLines:
             _format_lines(text.splitlines(keepends=True), 5, 10)
 
     def test_empty_file(self) -> None:
-        result = _format_lines([], 0, 10)
+        result = _format_lines([], 1, 10)
         assert result == '(empty file)\n'
+
+    def test_empty_file_offset_zero_still_rejected(self) -> None:
+        """offset validation must not depend on the file being empty."""
+        with pytest.raises(ValueError, match='1-indexed'):
+            _format_lines([], 0, 10)
 
     def test_no_trailing_newline(self) -> None:
         text = 'no newline'


### PR DESCRIPTION
## Summary
`FileSystem.read_file` used a 0-based `offset` while `ModalSandbox.read_file` (unmerged, #269) uses 1-indexed, matching `grep -n`, editors, and stack traces -- the convention `agent_docs/capability-authoring.md` now records as the standard. Same tool name, same parameter name, different meaning: a model that formed a paging habit on one silently read the wrong window on the other, with no error firing to reveal it.

## Changes
- `read_file`'s `offset` is now `int | None = None`, 1-indexed. `None` and `offset=1` both mean "start at the first line."
- `offset=0` (the old meaningful default) and any `offset < 1` are explicitly rejected with an error naming the 1-indexed convention, so a model still on the old 0-based habit gets a loud correction instead of a silently shifted window.
- `_format_lines`'s continuation hint (`"Use offset=N to continue reading"`) now reports 1-indexed values throughout.
- Updated `pydantic_ai_harness/filesystem/README.md` and `docs/filesystem.md` to document the convention and the `offset=0` rejection.

## Testing
Updated 13 existing tests to the new semantics and added 2 new tests (`offset=0` rejection, `offset=1` == default equivalence). Full `tests/filesystem/test_filesystem.py` suite + `ruff` + `pyright` pass on the changed files.

Fixes #395 