### PR TITLE
Require durability composition evidence for stateful capabilities

### DIFF
--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -96,8 +96,11 @@ Before treating a capability as done, check how it composes with:
 - deferred tools and approval flows
 - provider-native versus local fallback tools
 - streaming/event behavior when the capability emits or wraps events
-- durable execution when the capability affects tool calls, context,
-  serialization, retries, or lifecycle ordering
+- A stateful capability, or one that overrides `for_run`, must exercise its
+  public `Agent` path with every supported durability capability. Verify that
+  durable wrappers resolve the run-local toolset and state. If state cannot
+  survive activity, process, or replay boundaries, fail before the first tool
+  call and document the incompatibility.
 
 `CodeMode` is a useful reference for wrapper-toolset composition, tool
 selection, `ToolSearch` interaction, public docs, and test depth.

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -77,6 +77,10 @@ well before now, or that was built against unreleased Pydantic AI changes.
 - Tests cover the public `Agent(..., capabilities=[...])` path where possible.
 - Lower-level tests cover lifecycle, schemas, retries, and metadata when needed.
 - Error paths and important option combinations are covered.
+- For a stateful capability, or one that overrides `for_run`, require a public
+  `Agent` durability-composition test for every supported wrapper or an
+  explicit, tested incompatibility. Mocked lifecycle tests alone do not
+  establish state continuity across activity, process, or replay boundaries.
 - Relevant protocol-shaped output is snapshotted.
 - `make lint`, `make typecheck`, and `make test` pass before handoff.
 


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Summary

- Replace the broad durable-execution composition reminder with a concrete public-`Agent` test obligation for stateful capabilities and capabilities that override `for_run`.
- Require authors to verify that durability wrappers resolve run-local toolsets and state, or fail early and document incompatibility when state cannot cross durable boundaries.
- Add the matching reviewer evidence gate to the capability review checklist.

## Why

The Playwright capability review exposed a failure that the existing generic reminder did not prevent: normal composition with `TemporalDurability` routed tool calls to construction-time state and failed on the first browser tool call. The revised guidance turns “consider durability” into an observable test or explicit incompatibility.

## Validation

- `make lint`: pass
- `make typecheck`: pass
- `make test`: pass

## Deliberate scope

`AGENTS.md` is unchanged. The authoring guide and review checklist are already required by the repository preflight, so duplicating the rule globally would add noise without improving routing.