### PR TITLE
Add branch-context and adopt-pr skill scaffolding

### DIFF
--- a/.agents/skills/adopt-pr/SKILL.md
+++ b/.agents/skills/adopt-pr/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: adopt-pr
+description: Bootstrap branch-context on an existing PR. Writes issue-brief.md from the linked issue(s) + current PR state, and backfills pr-decisions.md with decision-bearing entries from already-resolved review threads. Use when picking up a PR mid-flight (yours or someone else's) without prior local context.
+user-invocable: true
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(jq:*), Bash(date:*), Bash(ls:*), Bash(cat:*), Bash(cp:*), Bash(.claude/skills/branch-context/*), Read, Write, Edit, Glob, Grep, AskUserQuestion
+---
+
+# Adopt PR -- bootstrap branch-context on an existing PR
+
+Populate `issue-brief.md` and `pr-decisions.md` for a worktree whose PR already
+exists and has history.
+
+## When to use
+
+- You checked out an existing PR and the branch-context files are empty
+  templates (or absent).
+- You are picking up someone else's PR.
+- Your own PR predates the branch-context setup and you want to backfill.
+
+Do not use this for fresh work with no PR yet -- write the brief from the linked
+issue directly.
+
+## Startup
+
+Bootstrapping presumes the linked issue describes a real problem. If you have
+not confirmed that, skim the issue before adopting -- authorship (a bot,
+contributor, or automated sweep) is not proof the problem is real.
+
+1. Read `CLAUDE.md` for project context.
+2. Instantiate the branch-context instances if they do not exist:
+   ```bash
+   cd "$(git rev-parse --show-toplevel)"
+   D=.claude/skills/branch-context
+   [ -f "$D/issue-brief.md" ]   || cp "$D/issue-brief.template.md" "$D/issue-brief.md"
+   [ -f "$D/pr-decisions.md" ]  || cp "$D/pr-decisions.template.md" "$D/pr-decisions.md"
+   ```
+   If `issue-brief.md` already has populated `issues:` frontmatter, ask via
+   `AskUserQuestion` whether to overwrite the brief, re-seed decisions, both, or
+   neither, before proceeding.
+
+## Step 1 -- Resolve the PR
+
+Parse `$ARGUMENTS`:
+- **PR number/URL** -> use it directly.
+- **Empty** -> detect from the current branch:
+  ```bash
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null)
+  ```
+  If detection fails, ask via `AskUserQuestion`.
+
+Fetch PR metadata:
+```bash
+gh pr view "$PR_NUMBER" --json number,title,url,state,headRefName,body,closingIssuesReferences,createdAt,author
+```
+
+## Step 2 -- Resolve linked issues
+
+Two sources, in order:
+1. `closingIssuesReferences` from the PR metadata (canonical -- set via the PR
+   sidebar or `Fixes #N` keywords).
+2. Fallback: grep the PR body for `(?:Fixes|Closes|Resolves|Relates to) #\d+` if
+   (1) is empty.
+
+For each linked issue:
+```bash
+gh issue view "<N>" --json number,url,title,state,body,labels,comments
+```
+
+If there is no linked issue and the body has no problem description worth
+linking, proceed with `issues: []` (free-text problem) -- ask the user whether to
+continue or abort.
+
+## Step 3 -- Study the existing diff
+
+Understand the code before synthesizing the brief:
+```bash
+git fetch origin main 2>/dev/null || git fetch origin master
+MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD origin/master)
+git diff --stat "$MERGE_BASE"..HEAD
+git log --oneline "$MERGE_BASE"..HEAD
+```
+
+Map the changes: which files/modules are touched, which tests exist on the
+branch (existing tests are implied success criteria), which public symbols
+changed, any notable new abstractions.
+
+## Step 4 -- Write `issue-brief.md`
+
+Use the schema in `issue-brief.template.md`. Adaptations for adoption:
+
+- `related_pr`: the PR URL (not `TBD` -- the PR already exists).
+- `branch`: `git rev-parse --abbrev-ref HEAD`.
+- **Success criteria** -- derive from the issue text and from tests already on
+  the branch (each existing test is a de facto criterion; cross-reference them
+  in the table).
+- **Affected surface** -- extract from the diff, not from a planning pass.
+- **Constraints** -- include anything reviewers have already emphasized in
+  comments (e.g. "must preserve backwards-compat" from a maintainer reply).
+
+Write to `.claude/skills/branch-context/issue-brief.md`, overwriting the
+template.
+
+## Step 5 -- Backfill `pr-decisions.md` from resolved threads
+
+Fetch resolved review threads via the GraphQL API:
+```bash
+read -r OWNER REPO < <(gh repo view --json owner,name -q '.owner.login + " " + .name')
+gh api graphql -f query='
+query($owner:String!,$repo:String!,$pr:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$pr){
+      reviewThreads(first:100){ nodes{
+        isResolved
+        comments(first:50){ nodes{ author{login} bodyText url path } }
+      }}
+    }
+  }
+}' -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved))'
+```
+
+For each resolved thread, read the full conversation, then classify:
+
+- **Decision-bearing** -- the thread debated two or more options, or a reviewer
+  flagged a concern and the author adjusted the code (e.g. "use kwargs over
+  positional", "renamed the public method", "moved the helper to a different
+  module").
+- **Noise** -- typo fixes, "nit: missing docstring", "good catch thanks",
+  resolved without a code change. Skip these.
+
+For each decision-bearing thread, append an entry (Source is the root comment's
+`url`):
+```bash
+.claude/skills/branch-context/append-pr-decision.sh \
+  --title "thread: <short title>" \
+  --decision "<one-line summary of what was decided>" \
+  --why "<one-line reason, quoting reviewer or author if concise>" \
+  --source "<thread URL>" \
+  --iter "-"
+```
+
+Decision budget: aim for <=10 entries. If more resolved threads than that seem
+worth logging, you are probably over-including noise -- re-apply the filter.
+
+## Step 6 -- Seed an "adoption" meta-entry
+
+Append one final entry marking the boundary between backfilled decisions
+(everything above) and live-logged ones (everything below):
+```bash
+.claude/skills/branch-context/append-pr-decision.sh \
+  --title "adopted PR #<N> at <DATE>" \
+  --decision "Branch-context bootstrapped from existing PR + issue(s). Decisions above are backfilled from resolved threads." \
+  --why "PR predates the branch-context setup" \
+  --source "<PR URL>" \
+  --iter "-"
+```
+
+## Step 7 -- Report
+
+Print a concise summary:
+```
+Adopted PR #<N> -- "<title>"
+  Issues linked: #<A>, #<B>
+  Resolved threads seeded: <count> decisions
+  Unresolved threads (for later triage): <count>
+```
+
+## Rules
+
+- Do not open a new PR (it already exists). Do not commit anything to the branch
+  during adoption -- only read, classify, and write the two branch-context files.
+- Do not re-classify unresolved threads during adoption -- just report the count.
+- Do not log every resolved thread -- only decision-bearing ones. The decisions
+  log is meant to reward reading; diluting it with noise defeats the point.
+- Every backfilled entry must have a thread URL in `Source:`. If you cannot find
+  one, you are over-inferring -- skip it.
+- If the existing brief/decisions files are already populated (not templates),
+  the user's Startup confirmation governs whether to overwrite.

--- a/.agents/skills/branch-context/SKILL.md
+++ b/.agents/skills/branch-context/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: branch-context
+description: Branch-local durable PR state -- issue brief, decisions log, and session handoffs. Read the brief, decisions, and latest handoff at session start; append decisions as you work; write a handoff only on user request or explicit session turnover.
+allowed-tools: Read, Write, Edit, Bash
+---
+
+# Branch Context
+
+This directory is the home for durable PR/branch state that outlives a single
+session. Three surfaces:
+
+| File / dir | Role | Lifetime |
+|------------|------|----------|
+| `issue-brief.md` | Synthesis of the issue(s) this branch addresses | Rewritten only when adopting or re-syncing a branch |
+| `pr-decisions.md` | Append-only log of non-obvious PR-shaping decisions | Append forever; supersede, never edit |
+| `handoffs/` + `handoffs-index.md` | Append-only session handoffs for the next agent | Never overwrite a handoff file; index points at the latest |
+
+The instances (`issue-brief.md`, `pr-decisions.md`, `handoffs-index.md`,
+`handoffs/`) are per-branch and git-ignored. The scaffolding (this file, the
+scripts, the `*.template.md` files) is committed. Instantiate the instances from
+the templates, or via `/adopt-pr` when a PR already exists.
+
+## Session defaults
+
+**On start, before coding:**
+
+1. Confirm the branch matches the brief's `branch:` field
+   (`git rev-parse --abbrev-ref HEAD`).
+2. Read `issue-brief.md`, `pr-decisions.md`, and `handoffs-index.md`.
+3. Read the latest handoff -- the last entry in `handoffs-index.md` points at
+   its file under `handoffs/`. That is what the previous session left for you.
+   If the index has no entries, there is no handoff yet; start from the brief.
+4. If the brief is still the unfilled template, populate it first: run
+   `/adopt-pr` when a PR already exists, or write it from the linked issue when
+   starting fresh.
+
+**While working -- persist without being asked:**
+
+- A non-obvious decision (picking path A over B, a plan deviation, an ambiguous
+  thread resolution) goes into `pr-decisions.md` via `append-pr-decision.sh` in
+  the same turn you make it, not "later".
+- Disk in this directory is the continuity channel, not chat history. Do not
+  rely on the conversation surviving a context clear or a new session.
+- Do not write a handoff because the context "feels full" -- that misjudges and
+  primes an early stop. Write a handoff only when the user asks, or when session
+  turnover is already decided (the user is clearing, switching tools, or ending
+  the sitting).
+
+## When to write each surface
+
+### `issue-brief.md`
+
+Rewritten only when adopting a branch (`/adopt-pr`) or re-syncing after new
+issue activity. Do not freestyle-edit it mid-session.
+
+### `pr-decisions.md`
+
+Append whenever you make a decision the issue did not already spell out:
+
+```bash
+.claude/skills/branch-context/append-pr-decision.sh \
+  --title "<short title>" \
+  --decision "<one-line decision>" \
+  --why "<one-line why>" \
+  --source "<source url -- mandatory>" \
+  [--iter N] [--supersedes "<earlier title>"]
+```
+
+Named flags are preferred (they resist arg-order mistakes). Positional order is
+`title decision why source [iter] [supersedes]` -- do not pass `iter` as the
+second argument.
+
+Entry shape (the script writes this):
+
+```
+## YYYY-MM-DD · <short title> · iter <N or "-">
+- Decision: <one line>
+- Why: <one line>
+- Source: <link -- mandatory>
+- Supersedes: <earlier title, if applicable>
+```
+
+When the decision restates a modal claim (always / never / only if / must /
+unless), quote that clause verbatim instead of paraphrasing -- "always X unless
+Y" compressed to "always X" is a different instruction.
+
+### Handoffs
+
+One handoff per session, newest last. Never overwrite another session's handoff.
+
+```bash
+.claude/skills/branch-context/append-handoff.sh [--writer <name>] "<one-line summary>" [path-to-body.md]
+```
+
+`--writer` tags the index line with the skill that produced the handoff. If you
+omit the body path, the script writes a stub you must fill in via Write/Edit
+before stopping; prefer writing the full body first and passing its path. To
+revise a handoff you already wrote this session, edit the file in place rather
+than appending a second index entry.
+
+Handoff body sections (required):
+
+```markdown
+# Handoff · YYYY-MM-DD · <summary>
+
+## Done
+- ...
+
+## Next
+- ... (ordered; first item is what the next agent starts on)
+
+## Commitments & constraints carried forward
+- ... (verbatim; or "none")
+
+## Key paths
+- `path` -- why
+
+## Open questions
+- ... (or "none")
+
+## Branch-context pointers
+- Brief: issue-brief.md (still valid? yes/no)
+- Decisions appended this session: <titles or "none">
+- Related plan file (if any): <path>
+```
+
+**Commitments & constraints is a required check, not an optional extra.** Before
+writing the handoff, sweep the session for two things and quote them verbatim --
+do not paraphrase, the modality is the payload:
+
+- **Constraints the user stated** that are not already in the brief's
+  Constraints section. "Always X unless Y" and "always X" are different
+  instructions, and a one-line paraphrase is where the qualifier gets dropped.
+- **Promises you made and have not kept** -- to the user ("I'll add the
+  regression test next"), or on the record in a PR/review comment ("I'll file a
+  follow-up issue", "I'll re-run this once CI clears"). A promise made to a
+  reviewer and then dropped across a session boundary is the expensive kind: the
+  next agent cannot know it exists, and the reviewer is still waiting.
+
+A longer, accurate handoff beats a short lossy one. Do not compress this section
+to save space.
+
+## Session turnover
+
+Write the handoff (and any unlogged decisions) when the user turns the session
+over. If the harness has a plan mode, capture the remaining work as a concrete
+plan (next steps, files, verification), persist the handoff, then exit plan mode
+so the fresh session inherits it. If the harness has no plan mode, persist the
+handoff and tell the user to start a new session in this worktree whose first
+action is to read `handoffs-index.md` and the latest handoff.
+
+## Scope boundary
+
+- Not for research notes or repro scripts -- those belong outside this
+  directory.
+- Not for durable codebase facts that outlive the PR -- those belong in
+  longer-lived project docs or memory. Rule of thumb: if removing the linked
+  thread would make this PR's diff confusing, it is a decision; if the fact still
+  helps after merge, it belongs elsewhere.
+
+## Helpers
+
+```bash
+.claude/skills/branch-context/status.sh              # JSON: brief/decisions/handoffs state
+.claude/skills/branch-context/append-pr-decision.sh ...
+.claude/skills/branch-context/append-handoff.sh ...
+```

--- a/.agents/skills/branch-context/append-handoff.sh
+++ b/.agents/skills/branch-context/append-handoff.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Register one append-only handoff under branch-context.
+#
+# Usage:
+#   append-handoff.sh [--writer <name>] <one-line-summary> [body-file]
+#
+# - Creates handoffs/YYYY-MM-DDTHHMMZ-<slug>.md (from body-file, or a stub to fill)
+# - Appends one line to handoffs-index.md, tagged with the writing skill
+# - Never overwrites another session's handoff
+#
+# One handoff per session, newest last. The reader reads the last entry in the
+# index. To revise a handoff you already wrote this session, edit the file in
+# place rather than calling this again.
+#
+# Prints the handoff path on stdout (last line) so agents can Write/Edit the body.
+
+set -e
+
+WRITER="handoff"
+if [ "${1:-}" = "--writer" ]; then
+    if [ -z "${2:-}" ]; then
+        echo "error: --writer needs a name" >&2
+        exit 1
+    fi
+    WRITER="$2"
+    shift 2
+fi
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 [--writer <name>] <one-line-summary> [body-file]" >&2
+    exit 1
+fi
+
+SUMMARY="$1"
+BODY_SRC="${2:-}"
+
+DIR=".claude/skills/branch-context"
+INDEX="$DIR/handoffs-index.md"
+HAND_DIR="$DIR/handoffs"
+
+if [ ! -d "$DIR" ]; then
+    echo "error: $DIR not found. Are you at the worktree root?" >&2
+    exit 1
+fi
+
+mkdir -p "$HAND_DIR"
+
+if [ ! -f "$INDEX" ]; then
+    if [ -f "$DIR/handoffs-index.template.md" ]; then
+        cp "$DIR/handoffs-index.template.md" "$INDEX"
+    else
+        printf '# Handoffs index\n\n<!-- entries below, newest at bottom -->\n' > "$INDEX"
+    fi
+fi
+
+TS="$(date -u +%Y-%m-%dT%H%MZ)"
+# slug: first ~40 chars of summary, safe filename
+SLUG="$(printf '%s' "$SUMMARY" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' | cut -c1-40)"
+[ -z "$SLUG" ] && SLUG="handoff"
+FNAME="${TS}-${SLUG}.md"
+DEST="$HAND_DIR/$FNAME"
+
+if [ -e "$DEST" ]; then
+    # collision within the same minute -- add seconds
+    TS="$(date -u +%Y-%m-%dT%H%M%SZ)"
+    FNAME="${TS}-${SLUG}.md"
+    DEST="$HAND_DIR/$FNAME"
+fi
+
+if [ -n "$BODY_SRC" ]; then
+    if [ ! -f "$BODY_SRC" ]; then
+        echo "error: body file not found: $BODY_SRC" >&2
+        exit 1
+    fi
+    cp "$BODY_SRC" "$DEST"
+else
+    cat > "$DEST" <<EOF
+# Handoff · ${TS} · ${SUMMARY}
+
+## Done
+- TODO
+
+## Next
+- TODO (first item = next agent starts here)
+
+## Commitments & constraints carried forward
+- TODO -- quote VERBATIM, never paraphrase: user constraints not already in issue-brief.md
+  (modality matters: "always X unless Y" != "always X"), and promises you made and have not
+  kept, including ones made on the record in a PR/review comment. Write "none" only after
+  actually sweeping the session for both.
+
+## Key paths
+- TODO
+
+## Open questions
+- none
+
+## Branch-context pointers
+- Brief: issue-brief.md -- still valid?
+- Decisions appended this session: none
+- Related plan file (if any): none
+EOF
+fi
+
+{
+    echo ""
+    echo "## $TS · handoffs/$FNAME · [$WRITER] $SUMMARY"
+} >> "$INDEX"
+
+echo "Appended handoff index entry → $INDEX" >&2
+echo "Handoff file: $DEST" >&2
+# stdout: path only (for scripting)
+echo "$DEST"

--- a/.agents/skills/branch-context/append-pr-decision.sh
+++ b/.agents/skills/branch-context/append-pr-decision.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Append one decision entry to .claude/skills/branch-context/pr-decisions.md
+#
+# Preferred (named flags -- resistant to arg-order mistakes):
+#   append-pr-decision.sh \
+#     --title "thread #123: use kwargs not positional" \
+#     --decision "Reviewer suggestion adopted: kwargs-only for new param" \
+#     --why "Reduces breakage risk at call sites" \
+#     --source "https://github.com/owner/repo/pull/4567#discussion_r987654" \
+#     [--iter 3] [--supersedes "..."]
+#
+# Positional (compat):
+#   append-pr-decision.sh <title> <decision> <why> <source-url> [iteration] [supersedes]
+#
+# Field order in the file is always: title, decision, why, source, iter.
+# Do NOT pass iteration as the second positional arg -- that mangles the entry.
+
+set -euo pipefail
+
+TITLE=""
+DECISION=""
+WHY=""
+SOURCE=""
+ITER="-"
+SUPERSEDES=""
+
+usage() {
+    cat >&2 <<'EOF'
+Usage:
+  append-pr-decision.sh --title T --decision D --why W --source URL [--iter N] [--supersedes S]
+  append-pr-decision.sh <title> <decision> <why> <source-url> [iteration] [supersedes]
+
+Named flags are preferred. Positional order is title, decision, why, source
+(NOT title, iter, decision, ...).
+EOF
+    exit 1
+}
+
+if [[ $# -eq 0 ]]; then
+    usage
+fi
+
+# Named-flag path if first arg starts with -
+if [[ "${1:-}" == -* ]]; then
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -h|--help) usage ;;
+            --title) TITLE="${2:?}"; shift 2 ;;
+            --decision) DECISION="${2:?}"; shift 2 ;;
+            --why) WHY="${2:?}"; shift 2 ;;
+            --source) SOURCE="${2:?}"; shift 2 ;;
+            --iter|--iteration) ITER="${2:?}"; shift 2 ;;
+            --supersedes) SUPERSEDES="${2:?}"; shift 2 ;;
+            *)
+                echo "error: unknown option $1" >&2
+                usage
+                ;;
+        esac
+    done
+else
+    # Named-flag mode triggers only on a leading flag, so `"$title" --decision D ...` parses
+    # as positional and writes the literal "--decision" into a field. Fail instead.
+    for arg in "$@"; do
+        if [[ "$arg" == --* ]]; then
+            echo "error: '$arg' looks like a named flag, but this call parsed as positional." >&2
+            echo "       Flags are only honoured when the FIRST argument is one." >&2
+            echo "       Pass every field as a flag, or none of them." >&2
+            usage
+        fi
+    done
+
+    if [[ $# -lt 4 ]]; then
+        usage
+    fi
+    TITLE="$1"
+    DECISION="$2"
+    WHY="$3"
+    SOURCE="$4"
+    ITER="${5:--}"
+    SUPERSEDES="${6:-}"
+fi
+
+if [[ -z "$TITLE" || -z "$DECISION" || -z "$WHY" || -z "$SOURCE" ]]; then
+    echo "error: --title, --decision, --why, and --source are required" >&2
+    usage
+fi
+
+# Source is the load-bearing field -- an entry whose link doesn't resolve can't be traced back,
+# and it's the field prose lands in when positional args go in the wrong order.
+case "$SOURCE" in
+    http://*|https://*) ;;
+    *)
+        echo "error: source must be a URL, got: $SOURCE" >&2
+        echo "       Prose here usually means the fields landed out of order." >&2
+        echo "       Positional order is: title, decision, why, source." >&2
+        exit 1
+        ;;
+esac
+
+# Must run from a worktree root -- locate the file relative to cwd.
+FILE=".claude/skills/branch-context/pr-decisions.md"
+if [ ! -f "$FILE" ]; then
+    echo "error: $FILE not found. Are you at the worktree root? Instantiate it from pr-decisions.template.md first." >&2
+    exit 1
+fi
+
+DATE="$(date -u +%Y-%m-%d)"
+
+{
+    echo ""
+    echo "## $DATE · $TITLE · iter $ITER"
+    echo "- Decision: $DECISION"
+    echo "- Why: $WHY"
+    echo "- Source: $SOURCE"
+    [ -n "$SUPERSEDES" ] && echo "- Supersedes: $SUPERSEDES"
+} >> "$FILE"
+
+echo "Appended decision to $FILE"

--- a/.agents/skills/branch-context/handoffs-index.template.md
+++ b/.agents/skills/branch-context/handoffs-index.template.md
@@ -1,0 +1,13 @@
+# Handoffs index
+
+Append-only pointer log. Newest at bottom. Full bodies live under `handoffs/` -- never overwrite a handoff file. The latest handoff is the last entry below.
+
+## Entry format
+
+```
+## YYYY-MM-DDTHHMMZ · handoffs/<filename>.md · [<writer>] <one-line summary>
+```
+
+---
+
+<!-- entries below, newest at bottom -->

--- a/.agents/skills/branch-context/issue-brief.template.md
+++ b/.agents/skills/branch-context/issue-brief.template.md
@@ -1,0 +1,68 @@
+---
+last_fetched_at: TODO
+last_fetched_comment_count: 0
+branch: TODO
+related_pr: TBD
+issues: []
+---
+
+# Issue Brief
+
+_This file has not been populated yet. Run `/adopt-pr` to fill it from an
+existing PR, or write it from the linked issue when starting fresh._
+
+<!--
+
+Populated schema below.
+
+## Issues
+
+- [#NNNN -- <title>](<url>) -- type: <bug|improvement|feature> -- role: <primary|related|follow-up>
+- ...
+
+## Problem
+
+<1-2 sentences: the user-visible symptom or missing capability>
+
+## Current behavior vs. expected (bugs only)
+
+- Current: <what happens>
+- Expected: <what should happen>
+
+## Scope
+
+**In:**
+- <specific change 1>
+- <specific change 2>
+
+**Out:**
+- <adjacent thing we're NOT touching>
+- <nice-to-have deferred to a follow-up>
+
+## Success criteria
+
+Each criterion maps to a test. If a test doesn't exist yet, name the file/function we'll add.
+
+| # | Criterion | Test |
+|---|-----------|------|
+| 1 | <what must be true> | `tests/path.py::test_name` |
+| 2 | ... | ... |
+
+## Constraints
+
+- Backwards compatibility: <statement>
+- Public API surface: <statement>
+- Other codebase rules that apply: <...>
+
+## Affected surface
+
+- `path/to/file.py` -- <role>
+- `path/to/module/` -- <role>
+
+## References
+
+- [similar PR #NNNN](<url>) -- <what it taught us>
+- [docs](<url>) -- <relevance>
+- [maintainer comment](<url>) -- <intent it set>
+
+-->

--- a/.agents/skills/branch-context/pr-decisions.template.md
+++ b/.agents/skills/branch-context/pr-decisions.template.md
@@ -1,0 +1,35 @@
+# PR Decisions Log
+
+Append-only record of decisions made during this PR's lifecycle that weren't obvious from the linked issue.
+
+## Entry format
+
+```
+## YYYY-MM-DD · <short title> · iter <N or "-">
+- Decision: <one line>
+- Why: <one line>
+- Source: <link to comment/thread/issue/commit -- mandatory>
+- Supersedes: <earlier entry title, if applicable>
+```
+
+No prose. No multi-paragraph rationale. The Source link carries the full context.
+
+**One exception -- modality.** When the Decision restates a modal claim (always / never / only if / must / unless), quote that clause verbatim instead of paraphrasing it. Brevity everywhere else, but "always X unless Y" compressed to "always X" is a different instruction, and the next agent has no way to notice the qualifier went missing.
+
+## When to append
+
+- You made a pick between two valid implementations and the reviewer later asked about it
+- A thread resolution chose path A over B
+- An ambiguity was settled during the work
+- You deviated from the plan while coding
+- A CI finding forced a design change
+
+## When NOT to append
+
+- Routine implementation work already captured by the diff
+- Decisions already spelled out in the issue or in `issue-brief.md`
+- Research notes (those belong outside this directory)
+
+---
+
+<!-- entries below, newest at bottom -->

--- a/.agents/skills/branch-context/status.sh
+++ b/.agents/skills/branch-context/status.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Emit JSON describing the branch-context state of a worktree.
+#
+# Usage:
+#   status.sh                      # use $PWD as the worktree
+#   status.sh <worktree-path>      # explicit worktree path
+#
+# Output (JSON, single line):
+#   {"initialized": <bool>,
+#    "brief_size": <int>,
+#    "decisions_count": <int>,
+#    "handoffs_count": <int>,
+#    "latest_handoff": "<relative path or empty>",
+#    "last_brief_update": "<ISO ts|>",
+#    "last_decision_at": "<ISO ts|>",
+#    "last_handoff_at": "<ISO ts|>",
+#    "worktree": "<path>"}
+
+set -e
+
+WT="${1:-$PWD}"
+WT="$(cd "$WT" && pwd)"
+DIR="$WT/.claude/skills/branch-context"
+BRIEF="$DIR/issue-brief.md"
+DEC="$DIR/pr-decisions.md"
+INDEX="$DIR/handoffs-index.md"
+HAND_DIR="$DIR/handoffs"
+
+initialized=false
+brief_size=0
+last_brief_update=""
+if [ -f "$BRIEF" ]; then
+    brief_size=$(wc -c < "$BRIEF" | tr -d ' ')
+    last_brief_update=$(date -u -r "$BRIEF" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+    first_line=$(head -1 "$BRIEF" 2>/dev/null || echo "")
+    if [ "$brief_size" -gt 200 ] && [[ "$first_line" != *"Issue Brief Template"* ]]; then
+        initialized=true
+    fi
+fi
+
+# Count only entries after the live marker so template examples in fenced
+# blocks above "<!-- entries below" don't inflate the totals.
+count_after_marker() {
+    local file="$1" pattern="$2"
+    [ -f "$file" ] || { echo 0; return; }
+    # `grep -c` already prints 0 on no match, but exits 1; `|| echo 0` would
+    # append a second 0 and the caller's printf then sees "0\n0".
+    if grep -q '<!-- entries below' "$file" 2>/dev/null; then
+        sed -n '/<!-- entries below/,$p' "$file" | grep -cE "$pattern" 2>/dev/null || true
+    else
+        grep -cE "$pattern" "$file" 2>/dev/null || true
+    fi
+}
+
+decisions_count=0
+last_decision_at=""
+if [ -f "$DEC" ]; then
+    decisions_count=$(count_after_marker "$DEC" '^## .* · ')
+    last_decision_at=$(date -u -r "$DEC" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+fi
+
+handoffs_count=0
+latest_handoff=""
+last_handoff_at=""
+if [ -f "$INDEX" ]; then
+    handoffs_count=$(count_after_marker "$INDEX" '^## .* · handoffs/')
+    # last matching header line after the marker → extract path
+    if grep -q '<!-- entries below' "$INDEX" 2>/dev/null; then
+        last_line=$(sed -n '/<!-- entries below/,$p' "$INDEX" | grep -E "^## .* · handoffs/" 2>/dev/null | tail -1 || true)
+    else
+        last_line=$(grep -E "^## .* · handoffs/" "$INDEX" 2>/dev/null | tail -1 || true)
+    fi
+    if [ -n "$last_line" ]; then
+        # ## TS · handoffs/foo.md · summary
+        latest_handoff=$(printf '%s' "$last_line" | sed -E 's/^## [^·]+ · (handoffs\/[^ ]+) · .*/\1/')
+        if [ -f "$DIR/$latest_handoff" ]; then
+            last_handoff_at=$(date -u -r "$DIR/$latest_handoff" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+        fi
+    fi
+elif [ -d "$HAND_DIR" ]; then
+    # fallback: newest file in handoffs/
+    newest=$(ls -t "$HAND_DIR"/*.md 2>/dev/null | head -1 || true)
+    if [ -n "$newest" ]; then
+        handoffs_count=$(ls "$HAND_DIR"/*.md 2>/dev/null | wc -l | tr -d ' ')
+        latest_handoff="handoffs/$(basename "$newest")"
+        last_handoff_at=$(date -u -r "$newest" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+    fi
+fi
+
+# JSON-escape latest_handoff (minimal: quotes/backslashes)
+latest_handoff_esc=$(printf '%s' "$latest_handoff" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+printf '{"initialized":%s,"brief_size":%d,"decisions_count":%d,"handoffs_count":%d,"latest_handoff":"%s","last_brief_update":"%s","last_decision_at":"%s","last_handoff_at":"%s","worktree":"%s"}\n' \
+    "$initialized" "$brief_size" "$decisions_count" "$handoffs_count" "$latest_handoff_esc" \
+    "$last_brief_update" "$last_decision_at" "$last_handoff_at" "$WT"

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,12 @@
 .mcp.json
 .DS_Store
 .agents/settings.local.json
-.agents/skills/branch-context/
+# branch-context: the skill scaffolding (SKILL.md, scripts, templates) is
+# committed; the per-branch instances it generates are local-only.
+.agents/skills/branch-context/issue-brief.md
+.agents/skills/branch-context/pr-decisions.md
+.agents/skills/branch-context/handoffs-index.md
+.agents/skills/branch-context/handoffs/
 # .agents/ (aka .claude via the symlink) is Claude Code config. Most of it is
 # per-developer, but the agents/ dir holds shared, committed agents such as the
 # docs-parity-reviewer -- keep it tracked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,18 @@ Before implementing or reviewing a capability change:
    retired; ACP is the sole remaining experimental capability (see
    `agent_docs/capability-authoring.md`, "Capability Submodules And Exports").
 
+## Branch context (optional)
+
+`.agents/skills/branch-context/` is opt-in per-branch state for work that spans
+sessions: an issue brief, an append-only decisions log, and session handoffs.
+The scaffolding (`SKILL.md`, scripts, `*.template.md`) is committed; the
+instances are git-ignored and created per branch.
+
+- If `.agents/skills/branch-context/issue-brief.md` exists, read it plus
+  `pr-decisions.md` and the latest handoff before making design decisions.
+- To adopt a branch, instantiate the surfaces from the templates or run
+  `/adopt-pr`. Contributors who never instantiate them can ignore this section.
+
 ## Capabilities API reference
 
 When implementing a new capability, reference these docs:


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

Review level: David requested this contribution and set its scope (generalize the personal skill, strip machine-local couplings, own PR); he has not yet reviewed the generalized content.

## Summary

Commits the scaffolding for two opt-in agent skills that give branches durable, cross-session state:

- **`branch-context`** (`.agents/skills/branch-context/`): three per-branch surfaces -- `issue-brief.md` (synthesis of the issue the branch addresses), `pr-decisions.md` (append-only log of non-obvious decisions, each with a mandatory source link), and `handoffs/` + `handoffs-index.md` (append-only session handoffs). Ships the SKILL.md, three append/status shell scripts, and the templates.
- **`adopt-pr`** (`.agents/skills/adopt-pr/`): bootstraps those surfaces on an existing PR -- writes the brief from the PR and its linked issues, and backfills the decisions log from already-resolved review threads, via `gh`.

Only the scaffolding is tracked. The per-branch instances stay git-ignored (the previous wholesale `.agents/skills/branch-context/` ignore is narrowed to the four data paths), so `git status` stays clean and contributors who never instantiate the surfaces are unaffected. A short "Branch context (optional)" section in `AGENTS.md` tells agents to read the surfaces when they exist and how to instantiate them.

## Why

Multi-session PR work loses its context at every session boundary: which decisions were already settled (and why), what the previous session left unfinished, and which commitments made to reviewers are still open. These skills have been running per-worktree via personal tooling during recent capability PRs (e.g. #420, where the decisions log and handoffs carried an SSRF-hardening split across three sessions and two review rounds); committing the generic core makes that continuity available to anyone working in this repo, and to any AICA harness that reads the files.

## What was deliberately left out

This is the generalized core of a personal skill; machine-local workflow was stripped rather than ported:

- Multi-manager "lanes" (concurrent sessions sharing one worktree) and the same-session handoff-amend machinery -- the committed version is single-lane: the latest handoff is the last index line.
- Per-harness session-turnover tables and personal skill-load steps -- replaced with one harness-neutral turnover paragraph.
- A slash-command routing table referencing commands that do not exist in this repo.

## Validation

- `make lint` and `make test` pass (no Python is touched).
- Scripts smoke-tested in isolation: named-flag and positional decision appends, missing-source rejection, handoff index ordering, and the JSON status reporter.
- Fresh-clone simulation confirms the intended tracked/ignored split: scaffolding tracked, the four instance paths ignored.
