### PR TITLE
Fix `ClampOversizedMessages` clamping typed `ToolCallPart` subclasses (`ToolSearchCallPart`, `LoadCapabilityCallPart`)

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -96,7 +96,7 @@ A part is clamped only when it is oversized *and* the clamp actually shrinks it,
 It clamps two kinds of part inside each `ModelResponse`:
 
 - **Response text** (`TextPart`) -- the critical case, a runaway model-response text part.
-- **Tool-call args** (`ToolCallPart`), when `clamp_tool_call_args=True` (the default) -- the same failure shape for a giant payload (for example a runaway `write_plan`). The args are replaced with a small JSON object `{"_clamped": "<head>...<tail>"}` so they stay valid function arguments; the original call already executed, so this only shrinks the history copy. Set `clamp_tool_call_args=False` to clamp response text only.
+- **Tool-call args** (`ToolCallPart`), when `clamp_tool_call_args=True` (the default) -- the same failure shape for a giant payload (for example a runaway `write_plan`). The args are replaced with a small JSON object `{"_clamped": "<head>...<tail>"}` so they stay valid function arguments; the original call already executed, so this only shrinks the history copy. Set `clamp_tool_call_args=False` to clamp response text only. Framework-typed call parts -- core's `search_tools` and `load_capability` calls -- are never clamped, because their typed args are validated when persisted history is restored (for example a `StepPersistence` resume) and the `_clamped` object would fail that round-trip.
 
 Request-side parts (user prompts, tool *returns*, system prompts) are deliberately out of scope: user input should not be silently rewritten, and oversized tool returns are the job of `ClearToolResults`.
 

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -72,7 +72,10 @@ It clamps two kinds of part inside each `ModelResponse`:
   shape for a giant payload (e.g. a runaway `write_plan`). The args are replaced with a small JSON
   object `{"_clamped": "<head>...<tail>"}` so they stay valid function arguments; the original call
   already executed, so this only shrinks the history copy. Set `clamp_tool_call_args=False` to clamp
-  response text only.
+  response text only. Framework-typed call parts -- core's `search_tools` and `load_capability`
+  calls -- are never clamped, because their typed args are validated when persisted history is
+  restored (for example a `StepPersistence` resume) and the `_clamped` object would fail that
+  round-trip.
 
 Request-side parts (user prompts, tool *returns*, system prompts) are deliberately out of scope:
 user input should not be silently rewritten, and oversized tool returns are the job of

--- a/pydantic_ai_harness/compaction/_clamp_oversized_messages.py
+++ b/pydantic_ai_harness/compaction/_clamp_oversized_messages.py
@@ -52,7 +52,9 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
     - `ToolCallPart` args, when `clamp_tool_call_args` is set (the same failure shape for a
       giant tool-call payload). The args are replaced with a small JSON object so they stay
       valid function arguments; the original call already executed, so this only shrinks the
-      history copy.
+      history copy. Framework-typed subclasses (`ToolSearchCallPart`, `LoadCapabilityCallPart`)
+      are never clamped: their typed args must survive the `ModelMessagesTypeAdapter`
+      round-trip that persistence relies on.
 
     Request-side parts (user prompts, tool returns, system prompts) are out of scope: user
     input should not be silently rewritten, and oversized tool *returns* are the job of
@@ -153,7 +155,13 @@ class ClampOversizedMessages(AbstractCapability[AgentDepsT]):
                         new_parts.append(replace(part, content=clamped))
                         changed = True
                         continue
-                elif isinstance(part, ToolCallPart) and self.clamp_tool_call_args:
+                # Exact type, not `isinstance`: typed `ToolCallPart` subclasses such as
+                # `ToolSearchCallPart` and `LoadCapabilityCallPart` narrow `args` to a typed shape
+                # that `ModelMessagesTypeAdapter` validates when persisted history is restored
+                # (e.g. a `StepPersistence` resume). Replacing that shape with the `_clamped`
+                # object keeps the concrete class but fails the round-trip, so only plain tool
+                # calls are clamped.
+                elif type(part) is ToolCallPart and self.clamp_tool_call_args:
                     clamped = self._clamp(part.args_as_json_str())
                     if clamped is not None:
                         new_parts.append(replace(part, args={_CLAMP_ARGS_KEY: clamped}))

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -18,7 +18,6 @@ from pydantic_ai.messages import (
     TextPart,
     ToolCallPart,
     ToolReturnPart,
-    ToolSearchArgs,
     ToolSearchCallPart,
     ToolSearchReturnContent,
     ToolSearchReturnPart,
@@ -1969,36 +1968,23 @@ class TestClampOversizedMessages:
         # history is restored (e.g. `StepPersistence` resume). Replacing that shape with the
         # `_clamped` object made the round-trip fail; clamping must skip typed subclasses and
         # touch only plain tool calls.
-        search_args: ToolSearchArgs = {'queries': ['find tools for ' + 'x' * 5_000]}
-        load_args = '{"id": "' + 'c' * 5_000 + '"}'
-        messages: list[ModelMessage] = [
-            ModelResponse(
-                parts=[
-                    ToolSearchCallPart(args=search_args, tool_call_id='ts1'),
-                    LoadCapabilityCallPart(args=load_args, tool_call_id='lc1'),
-                    ToolCallPart(tool_name='write_plan', args='p' * 5_000, tool_call_id='c1'),
-                ]
-            ),
-        ]
+        search_call = ToolSearchCallPart(args={'queries': ['find tools for ' + 'x' * 5_000]}, tool_call_id='ts1')
+        load_call = LoadCapabilityCallPart(args='{"id": "' + 'c' * 5_000 + '"}', tool_call_id='lc1')
+        plain_call = ToolCallPart(tool_name='write_plan', args='p' * 5_000, tool_call_id='c1')
+        messages: list[ModelMessage] = [ModelResponse(parts=[search_call, load_call, plain_call])]
         cap = ClampOversizedMessages(max_part_chars=1_000, keep_head_chars=50, keep_tail_chars=50)
         result = await cap.compact(messages, _make_ctx())
 
-        response = result[0]
-        assert isinstance(response, ModelResponse)
-        search, load, plain = response.parts
-        # Typed subclasses are left untouched (same objects, structured args intact).
-        assert search is messages[0].parts[0]
-        assert load is messages[0].parts[1]
-        # The plain oversized call is still clamped.
+        search, load, plain = result[0].parts
+        # Typed subclasses pass through as the same objects; the plain call is still clamped.
+        assert search is search_call
+        assert load is load_call
         assert isinstance(plain, ToolCallPart)
-        assert isinstance(plain.args, dict)
-        assert _CLAMP_ARGS_KEY in plain.args
-        # The real regression: the compacted history still round-trips through the type
-        # adapter, which is how `StepPersistence` restores it.
-        restored = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(result))
-        restored_search = restored[0].parts[0]
-        assert type(restored_search) is ToolSearchCallPart
-        assert restored_search.args == search_args
+        assert plain.args_as_dict().keys() == {_CLAMP_ARGS_KEY}
+        # The real regression: the compacted history survives the round-trip `StepPersistence`
+        # restores through. Equality covers the concrete part classes too, so this also pins
+        # that the typed parts come back typed with their structured args intact.
+        assert ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(result)) == result
 
     @pytest.mark.anyio
     async def test_small_tool_call_args_untouched(self):

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -9,13 +9,17 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from opentelemetry.trace import NoOpTracer, Tracer
 from pydantic_ai.messages import (
+    LoadCapabilityCallPart,
     ModelMessage,
+    ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
     SystemPromptPart,
     TextPart,
     ToolCallPart,
     ToolReturnPart,
+    ToolSearchArgs,
+    ToolSearchCallPart,
     ToolSearchReturnContent,
     ToolSearchReturnPart,
     UserPromptPart,
@@ -1957,6 +1961,44 @@ class TestClampOversizedMessages:
         assert _CLAMP_ARGS_KEY in part.args
         assert '[clamped: removed' in part.args[_CLAMP_ARGS_KEY]
         assert part.tool_call_id == 'c1'
+
+    @pytest.mark.anyio
+    async def test_preserves_typed_tool_call_subclasses(self):
+        # `ToolSearchCallPart` and `LoadCapabilityCallPart` subclass `ToolCallPart` but narrow
+        # `args` to a typed shape that `ModelMessagesTypeAdapter` validates when persisted
+        # history is restored (e.g. `StepPersistence` resume). Replacing that shape with the
+        # `_clamped` object made the round-trip fail; clamping must skip typed subclasses and
+        # touch only plain tool calls.
+        search_args: ToolSearchArgs = {'queries': ['find tools for ' + 'x' * 5_000]}
+        load_args = '{"id": "' + 'c' * 5_000 + '"}'
+        messages: list[ModelMessage] = [
+            ModelResponse(
+                parts=[
+                    ToolSearchCallPart(args=search_args, tool_call_id='ts1'),
+                    LoadCapabilityCallPart(args=load_args, tool_call_id='lc1'),
+                    ToolCallPart(tool_name='write_plan', args='p' * 5_000, tool_call_id='c1'),
+                ]
+            ),
+        ]
+        cap = ClampOversizedMessages(max_part_chars=1_000, keep_head_chars=50, keep_tail_chars=50)
+        result = await cap.compact(messages, _make_ctx())
+
+        response = result[0]
+        assert isinstance(response, ModelResponse)
+        search, load, plain = response.parts
+        # Typed subclasses are left untouched (same objects, structured args intact).
+        assert search is messages[0].parts[0]
+        assert load is messages[0].parts[1]
+        # The plain oversized call is still clamped.
+        assert isinstance(plain, ToolCallPart)
+        assert isinstance(plain.args, dict)
+        assert _CLAMP_ARGS_KEY in plain.args
+        # The real regression: the compacted history still round-trips through the type
+        # adapter, which is how `StepPersistence` restores it.
+        restored = ModelMessagesTypeAdapter.validate_json(ModelMessagesTypeAdapter.dump_json(result))
+        restored_search = restored[0].parts[0]
+        assert type(restored_search) is ToolSearchCallPart
+        assert restored_search.args == search_args
 
     @pytest.mark.anyio
     async def test_small_tool_call_args_untouched(self):


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

David's review level: none to light.

## Summary

`ClampOversizedMessages.compact` clamped tool-call args behind a plain `isinstance(part, ToolCallPart)`, which also matched the framework-typed subclasses `ToolSearchCallPart` and `LoadCapabilityCallPart`. `dataclasses.replace(part, args={'_clamped': ...})` keeps the concrete typed class while replacing its structured args, so the clamped part no longer round-trips through `ModelMessagesTypeAdapter`: `validate_json` and `validate_python` (over the serialized form) both raise, and serialization warns `Unexpected field '_clamped'`. The real-world failure is `ClampOversizedMessages` + `StepPersistence` + a large `search_tools` or `load_capability` args payload = failed resume.

This is the response-side twin of https://github.com/pydantic/pydantic-ai-harness/issues/380, fixed by https://github.com/pydantic/pydantic-ai-harness/pull/383 for `ClearToolResults`. The fix mirrors that precedent: the args-clamp predicate is now the exact-type check `type(part) is ToolCallPart`, so typed subclasses are never clamped and their structured args survive persistence. The carve-out is documented in the class docstring, the capability README, and `docs/compaction.md`, matching the note #383 added for `ClearToolResults`.

Reproduced before fixing with a runnable script driving the real `compact` path over an oversized `ToolSearchCallPart`; the regression test was written first (red) and pins both the skip behavior and the `ModelMessagesTypeAdapter` round-trip. One nuance vs. the issue text: `validate_python` over the live dataclass instances passes (pydantic accepts existing instances without revalidation); the failure surfaces on the serialized form, which is what persistence restores from.

Scope note: `rebuild_with_cleared`'s `clear_tool_inputs` branch in `_shared.py` also matches `ToolCallPart` broadly and replaces args, but it replaces them with the string `'{}'`, which is a valid member of the typed subclasses' `str | <TypedDict> | None` args union. The corruption does not reproduce there (verified empirically with a `dump_json`/`validate_json` round-trip), so it was deliberately left untouched.

## Linked Issue

Fixes #401

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (lint and full pyright ran via pre-commit; tests were run targeted per worktree policy: all 264 compaction tests pass with 100% branch coverage on the compaction package, full suite left to CI)
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)
