### PR TITLE
docs(agents): push-and-watch rule for agent contributors

### DIFF
--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: pushing-commits-to-the-repo
+description: What to do after you push — watch CI to green, triage every review comment to a reply
+  and a reaction, and escalate genuine design trade-offs to maintainers. Use whenever you push a
+  commit to a PR.
+---
+
+# pushing-commits-to-the-repo
+
+Pushing starts a loop; it does not end the task. **Work stops only when CI is green AND no comment
+is left unresolved.**
+
+## Before you push
+- Attempt the push. If it fails, read the real error — do not preemptively decide you lack
+  permission from a flag or setting.
+- Leave nothing unstaged or uncommitted locally, unless the user's instructions override this.
+
+## After you push — the loop
+1. **Watch CI to a terminal state.** Don't idle. If it fails, diagnose: fix if the failure is
+   yours; if it's a known flake or pre-existing on main, say so with evidence.
+2. **Triage every comment** (bots and humans alike). For each one:
+   - **Valid** → fix it, then reply saying what changed, and react 👍.
+   - **Invalid** → reply explaining concretely why (with code evidence), and react 👎.
+   - Never silently ignore a comment, and never resolve a thread without a reply.
+3. **Escalate real trade-offs, don't guess.** If a comment needs a maintainer decision (a design
+   choice, an API trade-off, a behavioral default), leave a comment containing: the background,
+   your reasoning, the decision that needs making, the trade-offs (pros/cons of each option), and
+   your recommendation. Then **poll every 30 minutes for a reply** and continue when it lands.
+4. Repeat until CI is green and no comment is outstanding.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,3 +155,18 @@ need.
 - Always link sources for any claims made during research
 - Run `make lint && make typecheck && make test` before every commit
 - Commit messages should summarize the "why", not the "what"
+
+## Pushing changes
+
+**A restriction is a conclusion you earn from a real failure, not a field you read.** Never report an
+operation as blocked, unavailable, or not-permitted based on a metadata flag, a config field, or a
+docs claim — attempt it and quote the actual error. (`maintainerCanModify: false` on a PR does *not*
+mean you cannot push: it governs the upstream-maintainer auto-grant, not your own access to the
+fork.) If you genuinely cannot attempt it, say "not attempted", never "we can't".
+
+**Pushing is not the end of the task.** After you push, do not go idle. The work is done when
+**CI is green and there are no unresolved comments** — see the `pushing-commits-to-the-repo` skill
+for the full loop.
+
+**Do not leave work uncommitted.** Don't end a turn with unstaged or uncommitted local changes
+unless the user's own instructions say otherwise.


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

Two instruction-text additions for agent contributors. No code changes.

## What

1. **`AGENTS.md` -> new `## Pushing changes` section**, placed next to the existing
   "Contributing rules for AICAs". Three invariants: a restriction is a conclusion you earn from a
   real failure rather than a field you read; pushing is not the end of the task; don't leave work
   uncommitted.

2. **New `pushing-commits-to-the-repo` skill** at
   `.agents/skills/pushing-commits-to-the-repo/SKILL.md`, holding the actual post-push loop --
   watch CI to a terminal state, triage every comment to a reply plus a reaction, escalate genuine
   design trade-offs to maintainers with pros/cons and a recommendation, repeat until green and
   clear.

## Why

Two recurring failure modes:

- Agents reported operations as blocked, unavailable, or not-permitted based on a **metadata flag**
  rather than an attempt. `maintainerCanModify: false` was read as "I cannot push", when it governs
  the upstream-maintainer auto-grant and says nothing about the agent's own access to the fork.
- Agents **went idle immediately after pushing**, treating the push as task completion instead of
  driving CI to green and answering review comments.

## Why split across two files

`AGENTS.md` is autoloaded by every agent on every task, so it carries only the short invariants.
The multi-step polling procedure is a workflow, so it lives in a skill the agent invokes when it
actually pushes -- keeping it out of what gets loaded for unrelated work.

The wording was reviewed and signed off by David before this PR was opened, and is copied verbatim
from that reviewed draft (one spelling normalization, `pre-emptively` -> `preemptively`, to satisfy
the repo's codespell hook).