### PR TITLE
Remove the README capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Pydantic AI's [capabilities](https://ai.pydantic.dev/capabilities/) and [hooks](
 
 **Pydantic AI Harness** is the official capability library for Pydantic AI, maintained by the [Pydantic AI](https://github.com/pydantic/pydantic-ai) team. Pydantic AI core ships capabilities that require model or framework support, and capabilities fundamental to every agent -- [web search](https://ai.pydantic.dev/capabilities/#provider-adaptive-tools), [tool search](https://ai.pydantic.dev/deferred-tools/), [thinking](https://ai.pydantic.dev/capabilities/#thinking). Everything else lives here: standalone building blocks you pick and choose to turn your agent into a coding agent, a research assistant, or anything else. This is also where new capabilities start -- as they stabilize and prove themselves broadly essential, they can graduate into core.
 
-The [capability matrix](#capability-matrix) tracks where we are. [Tell us what to prioritize.](#help-us-prioritize)
+[Browse the capability docs](https://pydantic.dev/docs/ai/harness/) or [tell us what to prioritize](#help-us-prioritize).
 
-**Contents:** [Installation](#installation) · [Quick start](#quick-start) · [DynamicWorkflow](#orchestrating-sub-agents-dynamicworkflow) · [Capability matrix](#capability-matrix) · [An ecosystem agent](#an-ecosystem-agent) · [Help us prioritize](#help-us-prioritize) · [Build your own](#build-your-own) · [Contributing](#contributing) · [Version policy](#version-policy) · [Pydantic AI references](#pydantic-ai-references) · [License](#license)
+**Contents:** [Installation](#installation) · [Quick start](#quick-start) · [DynamicWorkflow](#orchestrating-sub-agents-dynamicworkflow) · [An ecosystem agent](#an-ecosystem-agent) · [Help us prioritize](#help-us-prioritize) · [Build your own](#build-your-own) · [Contributing](#contributing) · [Version policy](#version-policy) · [Pydantic AI references](#pydantic-ai-references) · [License](#license)
 
 ## Installation
 
@@ -138,64 +138,9 @@ It composes with the rest of the harness:
 
 [Full tutorial →](pydantic_ai_harness/dynamic_workflow/)
 
-## Capability matrix
-
-We studied leading coding agents, agent frameworks, and Claw-style assistants to map every capability area that matters for production agents. Each one is tracked as an [issue](https://github.com/pydantic/pydantic-ai-harness/issues) in this repo.
-
-**Vote on whatever is linked in the Status column** -- PRs if we're actively building it, issues if it's planned -- to help us decide what to work on next.
-
-| Category | Capability | Description | Status | Community&nbsp;alternatives |
-|---|---|---|---|---|
-| **Tools &&nbsp;execution** | **Code mode** | Sandboxed Python execution via [Monty](https://github.com/pydantic/monty) -- one `run_code` call replaces N tool calls | :white_check_mark: [Docs](pydantic_ai_harness/code_mode/) | |
-| | **Tool search** | Progressive tool discovery for large tool sets | :white_check_mark: [Pydantic&nbsp;AI](https://pydantic.dev/docs/ai/tools-toolsets/toolsets/#deferred-loading) | |
-| | **File system** | Read, write, edit, search files with path traversal prevention | :white_check_mark: [Docs](pydantic_ai_harness/filesystem/) | [pydantic-ai-backend](https://github.com/vstorm-co/pydantic-ai-backend) (vstorm&#8209;co) |
-| | **Shell** | Execute commands with allowlists, denylists, and timeouts | :white_check_mark: [Docs](pydantic_ai_harness/shell/) | [pydantic-ai-backend](https://github.com/vstorm-co/pydantic-ai-backend) (vstorm&#8209;co) |
-| | **LocalStack** | Environment-backed AWS emulator with AWS CLI tools and optional Docker lifecycle | :white_check_mark: [Docs](pydantic_ai_harness/localstack/) | |
-| | **Modal sandbox** | Run commands and manage files in an isolated [Modal](https://modal.com) cloud sandbox | :white_check_mark: [Docs](pydantic_ai_harness/modal_sandbox/) | |
-| | **Repo context injection** | Auto-load CLAUDE.md/AGENTS.md and repo structure | :white_check_mark: [Docs](pydantic_ai_harness/context/) | [pydantic-deep](https://github.com/vstorm-co/pydantic-deepagents) (vstorm&#8209;co) |
-| | **Docs lookup** | On-demand `read_pyai_docs` tool for Pydantic AI docs | :white_check_mark: [Docs](pydantic_ai_harness/docs/) | |
-| | **Web research** | Web search returning relevant page excerpts, full single-page retrieval, and opt-in deep search with cited answers, backed by [Exa](https://exa.ai) | :white_check_mark: [Docs](pydantic_ai_harness/exa/) | |
-| | **Hosted research agent** | Delegate open-ended research to the [Exa](https://exa.ai) Agent API as deferred tool calls -- resolved inline or by the host application | :white_check_mark: [Docs](pydantic_ai_harness/exa/) | |
-| | **Verification loop** | Run tests after edits, auto-fix failures | :construction: [PR&nbsp;#169](https://github.com/pydantic/pydantic-ai-harness/pull/169) | |
-| | **Code review** | Run a local [Macroscope](https://docs.macroscope.com/cli) review (`macroscope codereview`) and hand findings to the agent | :white_check_mark: [Docs](pydantic_ai_harness/macroscope/) | |
-| **Editor integration** | **ACP** | Serve an agent to editors (Zed, etc.) over the [Agent Client Protocol](https://agentclientprotocol.com) -- streamed text, diff-rendered edits, tool approval | :white_check_mark: [Docs](pydantic_ai_harness/experimental/acp/) (experimental) | |
-| **Prompt management** | **Managed prompt** | Back an agent's instructions with a [Logfire](https://pydantic.dev/logfire)-managed prompt, editable without shipping code | :white_check_mark: [Docs](pydantic_ai_harness/logfire/) | |
-| **Context management** | **Sliding window** | Trim conversation history to stay within token limits | :white_check_mark: [Docs](pydantic_ai_harness/compaction/) | [summarization-pydantic-ai](https://github.com/vstorm-co/summarization-pydantic-ai) (vstorm&#8209;co) |
-| | **Context compaction** | LLM-powered summarization of older messages | :white_check_mark: [Docs](pydantic_ai_harness/compaction/) | [summarization-pydantic-ai](https://github.com/vstorm-co/summarization-pydantic-ai) (vstorm&#8209;co) |
-| | **Limit warnings** | Warn agent before hitting context/iteration limits | :white_check_mark: [Docs](pydantic_ai_harness/compaction/) | [summarization-pydantic-ai](https://github.com/vstorm-co/summarization-pydantic-ai) (vstorm&#8209;co) |
-| | **Tool output management** | Truncate, summarize, or spill large tool outputs | :white_check_mark: [Docs](pydantic_ai_harness/overflowing_tool_output/) | |
-| | **Cache-bust monitoring** | Warn when a run's prompt-cache prefix collapses between model requests | :white_check_mark: [Docs](pydantic_ai_harness/cache_stability/) | |
-| | **System reminders** | Inject periodic reminders to counteract instruction drift | :construction: [PR&nbsp;#181](https://github.com/pydantic/pydantic-ai-harness/pull/181) | |
-| **Memory &&nbsp;persistence** | **Memory** | Persistent, namespaced notebook with bounded prompt injection, on-demand search, and concurrency-safe stores | :white_check_mark: [Docs](pydantic_ai_harness/memory/) | [pydantic-deep](https://github.com/vstorm-co/pydantic-deepagents) (vstorm&#8209;co) |
-| | **Session persistence** | Save and restore full conversation state | :white_check_mark: [Docs](pydantic_ai_harness/step_persistence/) | |
-| | **Checkpointing** | Snapshot, resume (`continue_run`), and fork (`fork_run`) a run | :white_check_mark: [Docs](pydantic_ai_harness/step_persistence/) | [pydantic-deep](https://github.com/vstorm-co/pydantic-deepagents) (vstorm&#8209;co) |
-| | **Media externalization** | Offload large `BinaryContent` to content-addressed stores (building blocks) | :white_check_mark: [Docs](pydantic_ai_harness/media/) | |
-| **Agent orchestration** | **Sub-agents** | Delegate subtasks to specialized child agents | :white_check_mark: [Docs](pydantic_ai_harness/subagents/) | [subagents-pydantic-ai](https://github.com/vstorm-co/subagents-pydantic-ai) (vstorm&#8209;co) |
-| | **Dynamic workflow** | Orchestrate sub-agents from a model-written Python script -- fan-out, chaining, voting in one tool call | :white_check_mark: [Docs](pydantic_ai_harness/dynamic_workflow/) | |
-| | **Skills** | Progressive tool loading -- search, activate, deactivate | :construction: [PR&nbsp;#183](https://github.com/pydantic/pydantic-ai-harness/pull/183) | [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) (DougTrajano), [pydantic-deep](https://github.com/vstorm-co/pydantic-deepagents) (vstorm&#8209;co) |
-| | **Planning** | Break complex tasks into structured plans before execution | :white_check_mark: [Docs](pydantic_ai_harness/planning/) | |
-| | **Runtime authoring** | Let an agent author, validate, and load real capabilities at runtime | :white_check_mark: [Docs](pydantic_ai_harness/runtime_authoring/) | |
-| | **Task tracking** | Track tasks, subtasks, and dependencies | :memo: [#65](https://github.com/pydantic/pydantic-ai-harness/issues/65) | [pydantic-ai-todo](https://github.com/vstorm-co/pydantic-ai-todo) (vstorm&#8209;co) |
-| | **Teams** | Multi-agent teams with shared state and message bus | :memo: [#195](https://github.com/pydantic/pydantic-ai-harness/issues/195) | [pydantic-deep](https://github.com/vstorm-co/pydantic-deepagents) (vstorm&#8209;co) |
-| **Safety &&nbsp;guardrails** | **Input guardrails** | Validate user input before the agent run starts | :white_check_mark: [Docs](pydantic_ai_harness/guardrails/) | [pydantic-ai-shields](https://github.com/vstorm-co/pydantic-ai-shields) (vstorm&#8209;co) |
-| | **Output guardrails** | Validate model output after the run completes | :white_check_mark: [Docs](pydantic_ai_harness/guardrails/) | [pydantic-ai-shields](https://github.com/vstorm-co/pydantic-ai-shields) (vstorm&#8209;co) |
-| | **Cost/token budgets** | Enforce token and cost limits per run | :construction: [PR&nbsp;#182](https://github.com/pydantic/pydantic-ai-harness/pull/182) | [pydantic-ai-shields](https://github.com/vstorm-co/pydantic-ai-shields) (vstorm&#8209;co) |
-| | **Tool access control** | Block tools or require approval before execution | :construction: [PR&nbsp;#182](https://github.com/pydantic/pydantic-ai-harness/pull/182) | [pydantic-ai-shields](https://github.com/vstorm-co/pydantic-ai-shields) (vstorm&#8209;co) |
-| | **Async guardrails** | Run validation concurrently with model requests | :construction: [PR&nbsp;#182](https://github.com/pydantic/pydantic-ai-harness/pull/182) | [pydantic-ai-shields](https://github.com/vstorm-co/pydantic-ai-shields) (vstorm&#8209;co) |
-| | **Secret masking** | Detect and redact secrets in agent I/O | :construction: [PR&nbsp;#172](https://github.com/pydantic/pydantic-ai-harness/pull/172) | [pydantic-ai-shields](https://github.com/vstorm-co/pydantic-ai-shields) (vstorm&#8209;co) |
-| | **Approval workflows** | Require human approval for sensitive operations | :construction: [PR&nbsp;#173](https://github.com/pydantic/pydantic-ai-harness/pull/173) | [Pydantic&nbsp;AI](https://ai.pydantic.dev/deferred-tools/#human-in-the-loop-tool-approval) (built&#8209;in) |
-| | **Tool budget** | Limit total tool calls or cost per run | :construction: [PR&nbsp;#168](https://github.com/pydantic/pydantic-ai-harness/pull/168) | |
-| **Reliability** | **Stuck loop detection** | Detect and break out of repetitive agent loops | :construction: [PR&nbsp;#186](https://github.com/pydantic/pydantic-ai-harness/pull/186) | |
-| | **Tool error recovery** | Retry failed tool calls with backoff and budget | :construction: [PR&nbsp;#171](https://github.com/pydantic/pydantic-ai-harness/pull/171) | |
-| | **Tool orphan repair** | Fix orphaned tool calls in conversation history | :construction: [PR&nbsp;#184](https://github.com/pydantic/pydantic-ai-harness/pull/184) | |
-| **Reasoning** | **Adaptive reasoning** | Adjust thinking effort based on task complexity | :construction: [PR&nbsp;#174](https://github.com/pydantic/pydantic-ai-harness/pull/174) | |
-| | **Current time** | Inject current date/time into system prompt | :construction: [PR&nbsp;#170](https://github.com/pydantic/pydantic-ai-harness/pull/170) | |
-
-> Packages by [vstorm-co](https://github.com/vstorm-co) are endorsed by the Pydantic AI team. We're working with them to upstream some of their implementations into this repo.
-
 ## An ecosystem agent
 
-The Quick start above is deliberately small. Here's the other end of the spectrum -- an agent wired up with capabilities drawn from across the Pydantic AI ecosystem: this repo, core `pydantic-ai`, and the community packages we vouch for in the matrix above.
+The Quick start above is deliberately small. Here's the other end of the spectrum -- an agent wired up with capabilities drawn from across the Pydantic AI ecosystem: this repo, core `pydantic-ai`, and community packages.
 
 ```python
 import logfire
@@ -295,11 +240,11 @@ agent = Agent(
 )
 ```
 
-This snippet is illustrative, not literally copy-pasteable: a few capabilities have setup requirements (a `./skills` directory, a Postgres database for `TodoCapability`'s persistent storage), and the community packages move independently of this one. The [capability matrix](#capability-matrix) tracks each one's status. As the harness ships first-party versions, the imports above will collapse onto fewer packages -- but the example will keep working, since the API surface is the same.
+This snippet is illustrative, not literally copy-pasteable: a few capabilities have setup requirements (a `./skills` directory, a Postgres database for `TodoCapability`'s persistent storage), and the community packages move independently of this one. As the harness ships first-party versions, the imports above will collapse onto fewer packages -- but the example will keep working, since the API surface is the same.
 
 ## Help us prioritize
 
-**Vote on whatever is linked in the Status column above.** If there's a PR, vote on the PR -- it means we're actively building it. If there's only an issue, vote on the issue.
+Vote or comment on [open capability requests](https://github.com/pydantic/pydantic-ai-harness/issues?q=is%3Aissue%20state%3Aopen%20label%3Acapability) to help us decide what to work on next.
 
 Want something that's not on the list? [Open a capability request](https://github.com/pydantic/pydantic-ai-harness/issues/new?template=capability-request.yml).
 

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -132,11 +132,11 @@ Checks:
 - Docs explain composition constraints and safety implications.
 - The PR links an issue.
 
-The mechanical half of these checks (README present + linked, flat page present,
-source link present, name matches, no experimental strings on non-ACP pages, no
-hook name in the lead) is enforced by `tests/test_docs_parity.py`. The semantic
-half (does the prose match the code, are snippets truly runnable) is what the
-reviewer below is for.
+The mechanical half of these checks (README present and source-linked,
+designated flat page present and source-linked, name matches, no experimental
+strings on non-ACP pages, no hook name in the lead) is enforced by
+`tests/test_docs_parity.py`. The semantic half (does the prose match the code,
+are snippets truly runnable) is what the reviewer below is for.
 
 This is the last documentation gate before merge. Run the `docs-parity-reviewer`
 subagent (`.agents/agents/docs-parity-reviewer.md`) on the change as the final

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -1,10 +1,10 @@
-"""Keep the README honest about what ships.
+"""Keep the capability docs honest about what ships.
 
-Every capability package must document itself with a `README.md` and be linked
-from the top-level `README.md`. A capability cannot land without showing up in
-the docs, so the "what's available today" tables cannot silently fall behind the
-code. This is the mechanical half of docs parity; the semantic half (does the
-prose match the code as written) is a review-time concern, not a unit test.
+Every capability package must document itself with a `README.md` and a unified
+docs page. A capability cannot land without showing up in the docs site, so its
+document inventory cannot silently fall behind the code. This is the mechanical half of
+docs parity; the semantic half (does the prose match the code as written) is a
+review-time concern, not a unit test.
 """
 
 from __future__ import annotations
@@ -18,14 +18,14 @@ _ROOT = Path(__file__).parent.parent
 _PACKAGE = _ROOT / 'pydantic_ai_harness'
 
 # The `experimental` package is a namespace/warning shim, not a capability, so it
-# has no standalone README and is not listed in the top-level tables.
+# has no standalone README or unified docs page.
 _NAMESPACE_PACKAGES = {_PACKAGE / 'experimental'}
 
 
 def _is_deprecation_shim(package: Path) -> bool:
     """A package left at a moved capability's old path re-exports it and calls `warn_moved`.
 
-    Such shims carry no docs of their own, so they are excluded from the capability tables.
+    Such shims carry no docs of their own, so they are excluded from the capability docs inventory.
     """
     return 'warn_moved(' in (package / '__init__.py').read_text(encoding='utf-8')
 
@@ -65,16 +65,17 @@ def test_capability_has_readme(package: Path) -> None:
 
 
 @pytest.mark.parametrize('package', _CAPABILITY_PACKAGES, ids=lambda p: str(p.relative_to(_ROOT)))
-def test_capability_linked_from_top_readme(package: Path) -> None:
-    top_readme = (_ROOT / 'README.md').read_text(encoding='utf-8')
-    link_target = f'{package.relative_to(_ROOT).as_posix()}/'
-    # Require an actual Markdown link to the package, not just the path appearing
-    # anywhere (prose or an unrelated URL would otherwise satisfy the check).
-    linked = any(t.startswith(link_target) for t in _markdown_link_targets(top_readme))
-    assert linked, (
-        f'{package.relative_to(_ROOT)} is not linked from the top-level README.md. '
-        f'Add a row for it (linking `{link_target}`) to the "What\'s available today" or "Roadmap" tables '
-        'so the README stays in step with the code.'
+def test_capability_has_unified_doc(package: Path) -> None:
+    module = package.relative_to(_PACKAGE).as_posix()
+    source_link = f'github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/{module}/'
+    matching_pages = [
+        page
+        for page in (_ROOT / 'docs').glob('*.md')
+        if any(source_link in target for target in _markdown_link_targets(page.read_text(encoding='utf-8')))
+    ]
+    assert len(matching_pages) == 1, (
+        f'{package.relative_to(_ROOT)} must have exactly one unified docs page that links its source module; '
+        f'found {[page.relative_to(_ROOT).as_posix() for page in matching_pages]}.'
     )
 
 

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -127,6 +127,14 @@ def _markdown_link_targets(text: str) -> list[str]:
     return re.findall(r'\]\(([^)\s]+)\)', text)
 
 
+def _assert_page_links_source(page: Path, module: str) -> None:
+    expected = f'{_SOURCE_LINK}{module}/'
+    targets = _markdown_link_targets(page.read_text(encoding='utf-8'))
+    assert any(expected in target for target in targets), (
+        f'{page.relative_to(_ROOT)} must link its own source module (a Markdown link containing `{expected}`).'
+    )
+
+
 @pytest.mark.parametrize('package', _CAPABILITY_PACKAGES, ids=lambda p: str(p.relative_to(_ROOT)))
 def test_capability_has_unified_doc(package: Path) -> None:
     module = package.relative_to(_PACKAGE).as_posix()
@@ -140,12 +148,7 @@ def test_capability_has_unified_doc(package: Path) -> None:
     assert page.exists(), (
         f'{package.relative_to(_ROOT)} is missing its designated docs page: {page.relative_to(_ROOT)}.'
     )
-
-    expected = f'{_SOURCE_LINK}{module}/'
-    targets = _markdown_link_targets(page.read_text(encoding='utf-8'))
-    assert any(expected in target for target in targets), (
-        f'{page.relative_to(_ROOT)} must link its own source module (a Markdown link containing `{expected}`).'
-    )
+    _assert_page_links_source(page, module)
 
 
 def _strip_frontmatter(text: str) -> str:
@@ -258,12 +261,7 @@ def test_capability_doc_pages_discovered() -> None:
 @pytest.mark.parametrize('page', _CAPABILITY_DOC_PAGES, ids=lambda p: p.name)
 def test_doc_page_links_its_source(page: Path) -> None:
     module, _ = _CAPABILITY_PAGE_META[page.name]
-    expected = f'{_SOURCE_LINK}{module}/'
-    targets = _markdown_link_targets(page.read_text(encoding='utf-8'))
-    assert any(expected in t for t in targets), (
-        f'{page.relative_to(_ROOT)} must link its own source module as a Markdown link '
-        f'(target containing `{expected}`), not just mention the prefix or link a different module.'
-    )
+    _assert_page_links_source(page, module)
 
 
 @pytest.mark.parametrize('page', _CAPABILITY_DOC_PAGES, ids=lambda p: p.name)

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -64,21 +64,6 @@ def test_capability_has_readme(package: Path) -> None:
     )
 
 
-@pytest.mark.parametrize('package', _CAPABILITY_PACKAGES, ids=lambda p: str(p.relative_to(_ROOT)))
-def test_capability_has_unified_doc(package: Path) -> None:
-    module = package.relative_to(_PACKAGE).as_posix()
-    source_link = f'github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/{module}/'
-    matching_pages = [
-        page
-        for page in (_ROOT / 'docs').glob('*.md')
-        if any(source_link in target for target in _markdown_link_targets(page.read_text(encoding='utf-8')))
-    ]
-    assert len(matching_pages) == 1, (
-        f'{package.relative_to(_ROOT)} must have exactly one unified docs page that links its source module; '
-        f'found {[page.relative_to(_ROOT).as_posix() for page in matching_pages]}.'
-    )
-
-
 # --- Unified-docs page checks (docs/*.md) -----------------------------------
 #
 # The flat pages under `docs/` render on the unified site. These mechanical
@@ -140,6 +125,27 @@ _CAPABILITY_PAGE_META = {
 def _markdown_link_targets(text: str) -> list[str]:
     """Every `](target)` destination in the text -- so a bare path mention is not a link."""
     return re.findall(r'\]\(([^)\s]+)\)', text)
+
+
+@pytest.mark.parametrize('package', _CAPABILITY_PACKAGES, ids=lambda p: str(p.relative_to(_ROOT)))
+def test_capability_has_unified_doc(package: Path) -> None:
+    module = package.relative_to(_PACKAGE).as_posix()
+    designated_pages = [name for name, (source_module, _) in _CAPABILITY_PAGE_META.items() if source_module == module]
+    assert len(designated_pages) == 1, (
+        f'{package.relative_to(_ROOT)} must map to exactly one unified docs page in _CAPABILITY_PAGE_META; '
+        f'found {designated_pages}.'
+    )
+
+    page = _DOCS_DIR / designated_pages[0]
+    assert page.exists(), (
+        f'{package.relative_to(_ROOT)} is missing its designated docs page: {page.relative_to(_ROOT)}.'
+    )
+
+    expected = f'{_SOURCE_LINK}{module}/'
+    targets = _markdown_link_targets(page.read_text(encoding='utf-8'))
+    assert any(expected in target for target in targets), (
+        f'{page.relative_to(_ROOT)} must link its own source module (a Markdown link containing `{expected}`).'
+    )
 
 
 def _strip_frontmatter(text: str) -> str:


### PR DESCRIPTION
## Summary

- remove the capability matrix and its status references from the root README
- direct readers to the maintained capability docs and open capability requests
- update docs-parity coverage to require one unified docs page per capability instead of README matrix links

## Validation

- `make lint`
- `make typecheck`
- `make test` (3,083 passed, 35 skipped)
- docs-parity reviewer: all clear