### PR TITLE
Avoid unnecessary LocalStack approval gates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,34 +21,42 @@ permissions:
   contents: read
 
 jobs:
-  # Detect whether a pull request touches LocalStack. The live integration job
-  # installs the AWS CLI, pulls the LocalStack image, and starts a real
-  # container against an external auth token -- weight that only pays off when
-  # LocalStack code or its CI wiring changes. Only runs on pull_request; on
-  # push/tag events localstack-integration runs unconditionally.
+  # Detect whether a pull request or branch push touches LocalStack. The live
+  # integration job installs the AWS CLI, pulls the LocalStack image, and starts
+  # a real container against an external auth token -- weight that only pays off
+  # when LocalStack code or its CI wiring changes. Tag pushes skip detection so
+  # releases always exercise the live path.
   changes:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.ref_type == 'branch'
     runs-on: ubuntu-latest
-    # paths-filter runs without a checkout, so it lists PR files via the GitHub
-    # API (REST mode), which needs `pull-requests: read`. Public repos happen to
-    # allow it under `contents: read`; granting it explicitly keeps the job
-    # working if the repo goes private or default token scopes tighten.
-    permissions:
-      contents: read
-      pull-requests: read
     outputs:
-      localstack: ${{ steps.filter.outputs.localstack }}
+      localstack: ${{ steps.detect.outputs.localstack }}
     steps:
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          filters: |
-            localstack:
-              - 'pydantic_ai_harness/localstack/**'
-              - 'tests/localstack/**'
-              - 'integration_tests/localstack/**'
-              - 'Makefile'
-              - '.github/workflows/main.yml'
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: detect
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            pydantic_ai_harness/localstack \
+            tests/localstack \
+            integration_tests/localstack \
+            Makefile \
+            .github/workflows/main.yml
+          then
+            echo 'localstack=false' >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            if [ "$status" -ne 1 ]; then
+              exit "$status"
+            fi
+            echo 'localstack=true' >> "$GITHUB_OUTPUT"
+          fi
 
   lint:
     runs-on: ubuntu-latest
@@ -179,10 +187,10 @@ jobs:
 
   localstack-integration:
     needs: [changes]
-    # Skip on pull requests that leave LocalStack untouched; always run on
-    # push/tag events so releases exercise the live path. `always()` lets this
-    # evaluate even though `changes` is skipped on non-pull_request events.
-    if: ${{ always() && (github.event_name != 'pull_request' || needs.changes.outputs.localstack == 'true') }}
+    # Skip on pull requests and branch pushes that leave LocalStack untouched;
+    # always run on tags so releases exercise the live path. `always()` lets this
+    # evaluate even though `changes` is skipped on tag events.
+    if: ${{ always() && (github.ref_type == 'tag' || needs.changes.outputs.localstack == 'true') }}
     runs-on: ubuntu-latest
     name: LocalStack integration tests
     # The auth token secret lives in this environment; binding the job to it also
@@ -250,9 +258,9 @@ jobs:
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
-          # localstack-integration is skipped on pull requests that don't touch
-          # LocalStack, and `changes` is skipped on push/tag events. Both still
-          # vote (block the merge) when they actually run and fail.
+          # localstack-integration is skipped when a pull request or branch push
+          # doesn't touch LocalStack, and `changes` is skipped on tag events.
+          # Both still vote (block the merge) when they actually run and fail.
           allowed-skips: changes, localstack-integration
           jobs: ${{ toJSON(needs) }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,8 @@ jobs:
             tests/localstack \
             integration_tests/localstack \
             Makefile \
+            pyproject.toml \
+            uv.lock \
             .github/workflows/main.yml
           then
             echo 'localstack=false' >> "$GITHUB_OUTPUT"

--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -115,10 +115,10 @@ When a capability needs machinery of that weight:
 - Keep its runtime dependency behind the capability's own extra, so importing the
   root package never pulls it in (see "Capability Submodules And Exports").
 - Scope its expensive CI job to the capability. A `changes` job
-  (`dorny/paths-filter`) reports whether the PR touched the capability's paths,
-  and the heavy job runs only when it did. Run it unconditionally on `push`/tag
-  so releases still exercise the live path:
-  `if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.<name> == 'true')`.
+  compares the event's base and head commits against the capability's paths,
+  and the heavy job runs only when a PR or branch push touched them. Run the
+  heavy job unconditionally on tags so releases still exercise the live path:
+  `if: always() && (github.ref_type == 'tag' || needs.changes.outputs.<name> == 'true')`.
 - Keep the aggregate `check` job green when the heavy job is skipped but red when
   it runs and fails. `re-actors/alls-green` with
   `allowed-skips: changes, <heavy-job>` does both: a skip does not block, a real

--- a/tests/localstack/test_ci_workflow.py
+++ b/tests/localstack/test_ci_workflow.py
@@ -45,26 +45,35 @@ def test_localstack_ci_gates_the_aggregate_check() -> None:
 def test_localstack_integration_is_scoped_to_localstack_changes() -> None:
     lines = _workflow_lines()
 
-    # On a pull request the live job runs only when LocalStack paths change, so
-    # unrelated PRs don't pull the image, install the AWS CLI, or spend the token.
-    assert any('needs.changes.outputs.localstack' in line for line in lines)
-    assert any("- 'pydantic_ai_harness/localstack/**'" in line for line in lines)
+    # Pull requests and branch pushes run the live job only when LocalStack paths
+    # change; tags run it unconditionally so releases exercise the live path.
+    assert "    if: github.event_name == 'pull_request' || github.ref_type == 'branch'" in lines
+    assert (
+        "    if: ${{ always() && (github.ref_type == 'tag' || needs.changes.outputs.localstack == 'true') }}" in lines
+    )
 
     # A skipped live job must not fail the required aggregate check; a job that
     # actually runs and fails still votes (see allowed-skips semantics).
     assert any('allowed-skips: changes, localstack-integration' in line for line in lines)
 
 
-def test_changes_job_can_read_pull_request_files() -> None:
+def test_changes_job_uses_owned_git_diff_with_read_only_checkout() -> None:
     lines = _workflow_lines()
 
-    # paths-filter runs without a checkout, so it lists PR files via the GitHub
-    # API, which needs `pull-requests: read`. Without it the job fails on private
-    # repos (or under tightened default token scopes) and the live job is skipped.
     changes_index = lines.index('  changes:')
     lint_index = lines.index('  lint:')
     changes_block = lines[changes_index:lint_index]
-    assert '      pull-requests: read' in changes_block
+
+    assert not any('dorny/paths-filter' in line for line in changes_block)
+    assert '      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2' in changes_block
+    assert '          fetch-depth: 0' in changes_block
+    assert '          persist-credentials: false' in changes_block
+    assert '          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \\' in changes_block
+    assert '            pydantic_ai_harness/localstack \\' in changes_block
+    assert '            tests/localstack \\' in changes_block
+    assert '            integration_tests/localstack \\' in changes_block
+    assert '            Makefile \\' in changes_block
+    assert '            .github/workflows/main.yml' in changes_block
 
 
 def test_localstack_ci_scopes_the_auth_token_to_the_test_step() -> None:

--- a/tests/localstack/test_ci_workflow.py
+++ b/tests/localstack/test_ci_workflow.py
@@ -73,6 +73,8 @@ def test_changes_job_uses_owned_git_diff_with_read_only_checkout() -> None:
     assert '            tests/localstack \\' in changes_block
     assert '            integration_tests/localstack \\' in changes_block
     assert '            Makefile \\' in changes_block
+    assert '            pyproject.toml \\' in changes_block
+    assert '            uv.lock \\' in changes_block
     assert '            .github/workflows/main.yml' in changes_block
 
 


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Summary

- detect LocalStack path changes for both pull requests and pushes to `main`
- skip the protected LocalStack integration environment for unrelated merges
- keep the live integration unconditional on release tags
- replace `dorny/paths-filter` with an owned `git diff --quiet` check using the existing SHA-pinned `actions/checkout`
- update the workflow contract tests and capability-authoring guidance

## Root cause

The path detector ran only for `pull_request` events. On every post-merge `push`, the LocalStack condition therefore selected the live job unconditionally, entering the protected environment and requesting approval even when no LocalStack path changed.

## Supply-chain rationale

The existing `dorny/paths-filter` reference is pinned to the authentic v3.0.2 commit, which protects against mutable-tag replacement. However, its committed bundle contains `picomatch` 2.3.1, affected by [GHSA-c2c7-rcm5-vvqj](https://github.com/advisories/GHSA-c2c7-rcm5-vvqj) and [GHSA-3v7f-55p6-f55p](https://github.com/advisories/GHSA-3v7f-55p6-f55p). The current paths-filter v4.0.2 lockfile still resolves the same version.

The replacement executes no third-party path-filter bundle. The detection job retains only repository-wide `contents: read`, checks out through the existing full-SHA-pinned first-party action with `persist-credentials: false`, and never receives the downstream LocalStack environment secret.

## Validation

- focused LocalStack workflow contract tests: pass
- Monty merge simulation: LocalStack skipped
- LocalStack merge simulation: LocalStack selected
- repository hooks, including zizmor: pass
- lint, strict typecheck, and full tests: pass
- required all-passing and 100%-coverage bars: met