### PR TITLE
Fix `ClampOversizedMessages` corrupting typed `ToolCallPart` subclasses

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -21,7 +21,7 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 
 | Capability | Cost | What it does | Reach for it when |
 |---|---|---|---|
-| `ClampOversizedMessages` | zero-LLM | Head/tail-truncates a single oversized part (response text, tool-call args) | One runaway generation blew past the context cap and no other strategy can reach it |
+| `ClampOversizedMessages` | zero-LLM | Head/tail-truncates a single oversized part (response text, plain tool-call args) | One runaway generation blew past the context cap and no other strategy can reach it |
 | `SlidingWindow` | zero-LLM | Drops the oldest whole messages down to a tail | You only need the recent turns and can discard old context entirely |
 | `ClearToolResults` | zero-LLM | Blanks the content of old tool *results* in place, keeping the last `keep_pairs` | Tool outputs dominate context and can be re-fetched on demand (the cheap first tier) |
 | `DeduplicateFileReads` | zero-LLM | Blanks every file read superseded by a newer read of the same file | The agent re-reads files and only the latest version matters |
@@ -96,7 +96,7 @@ A part is clamped only when it is oversized *and* the clamp actually shrinks it,
 It clamps two kinds of part inside each `ModelResponse`:
 
 - **Response text** (`TextPart`) -- the critical case, a runaway model-response text part.
-- **Tool-call args** (`ToolCallPart`), when `clamp_tool_call_args=True` (the default) -- the same failure shape for a giant payload (for example a runaway `write_plan`). The args are replaced with a small JSON object `{"_clamped": "<head>...<tail>"}` so they stay valid function arguments; the original call already executed, so this only shrinks the history copy. Set `clamp_tool_call_args=False` to clamp response text only.
+- **Plain tool-call args** (`ToolCallPart`), when `clamp_tool_call_args=True` (the default) -- the same failure shape for a giant payload (for example a runaway `write_plan`). The args are replaced with a small JSON object `{"_clamped": "<head>...<tail>"}` so they stay valid function arguments; the original call already executed, so this only shrinks the history copy. Framework-typed calls such as core's `search_tools` and `load_capability` are left intact because their args use narrower structured schemas. Replacing them with the generic `_clamped` object would preserve the subclass while corrupting message-history serialization and restore. Typed calls therefore remain in the context even when oversized. Set `clamp_tool_call_args=False` to clamp response text only.
 
 Request-side parts (user prompts, tool *returns*, system prompts) are deliberately out of scope: user input should not be silently rewritten, and oversized tool returns are the job of `ClearToolResults`.
 

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -23,7 +23,7 @@ provider rejects an orphaned pair. The zero-LLM strategies never call a model.
 
 | Capability | Cost | What it does | Reach for it when |
 |---|---|---|---|
-| `ClampOversizedMessages` | zero-LLM | Head/tail-truncates a single oversized part (response text, tool-call args) | One runaway generation blew past the context cap and no other strategy can reach it |
+| `ClampOversizedMessages` | zero-LLM | Head/tail-truncates a single oversized part (response text, plain tool-call args) | One runaway generation blew past the context cap and no other strategy can reach it |
 | `SlidingWindow` | zero-LLM | Drops the oldest whole messages down to a tail | You only need the recent turns and can discard old context entirely |
 | `ClearToolResults` | zero-LLM | Blanks the content of old tool *results* in place, keeping the last `keep_pairs` | Tool outputs dominate context and can be re-fetched on demand (the cheap first tier) |
 | `DeduplicateFileReads` | zero-LLM | Blanks every file read superseded by a newer read of the same file | The agent re-reads files and only the latest version matters |
@@ -68,11 +68,14 @@ A part is clamped only when it is oversized *and* the clamp actually shrinks it,
 It clamps two kinds of part inside each `ModelResponse`:
 
 - **Response text** (`TextPart`) -- the critical case, a runaway model-response text part.
-- **Tool-call args** (`ToolCallPart`), when `clamp_tool_call_args=True` (default) -- the same failure
-  shape for a giant payload (e.g. a runaway `write_plan`). The args are replaced with a small JSON
-  object `{"_clamped": "<head>...<tail>"}` so they stay valid function arguments; the original call
-  already executed, so this only shrinks the history copy. Set `clamp_tool_call_args=False` to clamp
-  response text only.
+- **Plain tool-call args** (`ToolCallPart`), when `clamp_tool_call_args=True` (default) -- the same
+  failure shape for a giant payload (e.g. a runaway `write_plan`). The args are replaced with a small
+  JSON object `{"_clamped": "<head>...<tail>"}` so they stay valid function arguments; the original
+  call already executed, so this only shrinks the history copy. Framework-typed calls such as core's
+  `search_tools` and `load_capability` are left intact because their args use narrower structured
+  schemas. Replacing them with the generic `_clamped` object would preserve the subclass while
+  corrupting message-history serialization and restore. Typed calls therefore remain in the context
+  even when oversized. Set `clamp_tool_call_args=False` to clamp response text only.
 
 Request-side parts (user prompts, tool *returns*, system prompts) are deliberately out of scope:
 user input should not be silently rewritten, and oversized tool returns are the job of

--- a/pydantic_ai_harness/compaction/_clamp_oversized_messages.py
+++ b/pydantic_ai_harness/compaction/_clamp_oversized_messages.py
@@ -27,7 +27,7 @@ _CLAMP_MARKER = '\n[clamped: removed {removed} of {original} characters]\n'
 are filled with character counts."""
 
 _CLAMP_ARGS_KEY = '_clamped'
-"""Key of the single-entry object a clamped `ToolCallPart`'s args are replaced with.
+"""Key of the single-entry object a clamped plain `ToolCallPart`'s args are replaced with.
 
 Args stay a JSON object (not a bare marker string) so `args_as_json_str()` emits valid function
 arguments for the provider."""
@@ -35,7 +35,7 @@ arguments for the provider."""
 
 @dataclass
 class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
-    """Zero-cost head/tail truncation of any single oversized message part.
+    """Zero-cost head/tail truncation of oversized response text and plain tool-call args.
 
     A runaway generation -- a model response of repeated whitespace, a giant tool-call
     payload -- can produce one part so large the next request exceeds the provider's context
@@ -49,10 +49,12 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
     What it clamps, in each `ModelResponse`:
 
     - `TextPart` content (the critical case -- a runaway model-response text part).
-    - `ToolCallPart` args, when `clamp_tool_call_args` is set (the same failure shape for a
-      giant tool-call payload). The args are replaced with a small JSON object so they stay
+    - Plain `ToolCallPart` args, when `clamp_tool_call_args` is set (the same failure shape for
+      a giant tool-call payload). The args are replaced with a small JSON object so they stay
       valid function arguments; the original call already executed, so this only shrinks the
-      history copy.
+      history copy. Framework-typed subclasses are left intact because replacing their
+      structured args with the generic marker would violate their schemas and break
+      message-history persistence and restore.
 
     Request-side parts (user prompts, tool returns, system prompts) are out of scope: user
     input should not be silently rewritten, and oversized tool *returns* are the job of
@@ -64,8 +66,8 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
     A part is clamped only when it is oversized *and* the clamp actually shrinks it, so set
     `keep_head_chars` + `keep_tail_chars` well below your per-part threshold.
 
-    Composes as the first tier of a `TieredCompaction` (run it before `ClearToolResults`):
-    it is the only zero-LLM way to keep a run alive after a runaway generation.
+    Compose it as the first tier of a `TieredCompaction` (run it before `ClearToolResults`)
+    to handle supported runaway response parts without an LLM call.
 
     Example:
         ```python
@@ -92,7 +94,7 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
     """Characters of the part's tail to retain."""
 
     clamp_tool_call_args: bool = True
-    """When ``True``, also clamp oversized `ToolCallPart` args, not just response text."""
+    """When `True`, also clamp oversized plain `ToolCallPart` args, not just response text."""
 
     tokenizer: Callable[[str], int] | None = None
     """Optional tokenizer for accurate token counting.
@@ -137,7 +139,7 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
         messages: list[ModelMessage],
         ctx: RunContext[AgentDepsT],
     ) -> list[ModelMessage]:
-        """Clamp every oversized response text part (and tool-call args, if enabled)."""
+        """Clamp every oversized response text part (and plain tool-call args, if enabled)."""
         out: list[ModelMessage] = []
         for msg in messages:
             if not isinstance(msg, ModelResponse):
@@ -153,7 +155,9 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
                         new_parts.append(replace(part, content=clamped))
                         changed = True
                         continue
-                elif isinstance(part, ToolCallPart) and self.clamp_tool_call_args:
+                # Exact type: framework-typed subclasses narrow `args` to structured schemas.
+                # `replace` would preserve the subclass while bypassing validation and corrupting history round-trips.
+                elif type(part) is ToolCallPart and self.clamp_tool_call_args:
                     clamped = self._clamp(part.args_as_json_str())
                     if clamped is not None:
                         new_parts.append(replace(part, args={_CLAMP_ARGS_KEY: clamped}))

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -3,19 +3,23 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from opentelemetry.trace import NoOpTracer, Tracer
 from pydantic_ai.messages import (
+    LoadCapabilityCallPart,
     ModelMessage,
+    ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
     ToolReturnPart,
+    ToolSearchCallPart,
     ToolSearchReturnContent,
     ToolSearchReturnPart,
     UserPromptPart,
@@ -1957,6 +1961,49 @@ class TestClampOversizedMessages:
         assert _CLAMP_ARGS_KEY in part.args
         assert '[clamped: removed' in part.args[_CLAMP_ARGS_KEY]
         assert part.tool_call_id == 'c1'
+
+    @pytest.mark.anyio
+    async def test_preserves_typed_tool_call_args_and_round_trips(self):
+        query = 'q' * 5_000
+        capability_id = 'c' * 5_000
+        search_call = ToolSearchCallPart(args={'queries': [query]}, tool_call_id='ts1')
+        load_call = LoadCapabilityCallPart(args={'id': capability_id}, tool_call_id='lc1')
+        plain_call = ToolCallPart(tool_name='write_plan', args='p' * 5_000, tool_call_id='p1')
+        response = ModelResponse(parts=[search_call, load_call, plain_call])
+        cap = ClampOversizedMessages(max_part_chars=1_000, keep_head_chars=50, keep_tail_chars=50)
+
+        result = await cap.compact([response], _make_ctx())
+
+        out_search, out_load, out_plain = result[0].parts
+        assert out_search is search_call
+        assert isinstance(out_search, ToolSearchCallPart)
+        assert out_search.queries == [query]
+        assert out_load is load_call
+        assert isinstance(out_load, LoadCapabilityCallPart)
+        assert out_load.capability_id == capability_id
+        assert type(out_plain) is ToolCallPart
+        assert isinstance(out_plain.args, dict)
+        assert _CLAMP_ARGS_KEY in out_plain.args
+
+        dumped_python = ModelMessagesTypeAdapter.dump_python(result, mode='json')
+        dumped_json = ModelMessagesTypeAdapter.dump_json(result)
+        restored_variants = (
+            ModelMessagesTypeAdapter.validate_python(result),
+            ModelMessagesTypeAdapter.validate_python(dumped_python),
+            ModelMessagesTypeAdapter.validate_json(dumped_json),
+            ModelMessagesTypeAdapter.validate_python(json.loads(dumped_json.decode('utf-8'))),
+        )
+        for restored in restored_variants:
+            restored_response = restored[0]
+            assert isinstance(restored_response, ModelResponse)
+            restored_search, restored_load, restored_plain = restored_response.parts
+            assert type(restored_search) is ToolSearchCallPart
+            assert restored_search.queries == [query]
+            assert type(restored_load) is LoadCapabilityCallPart
+            assert restored_load.capability_id == capability_id
+            assert type(restored_plain) is ToolCallPart
+            assert isinstance(restored_plain.args, dict)
+            assert _CLAMP_ARGS_KEY in restored_plain.args
 
     @pytest.mark.anyio
     async def test_small_tool_call_args_untouched(self):


### PR DESCRIPTION
## Summary

`ClampOversizedMessages` matched tool-call parts with `isinstance(part, ToolCallPart)`. This also matched framework-typed subclasses such as `ToolSearchCallPart` and `LoadCapabilityCallPart`.

When oversized args were clamped, `dataclasses.replace` preserved the concrete subclass while replacing its narrowed structured args with the generic `{"_clamped": ...}` object. The resulting message could no longer round-trip through `ModelMessagesTypeAdapter`, which breaks history persistence and resume through `StepPersistence`.

This change limits args clamping to exact, plain `ToolCallPart` instances. Framework-typed subclasses retain their structured args, while existing clamping behavior for plain tool calls and response text remains unchanged.

## Linked Issue

Fixes #401

## Changes

- Restrict tool-call args clamping to exact `ToolCallPart` instances.
- Preserve `ToolSearchCallPart` and `LoadCapabilityCallPart` types and structured args.
- Add regression coverage for Python, JSON, and StepPersistence-shaped message round-trips.
- Document that framework-typed calls remain intact even when oversized.
- Keep existing plain tool-call and response-text clamping behavior unchanged.

## Testing

Local validation:

- `uv run pytest tests/compaction/test_compaction.py -k ClampOversizedMessages -q` -- 30 passed
- `uv run pytest tests/test_docs_parity.py tests/test_doc_snippets.py -q` -- 407 passed, 4 skipped
- `make lint` -- passed
- `make typecheck` -- 0 errors
- `make test` -- 2458 passed, 14 skipped
- `make testcov` -- 100% branch coverage

## Notes for reviewers

- The exact-type check mirrors the approach used for typed `ToolReturnPart` subclasses in #383.
- An explicit exclusion list was avoided so future `ToolCallPart` subclasses with narrowed schemas are preserved by default.
- Framework-typed calls intentionally remain in the context when oversized; replacing their args with the generic marker would violate their schema.
- This change introduces no public API or dependency changes.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added for the new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] No changes to `pyproject.toml` or `uv.lock`
- [x] Updated both compaction documentation surfaces
- [x] Docstrings use single backticks
