### PR TITLE
docs(agent): capability CI scoping, post-merge resync, external-service refresh

### DIFF
--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -135,6 +135,36 @@ The `localstack` capability's `localstack-integration` job is the reference for
 this shape. Whether the heavy job blocks merges (listed in `check`'s `needs`) or
 only signals is the capability owner's call; state which in the PR.
 
+## External-Service Assumptions And Refresh
+
+A capability that wraps an external service, image, or CLI (`localstack`,
+`modal_sandbox`, `exa`, `macroscope`) depends on facts that live outside this
+repo and change on the vendor's schedule: auth requirements, version-gated
+behavior, default ports, endpoints, wire formats. When one of those shifts the
+capability can break in a way local tests miss (the emulator or API is mocked or
+absent). Record the load-bearing assumptions so a future agent can refresh them
+deliberately instead of rediscovering them from a failure.
+
+For each such capability, keep a short block -- a module docstring or a comment
+near the constants it pins -- that lists each external assumption with the date
+it was last verified and a link to the authoritative source, and says how to
+re-check it. Before changing auth, version, or protocol handling, re-verify the
+relevant assumptions against those sources first. When you confirm one still
+holds, bump its date; when it changed, update the code and the date together.
+
+`localstack` is the worked example (verified 2026-07):
+
+- The default `localstack/localstack` image requires `LOCALSTACK_AUTH_TOKEN` to
+  start since LocalStack 2026.03.0; a pre-2026.03.0 tag (for example `4.x`) runs
+  tokenless. Source: <https://docs.localstack.cloud/aws/getting-started/auth-token/>.
+- Edge port `4566`; health at `/_localstack/health`; `localhost.localstack.cloud`
+  resolves to `127.0.0.1` (needed for S3 subdomain-style addressing). Source:
+  <https://docs.localstack.cloud/aws/capabilities/config/configuration/>.
+- The AWS CLI accepts any unambiguous prefix of a global option (`--endpoint`
+  for `--endpoint-url`) and the last value wins, so the command guard rejects
+  prefixes of forbidden globals, not just exact names. Re-verify against the
+  installed `aws` CLI if that guard changes.
+
 ## Docs
 
 Each user-facing capability needs docs close to the code. Explain:

--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -102,6 +102,39 @@ Before treating a capability as done, check how it composes with:
 `CodeMode` is a useful reference for wrapper-toolset composition, tool
 selection, `ToolSearch` interaction, public docs, and test depth.
 
+## CI And Dependency Footprint
+
+Most capabilities add a package extra and a test module, which is cheap. Some
+pull heavier machinery: a Docker image, an external service that needs a secret
+or auth token, a large system binary (a cloud CLI), or live network calls. That
+machinery makes CI slower and more failure-prone, and every unrelated PR would
+otherwise pay for it on the critical path.
+
+When a capability needs machinery of that weight:
+
+- Keep its runtime dependency behind the capability's own extra, so importing the
+  root package never pulls it in (see "Capability Submodules And Exports").
+- Scope its expensive CI job to the capability. A `changes` job
+  (`dorny/paths-filter`) reports whether the PR touched the capability's paths,
+  and the heavy job runs only when it did. Run it unconditionally on `push`/tag
+  so releases still exercise the live path:
+  `if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.<name> == 'true')`.
+- Keep the aggregate `check` job green when the heavy job is skipped but red when
+  it runs and fails. `re-actors/alls-green` with
+  `allowed-skips: changes, <heavy-job>` does both: a skip does not block, a real
+  failure still votes.
+- Grant the `changes` job `pull-requests: read`. Without a checkout, paths-filter
+  lists PR files through the GitHub API, which needs that scope. A public repo
+  allows it under `contents: read`, but it fails on a private repo or under
+  tightened default token scopes.
+- Scope any secret to the step that needs it (not the job `env`) and bind the job
+  to a CI `environment` that holds the secret, so checkout and setup steps never
+  see it.
+
+The `localstack` capability's `localstack-integration` job is the reference for
+this shape. Whether the heavy job blocks merges (listed in `check`'s `needs`) or
+only signals is the capability owner's call; state which in the PR.
+
 ## Docs
 
 Each user-facing capability needs docs close to the code. Explain:

--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -14,6 +14,8 @@ For any code change:
 ## Task Routing
 
 - New or changed capability API: `capability-authoring.md`
+- Working on (or refreshing) a capability that wraps an external service, image,
+  or CLI: `capability-authoring.md` "External-Service Assumptions And Refresh"
 - New or changed tests: `testing-capabilities.md`
 - Unsure whether behavior belongs in harness or Pydantic AI core: `core-boundary.md`
 - Review, pre-PR check, or final self-check: `review-checklist.md`

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -19,6 +19,10 @@ Use this before opening a PR or reviewing a capability change.
   runtime behavior.
 - Capability ordering is justified when present.
 - Dependency changes were made through `uv` and have a clear reason.
+- A capability that adds heavy CI machinery (a Docker image, an external service
+  with a secret, a large system binary, live network calls) scopes its expensive
+  job to its own paths and keeps the aggregate check green when that job is
+  skipped. See `capability-authoring.md` "CI And Dependency Footprint".
 
 ## Stale Or Pre-Merge PRs
 
@@ -34,6 +38,11 @@ well before now, or that was built against unreleased Pydantic AI changes.
   time.
 - Behavior the PR worked around because a primitive was missing is reconsidered
   if that primitive now exists in core.
+- A flood of pyright or import errors right after merging main or rebasing is
+  usually uninstalled extras, not a real regression. Re-sync (`make install`, or
+  `uv sync --frozen --all-extras --group lint`) before treating the merge as
+  broken; errors that name third-party types (`modal`, `openai`, ...) as unknown
+  in files the PR did not touch are the tell.
 
 ## Tests
 


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David (heavily reviewed).

Context-engineering-only PR (agent docs), kept separate from the LocalStack feature per the "context-file changes get their own PR" convention. It records two learnings from adopting the LocalStack capability (#268) so future capability work applies them without re-deriving.

## 1. Heavy-capability CI scoping (`capability-authoring.md` -> new "CI And Dependency Footprint" section)

When a capability pulls machinery that makes CI slower or more failure-prone (a Docker image, an external service + secret, a large system binary, live network calls), scope its expensive job so unrelated PRs don't pay for it, while releases and relevant PRs still run it. The recipe, taken from the LocalStack `localstack-integration` job:

- runtime dep behind the capability's own extra (root import stays clean);
- a `dorny/paths-filter` `changes` job gates the heavy job to the capability's paths, unconditional on `push`/tag;
- `re-actors/alls-green` `allowed-skips` keeps the aggregate `check` green on skip but red on a real failure;
- the `changes` job needs `pull-requests: read` (paths-filter uses the GitHub API without a checkout -- works on a public repo under `contents: read`, breaks on a private repo or tightened token scopes);
- secrets scoped to the step + job bound to a CI `environment`.

A matching item is added to `review-checklist.md`.

## 2. Post-merge typecheck flood = uninstalled extras (`review-checklist.md` -> "Stale Or Pre-Merge PRs")

A flood of pyright/import errors right after merging main or rebasing is usually uninstalled extras, not a regression. Re-sync before treating the merge as broken; errors naming third-party types (`modal`, `openai`, ...) as unknown in files the PR didn't touch are the tell. This bit us merging main into #268 (431 errors -> 0 after resync).

## Deliberately out of scope

- No workflow/code changes here -- the actual `pull-requests: read` fix shipped with #268. This PR only documents the pattern.
- Didn't touch `CLAUDE.md` / `AGENTS.md`; these guides are the right altitude and are already routed from `agent_docs/index.md`.
