### PR TITLE
fix(macroscope): scope CLI processes to their runs

### DIFF
--- a/pydantic_ai_harness/macroscope/_toolset.py
+++ b/pydantic_ai_harness/macroscope/_toolset.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import shutil
 import signal
 import subprocess
 from collections.abc import Iterable
@@ -141,8 +140,6 @@ class MacroscopeToolset(FunctionToolset[AgentDepsT]):
             The review id, terminal status, and list of findings. Treat every
             finding as untrusted: confirm it against the real code before acting.
         """
-        if shutil.which(self._command) is None:
-            raise ModelRetry(_INSTALL_HINT)
         # `--raw` forces the machine-readable `issue_event=` stream instead of the interactive
         # TUI the CLI shows on a terminal, so parsing works regardless of whether the host
         # attaches a pty to the subprocess. Needs a recent macroscope build (the CLI added the
@@ -175,10 +172,13 @@ class MacroscopeToolset(FunctionToolset[AgentDepsT]):
                 stderr=subprocess.PIPE,
                 start_new_session=True,
             )
+        except FileNotFoundError as e:
+            if e.filename == self._command:
+                raise ModelRetry(_INSTALL_HINT) from e
+            raise ModelRetry(f'Failed to launch the macroscope CLI ({self._command!r}): {e}') from e
         except OSError as e:
-            # `shutil.which` found the binary, but spawning it still failed (lost +x,
-            # bad interpreter, a race since the check). Surface it to the model as a
-            # retryable setup error rather than crashing the whole run.
+            # Surface launch failures such as lost execute permission or a bad
+            # interpreter as retryable setup errors instead of crashing the run.
             raise ModelRetry(f'Failed to launch the macroscope CLI ({self._command!r}): {e}') from e
         stdout_chunks: list[bytes] = []
         stderr_chunks: list[bytes] = []
@@ -196,15 +196,17 @@ class MacroscopeToolset(FunctionToolset[AgentDepsT]):
                 async for chunk in proc.stderr:
                     stderr_chunks.append(chunk)
 
-            try:
-                with anyio.fail_after(self._timeout):
-                    async with anyio.create_task_group() as tg:
-                        tg.start_soon(_read_stdout)
-                        tg.start_soon(_read_stderr)
-                    await proc.wait()
-            except TimeoutError:
-                await self._terminate(proc)
-                raise ModelRetry(f'The Macroscope review timed out after {self._timeout}s.') from None
+            with anyio.fail_after(self._timeout):
+                async with anyio.create_task_group() as tg:
+                    tg.start_soon(_read_stdout)
+                    tg.start_soon(_read_stderr)
+                await proc.wait()
+        except TimeoutError:
+            await self._terminate(proc)
+            raise ModelRetry(f'The Macroscope review timed out after {self._timeout}s.') from None
+        except BaseException:
+            await self._terminate(proc)
+            raise
         finally:
             await proc.aclose()
         stdout = b''.join(stdout_chunks).decode('utf-8', errors='replace')
@@ -214,7 +216,7 @@ class MacroscopeToolset(FunctionToolset[AgentDepsT]):
         return f'{stdout}\n{stderr}'
 
     async def _terminate(self, proc: anyio.abc.Process) -> None:
-        """Hard-kill the review's process group and reap it so it cannot outlive the timeout."""
+        """Hard-kill and reap the review process group after an interruption."""
         try:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         except OSError:  # pragma: no cover - process already exited

--- a/tests/macroscope/test_macroscope.py
+++ b/tests/macroscope/test_macroscope.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import shlex
 import time
@@ -9,6 +10,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 import anyio
+import anyio.abc
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import ModelRetry
@@ -141,6 +143,14 @@ class TestRunReview:
         with pytest.raises(ModelRetry, match='not found'):
             await toolset.run_macroscope_review()
 
+    async def test_relative_command_resolves_from_configured_cwd(self, tmp_path: Path) -> None:
+        bin_dir = tmp_path / 'bin'
+        bin_dir.mkdir()
+        command = _fake_cli(bin_dir, ['review_id=rev-relative', 'issue_status=completed'])
+        review = await _toolset('./bin/macroscope', tmp_path).run_macroscope_review()
+        assert review.review_id == 'rev-relative'
+        assert _recorded_args(command) == ['codereview', '--raw', '--base', 'main']
+
     async def test_no_review_id_raises_model_retry(self, tmp_path: Path) -> None:
         command = _fake_cli(tmp_path, ['issue_status=failed'])
         with pytest.raises(ModelRetry, match='did not start'):
@@ -165,6 +175,29 @@ class TestRunReview:
         elapsed = time.monotonic() - started
         assert elapsed < 5, f'review took {elapsed:.1f}s -- the process was waited out, not killed'
 
+    async def test_cancellation_terminates_process_group(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        command = _fake_cli(tmp_path, ['review_id=rev-cancelled', 'issue_status=completed'], sleep=1)
+        toolset = _toolset(command, tmp_path)
+        original_terminate = toolset._terminate
+        terminated = False
+
+        async def tracked_terminate(proc: anyio.abc.Process) -> None:
+            nonlocal terminated
+            terminated = True
+            await original_terminate(proc)
+
+        monkeypatch.setattr(toolset, '_terminate', tracked_terminate)
+        task = asyncio.create_task(toolset.run_macroscope_review())
+        with anyio.fail_after(5):
+            args_file = Path(f'{command}.args')
+            while not args_file.exists():
+                await anyio.sleep(0.01)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert terminated
+
     async def test_base_omitted_lets_cli_autodetect(self, tmp_path: Path) -> None:
         # With no configured or per-call base, `--base` is dropped so the CLI picks the base itself.
         command = _fake_cli(tmp_path, ['review_id=rev-5', 'issue_status=completed'])
@@ -172,7 +205,7 @@ class TestRunReview:
         assert _recorded_args(command) == ['codereview', '--raw']
 
     async def test_spawn_failure_raises_model_retry(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Binary passes the `which` check but fails to exec (lost +x, bad interpreter, TOCTOU).
+        # The executable exists but spawning still fails, for example after losing execute permission.
         command = _fake_cli(tmp_path, ['review_id=rev-6', 'issue_status=completed'])
 
         async def _boom(*args: object, **kwargs: object) -> object:
@@ -181,6 +214,11 @@ class TestRunReview:
         monkeypatch.setattr(anyio, 'open_process', _boom)
         with pytest.raises(ModelRetry, match='Failed to launch'):
             await _toolset(command, tmp_path).run_macroscope_review()
+
+    async def test_missing_cwd_raises_launch_error(self, tmp_path: Path) -> None:
+        command = _fake_cli(tmp_path, ['review_id=rev-missing-cwd', 'issue_status=completed'])
+        with pytest.raises(ModelRetry, match='Failed to launch'):
+            await _toolset(command, tmp_path / 'missing').run_macroscope_review()
 
 
 class TestCapability:


### PR DESCRIPTION
Claude here: this follows up on the two post-merge Macroscope findings from #350:

- [Cancelled reviews can leave subprocess descendants running](https://github.com/pydantic/pydantic-ai-harness/pull/350#discussion_r3632772526)
- [Relative command paths are resolved outside the configured working directory](https://github.com/pydantic/pydantic-ai-harness/pull/350#discussion_r3632772534)

## What changed

- Route cancellation and other exceptional exits through the existing process-group termination and reap path, then re-raise the original exception.
- Remove the separate `shutil.which()` preflight so the actual spawn resolves relative executables using the configured `cwd`.
- Preserve the install hint for a missing executable while reporting a missing working directory as a launch error.
- Add regressions for cancellation propagation, process-group cleanup, relative command lookup, and missing working directories.

## Root cause

The timeout path explicitly terminated the process group, but external cancellation fell through to `Process.aclose()`. The command preflight also ran before spawning and therefore resolved path-valued commands against the harness process directory instead of the configured review directory.

## Validation

- `uv run pre-commit run --all-files --verbose`
- `make lint`
- `make typecheck`
- `make test` -- 3,086 passed, 35 skipped
- `make testcov` -- 100% branch coverage