### PR TITLE
Keep pre-rename PyaiDocs agent specs loading

### DIFF
--- a/docs/pydantic-ai-docs.md
+++ b/docs/pydantic-ai-docs.md
@@ -85,6 +85,11 @@ print(result.output)
 
 Pass `custom_capability_types` so the spec loader knows how to instantiate `PydanticAIDocs`.
 
+Specs saved before the rename from `PyaiDocs` use the old block name. To keep loading
+them, pass the deprecated `PyaiDocs` class (imported from `pydantic_ai_harness.docs`,
+which emits a deprecation warning) alongside or instead of `PydanticAIDocs` -- it keeps
+the `PyaiDocs` serialization name. Re-save with `PydanticAIDocs` to migrate.
+
 ## API reference
 
 ::: pydantic_ai_harness.pydantic_ai_docs.PydanticAIDocs

--- a/pydantic_ai_harness/docs/__init__.py
+++ b/pydantic_ai_harness/docs/__init__.py
@@ -6,12 +6,11 @@ This module was renamed; importing from here still works but emits a
 
 from pydantic_ai_harness._warn import warn_module_renamed
 from pydantic_ai_harness.pydantic_ai_docs import (
-    PydanticAIDocs,
     PydanticAIDocsToolset,
     PydanticAIDocsTopic,
 )
+from pydantic_ai_harness.pydantic_ai_docs._deprecated import PyaiDocs
 
-PyaiDocs = PydanticAIDocs
 PyaiDocsToolset = PydanticAIDocsToolset
 PyaiDocsTopic = PydanticAIDocsTopic
 

--- a/pydantic_ai_harness/experimental/docs/__init__.py
+++ b/pydantic_ai_harness/experimental/docs/__init__.py
@@ -6,12 +6,11 @@ emits a `DeprecationWarning`. Import from `pydantic_ai_harness.pydantic_ai_docs`
 
 from pydantic_ai_harness.experimental._warn import warn_moved
 from pydantic_ai_harness.pydantic_ai_docs import (
-    PydanticAIDocs,
     PydanticAIDocsToolset,
     PydanticAIDocsTopic,
 )
+from pydantic_ai_harness.pydantic_ai_docs._deprecated import PyaiDocs
 
-PyaiDocs = PydanticAIDocs
 PyaiDocsToolset = PydanticAIDocsToolset
 PyaiDocsTopic = PydanticAIDocsTopic
 

--- a/pydantic_ai_harness/pydantic_ai_docs/_deprecated.py
+++ b/pydantic_ai_harness/pydantic_ai_docs/_deprecated.py
@@ -1,0 +1,24 @@
+"""Deprecated pre-rename name for `PydanticAIDocs`, kept for agent-spec compatibility."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic_ai.tools import AgentDepsT
+
+from pydantic_ai_harness.pydantic_ai_docs._capability import PydanticAIDocs
+
+
+@dataclass
+class PyaiDocs(PydanticAIDocs[AgentDepsT]):
+    """Deprecated name for `PydanticAIDocs`.
+
+    Keeps the pre-rename `'PyaiDocs'` agent-spec block name, so specs saved before the
+    rename still load when this class is passed via `custom_capability_types`. Specs
+    saved through this class keep the old block name; migrate to `PydanticAIDocs` to
+    save under the new one.
+    """
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        return 'PyaiDocs'

--- a/tests/experimental/test_deprecation_shims.py
+++ b/tests/experimental/test_deprecation_shims.py
@@ -19,7 +19,9 @@ _SHIMS = [
     ('overflow', 'tool_output_limits', 'OverflowingToolOutput', 'ToolOutputLimits'),
     ('compaction', 'compaction', 'TieredCompaction', 'TieredCompaction'),
     ('context', 'repo_context', 'RepoContext', 'RepoContext'),
-    ('docs', 'pydantic_ai_docs', 'PyaiDocs', 'PydanticAIDocs'),
+    # `PyaiDocs` is a subclass (it keeps the old spec name), not an alias, so the
+    # identity check uses the toolset.
+    ('docs', 'pydantic_ai_docs', 'PyaiDocsToolset', 'PydanticAIDocsToolset'),
     ('dynamic_workflow', 'dynamic_workflow', 'DynamicWorkflow', 'DynamicWorkflow'),
     ('media', 'media', 'S3MediaStore', 'S3MediaStore'),
     ('planning', 'planning', 'Planning', 'Planning'),

--- a/tests/pydantic_ai_docs/test_deprecated_names.py
+++ b/tests/pydantic_ai_docs/test_deprecated_names.py
@@ -7,6 +7,7 @@ import sys
 import warnings
 
 import pytest
+from pydantic_ai import Agent
 
 from pydantic_ai_harness import HarnessDeprecationWarning
 from pydantic_ai_harness.pydantic_ai_docs import PydanticAIDocs, PydanticAIDocsToolset, PydanticAIDocsTopic
@@ -22,7 +23,7 @@ def test_shim_warns_and_aliases_old_names() -> None:
     with pytest.warns(HarnessDeprecationWarning, match=r'`pydantic_ai_harness\.docs` has been renamed'):
         importlib.reload(shim)
 
-    assert shim.PyaiDocs is PydanticAIDocs
+    assert issubclass(shim.PyaiDocs, PydanticAIDocs)
     assert shim.PyaiDocsToolset is PydanticAIDocsToolset
     assert shim.PyaiDocsTopic is PydanticAIDocsTopic
 
@@ -32,4 +33,36 @@ def test_fresh_import_warns() -> None:
     with pytest.warns(HarnessDeprecationWarning, match=r'renamed to `pydantic_ai_harness\.pydantic_ai_docs`'):
         import pydantic_ai_harness.docs
 
-    assert pydantic_ai_harness.docs.PyaiDocs is PydanticAIDocs
+    assert issubclass(pydantic_ai_harness.docs.PyaiDocs, PydanticAIDocs)
+
+
+class TestPreRenameSpecCompatibility:
+    def test_serialization_names(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            from pydantic_ai_harness.docs import PyaiDocs
+
+        assert PyaiDocs.get_serialization_name() == 'PyaiDocs'
+        assert PydanticAIDocs.get_serialization_name() == 'PydanticAIDocs'
+
+    def test_old_spec_block_name_loads(self) -> None:
+        # A spec saved before the rename uses the `PyaiDocs` block name; passing the
+        # deprecated class through `custom_capability_types` must keep it loading.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            from pydantic_ai_harness.docs import PyaiDocs
+
+        agent = Agent.from_spec(
+            {'model': 'test', 'capabilities': [{'PyaiDocs': {}}]},
+            custom_capability_types=[PyaiDocs],
+        )
+        loaded = [c for c in agent.root_capability.capabilities if isinstance(c, PydanticAIDocs)]
+        assert len(loaded) == 1
+
+    def test_experimental_shim_exposes_the_same_class(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            from pydantic_ai_harness.docs import PyaiDocs
+            from pydantic_ai_harness.experimental.docs import PyaiDocs as experimental_pyai_docs
+
+        assert experimental_pyai_docs is PyaiDocs


### PR DESCRIPTION
Follow-up to #480, closing the one back-compat gap it disclosed: agent specs saved under the old `'PyaiDocs'` block name stopped loading, because the spec registry maps one name per class (derived from `get_serialization_name()`) and the shim's `PyaiDocs` was a plain alias of `PydanticAIDocs`.

`PyaiDocs` is now a subclass that keeps the old serialization name. Anyone with old spec files and old imports keeps working verbatim -- the import still emits the `HarnessDeprecationWarning`, `isinstance(..., PydanticAIDocs)` still holds, and re-saving through `PydanticAIDocs` migrates the block name. Covered by a real `Agent.from_spec` round-trip test with the old block name, plus docs note on the spec section.

No core changes needed; a general `get_serialization_aliases()` mechanism in core would be the long-term way to do this without a subclass, but this ships now without release coupling.

Opened as a draft by Claude Code, acting on @DouweM's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)