### PR TITLE
Warn on overlong Agent Skill descriptions

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -144,7 +144,7 @@ The loader uses these parts of `SKILL.md`:
 | Part | Requirement |
 |---|---|
 | `name` | Optional. Defaults to the parent directory name. If provided, it must match the directory after Unicode normalization. |
-| `description` | Required, non-blank, and at most 1,024 characters. This appears in the initial catalog. |
+| `description` | Required and non-blank. The Agent Skills limit is 1,024 characters; longer descriptions load with a warning. This appears in the initial catalog. |
 | Markdown body | Optional. This is loaded under a generated `# Skill: <name>` heading. |
 
 Skill names and `include` or `exclude` values are normalized with Unicode NFKC

--- a/pydantic_ai_harness/skills/README.md
+++ b/pydantic_ai_harness/skills/README.md
@@ -138,7 +138,7 @@ The loader uses these parts of `SKILL.md`:
 | Part | Requirement |
 |---|---|
 | `name` | Optional. Defaults to the parent directory name. If provided, it must match the directory after Unicode normalization. |
-| `description` | Required, non-blank, and at most 1,024 characters. This appears in the initial catalog. |
+| `description` | Required and non-blank. The Agent Skills limit is 1,024 characters; longer descriptions load with a warning. This appears in the initial catalog. |
 | Markdown body | Optional. This is loaded under a generated `# Skill: <name>` heading. |
 
 Skill names and `include` or `exclude` values are normalized with Unicode NFKC

--- a/pydantic_ai_harness/skills/_capability.py
+++ b/pydantic_ai_harness/skills/_capability.py
@@ -13,6 +13,8 @@ from pydantic_ai.tools import AgentDepsT
 
 from pydantic_ai_harness.skills._loader import SkillDefinition, load_skill_libraries
 
+_MAX_DESCRIPTION_LENGTH = 1024
+
 
 @dataclass(init=False, repr=False)
 class Skills(AbstractCapability[AgentDepsT]):
@@ -21,7 +23,8 @@ class Skills(AbstractCapability[AgentDepsT]):
     Libraries are scanned once during construction. Each selected immediate
     child containing `SKILL.md` becomes a deferred capability using the skill's
     name, description, and Markdown body. Bundled files are not loaded or
-    executed.
+    executed. Descriptions longer than the Agent Skills limit are preserved and
+    emit a warning.
     """
 
     directories: tuple[str | Path, ...]
@@ -76,6 +79,18 @@ class Skills(AbstractCapability[AgentDepsT]):
         self.exclude = self._normalize_selection('exclude', exclude) if exclude is not None else frozenset()
 
         definitions = load_skill_libraries(self.directories, include=self.include, exclude=self.exclude)
+        overlong_descriptions = [
+            f'{skill.name} ({len(skill.description):,} characters)'
+            for skill in definitions
+            if len(skill.description) > _MAX_DESCRIPTION_LENGTH
+        ]
+        if overlong_descriptions:
+            warnings.warn(
+                f'Agent Skill descriptions exceed the {_MAX_DESCRIPTION_LENGTH:,}-character limit: '
+                + '; '.join(overlong_descriptions),
+                UserWarning,
+                stacklevel=2,
+            )
         ignored = [
             f'{skill.name}: {", ".join(skill.ignored_behavioral_fields)}'
             for skill in definitions

--- a/pydantic_ai_harness/skills/_loader.py
+++ b/pydantic_ai_harness/skills/_loader.py
@@ -8,7 +8,7 @@ from collections.abc import Collection, Hashable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 
 # These fields affect invocation, permissions, model selection, execution, or
 # prompt rendering in clients that implement them. Skills accepts their files
@@ -39,7 +39,7 @@ class _SkillFrontmatter(BaseModel):
     model_config = ConfigDict(extra='allow')
 
     name: str | None = None
-    description: str = Field(min_length=1, max_length=1024)
+    description: str
 
     @field_validator('description', mode='after')
     @classmethod

--- a/tests/skills/test_skills.py
+++ b/tests/skills/test_skills.py
@@ -396,12 +396,15 @@ class TestSkillValidation:
         with pytest.raises(ValueError, match="found duplicate key 'description'"):
             Skills(library)
 
-    def test_description_is_limited(self, tmp_path: Path) -> None:
+    def test_overlong_description_warns_and_is_preserved(self, tmp_path: Path) -> None:
         library = tmp_path / 'skills'
-        _write_skill(library, 'verbose', description='x' * 1025)
+        description = 'x' * 1025
+        _write_skill(library, 'verbose', description=description)
 
-        with pytest.raises(ValueError, match='Invalid Agent Skill frontmatter'):
-            Skills(library)
+        with pytest.warns(UserWarning, match=r'verbose \(1,025 characters\)'):
+            leaves = _leaves(Skills(library))
+
+        assert [leaf.description for leaf in leaves] == [description]
 
     def test_duplicate_names_across_roots_are_rejected(self, tmp_path: Path) -> None:
         first = tmp_path / 'first'


### PR DESCRIPTION
Follow-up to #396.

## Summary

- preserve selected skill descriptions longer than 1,024 characters
- emit one `UserWarning` naming each overlong skill and its description length
- continue rejecting missing and blank descriptions
- document the compatibility behavior in both Skills docs

## Why

The [Agent Skills specification](https://agentskills.io/specification) limits descriptions to 1,024 characters, but a non-conforming package should not prevent every other skill in its library from loading. For example, Anthropic's [`claude-api` skill](https://github.com/anthropics/skills/blob/b29e7cf65e5cb78a5ac33d582270551bc74a14eb/skills/claude-api/SKILL.md) currently has a 1,068-character description.

This keeps the portability issue visible without truncating metadata or making the complete library unusable.

## Verification

- `make lint`
- `make typecheck`
- `make test`: 3,161 passed, 45 skipped
- `make testcov`: 100% statement and branch coverage
- Anthropic's 17-skill library loads with one warning and preserves the full 1,068-character description