### PR TITLE
fix(memory): scope-qualify injection marker so multiple `Memory` capabilities coexist

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -142,6 +142,27 @@ agent = Agent(
 
 Namespace isolation controls which records the capability addresses. It is not an authorization system for a custom or shared backing store. Validate the identity in application dependencies, restrict backend credentials, and ensure custom stores cannot escape the resolved namespace.
 
+## Multiple memories on one agent
+
+An agent can carry several `Memory` capabilities at once, for example a personal notebook plus a shared org notebook. Two constraints apply:
+
+- Give each instance a distinct `agent_name` or `namespace`. Injected blocks are tracked by their resolved scope, so instances that differ only in their store resolve the same scope and replace each other's injection.
+- All instances define the same tool names, so wrap every instance but one in `prefix_tools` to keep the tool schemas distinct.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.memory import FileStore, Memory
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[
+        Memory(FileStore('/var/lib/myapp/memory')),
+        Memory(FileStore('/var/lib/myapp/memory'), agent_name='org').prefix_tools('org'),
+    ],
+    defer_model_check=True,
+)
+```
+
 ## Search
 
 `search_memory` performs literal text search and always applies three bounds:

--- a/pydantic_ai_harness/memory/README.md
+++ b/pydantic_ai_harness/memory/README.md
@@ -137,6 +137,27 @@ agent = Agent(
 
 Namespace isolation controls which records the capability addresses. It is not an authorization system for a custom or shared backing store. Validate the identity in application dependencies, restrict backend credentials, and ensure custom stores cannot escape the resolved namespace.
 
+## Multiple memories on one agent
+
+An agent can carry several `Memory` capabilities at once, for example a personal notebook plus a shared org notebook. Two constraints apply:
+
+- Give each instance a distinct `agent_name` or `namespace`. Injected blocks are tracked by their resolved scope, so instances that differ only in their store resolve the same scope and replace each other's injection.
+- All instances define the same tool names, so wrap every instance but one in `prefix_tools` to keep the tool schemas distinct.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.memory import FileStore, Memory
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[
+        Memory(FileStore('/var/lib/myapp/memory')),
+        Memory(FileStore('/var/lib/myapp/memory'), agent_name='org').prefix_tools('org'),
+    ],
+    defer_model_check=True,
+)
+```
+
 ## Search
 
 `search_memory` performs literal text search and always applies three bounds:

--- a/pydantic_ai_harness/memory/_capability.py
+++ b/pydantic_ai_harness/memory/_capability.py
@@ -157,12 +157,14 @@ class Memory(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
     ) -> ModelRequestContext:
         """Add a bounded memory snapshot to only the current user request."""
-        self._remove_previous_injection(request_context.messages)
-        if not self.inject_memory:
-            return request_context
-
         store, scope = self.resolve_scope(ctx)
         scope_hash = hashlib.sha256(scope.encode()).hexdigest()[:16]
+        # Scope-qualify the marker so several `Memory` capabilities on one agent
+        # each refresh only their own injection instead of clobbering each other.
+        marker = f'{_MEMORY_PART_METADATA}:{scope_hash}'
+        self._remove_previous_injection(request_context.messages, marker)
+        if not self.inject_memory:
+            return request_context
         with ctx.tracer.start_as_current_span(
             'memory.inject', record_exception=False, set_status_on_exception=False
         ) as span:
@@ -211,7 +213,7 @@ class Memory(AbstractCapability[AgentDepsT]):
                     files_truncated=files_truncated,
                 )[:content_budget]
                 rendered = f'{_MEMORY_DATA_PREFIX}{rendered}{_MEMORY_DATA_SUFFIX}'
-                part = UserPromptPart([TextContent(rendered, metadata=_MEMORY_PART_METADATA)])
+                part = UserPromptPart([TextContent(rendered, metadata=marker)])
                 latest = request_context.messages[-1]
                 if not isinstance(latest, ModelRequest):  # pragma: no cover - guaranteed by the agent graph
                     raise RuntimeError('model request history must end with a ModelRequest')
@@ -229,7 +231,7 @@ class Memory(AbstractCapability[AgentDepsT]):
                 )
         return request_context
 
-    def _remove_previous_injection(self, messages: list[ModelMessage]) -> None:
+    def _remove_previous_injection(self, messages: list[ModelMessage], marker: str) -> None:
         for index, message in enumerate(messages):
             if not isinstance(message, ModelRequest):
                 continue
@@ -240,9 +242,7 @@ class Memory(AbstractCapability[AgentDepsT]):
                     parts.append(part)
                     continue
                 content = [
-                    item
-                    for item in part.content
-                    if not (isinstance(item, TextContent) and item.metadata == _MEMORY_PART_METADATA)
+                    item for item in part.content if not (isinstance(item, TextContent) and item.metadata == marker)
                 ]
                 if len(content) == len(part.content):
                     parts.append(part)

--- a/pydantic_ai_harness/memory/_capability.py
+++ b/pydantic_ai_harness/memory/_capability.py
@@ -241,8 +241,14 @@ class Memory(AbstractCapability[AgentDepsT]):
                 if not isinstance(part, UserPromptPart) or isinstance(part.content, str):
                     parts.append(part)
                     continue
+                # The bare `_MEMORY_PART_METADATA` match is a compatibility strip for
+                # histories persisted before markers were scope-qualified; without it a
+                # resumed pre-upgrade conversation keeps one stale block permanently.
+                # Removable once pre-upgrade histories are no longer a concern.
                 content = [
-                    item for item in part.content if not (isinstance(item, TextContent) and item.metadata == marker)
+                    item
+                    for item in part.content
+                    if not (isinstance(item, TextContent) and item.metadata in (marker, _MEMORY_PART_METADATA))
                 ]
                 if len(content) == len(part.content):
                     parts.append(part)

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -26,6 +26,7 @@ from pydantic_ai.messages import (
     UserContent,
     UserPromptPart,
 )
+from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
@@ -1043,6 +1044,30 @@ class TestInjection:
                 TestModel(),
                 capabilities=[Memory(store=OutOfScopeListingStore(), injection_errors='raise')],
             ).run('go')
+
+    async def test_multiple_scopes_do_not_clobber_each_others_injection(self) -> None:
+        store = InMemoryStore()
+        await _seed(store, 'main/MEMORY.md', '- personal fact')
+        await _seed(store, 'org/MEMORY.md', '- org fact')
+        personal = await Memory[None](store=store, agent_name='main').for_run(_ctx())
+        org = await Memory[None](store=store, agent_name='org').for_run(_ctx())
+
+        def fresh_context() -> ModelRequestContext:
+            return ModelRequestContext(
+                model=TestModel(),
+                messages=[ModelRequest(parts=[UserPromptPart('go')])],
+                model_settings=None,
+                model_request_parameters=ModelRequestParameters(),
+            )
+
+        rc = fresh_context()
+        for turn in range(2):
+            rc = await personal.before_model_request(_ctx(), rc)
+            rc = await org.before_model_request(_ctx(), rc)
+            contexts = _memory_contexts(rc.messages)
+            assert len(contexts) == 2, turn
+            assert any('personal fact' in c for c in contexts)
+            assert any('org fact' in c for c in contexts)
 
 
 class TestConfigurationAndSpecs:

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -26,7 +26,6 @@ from pydantic_ai.messages import (
     UserContent,
     UserPromptPart,
 )
-from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
@@ -1045,29 +1044,62 @@ class TestInjection:
                 capabilities=[Memory(store=OutOfScopeListingStore(), injection_errors='raise')],
             ).run('go')
 
-    async def test_multiple_scopes_do_not_clobber_each_others_injection(self) -> None:
+    async def test_multiple_memories_compose_on_one_agent_without_clobbering(self) -> None:
         store = InMemoryStore()
         await _seed(store, 'main/MEMORY.md', '- personal fact')
         await _seed(store, 'org/MEMORY.md', '- org fact')
-        personal = await Memory[None](store=store, agent_name='main').for_run(_ctx())
-        org = await Memory[None](store=store, agent_name='org').for_run(_ctx())
+        captured: list[list[str]] = []
 
-        def fresh_context() -> ModelRequestContext:
-            return ModelRequestContext(
-                model=TestModel(),
-                messages=[ModelRequest(parts=[UserPromptPart('go')])],
-                model_settings=None,
-                model_request_parameters=ModelRequestParameters(),
-            )
+        def capture(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            captured.append(_memory_contexts(messages))
+            return ModelResponse(parts=[TextPart('done')])
 
-        rc = fresh_context()
-        for turn in range(2):
-            rc = await personal.before_model_request(_ctx(), rc)
-            rc = await org.before_model_request(_ctx(), rc)
-            contexts = _memory_contexts(rc.messages)
-            assert len(contexts) == 2, turn
-            assert any('personal fact' in c for c in contexts)
-            assert any('org fact' in c for c in contexts)
+        agent = Agent(
+            FunctionModel(capture),
+            capabilities=[
+                Memory(store=store),
+                Memory(store=store, agent_name='org').prefix_tools('org'),
+            ],
+        )
+        first = await agent.run('first')
+        second = await agent.run('second', message_history=first.all_messages())
+
+        assert len(captured) == 2
+        for contexts in captured:
+            assert len(contexts) == 2
+            assert any('personal fact' in context for context in contexts)
+            assert any('org fact' in context for context in contexts)
+        assert len(_memory_contexts(second.all_messages())) == 2
+
+    async def test_legacy_unqualified_marker_is_stripped_from_continued_history(self) -> None:
+        store = InMemoryStore()
+        await _seed(store, 'main/MEMORY.md', '- durable fact')
+        history: list[ModelMessage] = [
+            ModelRequest(
+                parts=[
+                    UserPromptPart('earlier'),
+                    UserPromptPart(
+                        [TextContent('<memory>\n- stale fact\n</memory>', metadata='pydantic-ai-harness.memory.v1')]
+                    ),
+                ]
+            ),
+            ModelResponse(parts=[TextPart('ok')]),
+        ]
+        captured: list[list[str]] = []
+
+        def capture(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            captured.append(_memory_contexts(messages))
+            return ModelResponse(parts=[TextPart('done')])
+
+        result = await Agent(FunctionModel(capture), capabilities=[Memory(store=store)]).run(
+            'continue', message_history=history
+        )
+
+        assert len(captured) == 1
+        assert len(captured[0]) == 1
+        assert 'durable fact' in captured[0][0]
+        assert 'stale fact' not in captured[0][0]
+        assert len(_memory_contexts(result.all_messages())) == 1
 
 
 class TestConfigurationAndSpecs:


### PR DESCRIPTION
## Summary

`Memory.before_model_request` tagged its injected `<memory>` block with a module-global marker and `_remove_previous_injection` stripped any part carrying it. With more than one `Memory` on an agent the markers were identical, so the last capability in the hook chain removed every other instance's block and injected only its own -- the model saw a single memory scope.

The resolved `scope_hash` was already computed for tracing. This scope-qualifies the marker with it and matches on the qualified marker in `_remove_previous_injection`, so each instance refreshes only its own injection. `resolve_scope` moves above the strip because the strip now needs the marker.

The strip also still matches the bare pre-upgrade marker: histories persisted before scope qualification would otherwise keep one stale `<memory>` block permanently in every resumed conversation. The extra match is a compatibility measure, commented as removable once pre-upgrade histories stop mattering.

Composing two `Memory` capabilities on one `Agent` works today by wrapping all but one in `prefix_tools(...)` to avoid the tool-name collision; the test verifies isolation through the public `Agent` path this way, with `message_history` carried across two runs. Composed instances must differ in `agent_name` or `namespace` -- the injection scope does not include store identity -- and the README and docs page now document both constraints.

## Linked Issue

Fixes #408

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

Maintainer edit: David approved three follow-up commits pushed to this branch (`f93a6d9`, `e5e165e`, `479f396`) covering the legacy-marker strip, the `Agent`-level test, and the composition docs; he approved the changes without reading the diff line by line. The summary above was updated to describe the branch as it now stands. The original body claimed two `Memory` capabilities could not yet share one `Agent`; that was not accurate, and the paragraph has been corrected.
