### PR TITLE
test(docs): enforce `docs/nav.json` parity so pages cannot ship orphaned from the site nav

### DIFF
--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -9,6 +9,7 @@ prose match the code as written) is a review-time concern, not a unit test.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -294,6 +295,55 @@ def test_graduated_doc_page_has_no_experimental_framing(page: Path) -> None:
     assert hit is None, (
         f'{page.relative_to(_ROOT)}: graduated capability still carries experimental framing ({hit!r}). '
         'Only ACP keeps an experimental note; soften the rest to the README stability note.'
+    )
+
+
+# --- Site-nav parity (docs/nav.json) ----------------------------------------
+#
+# Every flat page under `docs/` must appear in the unified-site nav, and every
+# nav entry must point at a page that exists. `docs/skills.md` once shipped
+# orphaned from the nav; these checks fail CI the moment a page and the nav
+# disagree, in either direction.
+
+_NAV_JSON = _DOCS_DIR / 'nav.json'
+# The one page allowed to be absent from the site nav: a dev-only doc that is not
+# a capability page. Excluding any other page requires a reviewed edit here.
+_NAV_EXCLUDED_PAGES = {'mutation-testing.md'}
+
+
+def _nav_slugs() -> set[str]:
+    groups = json.loads(_NAV_JSON.read_text(encoding='utf-8'))
+    return {item['slug'] for group in groups for item in group['items']}
+
+
+_NAV_SLUGS = _nav_slugs()
+_NAV_LISTED_PAGES = [p for p in sorted(_DOCS_DIR.glob('*.md')) if p.name not in _NAV_EXCLUDED_PAGES]
+
+
+def test_nav_parity_inputs_discovered() -> None:
+    # Guard against an emptied nav or a moved docs root making the parity checks
+    # below vacuously pass.
+    assert len(_NAV_SLUGS) >= 12
+    assert len(_NAV_LISTED_PAGES) >= 12
+    # Pin the excluded set so a contributor can only drop a page from the nav
+    # check via a reviewed edit to this named constant, not silently.
+    assert _NAV_EXCLUDED_PAGES == {'mutation-testing.md'}
+
+
+@pytest.mark.parametrize('page', _NAV_LISTED_PAGES, ids=lambda p: p.name)
+def test_doc_page_is_in_site_nav(page: Path) -> None:
+    assert page.stem in _NAV_SLUGS, (
+        f'{page.relative_to(_ROOT)} is not listed in docs/nav.json, so it ships orphaned from the site nav. '
+        f'Add a `{{ "label": "...", "slug": "{page.stem}" }}` entry to docs/nav.json '
+        '(or add the page to _NAV_EXCLUDED_PAGES if it is intentionally unlisted).'
+    )
+
+
+@pytest.mark.parametrize('slug', sorted(_NAV_SLUGS), ids=lambda s: s)
+def test_nav_slug_has_page(slug: str) -> None:
+    assert (_DOCS_DIR / f'{slug}.md').exists(), (
+        f'docs/nav.json lists slug "{slug}" but docs/{slug}.md does not exist. '
+        'Fix the slug or remove its entry from docs/nav.json.'
     )
 
 


### PR DESCRIPTION
_This pull request was posted by Claude Code using claude-opus-4-8 on behalf of David._ David approved the approach (extend `test_docs_parity.py`, both directions, `nav.json` scope); he has not reviewed the final diff line-by-line.

## Summary

`docs/skills.md` recently shipped orphaned from the site navigation — the page was added and `docs/index.md` updated, but no `docs/nav.json` entry (hotfixed in 134516d). `tests/test_docs_parity.py` already enforces several docs-parity surfaces but never read `docs/nav.json`, so nothing failed CI.

This adds a site-nav parity check to the existing parity test (no new mechanism, no new CI wiring — runs in the existing `test` job), asserting both directions:

- every `docs/*.md` (minus a named exclusion set, currently just `mutation-testing.md`) is listed in `docs/nav.json` — catches the reported orphan;
- every `nav.json` slug points to a page that exists — catches a dangling nav after a rename/delete.

An anti-vacuous `test_nav_parity_inputs_discovered` guard pins the exclusion set to `{'mutation-testing.md'}`, so a page can only leave the check via a reviewed edit to that named constant, not silently. Verified: removing the `skills` nav entry fails the check with an actionable message; the check passes on the current tree.

There is no `mkdocs.yml` in this repo (the flat `docs/` pages render on the external unified site), so there is no docs-build `--strict` step to lean on — a test is the right vehicle.

## Linked Issue

Fixes #489

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] Verified locally: `ruff` (lint+format), `pyright tests/test_docs_parity.py`, and `pytest tests/test_docs_parity.py` (238 passed) — full suite left to CI
- [x] No changes to `pyproject.toml` or `uv.lock`
- [x] Docstrings use single backticks (not RST double backticks)
