### PR TITLE
Teach reviewers to trace execution boundaries

### DIFF
--- a/.agents/agents/docs-parity-reviewer.md
+++ b/.agents/agents/docs-parity-reviewer.md
@@ -36,10 +36,14 @@ problem as a finding (blocking / warning / nit) with a concrete fix.
    class, constructor params, defaults, tool names, extras, safety semantics)
    and only one of README / unified doc reflects it, that is blocking. A doc
    describing behavior the code no longer has is also blocking.
-2. **Snippets run.** Every code block in both docs has all imports and the
-   pieces needed to actually run (Agent construction, capability wiring). Class
-   names, params, and defaults match the current source. Model ids are unchanged
-   from what the source uses -- a changed model id is blocking.
+2. **Snippets parse and run.** Run `uv run pytest tests/test_doc_snippets.py`;
+   this checks parsing and harness imports only. Execute every changed
+   deterministic snippet unchanged. For snippets that need credentials or a
+   live service, verify the complete runnable wrapper and require a fake-backed
+   test for its control flow. Every block has all imports and capability wiring.
+   Class names, params, and defaults match the source. Model ids are unchanged
+   -- a changed model id is blocking. Illustrative signature pseudo-code uses
+   `{test="skip"}`.
 3. **README <-> unified doc consistency.** The two agree on install extras,
    option names, defaults, and safety caveats. They need not be identical prose,
    but they must not contradict each other or the code.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+inheritance: true
+
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - files: agent_docs/review-checklist.md
+        applyTo: '**/*'

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,12 @@
 ## Summary
 
 <!-- Brief description of the changes -->
+<!-- If this crosses a command/parser, process/container, network, resource-
+lifecycle, output-limit, or CI trust boundary, add "Boundary notes" covering:
+the downstream contract and focused reproduction; cleanup-failure and
+non-default-configuration evidence; final limit accounting; and, for CI, the
+event/ref -> checked-out code -> credentials -> executable steps map plus
+conditional-job path inputs. -->
 
 ## Linked Issue
 

--- a/.macroscope/correctness/ci-trust.md
+++ b/.macroscope/correctness/ci-trust.md
@@ -1,0 +1,14 @@
+---
+include:
+  - ".github/**"
+  - "Makefile"
+  - "integration_tests/**"
+  - "scripts/**"
+---
+
+Treat checked-out pull-request content and every command, import, script, or
+task it invokes as untrusted. Do not expose repository or environment secrets
+to that execution. Check both trusted and fork pull-request behavior and the
+aggregate required check. For path-gated jobs, start from the executed command
+and verify that the filter covers its task-runner or script entry point and all
+dependency, configuration, image, and workflow inputs that can change it.

--- a/.macroscope/correctness/docs-examples.md
+++ b/.macroscope/correctness/docs-examples.md
@@ -1,0 +1,10 @@
+---
+include:
+  - "README.md"
+  - "docs/**/*.md"
+  - "pydantic_ai_harness/**/README.md"
+---
+
+Every non-illustrative Python example must compile in its shown context, include
+all imports and runnable wrappers, and agree with the public API and defaults.
+Do not treat AST parsing alone as proof that a snippet compiles or runs.

--- a/.macroscope/correctness/external-effects.md
+++ b/.macroscope/correctness/external-effects.md
@@ -1,0 +1,13 @@
+---
+include:
+  - "pydantic_ai_harness/**/*.py"
+  - "tests/**/*.py"
+  - "integration_tests/**/*.py"
+---
+
+For user or model input passed to another parser, verify guards against the
+syntax that parser accepts, including aliases, abbreviations, normalization,
+separators, and repeated options. For external resources, report failed cleanup
+and preserve tracked identity until cleanup succeeds. Trace non-default
+addresses, endpoints, paths, and credentials through every consumer. Measure
+documented limits on the final returned value, including markers and metadata.

--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -17,6 +17,9 @@ For any code change:
 - New or changed tests: `testing-capabilities.md`
 - Unsure whether behavior belongs in harness or Pydantic AI core: `core-boundary.md`
 - Review, pre-PR check, or final self-check: `review-checklist.md`
+- Commands/parsers, processes/containers, network endpoints, resource cleanup,
+  output limits, or CI trust boundaries: `review-checklist.md` "Executable
+  Boundaries" before implementation and review
 
 ## Exemplar
 

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -20,6 +20,34 @@ Use this before opening a PR or reviewing a capability change.
 - Capability ordering is justified when present.
 - Dependency changes were made through `uv` and have a clear reason.
 
+## Executable Boundaries
+
+Apply these checks when a change invokes a command/parser, process/container,
+or network service, or changes CI:
+
+- Trace user or model input through every transformation to the downstream
+  parser. Verify guards against the syntax that parser accepts, including
+  aliases, abbreviations, normalization, separators, and repeated options.
+- Trace each created resource through readiness, use, and cleanup. Failed
+  cleanup is reported, and tracked identity remains recoverable until cleanup
+  succeeds.
+- Trace each configurable address, endpoint, path, or credential with a
+  non-default sentinel through provisioning, readiness, invocation, and
+  teardown.
+- Measure limits on the final value the caller receives, including framing,
+  truncation markers, envelopes, and metadata.
+- For each CI secret or write permission, trace event/ref -> checked-out code ->
+  credential -> executable step. PR-controlled code must not receive repository
+  or environment secrets; step-level scoping does not create that boundary.
+  Check trusted and fork PR outcomes, including the aggregate required check.
+- Starting from each conditional job's executed command, ensure its path filter
+  includes the task-runner or script entry point and every dependency,
+  configuration, image, and workflow input that can change execution.
+
+Passing coverage alone is not evidence that these contracts hold. For
+downstream-parser and external-runtime claims, run a focused reproduction and
+retain the command and result as review evidence.
+
 ## Stale Or Pre-Merge PRs
 
 Run these checks when adopting, rebasing, or re-reviewing a PR that was opened

--- a/agent_docs/testing-capabilities.md
+++ b/agent_docs/testing-capabilities.md
@@ -25,6 +25,21 @@ Direct toolset tests are appropriate when you need to inspect:
 Use the `CodeMode` tests as the current reference for direct `RunContext` and
 `ToolManager` setup.
 
+## Boundary Reproductions
+
+When a capability invokes another parser, process, service, or container, add
+focused tests for each applicable contract:
+
+- Reproduce the installed downstream parser's behavior when available, then
+  test accepted abbreviations, aliases, `--name=value` forms, separators, and
+  normalization through the capability's public entry point.
+- Make cleanup return non-zero and raise. Assert that failure is surfaced and
+  resource identity remains available until cleanup succeeds.
+- Pass a non-default sentinel for each configurable address, endpoint, or path.
+  Assert provisioning, readiness, invocation, and teardown all use it.
+- Assert size limits against the final returned or serialized value, including
+  headers, truncation markers, envelopes, and metadata.
+
 ## Coverage
 
 The project enforces 100% branch coverage with `make testcov`. Tests for a new


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Summary

- add an executable-boundaries review pass for parser semantics, external
  lifecycle state, configuration propagation, output limits, and CI trust/path
  graphs
- add focused boundary-reproduction guidance for capability tests
- require the docs-parity reviewer to distinguish static snippet checks from
  actual execution
- ask PR authors to provide boundary evidence when applicable
- map the shared checklist into CodeRabbit and add scoped Macroscope Correctness
  instructions for CI, external effects, and documentation examples

## Why

The review of #268 found several defects that individually looked unrelated but
shared one cause: implementation and review stopped at the repository-side
representation instead of tracing behavior across the external boundary. The
new guidance turns that into concrete verification actions rather than a broad
request to "review security more carefully."

## Developer impact

Ordinary changes are unaffected. Changes that invoke parsers, processes,
containers, network services, or conditional CI now carry focused reproduction
and review expectations. CodeRabbit and Macroscope receive the same criteria
through their documented repository configuration mechanisms.

## Validation

- repository pre-commit hooks: pass
- lint: pass
- source and test typecheck: pass
- full test suite: pass
- CodeRabbit configuration validated against its current official schema

## Deliberate scope

- This PR does not fix the LocalStack findings from #268; that work is proceeding
  separately.
- It reuses the existing implementation/test/review routing instead of adding
  another always-on reviewer agent.
- It does not change static snippet enforcement while current documentation
  fixes are being prepared in the separate follow-up.

Fixes #426
