### PR TITLE
Register skills page in docs nav.json

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -24,6 +24,7 @@
       { "label": "Guardrails", "slug": "guardrails" },
       { "label": "Managed Prompt", "slug": "managed-prompt" },
       { "label": "LocalStack", "slug": "localstack" },
+      { "label": "Skills", "slug": "skills" },
       { "label": "ACP", "slug": "acp" }
     ]
   }


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David.

## What

Adds the missing `skills` entry to `docs/nav.json`.

## Why

[#396](https://github.com/pydantic/pydantic-ai-harness/pull/396) shipped `docs/skills.md` (and the capability README) but never registered `skills` in `docs/nav.json`. The docs site mounts the harness section live from this repo, and `nav.json` is authoritative for **which pages get synced/built**, not just sidebar order (see unified-docs `src/config/libraries.ts`: *"the harness repo's `docs/nav.json` drives both the sub-nav and the set of files synced"*). With no entry, `docs/skills.md` was never synced, so https://pydantic.dev/docs/ai/harness/skills 404s despite the page existing in git.

## Note

The docs-parity test checks README <-> docs-page parity but not nav.json registration, which is why a fully orphaned page merged clean. A nav.json-coverage assertion would prevent a recurrence -- happy to add it as a follow-up if wanted.