### PR TITLE
fix(code-mode): surface unsupported-syntax parser errors as ModelRetry

### DIFF
--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -739,6 +739,12 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             raise ModelRetry(f'Type error in code:\n{e.display()}') from e
         except MontySyntaxError as e:
             raise ModelRetry(f'Syntax error in code:\n{e.display()}') from e
+        except MontyRuntimeError as e:
+            # The parser rejects syntax Monty does not implement (e.g. `with`
+            # statements) with a runtime error at construction time. That is a
+            # property of the code, not of the run -- surface it as a retry so
+            # the model can rewrite, matching this method's documented contract.
+            raise ModelRetry(f'Unsupported syntax in code:\n{e}') from e
 
 
 def _get_sigs_and_conflicting(

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -465,6 +465,25 @@ class TestCodeMode:
         with pytest.raises(ModelRetry, match=r"name 'undefined_var' is not defined"):
             await wrapper.call_tool('run_code', {'code': 'print(undefined_var)'}, ctx, run_code)
 
+    async def test_run_code_unsupported_syntax_becomes_model_retry(self, tmp_path: Path) -> None:
+        """Syntax Monty does not implement (`with` statements) is a `ModelRetry`, not a crash.
+
+        Needs a mount so `open` type-checks (as in real dataset-analysis runs): the
+        code then reaches Monty's parser, whose NotImplementedError surfaces as
+        `MontyRuntimeError` at construction. Before the guard, that escaped
+        `_type_check` and killed the whole agent run.
+        """
+        (tmp_path / 'f.txt').write_text('x')
+        wrapper = CodeMode[object](mount=MountDir('/work', str(tmp_path))).get_wrapper_toolset(
+            _build_function_toolset(add)
+        )
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        code = 'from pathlib import Path\nwith Path("/work/f.txt").open() as f:\n    f.read()'
+        with pytest.raises(ModelRetry, match=r'Unsupported syntax in code'):
+            await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+
     async def test_run_code_typing_error_becomes_model_retry(self) -> None:
         """A `MontyTypingError` from static type checking is translated into `ModelRetry`.
 


### PR DESCRIPTION
## Summary

`_type_check` catches `MontyTypingError` and `MontySyntaxError` and converts them to `ModelRetry`, per its documented contract. But Monty's parser raises `MontyRuntimeError` (`NotImplementedError`) at construction for syntax it does not implement -- e.g. `with` statements -- and that escaped uncaught, crashing the entire agent run.

The gap is reachable in practice: with a `mount` configured, `Path.open()` type-checks against the stubs, so a model writing the idiomatic

```python
with Path('/data/orders.csv').open() as f:
    ...
```

passes the type check, reaches the parser, and kills the run with an unhandled exception instead of getting a retry it would trivially recover from. Hit while exercising a dataset-analysis agent against a live model.

## Change

- `_type_check` now catches `MontyRuntimeError` and raises `ModelRetry('Unsupported syntax in code: ...')`, matching the treatment of type and syntax errors.
- Regression test reproduces the exact scenario (mounted filesystem + `Path.open` in a `with` block); verified red without the guard, green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)