### PR TITLE
Exclude agent state from typechecking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ quote-style = 'single'
 [tool.pyright]
 pythonVersion = '3.10'
 typeCheckingMode = 'strict'
-exclude = ['template', '.venv', 'mutants']
+exclude = ['template', '.venv', 'mutants', '.agents', '.claude']
 # `reportUnusedFunction` is disabled for tests because fixtures and `@agent.tool_plain`
 # helpers are registered via decorators and never referenced by name (matches pydantic-ai).
 executionEnvironments = [


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Why

Pyright stops applying its default hidden-directory exclusion when the project defines an explicit `exclude` list ([Pyright configuration docs](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#environment-options)). As a result, local `.agents/` state—including nested worktrees—can be treated as project source, making `make typecheck` scan duplicate repository trees. `.claude/` is equivalent harness-local state and belongs outside the typecheck boundary too.

## What changed

- exclude `.agents/` and `.claude/` from the Pyright project

## Checks

- `make lint`
- `make typecheck`
- `make test`
- `make testcov`
- `prek run --files pyproject.toml`

Closes #434
