### PR TITLE
Gate dependency-file changes on maintainer approval

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,5 +20,5 @@ Fixes #
 - [ ] Linked issue exists and is referenced above
 - [ ] Tests added/updated for new behavior
 - [ ] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
-- [ ] No changes to `pyproject.toml` or `uv.lock` (dependency changes require a separate issue)
+- [ ] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
 - [ ] Docstrings use single backticks (not RST double backticks)

--- a/.github/workflows/dependency-approval.yml
+++ b/.github/workflows/dependency-approval.yml
@@ -1,0 +1,100 @@
+name: Dependency approval
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] -- Base-owned workflow; no checkout or pull-request code execution.
+    branches: [main]
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+
+permissions:
+  issues: write
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: dependency-approval-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: evaluate dependency approval
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # This workflow runs from the base branch. Do not check out or execute
+      # pull-request code here.
+      - name: Require maintainer approval for dependency files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTION: ${{ github.event.action }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LABEL_NAME: ${{ github.event.label.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          files="$(
+            gh api \
+              --paginate \
+              --slurp \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100"
+          )"
+          expected="$(jq -r '.changed_files' <<<"$pr")"
+          found="$(jq -r 'flatten | length' <<<"$files")"
+          changed="$(jq -r '
+            flatten |
+            any(
+              .filename == "pyproject.toml" or
+              .filename == "uv.lock" or
+              .previous_filename == "pyproject.toml" or
+              .previous_filename == "uv.lock"
+            )
+          ' <<<"$files")"
+          approved="$(jq -r '
+            .labels | any(.name == "dependencies:approved")
+          ' <<<"$pr")"
+
+          if [ "$ACTION" = synchronize ] && [ "$approved" = true ]; then
+            gh api \
+              --method DELETE \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/dependencies%3Aapproved"
+            approved=false
+          elif [ "$ACTION" = labeled ] && [ "$LABEL_NAME" = dependencies:approved ]; then
+            permission="$(
+              gh api \
+                "repos/$GITHUB_REPOSITORY/collaborators/$GITHUB_ACTOR/permission" \
+                --jq '.permission'
+            )"
+            if [[ ! "$permission" =~ ^(admin|maintain|write)$ ]]; then
+              gh api \
+                --method DELETE \
+                "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/dependencies%3Aapproved"
+              approved=false
+            fi
+          fi
+
+          if [ "$found" -ne "$expected" ]; then
+            state=error
+            description='Could not inspect every changed file.'
+            error='The changed-file list was incomplete.'
+          elif [ "$changed" = false ]; then
+            state=success
+            description='No dependency files changed.'
+          elif [ "$approved" = true ]; then
+            state=success
+            description='Dependency changes approved by a maintainer.'
+          else
+            state=failure
+            description='Maintainer must add dependencies:approved.'
+            error='A maintainer must add dependencies:approved because this PR changes pyproject.toml or uv.lock.'
+          fi
+
+          gh api \
+            --method POST \
+            "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context='dependency approval' \
+            -f description="$description"
+
+          if [ "$state" != success ]; then
+            echo "::error::$error"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,9 +117,9 @@ Applies to docs, READMEs, docstrings, comments, commit messages, and PR text.
 
 ## Package management
 
-- Use `uv` for all dependency operations
-- Never edit `pyproject.toml` or `uv.lock` directly -- use `uv add`, `uv remove`
-- External PRs that change dependencies are auto-closed by CI
+- Change dependencies only when required. Use `uv` and link an issue.
+- PRs touching `pyproject.toml` or `uv.lock` require the
+  `dependencies:approved` label; pushes clear approval.
 
 ## Commands
 
@@ -172,7 +172,6 @@ need.
 
 ## Contributing rules for AICAs
 
-- Never change `pyproject.toml` or `uv.lock` -- if a dependency is needed, open an issue
 - Always link sources for any claims made during research
 - Run `make lint && make typecheck && make test` before every commit
 - Commit messages should summarize the "why", not the "what"

--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -114,8 +114,6 @@ warnings where practical.
 - Avoid `Any` in new public signatures.
 - Avoid casts. Fix the type shape instead.
 - Keep defaults conservative and easy to explain.
-- Do not add package dependencies without a clear issue and package-manager
-  command.
 - New remote-execution capabilities cap tool output with
   `max_output_bytes` / `max_output_lines` (the `modal_sandbox` names), not a new
   spelling. The released `max_output_chars` (shell) and `max_read_lines`

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -18,7 +18,9 @@ Use this before opening a PR or reviewing a capability change.
 - The implementation uses Pydantic AI hooks/toolsets instead of duplicating core
   runtime behavior.
 - Capability ordering is justified when present.
-- Dependency changes were made through `uv` and have a clear reason.
+- Dependency changes are required, linked to an issue, and made through `uv`;
+  every PR touching `pyproject.toml` or `uv.lock` carries
+  `dependencies:approved` for the current head.
 - A capability that adds heavy CI machinery (a Docker image, an external service
   with a secret, a large system binary, live network calls) scopes its expensive
   job to its own paths and keeps the aggregate check green when that job is


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Fixes #490

## Summary

- replace conflicting dependency instructions with one policy: change dependencies only when required, through `uv`, with a linked issue
- require `dependencies:approved` whenever a PR touches `pyproject.toml` or `uv.lock`
- clear approval on every push and accept approvals only from actors with write, maintain, or admin permission
- inspect renamed files and fail closed if GitHub's changed-file response is incomplete

## Security boundary

The gate uses `pull_request_target` so contributors cannot change the enforcing workflow in their PR. It runs the base-branch workflow, does not check out or execute pull-request code, and limits the token to reading PR state, managing the approval label, and posting the `dependency approval` status to the current PR head.

Runs are serialized per PR, scoped to `main`, and retargeting triggers re-evaluation.

## Verification

- `prek run --all-files`: passed
- `make lint && make typecheck && make test`: passed
- live paginated-file predicate: #419 detected dependency files; #442 did not

## Rollout

After this merges and the workflow emits its first status, add the exact `dependency approval` context to the `main` ruleset's required status checks. GitHub cannot require a status context before it exists.