### PR TITLE
Harden LocalStack capability after post-merge review

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
               - 'pydantic_ai_harness/localstack/**'
               - 'tests/localstack/**'
               - 'integration_tests/localstack/**'
+              - 'Makefile'
               - '.github/workflows/main.yml'
 
   lint:

--- a/docs/localstack.md
+++ b/docs/localstack.md
@@ -118,15 +118,18 @@ image that requires an auth token to start (a free Hobby/OSS token covers
 community usage). When `LOCALSTACK_AUTH_TOKEN` is set in the current process it
 is forwarded to the container automatically; a legacy `LOCALSTACK_API_KEY` value
 is forwarded when no auth token is set. Auth values are forwarded through the
-Docker CLI environment rather than embedded in the `docker run` arguments. To run
-without any token, pin an image tag from before the account requirement, such as
-a `localstack/localstack:4.x` release.
+Docker CLI environment rather than embedded in the `docker run` arguments. The
+default `localstack/localstack` image requires a token to start, so a managed run
+needs one configured. To run tokenless, set `image` to a tag from before the
+account requirement, such as a `localstack/localstack:4.x` release.
 
 Docker-backed services such as Lambda need the Docker socket mounted, and some
 services expose ports outside the gateway (LocalStack reserves `4510-4559`).
 Enable those explicitly when a service you test requires them:
 
 ```python
+from pydantic_ai_harness.localstack import LocalStack
+
 LocalStack(manage_container=True, service_port_range='4510-4559', mount_docker_socket=True)
 ```
 
@@ -137,10 +140,17 @@ environment is already trusted.
 The same lifecycle is available standalone as an async context manager:
 
 ```python
+import asyncio
+
 from pydantic_ai_harness.localstack import LocalStackContainer
 
-async with LocalStackContainer(environment={'DEBUG': '1'}) as localstack:
-    ...  # talk to localstack.endpoint_url
+
+async def main() -> None:
+    async with LocalStackContainer(environment={'DEBUG': '1'}) as localstack:
+        ...  # talk to localstack.endpoint_url
+
+
+asyncio.run(main())
 ```
 
 ## Configuration

--- a/integration_tests/localstack/test_live_localstack.py
+++ b/integration_tests/localstack/test_live_localstack.py
@@ -41,7 +41,7 @@ def _auth_environment() -> dict[str, str]:
     message = 'Set LOCALSTACK_AUTH_TOKEN to run live LocalStack integration tests.'
     if _requires_auth_token():
         pytest.fail(message)
-    return {}
+    pytest.skip(message)
 
 
 def _docker_path() -> str:
@@ -96,34 +96,47 @@ def _queue_name() -> str:
     return f'harness-{uuid.uuid4().hex}'
 
 
-def test_auth_token_is_not_required_for_default_live_tests(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default live tests should exercise community LocalStack without Pro credentials."""
+def test_auth_environment_returns_token_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A configured auth token flows through to the container environment."""
+    monkeypatch.setenv('LOCALSTACK_AUTH_TOKEN', 'test-token')
+    monkeypatch.delenv('LOCALSTACK_API_KEY', raising=False)
+
+    assert _auth_environment() == {'LOCALSTACK_AUTH_TOKEN': 'test-token'}
+
+
+def test_auth_environment_skips_locally_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default image requires a token to start, so live tests skip when none is set."""
     monkeypatch.delenv('LOCALSTACK_AUTH_TOKEN', raising=False)
     monkeypatch.delenv('LOCALSTACK_API_KEY', raising=False)
     monkeypatch.delenv('LOCALSTACK_REQUIRE_AUTH_TOKEN', raising=False)
 
-    try:
-        environment = _auth_environment()
-    except pytest.skip.Exception as exc:  # pragma: no cover - regression path
-        pytest.fail(f'default live tests should run against community LocalStack without auth: {exc}')
-
-    assert environment == {}
+    with pytest.raises(pytest.skip.Exception):
+        _auth_environment()
 
 
-def test_default_live_image_is_community_localstack(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Default live tests should not require the Pro image."""
+def test_auth_environment_fails_in_ci_without_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CI sets LOCALSTACK_REQUIRE_AUTH_TOKEN so a missing token fails loudly instead of skipping."""
+    monkeypatch.delenv('LOCALSTACK_AUTH_TOKEN', raising=False)
+    monkeypatch.delenv('LOCALSTACK_API_KEY', raising=False)
+    monkeypatch.setenv('LOCALSTACK_REQUIRE_AUTH_TOKEN', '1')
+
+    with pytest.raises(pytest.fail.Exception):
+        _auth_environment()
+
+
+def test_default_live_image_is_localstack(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Live tests default to the single `localstack/localstack` image."""
     monkeypatch.delenv('LOCALSTACK_IMAGE', raising=False)
 
     assert _localstack_image() == 'localstack/localstack'
 
 
 def test_live_container_environment_scopes_requested_services(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Live tests should keep harness-started LocalStack containers narrow enough for CI startup."""
-    monkeypatch.delenv('LOCALSTACK_AUTH_TOKEN', raising=False)
+    """Harness-started containers stay narrow while still carrying the required auth token."""
+    monkeypatch.setenv('LOCALSTACK_AUTH_TOKEN', 'test-token')
     monkeypatch.delenv('LOCALSTACK_API_KEY', raising=False)
-    monkeypatch.delenv('LOCALSTACK_REQUIRE_AUTH_TOKEN', raising=False)
 
-    assert _container_environment('s3') == {'SERVICES': 's3'}
+    assert _container_environment('s3') == {'SERVICES': 's3', 'LOCALSTACK_AUTH_TOKEN': 'test-token'}
 
 
 def test_live_tests_run_on_asyncio_backend(anyio_backend: str) -> None:

--- a/pydantic_ai_harness/localstack/README.md
+++ b/pydantic_ai_harness/localstack/README.md
@@ -67,6 +67,8 @@ localstack start
 Or let the capability manage a fresh Docker container for each run:
 
 ```python
+from pydantic_ai_harness.localstack import LocalStack
+
 LocalStack(manage_container=True)
 ```
 
@@ -110,6 +112,8 @@ container for each run and stops it when the run ends, so the agent always gets
 a fresh, isolated environment. Docker must be installed and running.
 
 ```python
+from pydantic_ai_harness.localstack import LocalStack
+
 LocalStack(
     manage_container=True,
     image='localstack/localstack',
@@ -138,8 +142,10 @@ When `LOCALSTACK_AUTH_TOKEN` is set in the current process it is forwarded to th
 container automatically; a legacy `LOCALSTACK_API_KEY` value is forwarded when no
 auth token is set, but new setups should use `LOCALSTACK_AUTH_TOKEN`. Auth values
 are forwarded through the Docker CLI environment rather than embedded in the
-`docker run` command arguments. To run without any token, pin an image tag from
-before the account requirement, such as a `localstack/localstack:4.x` release.
+`docker run` command arguments. The default `localstack/localstack` image
+requires a token to start, so a managed run needs one configured. To run
+tokenless, set `image` to a tag from before the account requirement, such as a
+`localstack/localstack:4.x` release.
 
 Some AWS services expose ports outside the gateway. LocalStack reserves
 `4510-4559` for those service endpoints, and Docker-backed services such as
@@ -147,6 +153,8 @@ Lambda need the Docker socket mounted. Enable those explicitly when the services
 you test require them:
 
 ```python
+from pydantic_ai_harness.localstack import LocalStack
+
 LocalStack(
     manage_container=True,
     service_port_range='4510-4559',
@@ -161,15 +169,24 @@ it and the run environment is already trusted.
 The same lifecycle is available standalone as an async context manager:
 
 ```python
+import asyncio
+
 from pydantic_ai_harness.localstack import LocalStackContainer
 
-async with LocalStackContainer(environment={'DEBUG': '1'}) as localstack:
-    ...  # talk to localstack.endpoint_url
+
+async def main() -> None:
+    async with LocalStackContainer(environment={'DEBUG': '1'}) as localstack:
+        ...  # talk to localstack.endpoint_url
+
+
+asyncio.run(main())
 ```
 
 ## Configuration
 
 ```python
+from pydantic_ai_harness.localstack import LocalStack
+
 LocalStack(
     endpoint_url='http://localhost.localstack.cloud:4566',  # edge endpoint (host port is reused when managed)
     region='us-east-1',                    # region for the CLI and environment

--- a/pydantic_ai_harness/localstack/README.md
+++ b/pydantic_ai_harness/localstack/README.md
@@ -135,7 +135,9 @@ starts and stops the container when it ends (even if the run raises). Each run
 gets its own container, so concurrent runs of one agent need distinct host ports
 or an externally managed instance (`manage_container=False`).
 
-Managed containers bind to `127.0.0.1` by default. The default image is
+Managed containers bind to `127.0.0.1` by default, reached through
+`localhost.localstack.cloud`. Set `host_address` to publish on a different
+address; a non-loopback value is then also used as the tool endpoint host. The default image is
 `localstack/localstack`, which since LocalStack 2026.03.0 is a single image that
 requires an auth token to start (a free Hobby/OSS token covers community usage).
 When `LOCALSTACK_AUTH_TOKEN` is set in the current process it is forwarded to the

--- a/pydantic_ai_harness/localstack/_container.py
+++ b/pydantic_ai_harness/localstack/_container.py
@@ -71,10 +71,15 @@ class LocalStackContainer:
     def endpoint_url(self) -> str:
         """URL of the container's edge endpoint.
 
-        Uses LocalStack's `localhost.localstack.cloud` domain (which resolves to
-        `127.0.0.1`) for compatibility with AWS SDKs that need subdomain-style hosts.
+        For the default loopback publish addresses (`127.0.0.1` and the
+        bind-all `0.0.0.0`, both reachable at `127.0.0.1`), uses LocalStack's
+        `localhost.localstack.cloud` domain, which resolves to `127.0.0.1` and
+        supports the subdomain-style hosts some AWS SDKs need. For any other
+        `host_address`, uses that address literally, since
+        `localhost.localstack.cloud` does not resolve there.
         """
-        return f'http://localhost.localstack.cloud:{self._host_port}'
+        host = 'localhost.localstack.cloud' if self._host_address in ('127.0.0.1', '0.0.0.0') else self._host_address
+        return f'http://{host}:{self._host_port}'
 
     @property
     def _readiness_url(self) -> str:
@@ -92,7 +97,10 @@ class LocalStackContainer:
         try:
             await self._wait_until_ready()
         except BaseException:
-            await self._stop()
+            try:
+                await self._stop()
+            except LocalStackError:
+                pass
             raise
         return self
 
@@ -202,13 +210,28 @@ class LocalStackContainer:
         return response.status_code == 200
 
     async def _stop(self) -> None:
-        """Stop the container if one is running, shielded from cancellation."""
+        """Stop the container if one is running, shielded from cancellation.
+
+        Clears `container_id` only after `docker stop` succeeds. A non-zero exit
+        code, a missing docker CLI, or a timeout raises `LocalStackError` and
+        leaves `container_id` set, so the state reflects that the container (and
+        its published ports) may still be running.
+        """
         if self._container_id is None:
             return
         container_id = self._container_id
-        self._container_id = None
         with anyio.CancelScope(shield=True):
             try:
-                await self._run_docker([self._docker_path, 'stop', container_id], self._docker_environment({}))
-            except (FileNotFoundError, subprocess.TimeoutExpired):
-                pass
+                result = await self._run_docker([self._docker_path, 'stop', container_id], self._docker_environment({}))
+            except FileNotFoundError as e:
+                raise LocalStackError(
+                    f'Docker CLI {self._docker_path!r} not found while stopping LocalStack container {container_id}.'
+                ) from e
+            except subprocess.TimeoutExpired as e:
+                raise LocalStackError(
+                    f'Docker did not stop the LocalStack container {container_id} within {self._startup_timeout}s.'
+                ) from e
+            if result.returncode != 0:
+                stderr = result.stderr.decode('utf-8', errors='replace').strip()
+                raise LocalStackError(f'Failed to stop LocalStack container {container_id}: {stderr}')
+        self._container_id = None

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -196,16 +196,24 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         return None
 
     def _check_global_options(self, tokens: Sequence[str]) -> None:
-        """Reject model-supplied AWS globals that can override the injected target or credentials."""
+        """Reject model-supplied AWS globals that can override the injected target or credentials.
+
+        The AWS CLI accepts any unambiguous prefix of a global option name (`--endpoint`
+        for `--endpoint-url`, `--prof` for `--profile`) and a later value overrides an
+        earlier one, so an exact-name check is not enough. Reject any `--` token whose
+        name is a prefix of a forbidden option (the exact name is the full-length prefix).
+        """
         for token in tokens:
             if not token.startswith('--'):
                 continue
             name = token.split('=', 1)[0]
-            if name in _FORBIDDEN_MODEL_GLOBAL_OPTIONS:
+            if len(name) < 3:
+                continue
+            if any(forbidden.startswith(name) for forbidden in _FORBIDDEN_MODEL_GLOBAL_OPTIONS):
                 forbidden = ', '.join(sorted(_FORBIDDEN_MODEL_GLOBAL_OPTIONS))
                 raise ModelRetry(
                     f'Do not pass AWS global options that change the LocalStack target or credentials '
-                    f'({forbidden}); the capability injects them.'
+                    f'({forbidden}), including abbreviations of them; the capability injects them.'
                 )
 
     def _check_service(self, tokens: Sequence[str]) -> None:
@@ -241,7 +249,10 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         if len(text) <= self._max_output_chars:
             return text
         marker = f'[... output truncated, showing last {self._max_output_chars} chars]\n'
-        return marker + text[-self._max_output_chars :]
+        tail_budget = self._max_output_chars - len(marker)
+        if tail_budget <= 0:
+            return text[-self._max_output_chars :]
+        return marker + text[-tail_budget:]
 
     async def aws_cli(self, command: str, *, timeout_seconds: float | None = None) -> str:
         """Run an AWS CLI command against the emulated AWS environment.

--- a/tests/localstack/test_container.py
+++ b/tests/localstack/test_container.py
@@ -77,12 +77,42 @@ def _hanging_docker_stub(tmp_path: Path) -> str:
     return str(stub)
 
 
+def _stop_failing_docker_stub(tmp_path: Path) -> str:
+    """A fake `docker` CLI whose `run` succeeds but whose `stop` fails on stderr."""
+    stub = tmp_path / 'docker-stop-fail'
+    stub.write_text(
+        '#!/bin/sh\n'
+        'if [ "$1" = run ]; then\n'
+        '  echo container-abc123\n'
+        '  exit 0\n'
+        'fi\n'
+        'echo "boom: cannot stop" >&2\n'
+        'exit 1\n'
+    )
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return str(stub)
+
+
 class TestProperties:
     def test_endpoint_url(self, tmp_path: Path) -> None:
         docker, _ = _docker_stub(tmp_path)
         assert (
             LocalStackContainer(docker_path=docker, host_port=4599).endpoint_url
             == 'http://localhost.localstack.cloud:4599'
+        )
+
+    def test_endpoint_url_uses_localstack_cloud_for_all_interface_binding(self, tmp_path: Path) -> None:
+        docker, _ = _docker_stub(tmp_path)
+        assert (
+            LocalStackContainer(docker_path=docker, host_address='0.0.0.0', host_port=4599).endpoint_url
+            == 'http://localhost.localstack.cloud:4599'
+        )
+
+    def test_endpoint_url_uses_literal_host_for_custom_binding(self, tmp_path: Path) -> None:
+        docker, _ = _docker_stub(tmp_path)
+        assert (
+            LocalStackContainer(docker_path=docker, host_address='127.0.0.2', host_port=4599).endpoint_url
+            == 'http://127.0.0.2:4599'
         )
 
     def test_readiness_url_uses_host_binding(self, tmp_path: Path) -> None:
@@ -266,20 +296,35 @@ class TestLifecycle:
             async with LocalStackContainer(docker_path=_hanging_docker_stub(tmp_path), startup_timeout=0.05):
                 pass  # pragma: no cover
 
-    async def test_stop_timeout_is_swallowed_when_docker_hangs(self, tmp_path: Path) -> None:
+    async def test_stop_timeout_raises_and_keeps_container_id(self, tmp_path: Path) -> None:
         container = LocalStackContainer(docker_path=_hanging_docker_stub(tmp_path), startup_timeout=0.05)
         container._container_id = 'stuck'
-        await container.__aexit__(None, None, None)
-        assert container.container_id is None
+        with pytest.raises(LocalStackError, match='did not stop the LocalStack container stuck within 0.05s'):
+            await container.__aexit__(None, None, None)
+        assert container.container_id == 'stuck'
+
+    async def test_stop_failure_raises_and_keeps_container_id(self, tmp_path: Path) -> None:
+        container = LocalStackContainer(docker_path=_failing_docker_stub(tmp_path))
+        container._container_id = 'stuck'
+        with pytest.raises(LocalStackError, match='Failed to stop LocalStack container stuck: boom: port in use'):
+            await container.__aexit__(None, None, None)
+        assert container.container_id == 'stuck'
 
     async def test_exit_without_start_is_safe(self, tmp_path: Path) -> None:
         docker, log = _docker_stub(tmp_path)
         await LocalStackContainer(docker_path=docker).__aexit__(None, None, None)
         assert not log.exists()
 
-    async def test_stop_never_raises_if_docker_vanishes(self, tmp_path: Path) -> None:
-        # Cleanup must not raise even if the docker binary is gone by exit time.
+    async def test_stop_missing_docker_raises_and_keeps_container_id(self, tmp_path: Path) -> None:
         container = LocalStackContainer(docker_path='/no/such/docker')
         container._container_id = 'orphan'
-        await container.__aexit__(None, None, None)
-        assert container.container_id is None
+        with pytest.raises(LocalStackError, match='Docker CLI .* not found while stopping'):
+            await container.__aexit__(None, None, None)
+        assert container.container_id == 'orphan'
+
+    async def test_readiness_failure_raises_original_error_even_if_stop_fails(self, tmp_path: Path) -> None:
+        docker = _stop_failing_docker_stub(tmp_path)
+        port = unused_tcp_port()
+        with pytest.raises(LocalStackError, match='did not become ready within 1.0s'):
+            async with LocalStackContainer(docker_path=docker, host_port=port, startup_timeout=1.0, poll_interval=0.01):
+                pass  # pragma: no cover

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -170,6 +170,30 @@ class TestAwsCli:
         with pytest.raises(ModelRetry, match='Do not pass AWS global options'):
             await _toolset(aws_cli_path=stub).aws_cli(command)
 
+    @pytest.mark.parametrize(
+        'command',
+        [
+            's3 ls --endpoint http://evil',
+            's3 ls --end http://evil',
+            's3 ls --prof prod',
+            's3 ls --no-sign',
+            's3 ls --reg eu-west-1',
+            's3api list-buckets --endpoint=http://evil',
+        ],
+    )
+    async def test_rejects_abbreviated_global_endpoint_or_credential_options(
+        self, command: str, tmp_path: Path
+    ) -> None:
+        stub = _make_stub(tmp_path, 'echo "$@"')
+        with pytest.raises(ModelRetry, match='Do not pass AWS global options'):
+            await _toolset(aws_cli_path=stub).aws_cli(command)
+
+    async def test_allows_safe_options_that_are_not_forbidden_prefixes(self, tmp_path: Path) -> None:
+        stub = _make_stub(tmp_path, 'echo "$@"')
+        result = await _toolset(aws_cli_path=stub).aws_cli('s3 ls --no-paginate --output json')
+        assert '--no-paginate' in result
+        assert '--output json' in result
+
     async def test_scrubs_aws_environment_before_running_cli(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -219,6 +243,21 @@ class TestAwsCli:
         stub = _make_stub(tmp_path, 'printf "%01000d" 0')
         result = await _toolset(max_output_chars=100, aws_cli_path=stub).aws_cli('s3 ls')
         assert 'output truncated' in result
+        assert len(result) <= 100
+
+    async def test_truncation_respects_small_cap_without_marker(self, tmp_path: Path) -> None:
+        stub = _make_stub(tmp_path, 'printf "%01000d" 0')
+        result = await _toolset(max_output_chars=10, aws_cli_path=stub).aws_cli('s3 ls')
+        assert len(result) <= 10
+        assert 'output truncated' not in result
+
+    async def test_truncation_keeps_tail_and_marker_for_normal_cap(self, tmp_path: Path) -> None:
+        stub = _make_stub(tmp_path, 'printf "HEAD"; printf "%0500dTAIL" 0')
+        result = await _toolset(max_output_chars=200, aws_cli_path=stub).aws_cli('s3 ls')
+        assert len(result) <= 200
+        assert 'output truncated' in result
+        assert result.endswith('TAIL')
+        assert 'HEAD' not in result
 
 
 class TestLocalStackHealth:
@@ -246,7 +285,8 @@ class TestLocalStackHealth:
     async def test_over_size_limit_keeps_tail(self) -> None:
         with http_server([HttpResponse(200, 'HEAD' + 'T' * 100)]) as server:
             result = await _toolset(endpoint_url=server.endpoint_url, max_output_chars=100).localstack_health()
-        assert result.endswith('T' * 100)
+        assert len(result) <= 100
+        assert result.endswith('T')
         assert 'HEAD' not in result
         assert 'output truncated' in result
 


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David (heavily reviewed).

Closes #424. Post-merge hardening of the LocalStack capability (#268), from an independent review. Every finding was validated against the merged code before fixing; findings that did not hold up are noted at the bottom.

## Fixes

**Security -- CLI escape via abbreviated global options.** The guard rejected only exact `--endpoint-url` / `--profile` / `--region` / `--no-sign-request`, but the AWS CLI accepts any unambiguous prefix and a later value overrides the injected one. Reproduced live: `s3 ls --endpoint http://198.51.100.1:9 ...` redirected the CLI off LocalStack to an arbitrary host. The guard now rejects any `--` option whose name is a prefix of a forbidden global (the exact name is the full-length prefix), while safe options like `--no-paginate` / `--output` still pass.

**Container cleanup no longer silently succeeds.** `_stop()` cleared `container_id` before calling `docker stop` and ignored a non-zero result, so a leaked container reported as stopped. It now clears the id only after a successful stop and raises `LocalStackError` on failure; `__aenter__`'s startup-failure path still lets the original error win over a failing cleanup.

**Custom `host_address` yields the right endpoint.** `endpoint_url` used `localhost.localstack.cloud` (→127.0.0.1) unconditionally; it now uses the literal address for any non-default bind, matching the `-p` publish and readiness check. Default and `0.0.0.0` still use `localhost.localstack.cloud`.

**`max_output_chars` is a real cap.** The truncation marker was added outside the cap; the result is now always within the cap, tail preserved.

**Docs.** The standalone container snippet used `async with` at module scope (a runtime `SyntaxError`; the doc test only ast-parses, so CI missed it) -- wrapped in an async function in both the README and the docs page. Auth wording reconciled: the default `localstack/localstack` image needs a token; to run tokenless, pin a pre-account-requirement tag. Added missing imports to config snippets.

**Live-integration auth reconciled.** Without a token the helper now skips the container tests locally (the image cannot start without one) and still fails loudly in CI (`LOCALSTACK_REQUIRE_AUTH_TOKEN=1`); removed the leftover tests that asserted a tokenless community path that no longer exists.

**CI path filter.** Added `Makefile` to the `changes` filter so a change to the `integration-localstack` recipe runs the live job.

## Infrastructure follow-up (not in this PR)

The `localstack-integration` environment has no protection rules, so the live job runs PR-controlled `make`/tests with `LOCALSTACK_AUTH_TOKEN` in scope. Decision: add `required_reviewers` (the `pydantic-ai-harness-maintain` team, mirroring `release`). That environment is managed by github-iac, so it must be added there by an admin, not via a workflow change. Tracked in #424. Accepted tradeoff: fork PRs touching LocalStack still cannot pass the required check (forks do not receive the secret).

## Verification

`make lint`, `make typecheck`, `make testcov` all pass; the harness 100% branch-coverage bar is met. The abbreviation escape was reproduced against a real AWS CLI before and confirmed blocked after.

## Findings that did not hold up

- "Docs use `LocalStack` without importing it" -- only a few config fences were missing the import; added. The doc-snippet test already enforced importability for the rest.
- The reviewer's recommended CI reshape (tokenless image on PR, authed only on push/schedule) was considered and set aside: the maintainer chose to keep the token on PR runs and add environment protection instead.
