### PR TITLE
Stop LocalStack deployment approval noise

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,9 +195,6 @@ jobs:
     if: ${{ always() && (github.ref_type == 'tag' || needs.changes.outputs.localstack == 'true') }}
     runs-on: ubuntu-latest
     name: LocalStack integration tests
-    # The auth token secret lives in this environment; binding the job to it also
-    # satisfies zizmor's secrets-outside-env audit (same pattern as the release job).
-    environment: localstack-integration
     env:
       # LOCALSTACK_REQUIRE_AUTH_TOKEN makes a missing token fail the job instead
       # of silently skipping the container tests. The token itself is scoped to
@@ -228,7 +225,8 @@ jobs:
       - run: make integration-localstack
         env:
           # Since LocalStack 2026.03.0 the single image requires an auth token to start.
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
+          # The job executes the full PR checkout, so path detection is not a security boundary.
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }} # zizmor: ignore[secrets-outside-env]
 
   coverage:
     needs: [test]

--- a/tests/localstack/test_ci_workflow.py
+++ b/tests/localstack/test_ci_workflow.py
@@ -82,8 +82,12 @@ def test_localstack_ci_scopes_the_auth_token_to_the_test_step() -> None:
     lines = _workflow_lines()
 
     # The token is scoped to the integration-test step, not the job-level env, so
-    # the checkout and setup steps never receive the secret.
+    # the checkout and setup steps never receive the secret. The job must not use
+    # a protected environment that creates deployment approval notifications.
     run_index = lines.index('      - run: make integration-localstack')
-    step_block = lines[run_index : run_index + 4]
-    assert '          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}' in step_block
+    step_block = lines[run_index : run_index + 5]
+    assert (
+        '          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }} # zizmor: ignore[secrets-outside-env]'
+    ) in step_block
     assert '      LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}' not in lines
+    assert '    environment: localstack-integration' not in lines


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Summary

- Remove the `localstack-integration` GitHub environment binding that pauses CI for deployment approval.
- Keep the repository-level auth token scoped to the integration-test step and keep the live job path-scoped.
- Add a regression assertion that the job remains ungated, with a narrow `zizmor` suppression documenting the intentional repository-secret usage.

## Why

PR #450 reduced how often the approval gate fired, but the remaining environment binding still generated repeated Core Team deployment-review notifications. The environment contains no environment-scoped secret, and the job executes the full PR checkout, so LocalStack path detection does not form a meaningful security boundary around the repository-level token.

## Impact

LocalStack integration tests run automatically when selected by the existing path filter. They continue to block the aggregate check when they run and fail, but no longer wait for a deployment review.

## Validation

- `make lint`
- `make typecheck`
- `make test`
- `make testcov`