### PR TITLE
subagents: per-delegation model selection via an opt-in model menu

### DIFF
--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -46,6 +46,7 @@ A delegate's name -- how the parent model refers to it, and how it is listed in 
 - The sub-agent runs with its own message history, so `task` must be self-contained.
 - An unknown `agent_name` raises `ModelRetry`, so the model can correct itself.
 - The result returned to the parent is `str(result.output)`.
+- With a `models` menu configured, the tool takes an extra `model` argument (see below).
 
 ## Deps, usage, tools, and capabilities
 
@@ -82,11 +83,50 @@ orchestrator = Agent(
 
 | Field | Effect |
 |---|---|
+| `models` | Which keys of the `SubAgents` model menu this delegate may run on, and which one it runs on by default: the first key listed. See "Per-delegation model selection" below. |
 | `usage_limits` | A request/token budget for one delegation. The child runs with its own usage accounting, so the budget counts only that child's requests and tokens (not the parent's or siblings'), even when `forward_usage=True`. The tradeoff: that child's tokens no longer aggregate into the parent's `usage`. Reaching the budget is a soft outcome (see below), not a run-stopping `UsageLimitExceeded`. |
 | `timeout_seconds` | A wall-clock budget for one delegation. When the child exceeds it, its run is cancelled and the parent gets a soft steering message instead of hanging on the child. The cancelled child's `event_stream_handler` (if any) stops receiving events without a terminal event. |
 | `max_calls` | The maximum number of delegations to this sub-agent per parent run. Once reached, further delegations return a soft budget-exhausted message without running the child. Counts are scoped to one `Agent.run` (a `run_id`) and cleared when it ends, so each parent run and each level of a nested tree budgets independently. |
 | `on_failure` | A steering message returned to the parent for any soft degradation of this delegate, in place of the built-in default. Setting it also makes child failures soft (see below). |
 | `contain_errors` | Whether an unexpected crash in this delegate is caught and returned to the parent as a bounded `ModelRetry` instead of aborting the parent run (see below). Unset inherits the `SubAgents(contain_errors=...)` default (off). |
+
+## Per-delegation model selection
+
+The orchestrator knows how hard a task is at the moment it writes the brief, so it is the right place to decide which model runs it. Configure a `models` menu and the delegate tool gains a `model` argument that names one of its keys.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai_harness.subagents import ModelOption, SubAgent, SubAgents
+
+reviewer = Agent('anthropic:claude-sonnet-4-6', name='reviewer', description='Reviews a diff')
+linter = Agent('anthropic:claude-sonnet-4-6', name='linter', description='Runs the linter and reports failures')
+
+orchestrator = Agent(
+    'anthropic:claude-opus-4-7',
+    capabilities=[
+        SubAgents(
+            agents=[SubAgent(reviewer), SubAgent(linter, models=['fast'])],
+            models={
+                'fast': 'anthropic:claude-haiku-4-5',
+                'standard': 'anthropic:claude-sonnet-4-6',
+                'deep': ModelOption(
+                    'anthropic:claude-opus-4-7',
+                    description='hard reasoning, multi-file changes',
+                    settings=ModelSettings(thinking='xhigh'),
+                ),
+            },
+        )
+    ],
+)
+```
+
+- **Off by default.** With no `models` menu the `model` argument is not in the tool schema at all, and every delegation runs exactly as it did before.
+- **The keys are the interface.** They are listed in the system prompt with each entry's model and description, and the tool schema offers them as an enum, so the model picks from the menu instead of inventing a model name. Name them for the job (`'fast'`, `'deep'`), not for the vendor.
+- **An entry is a model or a `ModelOption`.** `ModelOption(model, description=..., settings=...)` adds a routing hint and per-option `ModelSettings`, so one key can mean "same model, more thinking". Those settings merge over the sub-agent's own `model_settings`, which keeps the parts the option does not set.
+- **Resolution order.** The key the parent passed, else the delegate's first allowed key (see below), else the delegate's own model, else the parent run's model.
+- **A delegate can be restricted.** `SubAgent(linter, models=['fast'])` pins that delegate to `fast`: the first listed key is what it runs on when the parent passes no `model`, and the others are refused with a `ModelRetry`. The restriction is rendered in the prompt listing (`- linter: Runs the linter (models: fast)`). Restricting to a key the menu does not define is a `ValueError` at construction.
+- **A rejected key costs nothing.** An unknown or unavailable key comes back as a `ModelRetry` listing the valid options, before the delegate's `max_calls` budget is charged.
 
 ## Failure handling
 
@@ -180,6 +220,7 @@ When the same name appears in more than one source, the higher-precedence one wi
 ```python
 SubAgents(
     agents=(),             # Sequence[SubAgent[AgentDepsT]] -- each pairs an agent with its run controls
+    models={},             # Mapping[str, Model | str | ModelOption] -- per-delegation model menu (off when empty)
     agent_folders='agents',# folder-name str (convention) | Sequence[Path] | None (disable)
     agent_overrides={},    # Mapping[str, AgentOverride] -- per-disk-agent model/effort override
     tool_resolver=None,    # Callable[[str], Sequence[AgentToolset[object]] | None] -- disk-agent tool mapping
@@ -198,6 +239,7 @@ SubAgent(
     agent,                 # AbstractAgent[AgentDepsT, Any] -- the child agent to run
     name=None,             # delegate name; defaults to the agent's own `name`
     description=None,      # prompt-listing description; defaults to the agent's own `description`
+    models=None,           # Sequence[str] -- menu keys this delegate may run on; the first is its default
     usage_limits=None,     # per-delegation request/token budget (isolated accounting)
     timeout_seconds=None,  # per-delegation wall-clock budget
     max_calls=None,        # max delegations to this sub-agent per parent run
@@ -223,5 +265,7 @@ SubAgent(
 ::: pydantic_ai_harness.subagents.SubAgents
 
 ::: pydantic_ai_harness.subagents.SubAgent
+
+::: pydantic_ai_harness.subagents.ModelOption
 
 ::: pydantic_ai_harness.subagents.AgentOverride

--- a/pydantic_ai_harness/experimental/subagents/__init__.py
+++ b/pydantic_ai_harness/experimental/subagents/__init__.py
@@ -8,6 +8,7 @@ from pydantic_ai_harness.experimental._warn import warn_moved
 from pydantic_ai_harness.subagents import (
     MINIMUM_EFFORT_FLOOR,
     AgentOverride,
+    ModelOption,
     SubAgent,
     SubAgents,
     SubAgentToolset,
@@ -20,6 +21,7 @@ warn_moved('subagents', 'subagents')
 __all__ = [
     'MINIMUM_EFFORT_FLOOR',
     'AgentOverride',
+    'ModelOption',
     'SubAgent',
     'SubAgentToolset',
     'SubAgents',

--- a/pydantic_ai_harness/subagents/README.md
+++ b/pydantic_ai_harness/subagents/README.md
@@ -48,6 +48,7 @@ A delegate's name -- how the parent model refers to it, and how it is listed in 
 - The sub-agent runs with its own message history, so `task` must be self-contained.
 - An unknown `agent_name` raises `ModelRetry`, so the model can correct itself.
 - The result returned to the parent is `str(result.output)`.
+- With a `models` menu configured, the tool takes an extra `model` argument (see below).
 
 ## Deps, usage, tools, and capabilities
 
@@ -84,11 +85,50 @@ orchestrator = Agent(
 
 | Field | Effect |
 |---|---|
+| `models` | Which keys of the `SubAgents` model menu this delegate may run on, and which one it runs on by default: the first key listed. See "Per-delegation model selection" below. |
 | `usage_limits` | A request/token budget for one delegation. The child runs with its own usage accounting, so the budget counts only that child's requests and tokens (not the parent's or siblings'), even when `forward_usage=True`. The tradeoff: that child's tokens no longer aggregate into the parent's `usage`. Reaching the budget is a soft outcome (see below), not a run-stopping `UsageLimitExceeded`. |
 | `timeout_seconds` | A wall-clock budget for one delegation. When the child exceeds it, its run is cancelled and the parent gets a soft steering message instead of hanging on the child. The cancelled child's `event_stream_handler` (if any) stops receiving events without a terminal event. |
 | `max_calls` | The maximum number of delegations to this sub-agent per parent run. Once reached, further delegations return a soft budget-exhausted message without running the child. Counts are scoped to one `Agent.run` (a `run_id`) and cleared when it ends, so each parent run and each level of a nested tree budgets independently. |
 | `on_failure` | A steering message returned to the parent for any soft degradation of this delegate, in place of the built-in default. Setting it also makes child failures soft (see below). |
 | `contain_errors` | Whether an unexpected crash in this delegate is caught and returned to the parent as a bounded `ModelRetry` instead of aborting the parent run (see below). Unset inherits the `SubAgents(contain_errors=...)` default (off). |
+
+## Per-delegation model selection
+
+The orchestrator knows how hard a task is at the moment it writes the brief, so it is the right place to decide which model runs it. Configure a `models` menu and the delegate tool gains a `model` argument that names one of its keys.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai_harness.subagents import ModelOption, SubAgent, SubAgents
+
+reviewer = Agent('anthropic:claude-sonnet-4-6', name='reviewer', description='Reviews a diff')
+linter = Agent('anthropic:claude-sonnet-4-6', name='linter', description='Runs the linter and reports failures')
+
+orchestrator = Agent(
+    'anthropic:claude-opus-4-7',
+    capabilities=[
+        SubAgents(
+            agents=[SubAgent(reviewer), SubAgent(linter, models=['fast'])],
+            models={
+                'fast': 'anthropic:claude-haiku-4-5',
+                'standard': 'anthropic:claude-sonnet-4-6',
+                'deep': ModelOption(
+                    'anthropic:claude-opus-4-7',
+                    description='hard reasoning, multi-file changes',
+                    settings=ModelSettings(thinking='xhigh'),
+                ),
+            },
+        )
+    ],
+)
+```
+
+- **Off by default.** With no `models` menu the `model` argument is not in the tool schema at all, and every delegation runs exactly as it did before.
+- **The keys are the interface.** They are listed in the system prompt with each entry's model and description, and the tool schema offers them as an enum, so the model picks from the menu instead of inventing a model name. Name them for the job (`'fast'`, `'deep'`), not for the vendor.
+- **An entry is a model or a `ModelOption`.** `ModelOption(model, description=..., settings=...)` adds a routing hint and per-option `ModelSettings`, so one key can mean "same model, more thinking". Those settings merge over the sub-agent's own `model_settings`, which keeps the parts the option does not set.
+- **Resolution order.** The key the parent passed, else the delegate's first allowed key (see below), else the delegate's own model, else the parent run's model.
+- **A delegate can be restricted.** `SubAgent(linter, models=['fast'])` pins that delegate to `fast`: the first listed key is what it runs on when the parent passes no `model`, and the others are refused with a `ModelRetry`. The restriction is rendered in the prompt listing (`- linter: Runs the linter (models: fast)`). Restricting to a key the menu does not define is a `ValueError` at construction.
+- **A rejected key costs nothing.** An unknown or unavailable key comes back as a `ModelRetry` listing the valid options, before the delegate's `max_calls` budget is charged.
 
 ## Failure handling
 
@@ -182,6 +222,7 @@ When the same name appears in more than one source, the higher-precedence one wi
 ```python
 SubAgents(
     agents=(),             # Sequence[SubAgent[AgentDepsT]] -- each pairs an agent with its run controls
+    models={},             # Mapping[str, Model | str | ModelOption] -- per-delegation model menu (off when empty)
     agent_folders='agents',# folder-name str (convention) | Sequence[Path] | None (disable)
     agent_overrides={},    # Mapping[str, AgentOverride] -- per-disk-agent model/effort override
     tool_resolver=None,    # Callable[[str], Sequence[AgentToolset[object]] | None] -- disk-agent tool mapping
@@ -200,6 +241,7 @@ SubAgent(
     agent,                 # AbstractAgent[AgentDepsT, Any] -- the child agent to run
     name=None,             # delegate name; defaults to the agent's own `name`
     description=None,      # prompt-listing description; defaults to the agent's own `description`
+    models=None,           # Sequence[str] -- menu keys this delegate may run on; the first is its default
     usage_limits=None,     # per-delegation request/token budget (isolated accounting)
     timeout_seconds=None,  # per-delegation wall-clock budget
     max_calls=None,        # max delegations to this sub-agent per parent run

--- a/pydantic_ai_harness/subagents/__init__.py
+++ b/pydantic_ai_harness/subagents/__init__.py
@@ -3,11 +3,13 @@
 from pydantic_ai_harness.subagents._capability import SubAgents, ToolResolver
 from pydantic_ai_harness.subagents._disk import AgentOverride
 from pydantic_ai_harness.subagents._effort import MINIMUM_EFFORT_FLOOR, clamp_effort
+from pydantic_ai_harness.subagents._models import ModelOption
 from pydantic_ai_harness.subagents._toolset import SubAgent, SubAgentToolset
 
 __all__ = [
     'MINIMUM_EFFORT_FLOOR',
     'AgentOverride',
+    'ModelOption',
     'SubAgent',
     'SubAgentToolset',
     'SubAgents',

--- a/pydantic_ai_harness/subagents/_capability.py
+++ b/pydantic_ai_harness/subagents/_capability.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic_ai.agent import Agent, AgentRunResult, EventStreamHandler
 from pydantic_ai.capabilities import AbstractCapability, AgentCapability, WrapRunHandler
+from pydantic_ai.models import KnownModelName, Model
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets import AgentToolset
@@ -21,6 +22,7 @@ from pydantic_ai_harness.subagents._disk import (
     resolve_folders,
 )
 from pydantic_ai_harness.subagents._effort import clamp_effort
+from pydantic_ai_harness.subagents._models import ModelOption, as_option, model_label, validate_restriction
 from pydantic_ai_harness.subagents._toolset import SubAgent, SubAgentToolset
 
 if TYPE_CHECKING:
@@ -29,6 +31,12 @@ if TYPE_CHECKING:
 ToolResolver = Callable[[str], 'Sequence[AgentToolset[object]] | None']
 """Maps one tool name from a disk definition's `tools` list to the toolsets that
 provide it, or `None` when the name is unknown (the loader warns and skips it)."""
+
+
+def _option_line(key: str, option: ModelOption) -> str:
+    """One model-menu line for the prompt listing: the key, its model, its hint."""
+    label = f'- {key} ({model_label(option.model)})'
+    return f'{label}: {option.description}' if option.description else label
 
 
 @dataclass
@@ -46,6 +54,11 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     steering message, and optional `name`/`description` overrides). A delegate's
     name is its `SubAgent.name`, or the agent's own `name` when unset; two
     explicitly-passed delegates resolving to the same name is an error.
+
+    Delegations run on the sub-agent's own model unless a `models` menu is
+    configured, in which case `delegate_task` also takes a `model` argument naming
+    one of the menu's keys, so the parent routes each task to the model that fits
+    it. A `SubAgent` can restrict which keys it accepts (`SubAgent.models`).
 
     Sub-agents are also loaded from disk by default: each markdown agent definition
     under `./.agents/agents/` and `~/.agents/agents/` (or the `.claude/` equivalent)
@@ -82,6 +95,26 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     """The sub-agents to expose, each a `SubAgent` pairing an agent with its
     per-delegate run controls. See `SubAgent`. These take precedence over any
     disk-loaded agents of the same name."""
+
+    models: Mapping[str, Model | KnownModelName | str | ModelOption] = field(
+        default_factory=dict[str, 'Model | KnownModelName | str | ModelOption']
+    )
+    """A menu of models the parent can route an individual delegation to, keyed by
+    the name the parent uses to pick one. Off by default: with no menu the delegate
+    tool has no `model` argument and every delegation runs the way it always did.
+
+    Each value is a model reference, or a `ModelOption` carrying a routing hint and
+    its own `ModelSettings` (so one key can mean "same model, more thinking"). The
+    keys and their descriptions are listed in the system prompt, so name them for
+    the job -- `'fast'`, `'deep'` -- rather than for the vendor. `SubAgent.models`
+    restricts which of them a given delegate accepts.
+
+    ```python
+    from pydantic_ai_harness.subagents import SubAgents
+
+    SubAgents(models={'fast': 'anthropic:claude-haiku-4-5', 'deep': 'anthropic:claude-opus-4-7'})
+    ```
+    """
 
     agent_folders: str | Sequence[Path] | None = 'agents'
     """Where to load markdown agent definitions from, in addition to `agents`.
@@ -153,6 +186,10 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     """Sub-agents keyed by resolved name, built in `__post_init__` and passed to
     the toolset. Insertion order matches `agents` for a stable prompt listing."""
 
+    _menu: dict[str, ModelOption] = field(default_factory=dict[str, ModelOption], init=False, repr=False, compare=False)
+    """`models` normalized to `ModelOption` entries, built in `__post_init__`.
+    Insertion order matches `models` for a stable prompt listing and enum."""
+
     _call_counts: dict[str, dict[str, int]] = field(
         default_factory=dict[str, 'dict[str, int]'], init=False, repr=False, compare=False
     )
@@ -187,6 +224,9 @@ class SubAgents(AbstractCapability[AgentDepsT]):
                 continue
             by_name[name] = sub_agent
         self._by_name = by_name
+        self._menu = {key: as_option(value) for key, value in self.models.items()}
+        for name, sub_agent in by_name.items():
+            validate_restriction(name, sub_agent.models, self._menu)
 
     def _load_disk_agents(self) -> list[SubAgent[AgentDepsT]]:
         """Build a `SubAgent` for every markdown definition in `agent_folders`.
@@ -254,18 +294,27 @@ class SubAgents(AbstractCapability[AgentDepsT]):
             self._call_counts.pop(ctx.run_id or '', None)
 
     def get_instructions(self) -> AgentInstructions[AgentDepsT] | None:
-        """Static, cache-stable listing of the available sub-agents."""
+        """Static, cache-stable listing of the available sub-agents and models."""
         if not self._by_name:
             return None
         lines: list[str] = []
         for name, sub_agent in self._by_name.items():
             description = sub_agent.description or sub_agent.agent.description
-            lines.append(f'- {name}: {description}' if description else f'- {name}')
+            restriction = f' (models: {", ".join(sub_agent.models)})' if sub_agent.models else ''
+            lines.append(f'- {name}: {description}{restriction}' if description else f'- {name}{restriction}')
         listing = '\n'.join(lines)
-        return (
+        instructions = (
             f'You can delegate self-contained tasks to these sub-agents using the `{self.tool_name}` '
             f'tool. Each runs in its own fresh context and does not see this conversation, so pass '
             f'everything it needs.\n\nAvailable sub-agents:\n{listing}'
+        )
+        if not self._menu:
+            return instructions
+        options = '\n'.join(_option_line(key, option) for key, option in self._menu.items())
+        return (
+            f'{instructions}\n\nPass one of these keys as `model` to run a sub-agent on it, matching the '
+            f"option to how hard the task is. Omit `model` to use the sub-agent's default. A sub-agent "
+            f'listed with its own `(models: ...)` accepts only those.\n\nAvailable models:\n{options}'
         )
 
     def get_toolset(self) -> AgentToolset[AgentDepsT] | None:
@@ -282,6 +331,7 @@ class SubAgents(AbstractCapability[AgentDepsT]):
             tool_retries=self.tool_retries,
             contain_errors=self.contain_errors,
             call_counts=self._call_counts,
+            models=self._menu,
         )
 
     @classmethod

--- a/pydantic_ai_harness/subagents/_models.py
+++ b/pydantic_ai_harness/subagents/_models.py
@@ -1,0 +1,84 @@
+"""The model menu: named model options a delegation can be routed to."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from pydantic_ai.models import KnownModelName, Model
+from pydantic_ai.settings import ModelSettings
+
+
+@dataclass(frozen=True)
+class ModelOption:
+    """One entry on the model menu, as a model plus how it should run.
+
+    Pass bare model references when the menu keys speak for themselves, and a
+    `ModelOption` when an entry needs a routing hint or its own settings:
+
+    ```python
+    from pydantic_ai.settings import ModelSettings
+    from pydantic_ai_harness.subagents import ModelOption, SubAgents
+
+    SubAgents(
+        models={
+            'fast': 'anthropic:claude-haiku-4-5',
+            'deep': ModelOption(
+                'anthropic:claude-opus-4-7',
+                description='hard reasoning, multi-file changes',
+                settings=ModelSettings(thinking='xhigh'),
+            ),
+        },
+    )
+    ```
+    """
+
+    model: Model | KnownModelName | str
+    """The model a delegation routed to this option runs on."""
+
+    description: str | None = None
+    """What this option is for, listed in the prompt next to the key so the parent
+    can route on task difficulty rather than on model names alone."""
+
+    settings: ModelSettings | None = None
+    """Settings for a delegation routed to this option -- thinking effort,
+    temperature, and so on. They merge over the sub-agent's own `model_settings`,
+    which keeps whatever the sub-agent set and is not overridden here."""
+
+
+def as_option(value: Model | KnownModelName | str | ModelOption) -> ModelOption:
+    """Normalize one menu value: a bare model reference becomes a plain `ModelOption`."""
+    return value if isinstance(value, ModelOption) else ModelOption(value)
+
+
+def model_label(model: Model | KnownModelName | str) -> str:
+    """How a menu entry's model is named in the prompt listing.
+
+    A `Model` instance is labelled `<system>:<model_name>` to match the string form
+    users write; a string reference is used as given.
+    """
+    if isinstance(model, Model):
+        return f'{model.system}:{model.model_name}'
+    return model
+
+
+def validate_restriction(agent_name: str, allowed: Sequence[str] | None, menu: Mapping[str, ModelOption]) -> None:
+    """Check one delegate's `SubAgent.models` restriction against the configured menu.
+
+    Raises:
+        ValueError: the restriction is empty, or names a key the menu does not define.
+    """
+    if allowed is None:
+        return
+    if not allowed:
+        raise ValueError(
+            f'Sub-agent {agent_name!r} has an empty `models` restriction. '
+            f'Leave `models` unset to allow every configured model.'
+        )
+    unknown = [key for key in allowed if key not in menu]
+    if unknown:
+        available = ', '.join(menu) or '(none configured)'
+        raise ValueError(
+            f'Sub-agent {agent_name!r} restricts `models` to unknown option(s) {", ".join(repr(k) for k in unknown)}. '
+            f'Add them to `SubAgents(models=...)`; configured options: {available}.'
+        )

--- a/pydantic_ai_harness/subagents/_toolset.py
+++ b/pydantic_ai_harness/subagents/_toolset.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Generic
 
 from pydantic_ai.agent import AbstractAgent, EventStreamHandler
@@ -21,7 +21,9 @@ from pydantic_ai.exceptions import (
     UsageLimitExceeded,
     UserError,
 )
-from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.models import KnownModelName, Model
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.tools import AgentDepsT, ObjectJsonSchema, RunContext, ToolDefinition
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 
 # Private import: pydantic-ai has no public way to tell capability-contributed
@@ -29,7 +31,13 @@ from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 from pydantic_ai.toolsets._capability_owned import CapabilityOwnedToolset
 from pydantic_ai.usage import UsageLimits
 
+from pydantic_ai_harness.subagents._models import ModelOption, validate_restriction
+
 logger = logging.getLogger(__name__)
+
+_MODEL_ARG = 'model'
+"""Name of the delegate tool's model-selection argument, shared by the function
+signature and the schema rewrite that shapes it to the configured menu."""
 
 # Signals that must always reach the parent run, even when a delegate has
 # `contain_errors` on. Containing the first five would break the agent graph
@@ -70,6 +78,14 @@ class SubAgent(Generic[AgentDepsT]):
     description: str | None = None
     """Description for the system-prompt listing. Defaults to the agent's own
     `description` when unset; a delegate with neither is listed by name alone."""
+
+    models: Sequence[str] | None = None
+    """Which of `SubAgents.models` this delegate may run on, as menu keys, and
+    which one it runs on by default: the first key listed. Leave it unset to let
+    the parent pick any configured option and to fall back to the delegate's own
+    model when it picks none. Set it to pin a delegate to one option
+    (`models=['fast']`) or to bound an expensive delegate to a subset. Naming a key
+    the menu does not define is an error."""
 
     usage_limits: UsageLimits | None = None
     """Request/token budget for one delegation. When set, the child runs with
@@ -137,6 +153,10 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
     inherited when enabled; any `shared_capabilities` are applied to every
     sub-agent run; and sub-agent events are streamed to `event_stream_handler`
     when one is set. Per-delegate run controls come from each `SubAgent`.
+
+    When a `models` menu is configured, the delegate tool takes an extra `model`
+    argument carrying a menu key, so the parent routes each delegation to the
+    model that fits the task. Without a menu the argument is not offered at all.
     """
 
     def __init__(
@@ -151,6 +171,7 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
         tool_retries: int | None,
         contain_errors: bool,
         call_counts: dict[str, dict[str, int]],
+        models: Mapping[str, ModelOption] | None = None,
     ) -> None:
         super().__init__()
         self._agents: dict[str, SubAgent[AgentDepsT]] = dict(agents)
@@ -160,10 +181,38 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
         self._event_stream_handler = event_stream_handler
         self._tool_name = tool_name
         self._contain_errors = contain_errors
+        self._models: dict[str, ModelOption] = dict(models or {})
+        for name, sub_agent in self._agents.items():
+            validate_restriction(name, sub_agent.models, self._models)
         # Run-scoped delegation counts, keyed by run_id then sub-agent name.
         # Shared with the capability, which clears each run's entry in wrap_run.
         self._call_counts = call_counts
-        self.add_function(self.delegate_task, name=tool_name, retries=tool_retries)
+        self.add_function(self.delegate_task, name=tool_name, retries=tool_retries, prepare=self._prepare_delegate)
+
+    def _prepare_delegate(self, ctx: RunContext[AgentDepsT], tool_def: ToolDefinition) -> ToolDefinition:
+        """Shape the delegate tool's `model` argument to the configured menu.
+
+        With no menu the argument is dropped from the schema, so a capability that
+        does not opt in exposes exactly the tool it did before. With a menu the
+        argument becomes an enum of its keys, so the model picks from the offered
+        options rather than inventing a model name. The result depends only on
+        static configuration, which keeps the tool schema cache-stable.
+        """
+        schema: ObjectJsonSchema = {**tool_def.parameters_json_schema}
+        properties: dict[str, object] = {**schema.get('properties', {})}
+        if self._models:
+            properties[_MODEL_ARG] = {
+                'type': 'string',
+                'enum': list(self._models),
+                'description': (
+                    'Which model to run the sub-agent on, as one of the keys listed in the instructions. '
+                    "Omit it to use the sub-agent's default model."
+                ),
+            }
+        else:
+            properties.pop(_MODEL_ARG, None)
+        schema['properties'] = properties
+        return replace(tool_def, parameters_json_schema=schema)
 
     def _inherited_toolsets(self, ctx: RunContext[AgentDepsT]) -> list[AbstractToolset[AgentDepsT]] | None:
         """The parent agent's own toolsets, excluding capability-contributed ones.
@@ -202,7 +251,31 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
         counts[agent_name] = counts.get(agent_name, 0) + 1
         return counts[agent_name] > max_calls
 
-    async def delegate_task(self, ctx: RunContext[AgentDepsT], agent_name: str, task: str) -> str:
+    def _resolve_model(self, agent_name: str, sub_agent: SubAgent[AgentDepsT], key: str | None) -> ModelOption | None:
+        """The menu option one delegation runs on, or `None` to leave the model as it was.
+
+        An unset `key` falls back to the delegate's own first allowed option, and
+        to no option at all when the delegate allows the whole menu.
+
+        Raises:
+            ModelRetry: the key is not on the menu, or not one this delegate allows.
+        """
+        allowed = sub_agent.models
+        if key is None:
+            return self._models[allowed[0]] if allowed else None
+        option = self._models.get(key)
+        if option is None:
+            available = ', '.join(self._models) or '(none configured)'
+            raise ModelRetry(f'Unknown model {key!r}. Available models: {available}.')
+        if allowed is not None and key not in allowed:
+            raise ModelRetry(
+                f'Sub-agent {agent_name!r} cannot run on model {key!r}. Available models for it: {", ".join(allowed)}.'
+            )
+        return option
+
+    async def delegate_task(
+        self, ctx: RunContext[AgentDepsT], agent_name: str, task: str, model: str | None = None
+    ) -> str:
         """Delegate a self-contained task to a named sub-agent and return its result.
 
         The sub-agent runs in its own fresh context and does not see this
@@ -213,11 +286,17 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
             agent_name: Name of the sub-agent to run. Must be one of the agents
                 listed in the instructions.
             task: The complete, self-contained instruction for the sub-agent.
+            model: Which model to run the sub-agent on, as one of the model keys
+                listed in the instructions. Omit it to use the sub-agent's default
+                model. Only offered when a model menu is configured.
         """
         sub_agent = self._agents.get(agent_name)
         if sub_agent is None:
             available = ', '.join(sorted(self._agents))
             raise ModelRetry(f'Unknown sub-agent {agent_name!r}. Available sub-agents: {available}.')
+
+        # Resolved before the call budget is charged, so a bad model key costs nothing.
+        option = self._resolve_model(agent_name, sub_agent, model)
 
         if sub_agent.max_calls is not None and self._budget_exhausted(ctx, agent_name, sub_agent.max_calls):
             return self._steer(
@@ -240,13 +319,22 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
             usage = ctx.usage if self._forward_usage else None
             usage_limits = None
 
-        # A sub-agent with no model of its own (e.g. one loaded from disk) inherits
-        # the parent run's model; one that brought its own keeps it.
-        model = None if sub_agent.agent.model is not None else ctx.model
+        # A selected menu option decides the model and how it runs. Without one, a
+        # sub-agent with no model of its own (e.g. one loaded from disk) inherits the
+        # parent run's model, and one that brought its own keeps it.
+        run_model: Model | KnownModelName | str | None
+        settings: ModelSettings | None
+        if option is not None:
+            run_model = option.model
+            settings = option.settings
+        else:
+            run_model = None if sub_agent.agent.model is not None else ctx.model
+            settings = None
         run = sub_agent.agent.run(
             task,
             deps=ctx.deps,
-            model=model,
+            model=run_model,
+            model_settings=settings,
             usage=usage,
             usage_limits=usage_limits,
             toolsets=toolsets,

--- a/tests/subagents/test_subagents_models.py
+++ b/tests/subagents/test_subagents_models.py
@@ -1,0 +1,288 @@
+"""Tests for per-delegation model selection in the SubAgents capability."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import ModelMessage, ModelResponse, RetryPromptPart, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.tools import RunContext
+from pydantic_ai.usage import RunUsage
+
+from pydantic_ai_harness.subagents import ModelOption, SubAgent, SubAgents, SubAgentToolset
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run async tests on the asyncio backend (matching upstream pydantic-ai)."""
+    return 'asyncio'
+
+
+def _delegate_with_model(agent_name: str, model: str | None) -> FunctionModel:
+    """A parent model that delegates once (optionally naming a model), then replies."""
+    calls = {'n': 0}
+
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        calls['n'] += 1
+        if calls['n'] == 1:
+            args: dict[str, Any] = {'agent_name': agent_name, 'task': 't'}
+            if model is not None:
+                args['model'] = model
+            return ModelResponse(parts=[ToolCallPart('delegate_task', args, tool_call_id='c1')])
+        return ModelResponse(parts=[TextPart('all done')])
+
+    return FunctionModel(model_fn)
+
+
+def _recording_model(log: list[tuple[str, ModelSettings | None]], label: str) -> FunctionModel:
+    """A sub-agent model that records the label it ran under and its settings."""
+
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        log.append((label, info.model_settings))
+        return ModelResponse(parts=[TextPart(label)])
+
+    return FunctionModel(model_fn)
+
+
+def _delegate_returns(result: Any) -> list[str]:
+    """The `delegate_task` tool-return contents from a run result, in order."""
+    return [
+        str(part.content)
+        for message in result.all_messages()
+        for part in message.parts
+        if isinstance(part, ToolReturnPart) and part.tool_name == 'delegate_task'
+    ]
+
+
+def _delegate_retries(result: Any) -> list[str]:
+    """The `delegate_task` retry-prompt contents from a run result, in order."""
+    return [
+        str(part.content)
+        for message in result.all_messages()
+        for part in message.parts
+        if isinstance(part, RetryPromptPart) and part.tool_name == 'delegate_task'
+    ]
+
+
+def _delegate_schema(capability: SubAgents[object]) -> dict[str, Any]:
+    """The `delegate_task` parameter schema as the parent model is offered it."""
+    captured: dict[str, Any] = {}
+
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        captured.update(next(t.parameters_json_schema for t in info.function_tools if t.name == 'delegate_task'))
+        return ModelResponse(parts=[TextPart('done')])
+
+    Agent(FunctionModel(model_fn), capabilities=[capability]).run_sync('go')
+    return captured
+
+
+class TestSchema:
+    def test_no_menu_hides_the_model_argument(self) -> None:
+        capability = SubAgents[object](agents=[SubAgent(Agent(TestModel(), name='worker'))])
+        properties = _delegate_schema(capability)['properties']
+        assert set(properties) == {'agent_name', 'task'}
+
+    def test_menu_offers_the_keys_as_an_enum(self) -> None:
+        capability = SubAgents[object](
+            agents=[SubAgent(Agent(TestModel(), name='worker'))],
+            models={'fast': TestModel(), 'deep': TestModel()},
+        )
+        model_property = _delegate_schema(capability)['properties']['model']
+        assert model_property['enum'] == ['fast', 'deep']
+        assert model_property['type'] == 'string'
+        assert 'Omit it' in model_property['description']
+
+
+class TestInstructions:
+    def test_lists_the_menu_with_labels_and_hints(self) -> None:
+        capability = SubAgents[object](
+            agents=[SubAgent(Agent(TestModel(), name='worker'))],
+            models={
+                'fast': 'anthropic:claude-haiku-4-5',
+                'deep': ModelOption('anthropic:claude-opus-4-7', description='hard reasoning'),
+            },
+        )
+        instructions = capability.get_instructions()
+        assert isinstance(instructions, str)
+        assert '- fast (anthropic:claude-haiku-4-5)' in instructions
+        assert '- deep (anthropic:claude-opus-4-7): hard reasoning' in instructions
+
+    def test_labels_a_model_instance_by_system_and_name(self) -> None:
+        capability = SubAgents[object](
+            agents=[SubAgent(Agent(TestModel(), name='worker'))], models={'fast': TestModel()}
+        )
+        instructions = capability.get_instructions()
+        assert isinstance(instructions, str)
+        assert '- fast (test:test)' in instructions
+
+    def test_restricted_delegate_lists_its_options(self) -> None:
+        capability = SubAgents[object](
+            agents=[
+                SubAgent(Agent(TestModel(), name='linter', description='Runs the linter'), models=['fast']),
+                SubAgent(Agent(TestModel(), name='architect')),
+            ],
+            models={'fast': TestModel(), 'deep': TestModel()},
+        )
+        instructions = capability.get_instructions()
+        assert isinstance(instructions, str)
+        assert '- linter: Runs the linter (models: fast)' in instructions
+        assert '- architect\n' in instructions
+
+    def test_no_menu_leaves_instructions_unchanged(self) -> None:
+        capability = SubAgents[object](agents=[SubAgent(Agent(TestModel(), name='worker'))])
+        instructions = capability.get_instructions()
+        assert isinstance(instructions, str)
+        assert 'Available models' not in instructions
+
+
+class TestRouting:
+    async def test_selected_option_runs_the_sub_agent_on_that_model(self) -> None:
+        log: list[tuple[str, ModelSettings | None]] = []
+        worker = Agent(_recording_model(log, 'own'), name='worker')
+        parent: Agent[object, str] = Agent(
+            _delegate_with_model('worker', 'deep'),
+            capabilities=[
+                SubAgents(
+                    agents=[SubAgent(worker)],
+                    models={'fast': _recording_model(log, 'fast'), 'deep': _recording_model(log, 'deep')},
+                )
+            ],
+        )
+        result = await parent.run('go')
+        assert _delegate_returns(result) == ['deep']
+        assert [label for label, _ in log] == ['deep']
+
+    async def test_option_settings_merge_over_the_sub_agents_own(self) -> None:
+        log: list[tuple[str, ModelSettings | None]] = []
+        worker = Agent(TestModel(), name='worker', model_settings=ModelSettings(temperature=0.5, seed=7))
+        parent: Agent[object, str] = Agent(
+            _delegate_with_model('worker', 'deep'),
+            capabilities=[
+                SubAgents(
+                    agents=[SubAgent(worker)],
+                    models={
+                        'deep': ModelOption(_recording_model(log, 'deep'), settings=ModelSettings(temperature=0.1))
+                    },
+                )
+            ],
+        )
+        await parent.run('go')
+        settings = log[0][1]
+        assert settings is not None
+        assert settings.get('temperature') == 0.1  # the option wins
+        assert settings.get('seed') == 7  # the sub-agent's own setting survives
+
+    async def test_omitted_model_keeps_the_sub_agents_own(self) -> None:
+        log: list[tuple[str, ModelSettings | None]] = []
+        worker = Agent(_recording_model(log, 'own'), name='worker')
+        parent: Agent[object, str] = Agent(
+            _delegate_with_model('worker', None),
+            capabilities=[SubAgents(agents=[SubAgent(worker)], models={'deep': _recording_model(log, 'deep')})],
+        )
+        result = await parent.run('go')
+        assert _delegate_returns(result) == ['own']
+
+    async def test_restriction_first_key_is_the_delegates_default(self) -> None:
+        log: list[tuple[str, ModelSettings | None]] = []
+        worker = Agent(_recording_model(log, 'own'), name='worker')
+        parent: Agent[object, str] = Agent(
+            _delegate_with_model('worker', None),
+            capabilities=[
+                SubAgents(
+                    agents=[SubAgent(worker, models=['fast', 'deep'])],
+                    models={'fast': _recording_model(log, 'fast'), 'deep': _recording_model(log, 'deep')},
+                )
+            ],
+        )
+        result = await parent.run('go')
+        assert _delegate_returns(result) == ['fast']
+
+    async def test_unknown_model_retries_with_the_menu(self) -> None:
+        worker = Agent(TestModel(custom_output_text='OK'), name='worker')
+        parent: Agent[object, str] = Agent(
+            _delegate_with_model('worker', 'ghost'),
+            capabilities=[SubAgents(agents=[SubAgent(worker)], models={'fast': TestModel(), 'deep': TestModel()})],
+        )
+        result = await parent.run('go')
+        assert any(
+            "Unknown model 'ghost'" in retry and 'Available models: fast, deep' in retry
+            for retry in _delegate_retries(result)
+        )
+
+    async def test_restricted_delegate_rejects_an_unavailable_model(self) -> None:
+        worker = Agent(TestModel(custom_output_text='OK'), name='worker')
+        parent: Agent[object, str] = Agent(
+            _delegate_with_model('worker', 'deep'),
+            capabilities=[
+                SubAgents(
+                    agents=[SubAgent(worker, models=['fast'])],
+                    models={'fast': TestModel(), 'deep': TestModel()},
+                )
+            ],
+        )
+        result = await parent.run('go')
+        assert any(
+            "Sub-agent 'worker' cannot run on model 'deep'" in retry and 'Available models for it: fast' in retry
+            for retry in _delegate_retries(result)
+        )
+
+    async def test_rejected_model_does_not_spend_the_call_budget(self) -> None:
+        """A bad model key is resolved before `max_calls` is charged, so the delegate stays usable."""
+        toolset: SubAgentToolset[object] = SubAgentToolset(
+            agents={'worker': SubAgent(Agent(TestModel(custom_output_text='OK'), name='worker'), max_calls=1)},
+            forward_usage=True,
+            inherit_tools=False,
+            shared_capabilities=[],
+            event_stream_handler=None,
+            tool_name='delegate_task',
+            tool_retries=1,
+            contain_errors=False,
+            call_counts={},
+            models={'fast': ModelOption(TestModel(custom_output_text='FAST'))},
+        )
+        ctx: RunContext[object] = RunContext(deps=None, model=TestModel(), usage=RunUsage(), run_id='run-1')
+        with pytest.raises(ModelRetry):
+            await toolset.delegate_task(ctx, 'worker', 't', model='ghost')
+        assert await toolset.delegate_task(ctx, 'worker', 't', model='fast') == 'FAST'
+
+    async def test_unknown_model_without_a_menu_says_so(self) -> None:
+        toolset: SubAgentToolset[object] = SubAgentToolset(
+            agents={'worker': SubAgent(Agent(TestModel(), name='worker'))},
+            forward_usage=True,
+            inherit_tools=False,
+            shared_capabilities=[],
+            event_stream_handler=None,
+            tool_name='delegate_task',
+            tool_retries=1,
+            contain_errors=False,
+            call_counts={},
+        )
+        ctx: RunContext[object] = RunContext(deps=None, model=TestModel(), usage=RunUsage(), run_id='run-1')
+        with pytest.raises(ModelRetry, match=r'Available models: \(none configured\)'):
+            await toolset.delegate_task(ctx, 'worker', 't', model='fast')
+
+
+class TestRestrictionValidation:
+    def test_unknown_restriction_key_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"restricts `models` to unknown option\(s\) 'ghost'"):
+            SubAgents[object](
+                agents=[SubAgent(Agent(TestModel(), name='worker'), models=['ghost'])],
+                models={'fast': TestModel()},
+            )
+
+    def test_restriction_without_a_menu_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r'configured options: \(none configured\)'):
+            SubAgents[object](agents=[SubAgent(Agent(TestModel(), name='worker'), models=['fast'])])
+
+    def test_empty_restriction_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match='empty `models` restriction'):
+            SubAgents[object](
+                agents=[SubAgent(Agent(TestModel(), name='worker'), models=[])], models={'fast': TestModel()}
+            )


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David. David reviewed the design decisions (the two calls listed under "Design calls") and gave the implementation a light review.

Closes #357.

## What this adds

An opt-in model menu on `SubAgents`. When it is configured, `delegate_task` takes an extra `model` argument naming one of the menu's keys, so the parent routes each delegation to the model that fits the task it just wrote. When it is not configured, the argument is absent from the tool schema and every delegation runs exactly as before.

```python
orchestrator = Agent(
    'anthropic:claude-opus-4-7',
    capabilities=[
        SubAgents(
            agents=[SubAgent(reviewer), SubAgent(linter, models=['fast'])],
            models={
                'fast': 'anthropic:claude-haiku-4-5',
                'standard': 'anthropic:claude-sonnet-4-6',
                'deep': ModelOption(
                    'anthropic:claude-opus-4-7',
                    description='hard reasoning, multi-file changes',
                    settings=ModelSettings(thinking='xhigh'),
                ),
            },
        )
    ],
)
```

- **The keys are the interface.** They are listed in the system prompt with each entry's model and description (static, so the listing stays in the cached prefix), and the tool schema offers them as an `enum`, so the model picks from the menu instead of inventing a model name.
- **A menu entry is a model reference or a `ModelOption`.** `ModelOption` adds a routing hint and per-option `ModelSettings`, which merge over the sub-agent's own. That means one key can mean "same model, more thinking", so effort routing needs no second tool argument and no invalid model/effort combinations exist.
- **A delegate can be bounded.** `SubAgent(models=['fast'])` restricts which keys that delegate accepts; naming a key the menu does not define is a `ValueError` at construction, and picking an unavailable one at call time is a `ModelRetry` listing what it may use.
- **Resolution order.** The key the parent passed, else the delegate's first allowed key, else the delegate's own model, else the parent run's model (unchanged for delegates loaded from disk).
- A rejected key is resolved before the delegate's `max_calls` budget is charged, so a bad pick costs nothing.

## Design calls worth a look

- **`SubAgent.models`' first key is that delegate's default**, not just a filter on explicit picks. Otherwise `SubAgent(linter, models=['fast'])` would still send the linter to the parent's own (expensive) model whenever the parent passed no `model`, which is the opposite of what the restriction reads as.
- **The `model` argument is shaped by a `prepare` function** rather than by registering two tool variants: with no menu the property is dropped from the schema, and with a menu it becomes an enum of the keys. The output depends only on static configuration, so the tool schema stays cache-stable.

## Deliberately not in scope

- **No separate `effort` argument** on the delegate tool. A `ModelOption`'s `settings` already expresses "same model, higher thinking", and a second axis would let the model produce combinations the config never sanctioned.
- **`agent_overrides` (disk agents) is untouched.** It configures how a disk delegate is *built*; this menu configures how *one delegation* runs. They compose: a disk agent's override is its default, and a menu key overrides it for a single call.
- **No per-delegate menu definitions**, only restriction to keys of the one menu. A delegate that needs a model the menu does not list can still carry it as its own model.

## Verification

`make lint`, `make typecheck`, `make test` and `make testcov` pass; the repo's all-passing and 100%-branch-coverage bars are met, including the new `_models.py` and the delegate-tool changes. Tests are in `tests/subagents/test_subagents_models.py` and use `TestModel`/`FunctionModel` only. Docs updated in both places (`pydantic_ai_harness/subagents/README.md` and `docs/subagents.md`).
