### PR TITLE
Actually fix `release` skipping on tag pushes: opt out of skipped-ancestor propagation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -258,10 +258,13 @@ jobs:
 
   release:
     needs: [check]
-    # `changes` is skipped on tag pushes, and a skipped ancestor makes bare
-    # `success()` false even though `check` itself passed -- which silently
-    # skipped the publish for v0.10.0. Gate on `check`'s own result instead.
-    if: needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/')
+    # `changes` is skipped on tag pushes, and GitHub skips every downstream job
+    # of a skipped ancestor unless the condition opts out via `always()` /
+    # `!cancelled()` -- which silently skipped the publish for v0.10.0 even
+    # though `check` itself passed. `!cancelled()` restores evaluation without
+    # publishing from a cancelled run (same opt-out `localstack-integration`
+    # needs, one job up).
+    if: ${{ !cancelled() && needs.check.result == 'success' && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -283,7 +286,8 @@ jobs:
   send-tweet:
     name: Send tweet
     needs: [release]
-    if: needs.release.result == 'success'
+    # Same skipped-ancestor opt-out as `release` above.
+    if: ${{ !cancelled() && needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     environment: release
 


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

Follow-up to [#429](https://github.com/pydantic/pydantic-ai-harness/pull/429), which did not fix the bug. `v0.10.0` was re-cut with #429 in place and the `release` job [skipped again](https://github.com/pydantic/pydantic-ai-harness/actions/runs/29975315896) — still no PyPI publish.

## Actual cause

#429 assumed bare `success()` was the problem and swapped it for `needs.check.result == 'success'`. That condition is true on a tag push, but it never gets evaluated: **GitHub skips every downstream job of a skipped ancestor**, regardless of the `if` expression, unless that expression opts out with `always()` or `!cancelled()`.

`changes` is `if: github.event_name == 'pull_request'`, so it is skipped on every tag push, and `release` (via `check`) inherits the skip.

The precedent was already in this file — `localstack-integration` hits the identical problem one job up and solves it with `always()`:

> `always()` lets this evaluate even though `changes` is skipped on non-pull_request events.

## Fix

Add the `!cancelled()` opt-out to `release`, preferred over `always()` so a cancelled run cannot publish.

`send-tweet` needs the same opt-out: it sits downstream of the same skipped `changes` job, so it would keep skipping even once `release` starts succeeding.

## Verification

CI here only proves the PR path still passes — on a `pull_request` event both jobs are correctly skipped by the `startsWith(github.ref, 'refs/tags/')` guard. The real proof is the next tag push, which I'll confirm publishes to PyPI before calling the release done.
