### PR TITLE
feat: Browser Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ We studied leading coding agents, agent frameworks, and Claw-style assistants to
 | | **Docs lookup** | On-demand `read_pyai_docs` tool for Pydantic AI docs | :white_check_mark: [Docs](pydantic_ai_harness/docs/) | |
 | | **Web research** | Web search returning relevant page excerpts, full single-page retrieval, and opt-in deep search with cited answers, backed by [Exa](https://exa.ai) | :white_check_mark: [Docs](pydantic_ai_harness/exa/) | |
 | | **Hosted research agent** | Delegate open-ended research to the [Exa](https://exa.ai) Agent API as deferred tool calls -- resolved inline or by the host application | :white_check_mark: [Docs](pydantic_ai_harness/exa/) | |
+| | **Browser** | Control a real web browser via the [Browser Use](https://github.com/browser-use/browser-use) CLI | :white_check_mark: [Docs](pydantic_ai_harness/browser_use/) | |
 | | **Verification loop** | Run tests after edits, auto-fix failures | :construction: [PR&nbsp;#169](https://github.com/pydantic/pydantic-ai-harness/pull/169) | |
 | | **Code review** | Run a local [Macroscope](https://docs.macroscope.com/cli) review (`macroscope codereview`) and hand findings to the agent | :white_check_mark: [Docs](pydantic_ai_harness/macroscope/) | |
 | **Editor integration** | **ACP** | Serve an agent to editors (Zed, etc.) over the [Agent Client Protocol](https://agentclientprotocol.com) -- streamed text, diff-rendered edits, tool approval | :white_check_mark: [Docs](pydantic_ai_harness/experimental/acp/) (experimental) | |

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -70,7 +70,7 @@ These are what people most often ask a browser agent to do, in order of how comm
 |---|---|
 | `browser_exec` | Run Python in the browser and return whatever it prints. Optional `session` picks a named cloud browser; optional `timeout_seconds` bounds one call. |
 
-The agent writes Python to be executed within the browser and has a set of already made helpers -- `new_tab`, `goto_url`, `page_info`, `js`, `fill_input`, `press_key`, `scroll`, `wait_for_element`, `capture_screenshot`, tab management, and more.
+The agent writes Python to be executed within the browser and has a set of helpers -- `new_tab`, `goto_url`, `page_info`, `js`, `fill_input`, `press_key`, `scroll`, `wait_for_element`, `capture_screenshot`, tab management, and more.
 
 The browser stays open between calls, so the agent signs in once and keeps working for the rest of the run. Its calls share one persistent Python session, so variables carry over too -- open handles included -- letting it gather results across several calls and use them at the end.
 
@@ -105,7 +105,7 @@ from pydantic_ai_harness.browser_use import BrowserUse
 BrowserUse(browser='headless')
 ```
 
-`'local'` shares one browser with everything else on the machine, so you can only run one task at once. `'headless'` and `'cloud'` give each run its own browser, and both start signed out. You can import your logins to a cloud browser and run as many tasks as you want, and it automatically bypasses CAPTCHAs if necessary.
+`'local'` shares one browser with everything else on the machine, so you can only run one task at a time. `'headless'` and `'cloud'` give each run its own browser, and both start signed out. You can import your logins to a cloud browser and run as many tasks as you want, and it automatically bypasses CAPTCHAs if necessary.
 
 To point at a browser you are running yourself, set the `BU_CDP_URL` environment variable to its DevTools endpoint.
 
@@ -158,7 +158,7 @@ model: openai:gpt-5.5
 capabilities:
   - BrowserUse:
       browser: cloud
-      cloud_timeout_minutes: 30
+      default_timeout: 600
 ```
 
 ```python
@@ -173,7 +173,7 @@ Pass `custom_capability_types`, so the spec loader knows how to build `BrowserUs
 ## Further reading
 
 - [Browser Use documentation](https://docs.browser-use.com)
-- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
 - [Toolsets](/ai/tools-toolsets/toolsets/)
 
 ## API reference

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -148,6 +148,19 @@ BrowserUse(
 
 On a timeout, the CLI is killed, and the agent is told it can retry.
 
+`scope='agent'` shares one session across runs only while the agent is held open with `async with agent:`; without it, every run still gets a fresh session:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.browser_use import BrowserUse
+
+agent = Agent('openai:gpt-5.5', capabilities=[BrowserUse(scope='agent')])
+
+async with agent:
+    await agent.run('Log into the dashboard')
+    await agent.run('Now read the numbers')  # same browser and variables
+```
+
 ## Agent spec (YAML/JSON)
 
 `BrowserUse` works with Pydantic AI's [agent spec](/ai/core-concepts/agent-spec/), so you can declare it in a config file instead of Python:

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -168,7 +168,7 @@ from pydantic_ai_harness.browser_use import BrowserUse
 agent = Agent.from_file('agent.yaml', custom_capability_types=[BrowserUse])
 ```
 
-Pass `custom_capability_types`, so the spec loader knows how to build `BrowserUse`.
+Pass `custom_capability_types`, so the spec loader knows how to build `BrowserUse`. Loading YAML needs the `spec` extra: `uv add 'pydantic-ai-slim[spec]'`.
 
 ## Further reading
 

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -76,6 +76,21 @@ The browser stays open between calls, so the agent signs in once and keeps worki
 
 When the agent's code raises, the traceback and exit code come back to it as a [`ModelRetry`](/ai/tools-toolsets/tools-advanced/#tool-retries) rather than a hard error. The run continues and the model can fix its code and try again. The same is true when the CLI is missing or a call times out.
 
+Files the code produces flow through two channels. Screenshots come back attached as images, so the model can look at the page it captured. Every other file stays on disk, and each path the code prints is listed on the tool return's [`metadata`](/ai/tools-toolsets/tools-advanced/#advanced-tool-returns) under `files` (path, media type, size). Your application reads it from the run's `ToolReturnPart`:
+
+```python
+from pydantic_ai.messages import ModelRequest, ToolReturnPart
+
+for message in result.all_messages():
+    if isinstance(message, ModelRequest):
+        for part in message.parts:
+            if isinstance(part, ToolReturnPart) and part.metadata is not None:
+                for file in part.metadata.get('files', []):
+                    print(file['path'], file['media_type'], file['bytes'])
+```
+
+If your agent, for example, scrapes data and saves it as a CSV, you can then access the file.
+
 ## Choosing a browser
 
 | `browser` | What it uses | Reach for it when |
@@ -153,7 +168,7 @@ from pydantic_ai_harness.browser_use import BrowserUse
 agent = Agent.from_file('agent.yaml', custom_capability_types=[BrowserUse])
 ```
 
-Pass `custom_capability_types` so the spec loader knows how to build `BrowserUse`.
+Pass `custom_capability_types`, so the spec loader knows how to build `BrowserUse`.
 
 ## Further reading
 

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -1,0 +1,168 @@
+---
+title: Browser Use
+description: Your agent can log into websites, click buttons, fill out forms, extract data, and complete tasks for you.
+---
+
+# Browser Use
+
+Give an agent a real web browser powered by the [Browser Use](https://browser-use.com) CLI: automate your local browser, or spin up one in the cloud, to click, type, extract data, fill out forms, and complete tasks. Connecting to your local browser needs no API key, and it works with your websites already logged in.
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/browser_use/)
+
+## Installation
+
+```bash
+uv add pydantic-ai-harness
+```
+
+That is the only required step. The browser is controlled by the `browser-use` CLI.
+
+Installing the CLI outright avoids the first `uvx` run's download and pins the version you get:
+
+```bash
+uv tool install browser-use
+```
+
+Check that the CLI connects to your browser:
+
+```bash
+browser-use --doctor
+```
+
+The CLI attaches to the Google Chrome or Chromium browser on your computer. For cloud browsers, see [Cloud browsers](#cloud-browsers).
+
+## The problem
+
+An agent with search and fetch tools can read text on public websites, but it cannot use the web. Most of what people do involves actions: booking a flight, paying a bill, cancelling a subscription, finding invoices for an expense report, rescheduling a delivery, filling in the same details across a dozen job applications.
+
+## The solution
+
+`BrowserUse` gives the agent one tool that controls a real browser: your local Chrome, already signed into the websites you use, or a browser in the cloud. The agent writes Python in the browser that navigates, clicks, types, and reads the page.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.browser_use import BrowserUse
+
+agent = Agent('openai:gpt-5.5', capabilities=[BrowserUse()])
+
+result = agent.run_sync('Open news.ycombinator.com, and summarize the top 5 stories.')
+print(result.output)
+```
+
+## What agents do with it
+
+These are what people most often ask a browser agent to do, in order of how common they are:
+
+- **Research and compare across sites.** Answer a question that takes several sources, rank options, or check a claim -- the top repositories on GitHub, which fund recently bought a stock, what an organization is affiliated with.
+- **Pull repeated records into a table.** Scrape products, listings, prices, reviews, or videos into structured output: every offer on an Amazon product page, or every venue on Google Maps in one city.
+- **Reach a page and act on it.** Open a site, get through to the right screen, and do one thing there -- often waiting for you to log in first, then carrying on.
+- **Test a website end to end.** Walk a real user flow, audit the UX, hunt for bugs, or re-check a page after a change.
+- **Build and run browser automation.** Write UI tests for a page, script a repeatable crawl, or reproduce an interaction step by step.
+- **Fill in forms and account flows.** Registrations, surveys, course modules, assessments, and other multi-page sequences.
+- **Shop and book.** Compare products, prices, sellers, and coupons, search listings against your criteria, and go through checkout or a booking.
+- **Apply for jobs and update systems.** Work through applications, or log into an admin tool and update records, listings, and settings.
+
+## Tools
+
+`BrowserUse` contributes one tool to the agent:
+
+| Tool | Purpose |
+|---|---|
+| `browser_exec` | Run Python in the browser and return whatever it prints. Optional `session` picks a named cloud browser; optional `timeout_seconds` bounds one call. |
+
+The agent writes Python to be executed within the browser and has a set of already made helpers -- `new_tab`, `goto_url`, `page_info`, `js`, `fill_input`, `press_key`, `scroll`, `wait_for_element`, `capture_screenshot`, tab management, and more.
+
+The browser stays open between calls, so the agent signs in once and keeps working for the rest of the run. Its calls share one persistent Python session, so variables carry over too -- open handles included -- letting it gather results across several calls and use them at the end.
+
+When the agent's code raises, the traceback and exit code come back to it as a [`ModelRetry`](/ai/tools-toolsets/tools-advanced/#tool-retries) rather than a hard error. The run continues and the model can fix its code and try again. The same is true when the CLI is missing or a call times out.
+
+## Choosing a browser
+
+| `browser` | What it uses | Reach for it when |
+|---|---|---|
+| `'local'` (default) | Chrome or Chromium already running on your machine | You want the sites you are already signed into |
+| `'headless'` | It starts and stops headless Chromium for the run on a clean profile | You are on a server or CI, or several runs go at once and must not share tabs |
+| `'cloud'` | A [Browser Use Cloud](https://cloud.browser-use.com) browser | A site blocks automated traffic, or you want the run fully off your machine to run many browsers in parallel |
+
+```python
+from pydantic_ai_harness.browser_use import BrowserUse
+
+BrowserUse(browser='headless')
+```
+
+`'local'` shares one browser with everything else on the machine, so you can only run one task at once. `'headless'` and `'cloud'` give each run its own browser, and both start signed out. You can import your logins to a cloud browser and run as many tasks as you want, and it automatically bypasses CAPTCHAs if necessary.
+
+To point at a browser you are running yourself, set the `BU_CDP_URL` environment variable to its DevTools endpoint.
+
+## Cloud browsers
+
+Cloud browsers need an account. Sign in once, and the CLI remembers it:
+
+```bash
+browser-use auth login
+browser-use auth status   # confirm it worked
+```
+
+Or set the key yourself, from <https://cloud.browser-use.com>:
+
+```bash
+export BROWSER_USE_API_KEY=your-key
+```
+
+To import all the websites you're logged into on your computer to a cloud browser, so it can complete tasks while signed into your accounts, sync your Chrome profile:
+
+```bash
+export BROWSER_USE_API_KEY=your-key && curl -fsSL https://browser-use.com/profile.sh | sh
+```
+
+## Configuration
+
+Every field of `BrowserUse` with its default:
+
+```python
+from pydantic_ai_harness.browser_use import BrowserUse
+
+BrowserUse(
+    browser='local',         # 'local', 'headless', or 'cloud'
+    scope='run',             # 'agent' shares one session across runs (chat loops)
+    default_timeout=300.0,   # seconds per call when the agent gives no timeout
+    progress=None,           # narrate steps live, e.g. progress=print
+    guidance=None,           # None = default instructions, '' = none, str = custom
+)
+```
+
+On a timeout, the CLI is killed, and the agent is told it can retry.
+
+## Agent spec (YAML/JSON)
+
+`BrowserUse` works with Pydantic AI's [agent spec](/ai/core-concepts/agent-spec/), so you can declare it in a config file instead of Python:
+
+```yaml
+# agent.yaml
+model: openai:gpt-5.5
+capabilities:
+  - BrowserUse:
+      browser: cloud
+      cloud_timeout_minutes: 30
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.browser_use import BrowserUse
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[BrowserUse])
+```
+
+Pass `custom_capability_types` so the spec loader knows how to build `BrowserUse`.
+
+## Further reading
+
+- [Browser Use documentation](https://docs.browser-use.com)
+- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [Toolsets](/ai/tools-toolsets/toolsets/)
+
+## API reference
+
+::: pydantic_ai_harness.browser_use.BrowserUse
+
+::: pydantic_ai_harness.browser_use.BrowserUseToolset

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -74,7 +74,7 @@ The agent writes Python to be executed within the browser and has a set of helpe
 
 The browser stays open between calls, so the agent signs in once and keeps working for the rest of the run. Its calls share one persistent Python session, so variables carry over too -- open handles included -- letting it gather results across several calls and use them at the end.
 
-When the agent's code raises, the traceback and exit code come back to it as a [`ModelRetry`](/ai/tools-toolsets/tools-advanced/#tool-retries) rather than a hard error. The run continues and the model can fix its code and try again. The same is true when the CLI is missing or a call times out.
+When the agent's code raises, the traceback and exit code come back to it in the tool output, along with anything it printed first. The run continues and the model can fix its code and try again. When the CLI is missing or a call times out, the tool raises a [`ModelRetry`](/ai/tools-toolsets/tools-advanced/#tool-retries) rather than a hard error.
 
 Files the code produces flow through two channels. Screenshots come back attached as images, so the model can look at the page it captured. Every other file stays on disk, and each path the code prints is listed on the tool return's [`metadata`](/ai/tools-toolsets/tools-advanced/#advanced-tool-returns) under `files` (path, media type, size). Your application reads it from the run's `ToolReturnPart`:
 

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -9,6 +9,7 @@
       { "label": "Context", "slug": "context" },
       { "label": "Pydantic AI Docs", "slug": "pydantic-ai-docs" },
       { "label": "Exa Search", "slug": "exa-search" },
+      { "label": "Browser Use", "slug": "browser-use" },
       { "label": "Macroscope", "slug": "macroscope" },
       { "label": "Compaction", "slug": "compaction" },
       { "label": "Overflowing Tool Output", "slug": "overflowing-tool-output" },

--- a/examples/browser_use.py
+++ b/examples/browser_use.py
@@ -3,7 +3,6 @@
 uv run examples/browser_use.py                       # interactive chat (needs an LLM key)
 uv run examples/browser_use.py "YOUR TASK"           # same, with a task you specify
 uv run examples/browser_use.py --cloud "YOUR TASK"   # run in a Browser Use cloud browser (Browser Use API key needed)
-uv run examples/browser_use.py --verbose "YOUR TASK"  # show each step's code and output, not just its label
 """
 
 from __future__ import annotations
@@ -42,12 +41,11 @@ def _pick_model() -> str | None:
     return next((model for env_var, model in _PROVIDERS if os.environ.get(env_var)), None)
 
 
-async def chat(model: str, cloud: bool, verbose: bool, opening_task: str | None) -> None:  # noqa: D103
+async def chat(model: str, cloud: bool, opening_task: str | None) -> None:  # noqa: D103
     capability = BrowserUse(
         browser='cloud' if cloud else 'local',
         scope='agent',
         progress=print,
-        progress_detail='code' if verbose else 'steps',
         default_timeout=180.0,
     )
     agent = Agent(model, capabilities=[capability])
@@ -79,7 +77,7 @@ def main() -> int:
         )
         return 1
 
-    asyncio.run(chat(model, '--cloud' in flags, '--verbose' in flags, ' '.join(args) or None))
+    asyncio.run(chat(model, '--cloud' in flags, ' '.join(args) or None))
     return 0
 
 

--- a/examples/browser_use.py
+++ b/examples/browser_use.py
@@ -1,0 +1,87 @@
+"""Chat with a Pydantic AI agent that controls your browser via the BrowserUse capability.
+
+uv run examples/browser_use.py                       # interactive chat (needs an LLM key)
+uv run examples/browser_use.py "YOUR TASK"           # same, with a task you specify
+uv run examples/browser_use.py --cloud "YOUR TASK"   # run in a Browser Use cloud browser (Browser Use API key needed)
+uv run examples/browser_use.py --verbose "YOUR TASK"  # show each step's code and output, not just its label
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.browser_use import BrowserUse
+
+_PROVIDERS = (
+    ('OPENAI_API_KEY', 'openai:gpt-5.5'),
+    ('ANTHROPIC_API_KEY', 'anthropic:claude-sonnet-5'),
+    ('GEMINI_API_KEY', 'google-gla:gemini-2.0-flash'),
+)
+
+
+def _load_dotenv() -> None:
+    env_file = Path(__file__).parent.parent / '.env'
+    if not env_file.exists():
+        return
+    for line in env_file.read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if not line or line.startswith('#') or '=' not in line:
+            continue
+        name, _, value = line.partition('=')
+        os.environ.setdefault(name.strip(), value.strip().strip('"').strip("'"))
+
+
+def _pick_model() -> str | None:
+    if override := os.environ.get('MODEL'):
+        return override
+    return next((model for env_var, model in _PROVIDERS if os.environ.get(env_var)), None)
+
+
+async def chat(model: str, cloud: bool, verbose: bool, opening_task: str | None) -> None:  # noqa: D103
+    capability = BrowserUse(
+        browser='cloud' if cloud else 'local',
+        scope='agent',
+        progress=print,
+        progress_detail='code' if verbose else 'steps',
+        default_timeout=180.0,
+    )
+    agent = Agent(model, capabilities=[capability])
+    where = 'a cloud browser (started on first use, stops on /exit)' if cloud else 'your local Chrome'
+    print(f'--- model: {model}\n--- browser: {where}\n--- /exit to quit\n')
+
+    async with agent:
+        history = None
+        if opening_task is not None:
+            result = await agent.run(opening_task)
+            print(f'\n{result.output}\n')
+            history = result.all_messages()
+        await agent.to_cli(prog_name='browser-use', message_history=history)
+
+
+def main() -> int:
+    """Parse the flags and launch the chat, returning a process exit code."""
+    _load_dotenv()
+    flags = {a for a in sys.argv[1:] if a.startswith('--')}
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+
+    model = _pick_model()
+    if model is None:
+        keys = ', '.join(env_var for env_var, _ in _PROVIDERS)
+        print(
+            'No LLM API key found, so the agent cannot run.\n'
+            f'Set one of: {keys} (or MODEL=<provider:name> for something else).',
+            file=sys.stderr,
+        )
+        return 1
+
+    asyncio.run(chat(model, '--cloud' in flags, '--verbose' in flags, ' '.join(args) or None))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -121,7 +121,6 @@ from pydantic_ai_harness.browser_use import BrowserUse
 BrowserUse(
     browser='local',         # 'local', 'headless', or 'cloud'
     scope='run',             # 'agent' shares one session across runs (chat loops)
-    command='browser-use',   # CLI name or path
     default_timeout=300.0,   # seconds per call when the agent gives no timeout
     progress=None,           # narrate steps live, e.g. progress=print
     guidance=None,           # None = default instructions, '' = none, str = custom

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -74,6 +74,21 @@ The browser and the model's Python variables both persist across calls, so the a
 
 One persistent Python session serves the whole run, so everything the code assigns survives to the next call -- including open handles that a snapshot could never carry. A call that times out restarts the session, while the browser itself is unaffected, since it lives in the CLI's daemon. Each agent run gets its own session, discarded when the run ends, so concurrent runs never see each other's variables; `scope='agent'` instead shares one session across every run inside `async with agent:`, which is what a chat loop wants.
 
+Files the code produces flow through two channels. Screenshots come back attached as images, so the model can look at the page it captured. Every other file stays on disk, and each path the code prints is listed on the tool return's `metadata` under `files` (path, media type, size). Your application reads it from the run's `ToolReturnPart`:
+
+```python
+from pydantic_ai.messages import ModelRequest, ToolReturnPart
+
+for message in result.all_messages():
+    if isinstance(message, ModelRequest):
+        for part in message.parts:
+            if isinstance(part, ToolReturnPart) and part.metadata is not None:
+                for file in part.metadata.get('files', []):
+                    print(file['path'], file['media_type'], file['bytes'])
+```
+
+If your agent, for example, scrapes data and saves it as a CSV, you can then access the file.
+
 ## Instructions
 
 The model is told about the browser twice, and the two sources divide the work.

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -143,6 +143,19 @@ BrowserUse(
 
 On a timeout, the CLI is killed, and the agent is told it can retry.
 
+`scope='agent'` shares one session across runs only while the agent is held open with `async with agent:`; without it, every run still gets a fresh session:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.browser_use import BrowserUse
+
+agent = Agent('openai:gpt-5.5', capabilities=[BrowserUse(scope='agent')])
+
+async with agent:
+    await agent.run('Log into the dashboard')
+    await agent.run('Now read the numbers')  # same browser and variables
+```
+
 ## Agent spec (YAML/JSON)
 
 `BrowserUse` works with Pydantic AI's [agent spec](https://pydantic.dev/docs/ai/core-concepts/agent-spec/), so you can declare it in a config file instead of Python:

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -69,7 +69,7 @@ The agent writes Python to be executed within the browser and has a set of helpe
 
 The browser stays open between calls, so the agent signs in once and keeps working for the rest of the run. Its calls share one persistent Python session, so variables carry over too -- open handles included -- letting it gather results across several calls and use them at the end.
 
-When the agent's code raises, the traceback and exit code come back to it as a [`ModelRetry`](https://pydantic.dev/docs/ai/tools-toolsets/tools-advanced/#tool-retries) rather than a hard error. The run continues and the model can fix its code and try again. The same is true when the CLI is missing or a call times out.
+When the agent's code raises, the traceback and exit code come back to it in the tool output, along with anything it printed first. The run continues and the model can fix its code and try again. When the CLI is missing or a call times out, the tool raises a [`ModelRetry`](https://pydantic.dev/docs/ai/tools-toolsets/tools-advanced/#tool-retries) rather than a hard error.
 
 Files the code produces flow through two channels. Screenshots come back attached as images, so the model can look at the page it captured. Every other file stays on disk, and each path the code prints is listed on the tool return's [`metadata`](https://pydantic.dev/docs/ai/tools-toolsets/tools-advanced/#advanced-tool-returns) under `files` (path, media type, size). Your application reads it from the run's `ToolReturnPart`:
 

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -10,7 +10,7 @@ Give an agent a real web browser powered by the [Browser Use](https://browser-us
 uv add pydantic-ai-harness
 ```
 
-That is the only required step. The browser is driven by the `browser-use` CLI, which runs as a separate program rather than a Python import, so it is not a dependency of your project. When the CLI is not on your PATH, the tool runs `uvx browser-use` instead. When neither is available, it hands the agent the install command rather than failing the run.
+That is the only required step. The browser is controlled by the `browser-use` CLI.
 
 Installing the CLI outright avoids the first `uvx` run's download and pins the version you get:
 
@@ -18,25 +18,21 @@ Installing the CLI outright avoids the first `uvx` run's download and pins the v
 uv tool install browser-use
 ```
 
-Local browsing needs no account or API key. Check that the CLI reaches your browser:
+Check that the CLI connects to your browser:
 
 ```bash
 browser-use --doctor
 ```
 
-It attaches to a running Chrome or Chromium with remote debugging on, and walks you through turning it on if needed. For cloud browsers, see [Cloud browsers](#cloud-browsers).
+The CLI attaches to the Google Chrome or Chromium browser on your computer. For cloud browsers, see [Cloud browsers](#cloud-browsers).
 
 ## The problem
 
-An agent with search and fetch tools can read text on public websites, but it cannot use the web. Most of what people do involves actions: booking a flight, paying a bill, cancelling a subscription buried four clicks deep in account settings, pulling last year's invoices for an expense report, rescheduling a delivery, filling in the same details across a dozen job applications.
-
-None of that is reachable by reading. Fetch one of those pages and you get a login wall, a cookie banner, or an empty shell that fills in only once JavaScript runs. The work is behind a button, and a fetch tool has no way to press it.
-
-The same limit applies to an agent checking its own work. To confirm a fix really shipped, it has to sign in and click the button a user would click.
+An agent with search and fetch tools can read text on public websites, but it cannot use the web. Most of what people do involves actions: booking a flight, paying a bill, cancelling a subscription, finding invoices for an expense report, rescheduling a delivery, filling in the same details across a dozen job applications.
 
 ## The solution
 
-`BrowserUse` gives the agent one tool that drives a real browser: your local Chrome, already signed in to the sites you use, or a fresh browser in the cloud. The agent writes short Python that navigates, clicks, types, reads the page, and takes screenshots, and gets back whatever that code prints.
+`BrowserUse` gives the agent one tool that controls a real browser: your local Chrome, already signed into the websites you use, or a browser in the cloud. The agent writes Python in the browser that navigates, clicks, types, and reads the page.
 
 ```python
 from pydantic_ai import Agent
@@ -44,37 +40,38 @@ from pydantic_ai_harness.browser_use import BrowserUse
 
 agent = Agent('openai:gpt-5.5', capabilities=[BrowserUse()])
 
-result = agent.run_sync('Open news.ycombinator.com and summarize the top 5 stories.')
+result = agent.run_sync('Open news.ycombinator.com, and summarize the top 5 stories.')
 print(result.output)
 ```
 
 ## What agents do with it
 
-- **Read what sits behind a login.** Pull the numbers off a dashboard, an invoice out of a billing portal, a thread out of a support inbox -- through the session already open in your browser, with no API to wire up first.
-- **Fill in and submit.** Complete forms, place an order, file a ticket, upload a document, work through a checkout.
-- **Handle sites that only render in a browser.** Single-page apps, infinite scroll, filters and pagination that never change the URL.
-- **Test your own app.** Sign up, click through the flow, screenshot the result, check that a fix reached staging.
-- **Repeat the same admin work.** Copy a record from one internal tool into another, every morning, without an integration between them.
+These are what people most often ask a browser agent to do, in order of how common they are:
 
-## How it works
+- **Research and compare across sites.** Answer a question that takes several sources, rank options, or check a claim -- the top repositories on GitHub, which fund recently bought a stock, what an organization is affiliated with.
+- **Pull repeated records into a table.** Scrape products, listings, prices, reviews, or videos into structured output: every offer on an Amazon product page, or every venue on Google Maps in one city.
+- **Reach a page and act on it.** Open a site, get through to the right screen, and do one thing there -- often waiting for you to log in first, then carrying on.
+- **Test a website end to end.** Walk a real user flow, audit the UX, hunt for bugs, or re-check a page after a change.
+- **Build and run browser automation.** Write UI tests for a page, script a repeatable crawl, or reproduce an interaction step by step.
+- **Fill in forms and account flows.** Registrations, surveys, course modules, assessments, and other multi-page sequences.
+- **Shop and book.** Compare products, prices, sellers, and coupons, search listings against your criteria, and go through checkout or a booking.
+- **Apply for jobs and update systems.** Work through applications, or log into an admin tool and update records, listings, and settings.
 
-`BrowserUse` adds a single `browser_exec` tool that pipes the model's Python to the `browser-use` CLI on stdin. The CLI runs that code with browser helpers already imported (`new_tab`, `goto_url`, `page_info`, `js`, `fill_input`, `capture_screenshot`, and more) against a browser it keeps alive in a background daemon.
+## Tools
 
-Two things follow from running the CLI as a subprocess. The harness pulls in no new Python packages, so nothing collides with the versions your project pins. And because the daemon holds the browser open, tabs, cookies, and logins survive from one call to the next: the agent signs in once and keeps working for the rest of the run.
-
-One call also carries a whole step -- navigate, wait, extract, act -- rather than spending a model round trip per click.
-
-## The tool
+`BrowserUse` contributes one tool to the agent:
 
 | Tool | Purpose |
 |---|---|
-| `browser_exec` | Execute Python in the persistent browser session and return what it prints. Accepts optional `session` (named cloud browser) and `timeout_seconds`. |
+| `browser_exec` | Run Python in the browser and return whatever it prints. Optional `session` picks a named cloud browser; optional `timeout_seconds` bounds one call. |
 
-The browser and the model's Python variables both persist across calls, so the agent can gather results over several calls and use them later. Code that raises comes back to the model with the traceback and exit code, so it can correct itself and try again.
+The agent writes Python to be executed within the browser and has a set of helpers -- `new_tab`, `goto_url`, `page_info`, `js`, `fill_input`, `press_key`, `scroll`, `wait_for_element`, `capture_screenshot`, tab management, and more.
 
-One persistent Python session serves the whole run, so everything the code assigns survives to the next call -- including open handles that a snapshot could never carry. A call that times out restarts the session, while the browser itself is unaffected, since it lives in the CLI's daemon. Each agent run gets its own session, discarded when the run ends, so concurrent runs never see each other's variables; `scope='agent'` instead shares one session across every run inside `async with agent:`, which is what a chat loop wants.
+The browser stays open between calls, so the agent signs in once and keeps working for the rest of the run. Its calls share one persistent Python session, so variables carry over too -- open handles included -- letting it gather results across several calls and use them at the end.
 
-Files the code produces flow through two channels. Screenshots come back attached as images, so the model can look at the page it captured. Every other file stays on disk, and each path the code prints is listed on the tool return's `metadata` under `files` (path, media type, size). Your application reads it from the run's `ToolReturnPart`:
+When the agent's code raises, the traceback and exit code come back to it as a [`ModelRetry`](https://pydantic.dev/docs/ai/tools-toolsets/tools-advanced/#tool-retries) rather than a hard error. The run continues and the model can fix its code and try again. The same is true when the CLI is missing or a call times out.
+
+Files the code produces flow through two channels. Screenshots come back attached as images, so the model can look at the page it captured. Every other file stays on disk, and each path the code prints is listed on the tool return's [`metadata`](https://pydantic.dev/docs/ai/tools-toolsets/tools-advanced/#advanced-tool-returns) under `files` (path, media type, size). Your application reads it from the run's `ToolReturnPart`:
 
 ```python
 from pydantic_ai.messages import ModelRequest, ToolReturnPart
@@ -89,44 +86,46 @@ for message in result.all_messages():
 
 If your agent, for example, scrapes data and saves it as a CSV, you can then access the file.
 
-## Instructions
+## Choosing a browser
 
-The model is told about the browser twice, and the two sources divide the work.
+| `browser` | What it uses | Reach for it when |
+|---|---|---|
+| `'local'` (default) | Chrome or Chromium already running on your machine | You want the sites you are already signed into |
+| `'headless'` | It starts and stops headless Chromium for the run on a clean profile | You are on a server or CI, or several runs go at once and must not share tabs |
+| `'cloud'` | A [Browser Use Cloud](https://cloud.browser-use.com) browser | A site blocks automated traffic, or you want the run fully off your machine to run many browsers in parallel |
 
-The system prompt gets a short note, set with `guidance` (or `''` for none). It covers only what the CLI's own documentation cannot: that variables persist between calls here, unlike at the shell, and which values do not survive. Batching a whole step into one call is still worth doing, since it costs a round trip rather than a line of code.
+```python
+from pydantic_ai_harness.browser_use import BrowserUse
 
-The model also gets the CLI's own reference documentation, fetched once with `browser-use skill show` and appended to the `browser_exec` description. The model writes the Python this tool runs, so it needs that reference to write it correctly: full helper signatures, and the workflow the CLI recommends -- drive from the accessibility tree rather than screenshots, verify after each click, wait for load after navigating, stop and ask at a login wall, and prefer a plain HTTP fetch when no browser is needed. It is the same text the CLI hands to any other agent, and it tracks whichever CLI version is installed.
+BrowserUse(browser='headless')
+```
 
-When the CLI is missing or slow to answer, the tool keeps its short built-in description; a setup problem then surfaces when the model calls the tool, rather than breaking agent construction.
+`'local'` shares one browser with everything else on the machine, so you can only run one task at a time. `'headless'` and `'cloud'` give each run its own browser, and both start signed out. You can import your logins to a cloud browser and run as many tasks as you want, and it automatically bypasses CAPTCHAs if necessary.
+
+To point at a browser you are running yourself, set the `BU_CDP_URL` environment variable to its DevTools endpoint.
 
 ## Cloud browsers
 
-Cloud browsers are optional. Reach for one when the agent runs on a headless server, when several agents browse at once (they would otherwise fight over the tabs of one local Chrome), or when a site blocks automated traffic -- Browser Use runs cloud browsers with managed IPs and stealth settings.
-
-Sign in once and the CLI stores the credentials:
+Cloud browsers need an account. Sign in once, and the CLI remembers it:
 
 ```bash
-browser-use auth login    # add --device-code over SSH
+browser-use auth login
 browser-use auth status   # confirm it worked
 ```
 
-Or set the key yourself. Create one at <https://cloud.browser-use.com>, then export it:
+Or set the key yourself, from <https://cloud.browser-use.com>:
 
 ```bash
 export BROWSER_USE_API_KEY=your-key
 ```
 
-The environment variable wins when both are set.
-
-To run in a named cloud browser, the agent starts one with `start_remote_daemon('<name>')` and passes that name as the tool's `session` argument. To carry your logins into it, first sync your local browser profile (interactive; prints the profile to use, and re-sync when a site's login expires):
+To import all the websites you're logged into on your computer to a cloud browser, so it can complete tasks while signed into your accounts, sync your Chrome profile:
 
 ```bash
 export BROWSER_USE_API_KEY=your-key && curl -fsSL https://browser-use.com/profile.sh | sh
 ```
 
-then attach it when the browser is created: `start_remote_daemon('<name>', profileName='<profile>')`. A cloud browser without a profile starts logged out.
-
-## Options
+## Configuration
 
 Every field of `BrowserUse` with its default:
 
@@ -142,24 +141,18 @@ BrowserUse(
 )
 ```
 
-On timeout the CLI's process group is killed and the model is told it can retry; the browser daemon keeps running, so the session is not lost. To attach to a browser you run yourself, set the `BU_CDP_URL` environment variable to its DevTools endpoint; `BH_CHROME_PATH` picks the binary for headless mode.
-
-## Security
-
-The agent's code runs on your machine with no sandbox, and it reaches every site your browser is signed in to. Treat `BrowserUse` the way you treat `Shell`: give it to agents whose prompts you control. LLM provider API keys (`OPENAI_*`, `ANTHROPIC_*`, `GOOGLE_*`, ...) are scrubbed from the browser subprocess automatically; your Browser Use cloud credentials pass through, since the CLI needs them.
-
-For stronger isolation, point the agent at a cloud browser rather than your local Chrome: it starts clean, sees none of your logged-in sessions, and carries only the cookies you sync to it.
+On a timeout, the CLI is killed, and the agent is told it can retry.
 
 ## Agent spec (YAML/JSON)
 
-`BrowserUse` works with Pydantic AI's [agent spec](https://ai.pydantic.dev/agent-spec/):
+`BrowserUse` works with Pydantic AI's [agent spec](https://pydantic.dev/docs/ai/core-concepts/agent-spec/), so you can declare it in a config file instead of Python:
 
 ```yaml
 # agent.yaml
 model: openai:gpt-5.5
 capabilities:
   - BrowserUse:
-      workspace: /tmp/agent-workspace
+      browser: cloud
       default_timeout: 600
 ```
 
@@ -170,10 +163,10 @@ from pydantic_ai_harness.browser_use import BrowserUse
 agent = Agent.from_file('agent.yaml', custom_capability_types=[BrowserUse])
 ```
 
-Pass `custom_capability_types` so the spec loader knows how to instantiate `BrowserUse`.
+Pass `custom_capability_types`, so the spec loader knows how to build `BrowserUse`.
 
 ## Further reading
 
 - [Browser Use documentation](https://docs.browser-use.com)
-- [Pydantic AI capabilities](https://ai.pydantic.dev/capabilities/)
-- [Toolsets](https://ai.pydantic.dev/toolsets/)
+- [Pydantic AI capabilities](https://pydantic.dev/docs/ai/capabilities/overview/)
+- [Toolsets](https://pydantic.dev/docs/ai/tools-toolsets/toolsets/)

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -163,7 +163,7 @@ from pydantic_ai_harness.browser_use import BrowserUse
 agent = Agent.from_file('agent.yaml', custom_capability_types=[BrowserUse])
 ```
 
-Pass `custom_capability_types`, so the spec loader knows how to build `BrowserUse`.
+Pass `custom_capability_types`, so the spec loader knows how to build `BrowserUse`. Loading YAML needs the `spec` extra: `uv add 'pydantic-ai-slim[spec]'`.
 
 ## Further reading
 

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -1,0 +1,165 @@
+# Browser Use
+
+Give an agent a real web browser powered by the [Browser Use](https://browser-use.com) CLI: automate your local browser, or spin up one in the cloud, to click, type, extract data, fill out forms, and complete tasks. Connecting to your local browser needs no API key, and it works with your websites already logged in.
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/browser_use/)
+
+## Installation
+
+```bash
+uv add pydantic-ai-harness
+```
+
+That is the only required step. The browser is driven by the `browser-use` CLI, which runs as a separate program rather than a Python import, so it is not a dependency of your project. When the CLI is not on your PATH, the tool runs `uvx browser-use` instead. When neither is available, it hands the agent the install command rather than failing the run.
+
+Installing the CLI outright avoids the first `uvx` run's download and pins the version you get:
+
+```bash
+uv tool install browser-use
+```
+
+Local browsing needs no account or API key. Check that the CLI reaches your browser:
+
+```bash
+browser-use --doctor
+```
+
+It attaches to a running Chrome or Chromium with remote debugging on, and walks you through turning it on if needed. For cloud browsers, see [Cloud browsers](#cloud-browsers).
+
+## The problem
+
+An agent with search and fetch tools can read text on public websites, but it cannot use the web. Most of what people do involves actions: booking a flight, paying a bill, cancelling a subscription buried four clicks deep in account settings, pulling last year's invoices for an expense report, rescheduling a delivery, filling in the same details across a dozen job applications.
+
+None of that is reachable by reading. Fetch one of those pages and you get a login wall, a cookie banner, or an empty shell that fills in only once JavaScript runs. The work is behind a button, and a fetch tool has no way to press it.
+
+The same limit applies to an agent checking its own work. To confirm a fix really shipped, it has to sign in and click the button a user would click.
+
+## The solution
+
+`BrowserUse` gives the agent one tool that drives a real browser: your local Chrome, already signed in to the sites you use, or a fresh browser in the cloud. The agent writes short Python that navigates, clicks, types, reads the page, and takes screenshots, and gets back whatever that code prints.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.browser_use import BrowserUse
+
+agent = Agent('openai:gpt-5.5', capabilities=[BrowserUse()])
+
+result = agent.run_sync('Open news.ycombinator.com and summarize the top 5 stories.')
+print(result.output)
+```
+
+## What agents do with it
+
+- **Read what sits behind a login.** Pull the numbers off a dashboard, an invoice out of a billing portal, a thread out of a support inbox -- through the session already open in your browser, with no API to wire up first.
+- **Fill in and submit.** Complete forms, place an order, file a ticket, upload a document, work through a checkout.
+- **Handle sites that only render in a browser.** Single-page apps, infinite scroll, filters and pagination that never change the URL.
+- **Test your own app.** Sign up, click through the flow, screenshot the result, check that a fix reached staging.
+- **Repeat the same admin work.** Copy a record from one internal tool into another, every morning, without an integration between them.
+
+## How it works
+
+`BrowserUse` adds a single `browser_exec` tool that pipes the model's Python to the `browser-use` CLI on stdin. The CLI runs that code with browser helpers already imported (`new_tab`, `goto_url`, `page_info`, `js`, `fill_input`, `capture_screenshot`, and more) against a browser it keeps alive in a background daemon.
+
+Two things follow from running the CLI as a subprocess. The harness pulls in no new Python packages, so nothing collides with the versions your project pins. And because the daemon holds the browser open, tabs, cookies, and logins survive from one call to the next: the agent signs in once and keeps working for the rest of the run.
+
+One call also carries a whole step -- navigate, wait, extract, act -- rather than spending a model round trip per click.
+
+## The tool
+
+| Tool | Purpose |
+|---|---|
+| `browser_exec` | Execute Python in the persistent browser session and return what it prints. Accepts optional `session` (named cloud browser) and `timeout_seconds`. |
+
+The browser and the model's Python variables both persist across calls, so the agent can gather results over several calls and use them later. Code that raises comes back to the model with the traceback and exit code, so it can correct itself and try again.
+
+One persistent Python session serves the whole run, so everything the code assigns survives to the next call -- including open handles that a snapshot could never carry. A call that times out restarts the session, while the browser itself is unaffected, since it lives in the CLI's daemon. Each agent run gets its own session, discarded when the run ends, so concurrent runs never see each other's variables; `scope='agent'` instead shares one session across every run inside `async with agent:`, which is what a chat loop wants.
+
+## Instructions
+
+The model is told about the browser twice, and the two sources divide the work.
+
+The system prompt gets a short note, set with `guidance` (or `''` for none). It covers only what the CLI's own documentation cannot: that variables persist between calls here, unlike at the shell, and which values do not survive. Batching a whole step into one call is still worth doing, since it costs a round trip rather than a line of code.
+
+The model also gets the CLI's own reference documentation, fetched once with `browser-use skill show` and appended to the `browser_exec` description. The model writes the Python this tool runs, so it needs that reference to write it correctly: full helper signatures, and the workflow the CLI recommends -- drive from the accessibility tree rather than screenshots, verify after each click, wait for load after navigating, stop and ask at a login wall, and prefer a plain HTTP fetch when no browser is needed. It is the same text the CLI hands to any other agent, and it tracks whichever CLI version is installed.
+
+When the CLI is missing or slow to answer, the tool keeps its short built-in description; a setup problem then surfaces when the model calls the tool, rather than breaking agent construction.
+
+## Cloud browsers
+
+Cloud browsers are optional. Reach for one when the agent runs on a headless server, when several agents browse at once (they would otherwise fight over the tabs of one local Chrome), or when a site blocks automated traffic -- Browser Use runs cloud browsers with managed IPs and stealth settings.
+
+Sign in once and the CLI stores the credentials:
+
+```bash
+browser-use auth login    # add --device-code over SSH
+browser-use auth status   # confirm it worked
+```
+
+Or set the key yourself. Create one at <https://cloud.browser-use.com>, then export it:
+
+```bash
+export BROWSER_USE_API_KEY=your-key
+```
+
+The environment variable wins when both are set.
+
+To run in a named cloud browser, the agent starts one with `start_remote_daemon('<name>')` and passes that name as the tool's `session` argument. To carry your logins into it, first sync your local browser profile (interactive; prints the profile to use, and re-sync when a site's login expires):
+
+```bash
+export BROWSER_USE_API_KEY=your-key && curl -fsSL https://browser-use.com/profile.sh | sh
+```
+
+then attach it when the browser is created: `start_remote_daemon('<name>', profileName='<profile>')`. A cloud browser without a profile starts logged out.
+
+## Options
+
+Every field of `BrowserUse` with its default:
+
+```python
+from pydantic_ai_harness.browser_use import BrowserUse
+
+BrowserUse(
+    browser='local',         # 'local', 'headless', or 'cloud'
+    scope='run',             # 'agent' shares one session across runs (chat loops)
+    command='browser-use',   # CLI name or path
+    default_timeout=300.0,   # seconds per call when the agent gives no timeout
+    progress=None,           # narrate steps live, e.g. progress=print
+    guidance=None,           # None = default instructions, '' = none, str = custom
+)
+```
+
+On timeout the CLI's process group is killed and the model is told it can retry; the browser daemon keeps running, so the session is not lost. To attach to a browser you run yourself, set the `BU_CDP_URL` environment variable to its DevTools endpoint; `BH_CHROME_PATH` picks the binary for headless mode.
+
+## Security
+
+The agent's code runs on your machine with no sandbox, and it reaches every site your browser is signed in to. Treat `BrowserUse` the way you treat `Shell`: give it to agents whose prompts you control. LLM provider API keys (`OPENAI_*`, `ANTHROPIC_*`, `GOOGLE_*`, ...) are scrubbed from the browser subprocess automatically; your Browser Use cloud credentials pass through, since the CLI needs them.
+
+For stronger isolation, point the agent at a cloud browser rather than your local Chrome: it starts clean, sees none of your logged-in sessions, and carries only the cookies you sync to it.
+
+## Agent spec (YAML/JSON)
+
+`BrowserUse` works with Pydantic AI's [agent spec](https://ai.pydantic.dev/agent-spec/):
+
+```yaml
+# agent.yaml
+model: openai:gpt-5.5
+capabilities:
+  - BrowserUse:
+      workspace: /tmp/agent-workspace
+      default_timeout: 600
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.browser_use import BrowserUse
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[BrowserUse])
+```
+
+Pass `custom_capability_types` so the spec loader knows how to instantiate `BrowserUse`.
+
+## Further reading
+
+- [Browser Use documentation](https://docs.browser-use.com)
+- [Pydantic AI capabilities](https://ai.pydantic.dev/capabilities/)
+- [Toolsets](https://ai.pydantic.dev/toolsets/)

--- a/pydantic_ai_harness/browser_use/__init__.py
+++ b/pydantic_ai_harness/browser_use/__init__.py
@@ -1,0 +1,14 @@
+"""Browser Use: drive a real web browser through the Browser Use CLI"""
+# ruff: noqa: D415
+
+from pydantic_ai_harness.browser_use._capability import BrowserUse
+from pydantic_ai_harness.browser_use._progress import browser_progress
+from pydantic_ai_harness.browser_use._toolset import BrowserUseToolset, adapt_skill_to_tool, find_chrome
+
+__all__ = [
+    'BrowserUse',
+    'BrowserUseToolset',
+    'browser_progress',
+    'adapt_skill_to_tool',
+    'find_chrome',
+]

--- a/pydantic_ai_harness/browser_use/_capability.py
+++ b/pydantic_ai_harness/browser_use/_capability.py
@@ -3,17 +3,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass, field
-from pathlib import Path
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Literal
 
 from pydantic_ai._instructions import AgentInstructions
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.tools import AgentDepsT, RunContext
 
-from pydantic_ai_harness.browser_use._progress import Detail
-from pydantic_ai_harness.browser_use._toolset import SESSION_RE, SKILL_HEADER, BrowserUseToolset
+from pydantic_ai_harness.browser_use._toolset import SKILL_HEADER, BrowserUseToolset
 
 _BROWSER_INSTRUCTIONS = (
     'Both the browser and your Python variables persist between `browser_exec` calls, so you can '
@@ -40,67 +38,28 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
     ```
 
     Needs the `browser-use` CLI (`uv tool install browser-use`); falls back to
-    `uvx browser-use` when `uvx` is available.
+    `uvx browser-use` when `uvx` is available. LLM provider API keys are
+    scrubbed from the CLI subprocess automatically.
     """
 
     browser: Literal['local', 'headless', 'cloud'] = 'local'
     """'local' = the Chrome already running here, logins included; 'headless' = a
-    throwaway Chrome launched per run; 'cloud' = a Browser Use cloud browser
-    (needs auth, bills while running). Ignored when `cdp_url` is set."""
-
-    cloud_session: str | None = None
-    """Attach to a cloud browser you manage, instead of one per run"""
-
-    cloud_timeout_minutes: int = 60
-    """Server-side lifetime cap on a per-run cloud browser (1-240); the billing
-    backstop when the process dies before cleanup"""
-
-    chrome_path: str | None = None
-    """Chrome or Chromium executable to launch when `browser='headless'`"""
-
-    cdp_url: str | None = None
-    """Connect to an existing browser over CDP instead of finding one"""
-
-    command: str = 'browser-use'
-    """Name or path of the CLI binary"""
-
-    cwd: str | Path = '.'
-    """Working directory the CLI runs in"""
-
-    default_timeout: float = 300.0
-    """Seconds per call when the model passes no `timeout_seconds`"""
-
-    max_timeout: float = 1800.0
-    """Cap on a model-supplied `timeout_seconds`"""
-
-    max_output_chars: int = 50_000
-    """Output cap per call, keeping the tail"""
-
-    workspace: str | Path | None = None
-    """CLI agent-workspace dir (`BH_AGENT_WORKSPACE`); persists across calls"""
-
-    env: Mapping[str, str] | None = None
-    """Explicit environment for the CLI subprocess, replacing inheritance"""
-
-    denied_env_patterns: Sequence[str] = field(default_factory=list[str])
-    """Glob patterns for environment variable names to strip before spawning"""
-
-    fallback_to_uvx: bool = True
-    """Run `uvx browser-use` when the CLI is not on PATH"""
-
-    persist_variables: bool = True
-    """One persistent Python session per run: variables survive between calls, a
-    timeout restarts the session (the browser survives). `False` = stateless."""
+    throwaway Chrome launched per run (`BH_CHROME_PATH` picks the binary);
+    'cloud' = a Browser Use cloud browser, provisioned and stopped per run
+    (needs auth, bills while running)."""
 
     scope: Literal['run', 'agent'] = 'run'
     """'run' = fresh session per run, safe concurrently; 'agent' = one session
     shared across runs inside `async with agent:` (chat loops)"""
 
-    progress: Callable[[str], None] | None = None
-    """Sink for live narration of browser calls, e.g. `print`"""
+    command: str = 'browser-use'
+    """Name or path of the CLI binary"""
 
-    progress_detail: Detail = 'steps'
-    """'steps' = one label per call plus errors; 'code' = also code and output"""
+    default_timeout: float = 300.0
+    """Seconds per call when the model passes no `timeout_seconds`"""
+
+    progress: Callable[[str], None] | None = None
+    """Sink for live narration of browser steps, e.g. `print`"""
 
     guidance: str | None = None
     """Replace the default system-prompt guidance; `''` disables it"""
@@ -109,36 +68,15 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
         """Reject out-of-range configuration"""
         if self.default_timeout <= 0:
             raise ValueError(f'default_timeout must be positive, got {self.default_timeout}')
-        if self.max_timeout < self.default_timeout:
-            raise ValueError(f'max_timeout ({self.max_timeout}) must be >= default_timeout ({self.default_timeout})')
-        if self.max_output_chars <= 0:
-            raise ValueError(f'max_output_chars must be positive, got {self.max_output_chars}')
-        if not 1 <= self.cloud_timeout_minutes <= 240:
-            raise ValueError(f'cloud_timeout_minutes must be between 1 and 240, got {self.cloud_timeout_minutes}')
-        if self.cloud_session is not None and SESSION_RE.match(self.cloud_session) is None:
-            raise ValueError(f'invalid cloud_session {self.cloud_session!r}: use 1-64 chars from [A-Za-z0-9_-]')
 
     def get_toolset(self) -> BrowserUseToolset[AgentDepsT]:
         """Build the toolset that provides the `browser_exec` tool"""
         return BrowserUseToolset[AgentDepsT](
             command=self.command,
-            cwd=Path(self.cwd),
             default_timeout=self.default_timeout,
-            max_timeout=self.max_timeout,
-            max_output_chars=self.max_output_chars,
-            workspace=Path(self.workspace) if self.workspace is not None else None,
-            env=self.env,
-            denied_env_patterns=self.denied_env_patterns,
-            fallback_to_uvx=self.fallback_to_uvx,
-            persist_variables=self.persist_variables,
             browser=self.browser,
-            cloud_session=self.cloud_session,
-            cloud_timeout_minutes=self.cloud_timeout_minutes,
-            cdp_url=self.cdp_url,
-            chrome_path=self.chrome_path,
             scope=self.scope,
             progress=self.progress,
-            progress_detail=self.progress_detail,
         )
 
     def get_instructions(self) -> AgentInstructions[AgentDepsT]:

--- a/pydantic_ai_harness/browser_use/_capability.py
+++ b/pydantic_ai_harness/browser_use/_capability.py
@@ -65,6 +65,10 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
         """Reject out-of-range configuration"""
         if self.default_timeout <= 0:
             raise ValueError(f'default_timeout must be positive, got {self.default_timeout}')
+        if self.browser not in ('local', 'headless', 'cloud'):
+            raise ValueError(f"browser must be 'local', 'headless', or 'cloud', got {self.browser!r}")
+        if self.scope not in ('run', 'agent'):
+            raise ValueError(f"scope must be 'run' or 'agent', got {self.scope!r}")
 
     def get_toolset(self) -> BrowserUseToolset[AgentDepsT]:
         """Build the toolset that provides the `browser_exec` tool"""

--- a/pydantic_ai_harness/browser_use/_capability.py
+++ b/pydantic_ai_harness/browser_use/_capability.py
@@ -52,9 +52,6 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
     """'run' = fresh session per run, safe concurrently; 'agent' = one session
     shared across runs inside `async with agent:` (chat loops)"""
 
-    command: str = 'browser-use'
-    """Name or path of the CLI binary"""
-
     default_timeout: float = 300.0
     """Seconds per call when the model passes no `timeout_seconds`"""
 
@@ -72,7 +69,6 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> BrowserUseToolset[AgentDepsT]:
         """Build the toolset that provides the `browser_exec` tool"""
         return BrowserUseToolset[AgentDepsT](
-            command=self.command,
             default_timeout=self.default_timeout,
             browser=self.browser,
             scope=self.scope,

--- a/pydantic_ai_harness/browser_use/_capability.py
+++ b/pydantic_ai_harness/browser_use/_capability.py
@@ -1,0 +1,158 @@
+"""Browser Use capability via the Browser Use CLI"""
+# ruff: noqa: D415
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from pydantic_ai._instructions import AgentInstructions
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.tools import AgentDepsT, RunContext
+
+from pydantic_ai_harness.browser_use._progress import Detail
+from pydantic_ai_harness.browser_use._toolset import SESSION_RE, SKILL_HEADER, BrowserUseToolset
+
+_BROWSER_INSTRUCTIONS = (
+    'Both the browser and your Python variables persist between `browser_exec` calls, so you can '
+    'collect results over several calls and use them later. If a call times out, the Python '
+    'session restarts while the browser survives, so re-derive what you need from the page. '
+    'Batching a whole step (navigate, wait, extract, act) into one call is still faster than one '
+    'call per action.'
+)
+
+
+@dataclass
+class BrowserUse(AbstractCapability[AgentDepsT]):
+    """Web browsing for agents powered by the [Browser Use](https://browser-use.com) CLI.
+
+    Adds a `browser_exec` tool: model-written Python runs against a persistent
+    browser session -- local Chrome over CDP, a headless Chrome, or a Browser Use
+    cloud browser. Local browsing needs no account or API key.
+
+    ```python
+    from pydantic_ai import Agent
+    from pydantic_ai_harness.browser_use import BrowserUse
+
+    agent = Agent('openai:gpt-5.5', capabilities=[BrowserUse()])
+    ```
+
+    Needs the `browser-use` CLI (`uv tool install browser-use`); falls back to
+    `uvx browser-use` when `uvx` is available.
+    """
+
+    browser: Literal['local', 'headless', 'cloud'] = 'local'
+    """'local' = the Chrome already running here, logins included; 'headless' = a
+    throwaway Chrome launched per run; 'cloud' = a Browser Use cloud browser
+    (needs auth, bills while running). Ignored when `cdp_url` is set."""
+
+    cloud_session: str | None = None
+    """Attach to a cloud browser you manage, instead of one per run"""
+
+    cloud_timeout_minutes: int = 60
+    """Server-side lifetime cap on a per-run cloud browser (1-240); the billing
+    backstop when the process dies before cleanup"""
+
+    chrome_path: str | None = None
+    """Chrome or Chromium executable to launch when `browser='headless'`"""
+
+    cdp_url: str | None = None
+    """Connect to an existing browser over CDP instead of finding one"""
+
+    command: str = 'browser-use'
+    """Name or path of the CLI binary"""
+
+    cwd: str | Path = '.'
+    """Working directory the CLI runs in"""
+
+    default_timeout: float = 300.0
+    """Seconds per call when the model passes no `timeout_seconds`"""
+
+    max_timeout: float = 1800.0
+    """Cap on a model-supplied `timeout_seconds`"""
+
+    max_output_chars: int = 50_000
+    """Output cap per call, keeping the tail"""
+
+    workspace: str | Path | None = None
+    """CLI agent-workspace dir (`BH_AGENT_WORKSPACE`); persists across calls"""
+
+    env: Mapping[str, str] | None = None
+    """Explicit environment for the CLI subprocess, replacing inheritance"""
+
+    denied_env_patterns: Sequence[str] = field(default_factory=list[str])
+    """Glob patterns for environment variable names to strip before spawning"""
+
+    fallback_to_uvx: bool = True
+    """Run `uvx browser-use` when the CLI is not on PATH"""
+
+    persist_variables: bool = True
+    """One persistent Python session per run: variables survive between calls, a
+    timeout restarts the session (the browser survives). `False` = stateless."""
+
+    scope: Literal['run', 'agent'] = 'run'
+    """'run' = fresh session per run, safe concurrently; 'agent' = one session
+    shared across runs inside `async with agent:` (chat loops)"""
+
+    progress: Callable[[str], None] | None = None
+    """Sink for live narration of browser calls, e.g. `print`"""
+
+    progress_detail: Detail = 'steps'
+    """'steps' = one label per call plus errors; 'code' = also code and output"""
+
+    guidance: str | None = None
+    """Replace the default system-prompt guidance; `''` disables it"""
+
+    def __post_init__(self) -> None:
+        """Reject out-of-range configuration"""
+        if self.default_timeout <= 0:
+            raise ValueError(f'default_timeout must be positive, got {self.default_timeout}')
+        if self.max_timeout < self.default_timeout:
+            raise ValueError(f'max_timeout ({self.max_timeout}) must be >= default_timeout ({self.default_timeout})')
+        if self.max_output_chars <= 0:
+            raise ValueError(f'max_output_chars must be positive, got {self.max_output_chars}')
+        if not 1 <= self.cloud_timeout_minutes <= 240:
+            raise ValueError(f'cloud_timeout_minutes must be between 1 and 240, got {self.cloud_timeout_minutes}')
+        if self.cloud_session is not None and SESSION_RE.match(self.cloud_session) is None:
+            raise ValueError(f'invalid cloud_session {self.cloud_session!r}: use 1-64 chars from [A-Za-z0-9_-]')
+
+    def get_toolset(self) -> BrowserUseToolset[AgentDepsT]:
+        """Build the toolset that provides the `browser_exec` tool"""
+        return BrowserUseToolset[AgentDepsT](
+            command=self.command,
+            cwd=Path(self.cwd),
+            default_timeout=self.default_timeout,
+            max_timeout=self.max_timeout,
+            max_output_chars=self.max_output_chars,
+            workspace=Path(self.workspace) if self.workspace is not None else None,
+            env=self.env,
+            denied_env_patterns=self.denied_env_patterns,
+            fallback_to_uvx=self.fallback_to_uvx,
+            persist_variables=self.persist_variables,
+            browser=self.browser,
+            cloud_session=self.cloud_session,
+            cloud_timeout_minutes=self.cloud_timeout_minutes,
+            cdp_url=self.cdp_url,
+            chrome_path=self.chrome_path,
+            scope=self.scope,
+            progress=self.progress,
+            progress_detail=self.progress_detail,
+        )
+
+    def get_instructions(self) -> AgentInstructions[AgentDepsT]:
+        """Contribute the capability's guidance plus the CLI's own skill documentation"""
+
+        async def instructions(ctx: RunContext[AgentDepsT]) -> str | None:
+            parts: list[str] = []
+            if self.guidance is None:
+                parts.append(_BROWSER_INSTRUCTIONS)
+            elif self.guidance:
+                parts.append(self.guidance)
+            skill = await self.get_toolset().cli_skill_text()
+            if skill is not None:
+                parts.append(f'{SKILL_HEADER.strip()}\n\n{skill}')
+            return '\n\n'.join(parts) or None
+
+        return instructions

--- a/pydantic_ai_harness/browser_use/_progress.py
+++ b/pydantic_ai_harness/browser_use/_progress.py
@@ -56,7 +56,7 @@ def narrate_result(sink: Callable[[str], None], text: str, images: int, detail: 
     if detail == 'steps' and not failed:
         return
     limit = ERROR_LIMIT if failed else OUTPUT_LIMIT
-    sink(indent(clip(text.rstrip(), limit), '  | '))
+    sink(indent(clip(text.rstrip(), limit, from_end=failed), '  | '))
     if images and detail == 'code':
         sink(f'  | [{images} screenshot{"s" if images > 1 else ""} attached]')
 
@@ -70,8 +70,11 @@ def indent(text: str, prefix: str) -> str:
     return '\n'.join(prefix + line for line in text.splitlines())
 
 
-def clip(text: str, limit: int) -> str:
-    return text if len(text) <= limit else text[:limit] + ' ...'
+def clip(text: str, limit: int, *, from_end: bool = False) -> str:
+    """Truncate to `limit`; `from_end` keeps the tail, where error markers live"""
+    if len(text) <= limit:
+        return text
+    return '... ' + text[-limit:] if from_end else text[:limit] + ' ...'
 
 
 def browser_progress(
@@ -108,7 +111,7 @@ def browser_progress(
                 if detail == 'steps' and not failed:
                     continue
                 limit = error_limit if failed else output_limit
-                sink(indent(clip(text, limit), '  | '))
+                sink(indent(clip(text, limit, from_end=failed), '  | '))
                 if images and detail == 'code':
                     sink(f'  | [{images} screenshot{"s" if images > 1 else ""} attached]')
 

--- a/pydantic_ai_harness/browser_use/_progress.py
+++ b/pydantic_ai_harness/browser_use/_progress.py
@@ -1,0 +1,115 @@
+"""Progress reporting for `browser_exec`"""
+# ruff: noqa: D415
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterable, Callable
+from typing import Any, Literal
+
+from pydantic_ai.messages import (
+    AgentStreamEvent,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    RetryPromptPart,
+    ToolReturn,
+)
+from pydantic_ai.tools import RunContext
+
+_TOOL_NAME = 'browser_exec'
+
+Detail = Literal['steps', 'code']
+"""'steps' = one label line per call plus errors; 'code' = also the raw Python and output"""
+
+STEP_LABEL_LIMIT = 80
+
+ERROR_MARKER = '[exit code:'
+"""Present in tool output whenever the executed code failed"""
+
+CODE_LIMIT = 2_000
+OUTPUT_LIMIT = 800
+ERROR_LIMIT = 4_000  # tracebacks deserve more room than ordinary output
+
+
+def step_label(code: str) -> str:
+    """Leading `#` comment if the model wrote one, else the first code line"""
+    for line in code.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith('#'):
+            label = stripped.lstrip('#').strip()
+            return clip(label, STEP_LABEL_LIMIT) if label else '(browser step)'
+        return clip(stripped, STEP_LABEL_LIMIT)
+    return '(browser step)'
+
+
+def narrate_call(sink: Callable[[str], None], code: str, detail: Detail = 'code') -> None:
+    """Report one `browser_exec` invocation before it runs"""
+    sink(f'* {step_label(code)}')
+    if detail == 'code':
+        sink(indent(clip(code.rstrip(), CODE_LIMIT), '    '))
+
+
+def narrate_result(sink: Callable[[str], None], text: str, images: int, detail: Detail = 'code') -> None:
+    """Report what one invocation produced; in 'steps' detail only failures surface"""
+    failed = ERROR_MARKER in text
+    if detail == 'steps' and not failed:
+        return
+    limit = ERROR_LIMIT if failed else OUTPUT_LIMIT
+    sink(indent(clip(text.rstrip(), limit), '  | '))
+    if images and detail == 'code':
+        sink(f'  | [{images} screenshot{"s" if images > 1 else ""} attached]')
+
+
+def narrate_error(sink: Callable[[str], None], message: str) -> None:
+    """Report a call the tool rejected or that failed before producing output"""
+    sink(indent(clip(message, ERROR_LIMIT), '  ! '))
+
+
+def indent(text: str, prefix: str) -> str:
+    return '\n'.join(prefix + line for line in text.splitlines())
+
+
+def clip(text: str, limit: int) -> str:
+    return text if len(text) <= limit else text[:limit] + ' ...'
+
+
+def browser_progress(
+    sink: Callable[[str], None] = print,
+    *,
+    detail: Detail = 'steps',
+    code_limit: int = CODE_LIMIT,
+    output_limit: int = OUTPUT_LIMIT,
+    error_limit: int = ERROR_LIMIT,
+) -> Callable[[RunContext[Any], AsyncIterable[AgentStreamEvent]], Any]:
+    """Build an `event_stream_handler` that narrates the agent's browser activity"""
+
+    async def handler(ctx: RunContext[Any], events: AsyncIterable[AgentStreamEvent]) -> None:
+        async for event in events:
+            if isinstance(event, FunctionToolCallEvent) and event.part.tool_name == _TOOL_NAME:
+                code = str(event.part.args_as_dict().get('code', ''))
+                sink(f'* {step_label(code)}')
+                if detail == 'code':
+                    sink(indent(clip(code.rstrip(), code_limit), '    '))
+            elif isinstance(event, FunctionToolResultEvent) and event.part.tool_name == _TOOL_NAME:
+                if isinstance(event.part, RetryPromptPart):
+                    sink(indent(clip(event.part.model_response(), error_limit), '  ! '))
+                    continue
+
+                # the agent unwraps ToolReturn before emitting: text on part.content, media on event.content
+                content = event.part.content
+                extra: list[object] = list(event.content) if isinstance(event.content, list) else []
+                if isinstance(content, ToolReturn):  # pragma: no cover - direct-call paths only
+                    extra = list(content.content or [])
+                    content = content.return_value
+                images = sum(1 for item in extra if not isinstance(item, str))
+                text = str(content).rstrip()
+                failed = ERROR_MARKER in text
+                if detail == 'steps' and not failed:
+                    continue
+                limit = error_limit if failed else output_limit
+                sink(indent(clip(text, limit), '  | '))
+                if images and detail == 'code':
+                    sink(f'  | [{images} screenshot{"s" if images > 1 else ""} attached]')
+
+    return handler

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -1,0 +1,693 @@
+"""Browser Use toolset: runs model-written Python through the `browser-use` CLI"""
+# ruff: noqa: D415
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+import anyio
+import anyio.abc
+import anyio.to_thread
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import BinaryContent, ToolReturn
+from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
+
+from pydantic_ai_harness.browser_use._progress import Detail, narrate_call, narrate_error, narrate_result
+
+_INSTALL_HINT = (
+    'The `browser-use` CLI was not found on PATH, and no `uvx` fallback was available. Install it with:\n'
+    '    uv tool install browser-use\n'
+    'then run `browser-use --doctor` once to verify the browser connection.'
+)
+
+_SKILL_FETCH_TIMEOUT = 30.0
+
+_ERROR_TAIL_CHARS = 2000
+"""Tail of CLI output shown when cloud provisioning fails"""
+
+SKILL_HEADER = """
+
+--- Browser Use CLI reference ---
+
+"""
+
+_SKILL_CACHE: dict[str, str | None] = {}
+"""Skill text per command, fetched once per process"""
+
+_HEREDOC_RE = re.compile(
+    r"(?:BU_NAME=(?P<session>\S+)[ \t]+)?browser-use[ \t]*<<'PY'\n(?P<code>.*?)\nPY\n?",
+    re.DOTALL,
+)
+"""One heredoc invocation, with optional `BU_NAME=` prefix"""
+
+_BASH_BLOCK_RE = re.compile(r'```bash\n(?P<body>.*?)```', re.DOTALL)
+
+_PROSE_SUBS = (
+    (
+        re.compile(r'- Invoke as `browser-use`\. Use heredocs for multi-line commands\.'),
+        "- Pass the Python as this tool's `code` argument.",
+    ),
+    (re.compile(r'BU_NAME=(?P<name>\S+)'), r'session=\g<name>'),
+    (re.compile(r'`BU_NAME`'), '`session`'),
+)
+
+
+def _heredoc_to_code(match: re.Match[str]) -> str:
+    """Unwrap one shell invocation into the Python it would have piped"""
+    code = match.group('code')
+    session = match.group('session')
+    if session is None:
+        return f'{code}\n'
+    return f'# pass session={session!r} to this tool\n{code}\n'
+
+
+def _rewrite_bash_block(match: re.Match[str]) -> str:
+    """Turn a fenced shell block of heredocs into a Python block, leaving other shell blocks alone"""
+    body = match.group('body')
+    if "<<'PY'" not in body:
+        return match.group(0)
+    return '```python\n' + _HEREDOC_RE.sub(_heredoc_to_code, body).strip() + '\n```'
+
+
+def adapt_skill_to_tool(text: str) -> str:
+    """Rewrite the CLI's skill documentation to address a tool caller instead of a shell user"""
+    text = _BASH_BLOCK_RE.sub(_rewrite_bash_block, text)
+    for pattern, replacement in _PROSE_SUBS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+_SESSION_BOOT = """
+import sys, io, json, traceback
+from contextlib import redirect_stdout, redirect_stderr
+_bu_ns = dict(globals())
+while True:
+    with open({inp!r}) as _bu_f:
+        _bu_code = _bu_f.read()
+    if not _bu_code.strip():
+        break
+    _bu_buf = io.StringIO()
+    try:
+        with redirect_stdout(_bu_buf), redirect_stderr(_bu_buf):
+            exec(_bu_code, _bu_ns)
+        _bu_err = 0
+    except BaseException:
+        traceback.print_exc(file=_bu_buf)
+        _bu_err = 1
+    with open({outp!r}, "w") as _bu_f:
+        _bu_f.write(json.dumps({{"exit": _bu_err, "out": _bu_buf.getvalue()}}))
+"""
+
+
+class _Session:
+    """One long-lived CLI interpreter"""
+
+    def __init__(self, argv: list[str], cwd: Path, env: dict[str, str] | None) -> None:
+        self._argv = argv
+        self._cwd = cwd
+        self._env = env
+        self._dir: Path | None = None
+        self._proc: anyio.abc.Process | None = None
+
+    @property
+    def alive(self) -> bool:
+        return self._proc is not None and self._proc.returncode is None
+
+    async def start(self) -> None:
+        """Spawn the CLI running the session loop"""
+        self._dir = Path(tempfile.mkdtemp(prefix='harness_browser_session_'))
+        inp, outp = self._dir / 'in', self._dir / 'out'
+        await anyio.to_thread.run_sync(os.mkfifo, inp)
+        await anyio.to_thread.run_sync(os.mkfifo, outp)
+        boot = _SESSION_BOOT.format(inp=str(inp), outp=str(outp))
+        self._proc = await anyio.open_process(
+            self._argv,
+            cwd=self._cwd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            env=self._env,
+        )
+        assert self._proc.stdin is not None
+        await self._proc.stdin.send(boot.encode())
+        await self._proc.stdin.aclose()
+
+    async def call(self, code: str, timeout: float) -> tuple[int, str]:
+        """Run `code` in the session, and return its exit flag and combined output"""
+        assert self._dir is not None
+        inp, outp = self._dir / 'in', self._dir / 'out'
+        deadline = time.monotonic() + timeout
+        await self._write(inp, code, deadline)
+        raw = await self._read(outp, deadline)
+        payload = json.loads(raw)
+        return int(payload['exit']), str(payload['out'])
+
+    async def _write(self, fifo: Path, text: str, deadline: float) -> None:
+        """Write once a reader attaches, giving up at the deadline"""
+        while True:
+            try:
+                fd = os.open(fifo, os.O_WRONLY | os.O_NONBLOCK)
+            except OSError:  # no reader yet
+                if time.monotonic() >= deadline or not self.alive:
+                    raise TimeoutError from None
+                await anyio.sleep(0.05)
+                continue
+            with os.fdopen(fd, 'w') as handle:
+                handle.write(text)
+            return
+
+    async def _read(self, fifo: Path, deadline: float) -> str:
+        """Collect the reply, giving up at the deadline"""
+        fd = os.open(fifo, os.O_RDONLY | os.O_NONBLOCK)
+        chunks: list[bytes] = []
+        try:
+            while True:
+                try:
+                    chunk = os.read(fd, 65536)
+                except BlockingIOError:  # pragma: no cover - writer attached but idle
+                    chunk = b''
+                if chunk:
+                    chunks.append(chunk)
+                elif chunks:
+                    return b''.join(chunks).decode('utf-8', errors='replace')
+                if time.monotonic() >= deadline:
+                    raise TimeoutError
+                await anyio.sleep(0.02)
+        finally:
+            os.close(fd)
+
+    async def close(self) -> None:
+        """Kill the interpreter and delete its pipes"""
+        proc, self._proc = self._proc, None
+        directory, self._dir = self._dir, None
+        if proc is not None:  # pragma: no branch
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except OSError:  # pragma: no cover - already exited
+                pass
+            with anyio.CancelScope(shield=True):
+                await proc.wait()
+            await proc.aclose()
+        if directory is not None:  # pragma: no branch
+            shutil.rmtree(directory, ignore_errors=True)
+
+
+_SCREENSHOT_RE = re.compile(r'(?<![\w/])(/[^\s\'"]+\.(?:png|jpe?g|webp))(?![\w])', re.IGNORECASE)
+"""Absolute image path in output, as printed by `capture_screenshot()`"""
+
+_MAX_SCREENSHOTS = 4
+
+_MAX_SCREENSHOT_BYTES = 8 * 1024 * 1024  # bigger than this stays out of context
+
+_MEDIA_TYPES = {'.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp'}
+
+
+def collect_screenshots(output: str, *, newer_than: float) -> list[BinaryContent]:
+    """Read image files the executed code printed, so the model can see the page"""
+    found: list[BinaryContent] = []
+    for match in dict.fromkeys(_SCREENSHOT_RE.findall(output)):
+        path = Path(match)
+        try:
+            stat = path.stat()
+            if stat.st_mtime < newer_than - 1 or stat.st_size > _MAX_SCREENSHOT_BYTES:
+                continue
+            data = path.read_bytes()
+        except OSError:  # pragma: no cover - printed a path that is not readable
+            continue
+        found.append(BinaryContent(data=data, media_type=_MEDIA_TYPES[path.suffix.lower()]))
+        if len(found) == _MAX_SCREENSHOTS:
+            break
+    return found
+
+
+_CHROME_CANDIDATES = (
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+)
+
+_CHROME_COMMANDS = ('google-chrome-stable', 'google-chrome', 'chromium-browser', 'chromium', 'chrome')
+
+_HEADLESS_STARTUP_TIMEOUT = 30.0  # seconds until DevToolsActivePort must appear
+
+
+def find_chrome() -> str | None:
+    """Locate a Chrome or Chromium binary to launch headlessly"""
+    for variable in ('BH_CHROME_PATH', 'CHROME_PATH'):
+        if configured := os.environ.get(variable):
+            return configured
+    for command in _CHROME_COMMANDS:
+        if found := shutil.which(command):
+            return found
+    return next((path for path in _CHROME_CANDIDATES if Path(path).exists()), None)
+
+
+SESSION_RE = re.compile(r'^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$')
+"""The CLI's `BU_NAME` naming rules"""
+
+
+class BrowserUseToolset(FunctionToolset[AgentDepsT]):
+    """A single `browser_exec` tool backed by a persistent CLI interpreter session"""
+
+    def __init__(
+        self,
+        *,
+        command: str,
+        cwd: Path,
+        default_timeout: float,
+        max_timeout: float,
+        max_output_chars: int,
+        workspace: Path | None,
+        env: Mapping[str, str] | None,
+        denied_env_patterns: Sequence[str],
+        fallback_to_uvx: bool,
+        persist_variables: bool = True,
+        browser: Literal['local', 'headless', 'cloud'] = 'local',
+        cloud_session: str | None = None,
+        cloud_timeout_minutes: int = 60,
+        cdp_url: str | None = None,
+        chrome_path: str | None = None,
+        scope: Literal['run', 'agent'] = 'run',
+        progress: Callable[[str], None] | None = None,
+        progress_detail: Detail = 'steps',
+    ) -> None:
+        super().__init__()
+        self._command = command
+        self._cwd = cwd.resolve()
+        self._default_timeout = default_timeout
+        self._max_timeout = max_timeout
+        self._max_output_chars = max_output_chars
+        self._workspace = workspace
+        self._env = dict(env) if env is not None else None
+        self._denied_env_patterns = list(denied_env_patterns)
+        self._fallback_to_uvx = fallback_to_uvx
+        self._persist_session = persist_variables
+        self._scope: Literal['run', 'agent'] = scope
+        self._progress = progress
+        self._progress_detail: Detail = progress_detail
+        self._enter_count = 0
+        self._session: _Session | None = None
+        self._browser: Literal['local', 'headless', 'cloud'] = browser
+        self._cloud_session = cloud_session
+        self._cloud_timeout_minutes = cloud_timeout_minutes
+        self._cdp_url = cdp_url
+        self._chrome_path = chrome_path
+        self._headless_proc: anyio.abc.Process | None = None
+        self._headless_profile: Path | None = None
+        self._headless_cdp_url: str | None = None
+        self._owned_session: str | None = None
+        self.add_function(self.browser_exec, name='browser_exec')
+
+    async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
+        """Give each run its own interpreter state, unless scoped to the agent"""
+        if self._scope == 'agent':
+            return self
+        return BrowserUseToolset[AgentDepsT](
+            command=self._command,
+            cwd=self._cwd,
+            default_timeout=self._default_timeout,
+            max_timeout=self._max_timeout,
+            max_output_chars=self._max_output_chars,
+            workspace=self._workspace,
+            env=self._env,
+            denied_env_patterns=self._denied_env_patterns,
+            fallback_to_uvx=self._fallback_to_uvx,
+            persist_variables=self._persist_session,
+            browser=self._browser,
+            cloud_session=self._cloud_session,
+            cloud_timeout_minutes=self._cloud_timeout_minutes,
+            cdp_url=self._cdp_url,
+            chrome_path=self._chrome_path,
+            scope=self._scope,
+            progress=self._progress,
+            progress_detail=self._progress_detail,
+        )
+
+    async def __aenter__(self) -> BrowserUseToolset[AgentDepsT]:
+        """Track nesting so an agent-scoped toolset survives per-run exits"""
+        self._enter_count += 1
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        """End the interpreter and stop any owned browser, at the outermost exit only"""
+        self._enter_count = max(0, self._enter_count - 1)
+        if self._enter_count > 0:
+            return
+        if self._session is not None:
+            await self._session.close()
+            self._session = None
+        if self._owned_session is not None:
+            session, self._owned_session = self._owned_session, None
+            # shielded: a browser that bills must stop even on cancel
+            with anyio.CancelScope(shield=True):
+                try:
+                    await self._run_cli(
+                        self._resolve_argv(),
+                        f'stop_remote_daemon({session!r})\n',
+                        self._default_timeout,
+                        self._build_env(None),
+                        raise_on_timeout=False,
+                    )
+                except ModelRetry:  # pragma: no cover - the CLI vanished mid-run
+                    pass
+        await self._stop_headless_browser()
+
+    async def _ensure_headless_browser(self) -> str | None:
+        """Launch headless Chrome on first use and return its DevTools URL"""
+        if self._browser != 'headless' or self._cdp_url is not None:
+            return None
+        if self._headless_cdp_url is not None:
+            return self._headless_cdp_url
+
+        binary = self._chrome_path or find_chrome()
+        if binary is None:
+            raise ModelRetry(
+                'No Chrome or Chromium binary was found to launch headless. Install Chrome, or set '
+                "BH_CHROME_PATH (or the capability's `chrome_path`) to the executable."
+            )
+        profile = Path(tempfile.mkdtemp(prefix='harness_browser_profile_'))
+        try:
+            proc = await anyio.open_process(
+                [
+                    binary,
+                    '--headless=new',
+                    '--remote-debugging-port=0',
+                    f'--user-data-dir={profile}',
+                    '--no-first-run',
+                    '--no-default-browser-check',
+                    'about:blank',
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except OSError as e:
+            shutil.rmtree(profile, ignore_errors=True)
+            raise ModelRetry(f'Failed to launch headless Chrome ({binary!r}): {e}') from e
+
+        self._headless_proc = proc
+        self._headless_profile = profile
+        port_file = profile / 'DevToolsActivePort'
+        try:
+            with anyio.fail_after(_HEADLESS_STARTUP_TIMEOUT):
+                while True:
+                    if port_file.exists() and (port := port_file.read_text().splitlines()[:1]):
+                        break
+                    await anyio.sleep(0.1)
+        except TimeoutError:
+            await self._stop_headless_browser()
+            raise ModelRetry(
+                f'Headless Chrome did not report a DevTools port within {_HEADLESS_STARTUP_TIMEOUT}s.'
+            ) from None
+        self._headless_cdp_url = f'http://127.0.0.1:{port[0]}'
+        return self._headless_cdp_url
+
+    async def _stop_headless_browser(self) -> None:
+        """Kill the launched headless Chrome and delete its profile"""
+        proc, self._headless_proc = self._headless_proc, None
+        profile, self._headless_profile = self._headless_profile, None
+        self._headless_cdp_url = None
+        if proc is not None:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except OSError:  # pragma: no cover - already exited
+                pass
+            with anyio.CancelScope(shield=True):
+                await proc.wait()
+            await proc.aclose()
+        if profile is not None:
+            shutil.rmtree(profile, ignore_errors=True)
+
+    async def _ensure_cloud_session(self) -> str | None:
+        """Return the cloud browser name for this run, provisioning one on first use"""
+        if self._browser != 'cloud' or self._cdp_url is not None:
+            return None
+        if self._cloud_session is not None:
+            return self._cloud_session
+        if self._owned_session is not None:
+            return self._owned_session
+        name = f'pyai{uuid.uuid4().hex[:12]}'
+        exit_code, stdout, stderr = await self._run_cli(
+            self._resolve_argv(),
+            f'start_remote_daemon({name!r}, timeout={self._cloud_timeout_minutes})\n',
+            self._default_timeout,
+            self._build_env(None),
+        )
+        if exit_code != 0:
+            raise ModelRetry(
+                'Could not start a Browser Use cloud browser. Sign in with `browser-use auth login` '
+                f'or set BROWSER_USE_API_KEY.\n\n{(stdout + stderr)[-_ERROR_TAIL_CHARS:]}'
+            )
+        self._owned_session = name
+        return name
+
+    async def cli_skill_text(self) -> str | None:
+        """Return the CLI's skill documentation, fetching it at most once per command"""
+        if self._command in _SKILL_CACHE:
+            return _SKILL_CACHE[self._command]
+        try:
+            argv = self._resolve_argv()
+        except ModelRetry:
+            return None
+        exit_code, stdout, _ = await self._run_cli(
+            [*argv, 'skill', 'show'],
+            '',
+            min(_SKILL_FETCH_TIMEOUT, self._default_timeout),
+            self._build_env(None),
+            raise_on_timeout=False,
+        )
+        skill = adapt_skill_to_tool(stdout.strip()) if exit_code == 0 and stdout.strip() else None
+        _SKILL_CACHE[self._command] = skill
+        return skill
+
+    async def browser_exec(
+        self, code: str, session: str | None = None, timeout_seconds: float | None = None
+    ) -> ToolReturn[str]:
+        """Run Python code in a real web browser via the Browser Use CLI.
+
+        Browser helpers pre-imported: `new_tab(url)`, `goto_url(url)`,
+        `page_info()`, `js(expression)`, `click_at_xy(x, y)`, `fill_input(...)`,
+        `type_text(...)`, `press_key(...)`, `scroll(...)`, `wait_for_load()`,
+        `wait_for_element(...)`, `capture_screenshot()`, `list_tabs()`,
+        `switch_tab(...)`, and more. Use `print(...)` for any
+        data you need back -- the tool returns what the code prints. Start
+        `code` with a one-line `#` comment describing the step for the user in
+        plain, non-technical language (under 60 characters); it is shown as the
+        step's label while the call runs.
+
+        Your calls run in one persistent Python session, so variables you
+        assign survive to your next call, as does the browser itself. If a call
+        times out the session restarts (the browser survives); re-derive what
+        you need from the page. Batching a whole sub-procedure (navigate, wait,
+        extract) into one call is still faster than one call per action.
+        """
+        if self._progress is None:
+            return await self._exec(code, session, timeout_seconds)
+        narrate_call(self._progress, code, self._progress_detail)
+        try:
+            result = await self._exec(code, session, timeout_seconds)
+        except ModelRetry as error:
+            narrate_error(self._progress, str(error))
+            raise
+        images = sum(1 for item in (result.content or []) if not isinstance(item, str))
+        narrate_result(self._progress, str(result.return_value), images, self._progress_detail)
+        return result
+
+    async def _exec(self, code: str, session: str | None, timeout_seconds: float | None) -> ToolReturn[str]:
+        """Validate, run, and package one call"""
+        if not code.strip():
+            raise ModelRetry('The `code` argument was empty. Pass Python that uses the pre-imported browser helpers.')
+        if session is not None and SESSION_RE.match(session) is None:
+            raise ModelRetry(
+                f'Invalid session name {session!r}: use 1-64 characters from [A-Za-z0-9_-], starting alphanumeric.'
+            )
+
+        session = await self._ensure_cloud_session() or session
+        await self._ensure_headless_browser()
+        if timeout_seconds is None or timeout_seconds <= 0:
+            timeout = self._default_timeout
+        else:
+            timeout = min(timeout_seconds, self._max_timeout)
+
+        started = time.time()
+        exit_code, stdout, stderr = await self._execute(code, timeout, session)
+
+        parts: list[str] = []
+        if stdout:
+            parts.append(stdout)
+        if exit_code != 0:
+            if stderr:
+                parts.append(f'[stderr]\n{stderr}')
+            parts.append(f'[exit code: {exit_code}]')
+        text = self._truncate('\n'.join(parts)) if parts else '(no output -- use print() in the code to return data)'
+
+        images = collect_screenshots(stdout, newer_than=started)
+        if not images:
+            return ToolReturn[str](return_value=text)
+        label = 'screenshot' if len(images) == 1 else 'screenshots'
+        return ToolReturn[str](
+            return_value=text,
+            content=[f'The {label} this call captured, attached so you can look at the page:', *images],
+        )
+
+    async def _execute(self, code: str, timeout: float, session: str | None) -> tuple[int, str, str]:
+        """Run the model's code in this run's interpreter, starting one if needed"""
+        if self._persist_session:
+            if self._session is None or not self._session.alive:
+                self._session = _Session(self._resolve_argv(), self._cwd, self._build_env(session))
+                await self._session.start()
+            try:
+                exit_code, output = await self._session.call(code, timeout)
+            except TimeoutError:
+                await self._session.close()
+                self._session = None
+                raise ModelRetry(
+                    f'browser_exec timed out after {timeout}s, so the browser session was restarted. '
+                    'The browser itself is still open; re-read what you need from the page.'
+                ) from None
+            except (OSError, ValueError) as e:  # pragma: no cover - the session died mid-call
+                await self._session.close()
+                self._session = None
+                raise ModelRetry(f'The browser session ended unexpectedly ({e}). Try the call again.') from e
+            return exit_code, output, ''
+        return await self._run_cli(self._resolve_argv(), code, timeout, self._build_env(session))
+
+    def _resolve_argv(self) -> list[str]:
+        """Locate the CLI, falling back to `uvx browser-use`"""
+        resolved = shutil.which(self._command)
+        if resolved is not None:
+            return [resolved]
+        if self._fallback_to_uvx:
+            uvx = shutil.which('uvx')
+            if uvx is not None:
+                return [uvx, 'browser-use']
+        raise ModelRetry(_INSTALL_HINT)
+
+    def _build_env(self, session: str | None) -> dict[str, str] | None:
+        overlays: dict[str, str] = {}
+        if session is not None:
+            overlays['BU_NAME'] = session
+        if self._workspace is not None:
+            overlays['BH_AGENT_WORKSPACE'] = str(self._workspace)
+        endpoint = self._cdp_url or self._headless_cdp_url
+        if endpoint is not None:
+            # ws -> BU_CDP_WS, http -> BU_CDP_URL; either blocks local discovery
+            key = 'BU_CDP_WS' if endpoint.startswith(('ws://', 'wss://')) else 'BU_CDP_URL'
+            overlays[key] = endpoint
+
+        base: dict[str, str] | None
+        if self._env is None and not self._denied_env_patterns:
+            base = None
+        else:
+            base = dict(self._env) if self._env is not None else dict(os.environ)
+            if self._denied_env_patterns:
+                base = {
+                    name: value
+                    for name, value in base.items()
+                    if not any(fnmatch.fnmatchcase(name, pattern) for pattern in self._denied_env_patterns)
+                }
+        if not overlays:
+            return base
+        if base is None:
+            base = dict(os.environ)
+        return base | overlays
+
+    def _truncate(self, text: str) -> str:
+        """Cap output, keeping the tail"""
+        if len(text) <= self._max_output_chars:
+            return text
+        marker = f'[... output truncated, showing last {self._max_output_chars} chars]\n'
+        return marker + text[-self._max_output_chars :]
+
+    async def _run_cli(
+        self,
+        args: list[str],
+        code: str,
+        timeout: float,
+        env: dict[str, str] | None,
+        *,
+        raise_on_timeout: bool = True,
+    ) -> tuple[int, str, str]:
+        """One-shot CLI invocation: pipe `code` on stdin, return (exit, out, err)"""
+        try:
+            proc = await anyio.open_process(
+                args,
+                cwd=self._cwd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+                env=env,
+            )
+        except OSError as e:
+            # which() passed but exec failed (lost +x, TOCTOU)
+            raise ModelRetry(f'Failed to launch the browser-use CLI ({args[0]!r}): {e}') from e
+        stdout_chunks: list[bytes] = []
+        stderr_chunks: list[bytes] = []
+        try:
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
+
+            async def _write_stdin() -> None:
+                assert proc.stdin is not None
+                try:
+                    await proc.stdin.send(code.encode('utf-8'))
+                    await proc.stdin.aclose()
+                except (anyio.BrokenResourceError, anyio.ClosedResourceError):  # pragma: no cover
+                    pass  # CLI exited before draining stdin
+
+            async def _read_stdout() -> None:
+                assert proc.stdout is not None
+                async for chunk in proc.stdout:
+                    stdout_chunks.append(chunk)
+
+            async def _read_stderr() -> None:
+                assert proc.stderr is not None
+                async for chunk in proc.stderr:
+                    stderr_chunks.append(chunk)
+
+            try:
+                with anyio.fail_after(timeout):
+                    async with anyio.create_task_group() as tg:
+                        tg.start_soon(_write_stdin)
+                        tg.start_soon(_read_stdout)
+                        tg.start_soon(_read_stderr)
+                    await proc.wait()
+            except TimeoutError:
+                await self._terminate(proc)
+                if not raise_on_timeout:
+                    return 1, '', f'timed out after {timeout}s'
+                raise ModelRetry(
+                    f'browser_exec timed out after {timeout}s. The browser daemon may still be working; '
+                    'retry with a larger timeout_seconds, or split the work into smaller calls that '
+                    'append intermediate results to files in the workspace.'
+                ) from None
+        finally:
+            await proc.aclose()
+        stdout = b''.join(stdout_chunks).decode('utf-8', errors='replace')
+        stderr = b''.join(stderr_chunks).decode('utf-8', errors='replace')
+        exit_code = proc.returncode if proc.returncode is not None else 0
+        return exit_code, stdout, stderr
+
+    async def _terminate(self, proc: anyio.abc.Process) -> None:
+        """Kill the CLI's process group and reap it"""
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except OSError:  # pragma: no cover - process already exited
+            pass
+        with anyio.CancelScope(shield=True):
+            await proc.wait()

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -214,11 +214,36 @@ class _Session:
 _SCREENSHOT_RE = re.compile(r'(?<![\w/])(/[^\s\'"]+\.(?:png|jpe?g|webp))(?![\w])', re.IGNORECASE)
 """Absolute image path in output, as printed by `capture_screenshot()`"""
 
+_FILE_RE = re.compile(r'(?<![\w/])(/[^\s\'"]+\.[A-Za-z0-9]{1,8})(?![\w])')
+"""Any absolute file path the code printed"""
+
+_MAX_FILES = 16
+
 _MAX_SCREENSHOTS = 4
 
 _MAX_SCREENSHOT_BYTES = 8 * 1024 * 1024  # bigger than this stays out of context
 
 _MEDIA_TYPES = {'.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp'}
+
+
+def collect_files(output: str, *, newer_than: float) -> list[dict[str, str | int]]:
+    """Files the executed code printed and wrote during this call"""
+    import mimetypes
+
+    found: list[dict[str, str | int]] = []
+    for match in dict.fromkeys(_FILE_RE.findall(output)):
+        path = Path(match)
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        if stat.st_mtime < newer_than - 1 or not path.is_file():
+            continue
+        media_type = mimetypes.guess_type(path.name)[0] or 'application/octet-stream'
+        found.append({'path': str(path), 'media_type': media_type, 'bytes': stat.st_size})
+        if len(found) == _MAX_FILES:
+            break
+    return found
 
 
 def collect_screenshots(output: str, *, newer_than: float) -> list[BinaryContent]:
@@ -498,12 +523,15 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         text = self._truncate('\n'.join(parts)) if parts else '(no output -- use print() in the code to return data)'
 
         images = collect_screenshots(stdout, newer_than=started)
+        files = collect_files(stdout, newer_than=started)
+        metadata = {'files': files} if files else None
         if not images:
-            return ToolReturn[str](return_value=text)
+            return ToolReturn[str](return_value=text, metadata=metadata)
         label = 'screenshot' if len(images) == 1 else 'screenshots'
         return ToolReturn[str](
             return_value=text,
             content=[f'The {label} this call captured, attached so you can look at the page:', *images],
+            metadata=metadata,
         )
 
     async def _execute(self, code: str, timeout: float, session: str | None) -> tuple[int, str, str]:

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -182,16 +182,17 @@ class _Session:
         try:
             while True:
                 try:
-                    chunk = os.read(fd, 65536)
+                    chunk: bytes | None = os.read(fd, 65536)
                 except BlockingIOError:  # pragma: no cover - writer attached but idle
-                    chunk = b''
+                    chunk = None
                 if chunk:
                     chunks.append(chunk)
-                elif chunks:
+                elif chunk is not None and chunks:
                     return b''.join(chunks).decode('utf-8', errors='replace')
                 if time.monotonic() >= deadline:
                     raise TimeoutError
-                await anyio.sleep(0.02)
+                if not chunk:
+                    await anyio.sleep(0.02)
         finally:
             os.close(fd)
 

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -13,7 +13,7 @@ import subprocess
 import tempfile
 import time
 import uuid
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal
 
@@ -25,7 +25,8 @@ from pydantic_ai.messages import BinaryContent, ToolReturn
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 
-from pydantic_ai_harness.browser_use._progress import Detail, narrate_call, narrate_error, narrate_result
+from pydantic_ai_harness.browser_use._progress import narrate_call, narrate_error, narrate_result
+from pydantic_ai_harness.shell import LLM_API_KEY_ENV_PATTERNS
 
 _INSTALL_HINT = (
     'The `browser-use` CLI was not found on PATH, and no `uvx` fallback was available. Install it with:\n'
@@ -34,6 +35,10 @@ _INSTALL_HINT = (
 )
 
 _SKILL_FETCH_TIMEOUT = 30.0
+
+_MAX_TIMEOUT = 1800.0  # ceiling on a model-supplied timeout_seconds
+_MAX_OUTPUT_CHARS = 50_000
+_CLOUD_TIMEOUT_MINUTES = 60  # server-side backstop on a per-run cloud browser
 
 _ERROR_TAIL_CHARS = 2000
 """Tail of CLI output shown when cloud provisioning fails"""
@@ -265,46 +270,21 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
-        command: str,
-        cwd: Path,
-        default_timeout: float,
-        max_timeout: float,
-        max_output_chars: int,
-        workspace: Path | None,
-        env: Mapping[str, str] | None,
-        denied_env_patterns: Sequence[str],
-        fallback_to_uvx: bool,
-        persist_variables: bool = True,
+        command: str = 'browser-use',
+        default_timeout: float = 300.0,
         browser: Literal['local', 'headless', 'cloud'] = 'local',
-        cloud_session: str | None = None,
-        cloud_timeout_minutes: int = 60,
-        cdp_url: str | None = None,
-        chrome_path: str | None = None,
         scope: Literal['run', 'agent'] = 'run',
         progress: Callable[[str], None] | None = None,
-        progress_detail: Detail = 'steps',
     ) -> None:
         super().__init__()
         self._command = command
-        self._cwd = cwd.resolve()
+        self._cwd = Path.cwd()
         self._default_timeout = default_timeout
-        self._max_timeout = max_timeout
-        self._max_output_chars = max_output_chars
-        self._workspace = workspace
-        self._env = dict(env) if env is not None else None
-        self._denied_env_patterns = list(denied_env_patterns)
-        self._fallback_to_uvx = fallback_to_uvx
-        self._persist_session = persist_variables
         self._scope: Literal['run', 'agent'] = scope
         self._progress = progress
-        self._progress_detail: Detail = progress_detail
         self._enter_count = 0
         self._session: _Session | None = None
         self._browser: Literal['local', 'headless', 'cloud'] = browser
-        self._cloud_session = cloud_session
-        self._cloud_timeout_minutes = cloud_timeout_minutes
-        self._cdp_url = cdp_url
-        self._chrome_path = chrome_path
         self._headless_proc: anyio.abc.Process | None = None
         self._headless_profile: Path | None = None
         self._headless_cdp_url: str | None = None
@@ -317,23 +297,10 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
             return self
         return BrowserUseToolset[AgentDepsT](
             command=self._command,
-            cwd=self._cwd,
             default_timeout=self._default_timeout,
-            max_timeout=self._max_timeout,
-            max_output_chars=self._max_output_chars,
-            workspace=self._workspace,
-            env=self._env,
-            denied_env_patterns=self._denied_env_patterns,
-            fallback_to_uvx=self._fallback_to_uvx,
-            persist_variables=self._persist_session,
             browser=self._browser,
-            cloud_session=self._cloud_session,
-            cloud_timeout_minutes=self._cloud_timeout_minutes,
-            cdp_url=self._cdp_url,
-            chrome_path=self._chrome_path,
             scope=self._scope,
             progress=self._progress,
-            progress_detail=self._progress_detail,
         )
 
     async def __aenter__(self) -> BrowserUseToolset[AgentDepsT]:
@@ -367,12 +334,12 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
 
     async def _ensure_headless_browser(self) -> str | None:
         """Launch headless Chrome on first use and return its DevTools URL"""
-        if self._browser != 'headless' or self._cdp_url is not None:
+        if self._browser != 'headless':
             return None
         if self._headless_cdp_url is not None:
             return self._headless_cdp_url
 
-        binary = self._chrome_path or find_chrome()
+        binary = find_chrome()
         if binary is None:
             raise ModelRetry(
                 'No Chrome or Chromium binary was found to launch headless. Install Chrome, or set '
@@ -433,16 +400,14 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
 
     async def _ensure_cloud_session(self) -> str | None:
         """Return the cloud browser name for this run, provisioning one on first use"""
-        if self._browser != 'cloud' or self._cdp_url is not None:
+        if self._browser != 'cloud':
             return None
-        if self._cloud_session is not None:
-            return self._cloud_session
         if self._owned_session is not None:
             return self._owned_session
         name = f'pyai{uuid.uuid4().hex[:12]}'
         exit_code, stdout, stderr = await self._run_cli(
             self._resolve_argv(),
-            f'start_remote_daemon({name!r}, timeout={self._cloud_timeout_minutes})\n',
+            f'start_remote_daemon({name!r}, timeout={_CLOUD_TIMEOUT_MINUTES})\n',
             self._default_timeout,
             self._build_env(None),
         )
@@ -496,14 +461,14 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         """
         if self._progress is None:
             return await self._exec(code, session, timeout_seconds)
-        narrate_call(self._progress, code, self._progress_detail)
+        narrate_call(self._progress, code, 'steps')
         try:
             result = await self._exec(code, session, timeout_seconds)
         except ModelRetry as error:
             narrate_error(self._progress, str(error))
             raise
         images = sum(1 for item in (result.content or []) if not isinstance(item, str))
-        narrate_result(self._progress, str(result.return_value), images, self._progress_detail)
+        narrate_result(self._progress, str(result.return_value), images, 'steps')
         return result
 
     async def _exec(self, code: str, session: str | None, timeout_seconds: float | None) -> ToolReturn[str]:
@@ -521,7 +486,7 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
             timeout = self._default_timeout
         else:
             # floor: the first call in a session pays interpreter + daemon cold start
-            timeout = min(max(timeout_seconds, min(60.0, self._default_timeout)), self._max_timeout)
+            timeout = min(max(timeout_seconds, min(60.0, self._default_timeout)), _MAX_TIMEOUT)
 
         started = time.time()
         exit_code, stdout, stderr = await self._execute(code, timeout, session)
@@ -546,72 +511,53 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
 
     async def _execute(self, code: str, timeout: float, session: str | None) -> tuple[int, str, str]:
         """Run the model's code in this run's interpreter, starting one if needed"""
-        if self._persist_session:
-            if self._session is None or not self._session.alive:
-                self._session = _Session(self._resolve_argv(), self._cwd, self._build_env(session))
-                await self._session.start()
-            try:
-                exit_code, output = await self._session.call(code, timeout)
-            except TimeoutError:
-                await self._session.close()
-                self._session = None
-                raise ModelRetry(
-                    f'browser_exec timed out after {timeout}s, so the browser session was restarted. '
-                    'The browser itself is still open; re-read what you need from the page.'
-                ) from None
-            except (OSError, ValueError) as e:  # pragma: no cover - the session died mid-call
-                await self._session.close()
-                self._session = None
-                raise ModelRetry(f'The browser session ended unexpectedly ({e}). Try the call again.') from e
-            return exit_code, output, ''
-        return await self._run_cli(self._resolve_argv(), code, timeout, self._build_env(session))
+        if self._session is None or not self._session.alive:
+            self._session = _Session(self._resolve_argv(), self._cwd, self._build_env(session))
+            await self._session.start()
+        try:
+            exit_code, output = await self._session.call(code, timeout)
+        except TimeoutError:
+            await self._session.close()
+            self._session = None
+            raise ModelRetry(
+                f'browser_exec timed out after {timeout}s, so the browser session was restarted. '
+                'The browser itself is still open; re-read what you need from the page.'
+            ) from None
+        except (OSError, ValueError) as e:  # pragma: no cover - the session died mid-call
+            await self._session.close()
+            self._session = None
+            raise ModelRetry(f'The browser session ended unexpectedly ({e}). Try the call again.') from e
+        return exit_code, output, ''
 
     def _resolve_argv(self) -> list[str]:
         """Locate the CLI, falling back to `uvx browser-use`"""
         resolved = shutil.which(self._command)
         if resolved is not None:
             return [resolved]
-        if self._fallback_to_uvx:
-            uvx = shutil.which('uvx')
-            if uvx is not None:
-                return [uvx, 'browser-use']
+        uvx = shutil.which('uvx')
+        if uvx is not None:
+            return [uvx, 'browser-use']
         raise ModelRetry(_INSTALL_HINT)
 
-    def _build_env(self, session: str | None) -> dict[str, str] | None:
-        overlays: dict[str, str] = {}
+    def _build_env(self, session: str | None) -> dict[str, str]:
+        """Inherited environment minus LLM provider keys, plus the browser overlays"""
+        env = {
+            name: value
+            for name, value in os.environ.items()
+            if not any(fnmatch.fnmatchcase(name, pattern) for pattern in LLM_API_KEY_ENV_PATTERNS)
+        }
         if session is not None:
-            overlays['BU_NAME'] = session
-        if self._workspace is not None:
-            overlays['BH_AGENT_WORKSPACE'] = str(self._workspace)
-        endpoint = self._cdp_url or self._headless_cdp_url
-        if endpoint is not None:
-            # ws -> BU_CDP_WS, http -> BU_CDP_URL; either blocks local discovery
-            key = 'BU_CDP_WS' if endpoint.startswith(('ws://', 'wss://')) else 'BU_CDP_URL'
-            overlays[key] = endpoint
-
-        base: dict[str, str] | None
-        if self._env is None and not self._denied_env_patterns:
-            base = None
-        else:
-            base = dict(self._env) if self._env is not None else dict(os.environ)
-            if self._denied_env_patterns:
-                base = {
-                    name: value
-                    for name, value in base.items()
-                    if not any(fnmatch.fnmatchcase(name, pattern) for pattern in self._denied_env_patterns)
-                }
-        if not overlays:
-            return base
-        if base is None:
-            base = dict(os.environ)
-        return base | overlays
+            env['BU_NAME'] = session
+        if self._headless_cdp_url is not None:
+            env['BU_CDP_URL'] = self._headless_cdp_url
+        return env
 
     def _truncate(self, text: str) -> str:
         """Cap output, keeping the tail"""
-        if len(text) <= self._max_output_chars:
+        if len(text) <= _MAX_OUTPUT_CHARS:
             return text
-        marker = f'[... output truncated, showing last {self._max_output_chars} chars]\n'
-        return marker + text[-self._max_output_chars :]
+        marker = f'[... output truncated, showing last {_MAX_OUTPUT_CHARS} chars]\n'
+        return marker + text[-_MAX_OUTPUT_CHARS:]
 
     async def _run_cli(
         self,

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -520,7 +520,8 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         if timeout_seconds is None or timeout_seconds <= 0:
             timeout = self._default_timeout
         else:
-            timeout = min(timeout_seconds, self._max_timeout)
+            # floor: the first call in a session pays interpreter + daemon cold start
+            timeout = min(max(timeout_seconds, min(60.0, self._default_timeout)), self._max_timeout)
 
         started = time.time()
         exit_code, stdout, stderr = await self._execute(code, timeout, session)

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -206,7 +206,7 @@ class _Session:
                 pass
             with anyio.CancelScope(shield=True):
                 await proc.wait()
-            await proc.aclose()
+                await proc.aclose()
         if directory is not None:  # pragma: no branch
             shutil.rmtree(directory, ignore_errors=True)
 
@@ -307,11 +307,14 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         self._progress = progress
         self._enter_count = 0
         self._session: _Session | None = None
+        self._session_name: str | None = None
+        self._lock = anyio.Lock()
         self._browser: Literal['local', 'headless', 'cloud'] = browser
         self._headless_proc: anyio.abc.Process | None = None
         self._headless_profile: Path | None = None
         self._headless_cdp_url: str | None = None
         self._owned_session: str | None = None
+        self._provisioned: list[str] = []
         self.add_function(self.browser_exec, name='browser_exec')
 
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
@@ -335,74 +338,80 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         self._enter_count = max(0, self._enter_count - 1)
         if self._enter_count > 0:
             return
-        if self._session is not None:
-            await self._session.close()
-            self._session = None
-        if self._owned_session is not None:
-            session, self._owned_session = self._owned_session, None
-            # shielded: a browser that bills must stop even on cancel
-            with anyio.CancelScope(shield=True):
+        # shielded as a whole: a browser that bills must stop even on cancel
+        with anyio.CancelScope(shield=True):
+            if self._session is not None:
+                await self._session.close()
+                self._session = None
+                self._session_name = None
+            still_running: list[str] = []
+            for name in self._provisioned:
                 try:
-                    await self._run_cli(
+                    exit_code, _, _ = await self._run_cli(
                         self._resolve_argv(),
-                        f'stop_remote_daemon({session!r})\n',
+                        f'stop_remote_daemon({name!r})\n',
                         self._default_timeout,
                         self._build_env(None),
                         raise_on_timeout=False,
                     )
                 except ModelRetry:  # pragma: no cover - the CLI vanished mid-run
-                    pass
-        await self._stop_headless_browser()
+                    exit_code = 1
+                if exit_code != 0:  # keep the name so a later exit can retry the stop
+                    still_running.append(name)
+            self._provisioned = still_running
+            if self._owned_session is not None and self._owned_session not in still_running:
+                self._owned_session = None
+            await self._stop_headless_browser()
 
     async def _ensure_headless_browser(self) -> str | None:
         """Launch headless Chrome on first use and return its DevTools URL"""
         if self._browser != 'headless':
             return None
-        if self._headless_cdp_url is not None:
+        async with self._lock:
+            if self._headless_cdp_url is not None:
+                return self._headless_cdp_url
+
+            binary = find_chrome()
+            if binary is None:
+                raise ModelRetry(
+                    'No Chrome or Chromium binary was found to launch headless. Install Chrome, or set '
+                    'BH_CHROME_PATH to the executable.'
+                )
+            profile = Path(tempfile.mkdtemp(prefix='harness_browser_profile_'))
+            try:
+                proc = await anyio.open_process(
+                    [
+                        binary,
+                        '--headless=new',
+                        '--remote-debugging-port=0',
+                        f'--user-data-dir={profile}',
+                        '--no-first-run',
+                        '--no-default-browser-check',
+                        'about:blank',
+                    ],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+            except OSError as e:
+                shutil.rmtree(profile, ignore_errors=True)
+                raise ModelRetry(f'Failed to launch headless Chrome ({binary!r}): {e}') from e
+
+            self._headless_proc = proc
+            self._headless_profile = profile
+            port_file = profile / 'DevToolsActivePort'
+            try:
+                with anyio.fail_after(_HEADLESS_STARTUP_TIMEOUT):
+                    while True:
+                        if port_file.exists() and (port := port_file.read_text().splitlines()[:1]):
+                            break
+                        await anyio.sleep(0.1)
+            except (TimeoutError, OSError) as e:
+                await self._stop_headless_browser()
+                detail = str(e) or f'not ready within {_HEADLESS_STARTUP_TIMEOUT}s'
+                raise ModelRetry(f'Headless Chrome did not report a DevTools port ({detail}).') from e
+            self._headless_cdp_url = f'http://127.0.0.1:{port[0]}'
             return self._headless_cdp_url
-
-        binary = find_chrome()
-        if binary is None:
-            raise ModelRetry(
-                'No Chrome or Chromium binary was found to launch headless. Install Chrome, or set '
-                "BH_CHROME_PATH (or the capability's `chrome_path`) to the executable."
-            )
-        profile = Path(tempfile.mkdtemp(prefix='harness_browser_profile_'))
-        try:
-            proc = await anyio.open_process(
-                [
-                    binary,
-                    '--headless=new',
-                    '--remote-debugging-port=0',
-                    f'--user-data-dir={profile}',
-                    '--no-first-run',
-                    '--no-default-browser-check',
-                    'about:blank',
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                start_new_session=True,
-            )
-        except OSError as e:
-            shutil.rmtree(profile, ignore_errors=True)
-            raise ModelRetry(f'Failed to launch headless Chrome ({binary!r}): {e}') from e
-
-        self._headless_proc = proc
-        self._headless_profile = profile
-        port_file = profile / 'DevToolsActivePort'
-        try:
-            with anyio.fail_after(_HEADLESS_STARTUP_TIMEOUT):
-                while True:
-                    if port_file.exists() and (port := port_file.read_text().splitlines()[:1]):
-                        break
-                    await anyio.sleep(0.1)
-        except TimeoutError:
-            await self._stop_headless_browser()
-            raise ModelRetry(
-                f'Headless Chrome did not report a DevTools port within {_HEADLESS_STARTUP_TIMEOUT}s.'
-            ) from None
-        self._headless_cdp_url = f'http://127.0.0.1:{port[0]}'
-        return self._headless_cdp_url
 
     async def _stop_headless_browser(self) -> None:
         """Kill the launched headless Chrome and delete its profile"""
@@ -414,9 +423,10 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except OSError:  # pragma: no cover - already exited
                 pass
+            # shielded through aclose so the profile deletion below is always reached
             with anyio.CancelScope(shield=True):
                 await proc.wait()
-            await proc.aclose()
+                await proc.aclose()
         if profile is not None:
             shutil.rmtree(profile, ignore_errors=True)
 
@@ -424,22 +434,25 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         """Return the cloud browser name for this run, provisioning one on first use"""
         if self._browser != 'cloud':
             return None
-        if self._owned_session is not None:
-            return self._owned_session
-        name = f'pyai{uuid.uuid4().hex[:12]}'
-        exit_code, stdout, stderr = await self._run_cli(
-            self._resolve_argv(),
-            f'start_remote_daemon({name!r}, timeout={_CLOUD_TIMEOUT_MINUTES})\n',
-            self._default_timeout,
-            self._build_env(None),
-        )
-        if exit_code != 0:
-            raise ModelRetry(
-                'Could not start a Browser Use cloud browser. Sign in with `browser-use auth login` '
-                f'or set BROWSER_USE_API_KEY.\n\n{(stdout + stderr)[-_ERROR_TAIL_CHARS:]}'
+        async with self._lock:
+            if self._owned_session is not None:
+                return self._owned_session
+            name = f'pyai{uuid.uuid4().hex[:12]}'
+            # recorded before provisioning so cleanup can stop a half-started browser
+            self._provisioned.append(name)
+            exit_code, stdout, stderr = await self._run_cli(
+                self._resolve_argv(),
+                f'start_remote_daemon({name!r}, timeout={_CLOUD_TIMEOUT_MINUTES})\n',
+                self._default_timeout,
+                self._build_env(None),
             )
-        self._owned_session = name
-        return name
+            if exit_code != 0:
+                raise ModelRetry(
+                    'Could not start a Browser Use cloud browser. Sign in with `browser-use auth login` '
+                    f'or set BROWSER_USE_API_KEY.\n\n{(stdout + stderr)[-_ERROR_TAIL_CHARS:]}'
+                )
+            self._owned_session = name
+            return name
 
     async def cli_skill_text(self) -> str | None:
         """Return the CLI's skill documentation, fetching it at most once per command"""
@@ -535,24 +548,34 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         )
 
     async def _execute(self, code: str, timeout: float, session: str | None) -> tuple[int, str, str]:
-        """Run the model's code in this run's interpreter, starting one if needed"""
-        if self._session is None or not self._session.alive:
-            self._session = _Session(self._resolve_argv(), self._cwd, self._build_env(session))
-            await self._session.start()
-        try:
-            exit_code, output = await self._session.call(code, timeout)
-        except TimeoutError:
-            await self._session.close()
-            self._session = None
-            raise ModelRetry(
-                f'browser_exec timed out after {timeout}s, so the browser session was restarted. '
-                'The browser itself is still open; re-read what you need from the page.'
-            ) from None
-        except (OSError, ValueError) as e:  # pragma: no cover - the session died mid-call
-            await self._session.close()
-            self._session = None
-            raise ModelRetry(f'The browser session ended unexpectedly ({e}). Try the call again.') from e
-        return exit_code, output, ''
+        """Run the model's code in this run's interpreter, starting one if needed
+
+        The lock serializes concurrent calls on one interpreter (its FIFOs carry
+        one request at a time) and restarts it when a different `session` is
+        requested, since `BU_NAME` is fixed at spawn.
+        """
+        async with self._lock:
+            if self._session is not None and (not self._session.alive or session != self._session_name):
+                await self._session.close()
+                self._session = None
+            if self._session is None:
+                self._session = _Session(self._resolve_argv(), self._cwd, self._build_env(session))
+                self._session_name = session
+                await self._session.start()
+            try:
+                exit_code, output = await self._session.call(code, timeout)
+            except TimeoutError:
+                await self._session.close()
+                self._session = None
+                raise ModelRetry(
+                    f'browser_exec timed out after {timeout}s, so the browser session was restarted. '
+                    'The browser itself is still open; re-read what you need from the page.'
+                ) from None
+            except (OSError, ValueError) as e:  # pragma: no cover - the session died mid-call
+                await self._session.close()
+                self._session = None
+                raise ModelRetry(f'The browser session ended unexpectedly ({e}). Try the call again.') from e
+            return exit_code, output, ''
 
     def _resolve_argv(self) -> list[str]:
         """Locate the CLI, falling back to `uvx browser-use`"""
@@ -649,7 +672,11 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
                     'append intermediate results to files in the workspace.'
                 ) from None
         finally:
-            await proc.aclose()
+            # shielded: cancellation of the agent run must still reap the process group
+            with anyio.CancelScope(shield=True):
+                if proc.returncode is None:
+                    await self._terminate(proc)
+                await proc.aclose()
         stdout = b''.join(stdout_chunks).decode('utf-8', errors='replace')
         stderr = b''.join(stderr_chunks).decode('utf-8', errors='replace')
         exit_code = proc.returncode if proc.returncode is not None else 0

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -270,14 +270,12 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
-        command: str = 'browser-use',
         default_timeout: float = 300.0,
         browser: Literal['local', 'headless', 'cloud'] = 'local',
         scope: Literal['run', 'agent'] = 'run',
         progress: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__()
-        self._command = command
         self._cwd = Path.cwd()
         self._default_timeout = default_timeout
         self._scope: Literal['run', 'agent'] = scope
@@ -296,7 +294,6 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         if self._scope == 'agent':
             return self
         return BrowserUseToolset[AgentDepsT](
-            command=self._command,
             default_timeout=self._default_timeout,
             browser=self._browser,
             scope=self._scope,
@@ -421,12 +418,12 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
 
     async def cli_skill_text(self) -> str | None:
         """Return the CLI's skill documentation, fetching it at most once per command"""
-        if self._command in _SKILL_CACHE:
-            return _SKILL_CACHE[self._command]
         try:
             argv = self._resolve_argv()
         except ModelRetry:
             return None
+        if argv[0] in _SKILL_CACHE:
+            return _SKILL_CACHE[argv[0]]
         exit_code, stdout, _ = await self._run_cli(
             [*argv, 'skill', 'show'],
             '',
@@ -435,7 +432,7 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
             raise_on_timeout=False,
         )
         skill = adapt_skill_to_tool(stdout.strip()) if exit_code == 0 and stdout.strip() else None
-        _SKILL_CACHE[self._command] = skill
+        _SKILL_CACHE[argv[0]] = skill
         return skill
 
     async def browser_exec(
@@ -531,7 +528,7 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
 
     def _resolve_argv(self) -> list[str]:
         """Locate the CLI, falling back to `uvx browser-use`"""
-        resolved = shutil.which(self._command)
+        resolved = shutil.which('browser-use')
         if resolved is not None:
             return [resolved]
         uvx = shutil.which('uvx')

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -120,6 +120,7 @@ _CAPABILITY_PAGE_META = {
     'context.md': ('context', 'Context'),
     'pydantic-ai-docs.md': ('docs', 'Pydantic AI Docs'),
     'exa-search.md': ('exa', 'Exa Search'),
+    'browser-use.md': ('browser_use', 'Browser Use'),
     'macroscope.md': ('macroscope', 'Macroscope'),
     'compaction.md': ('compaction', 'Compaction'),
     'overflowing-tool-output.md': ('overflowing_tool_output', 'Overflowing Tool Output'),


### PR DESCRIPTION
## Summary

Adds `BrowserUse`, a capability that gives an agent a real web browser through the [Browser Use](https://browser-use.com) CLI.

- One `browser_exec` tool: the model writes Python, the CLI runs it inside a real web browser -- your local Google Chrome browser, a headless Chromium browser, or a browser running in the cloud.
- The CLI runs as a subprocess, so it adds no Python dependencies.

## Checklist

- [ ] Linked issue exists and is referenced above
- [ ] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
- [x] Docstrings use single backticks (not RST double backticks)