### PR TITLE
Fix `release` job silently skipping on tag pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -258,7 +258,10 @@ jobs:
 
   release:
     needs: [check]
-    if: success() && startsWith(github.ref, 'refs/tags/')
+    # `changes` is skipped on tag pushes, and a skipped ancestor makes bare
+    # `success()` false even though `check` itself passed -- which silently
+    # skipped the publish for v0.10.0. Gate on `check`'s own result instead.
+    if: needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

## Problem

`v0.10.0` was tagged and released on GitHub, but **never published to PyPI** — the `release` job was skipped.

[#268](https://github.com/pydantic/pydantic-ai-harness/pull/268) added a `changes` job gated on `if: github.event_name == 'pull_request'`. On a tag push that job is **skipped**, and the `release` job's bare `success()` is evaluated across the whole ancestor graph, not just its direct `needs`. A skipped ancestor makes it `false`, so `release` (and therefore `send-tweet`) silently skipped even though `check` itself passed.

Evidence:

- [v0.10.0 tag run](https://github.com/pydantic/pydantic-ai-harness/actions/runs/29974589352) — `changes` skipped, `check` success, `release` **skipped**, `Send tweet` skipped
- [v0.9.0 tag run](https://github.com/pydantic/pydantic-ai-harness/actions/runs/29883095536) — predates `changes`; `release` and `Send tweet` both success

The failure mode is silent: the tag run is reported green overall, so a release looks successful while nothing ships.

## Fix

Gate on `check`'s own result instead of bare `success()`, which is unaffected by skipped ancestors.

`send-tweet` already used this idiom (`needs.release.result == 'success'`), so this makes the two consistent.
