### PR TITLE
fix(ci): let dependency approval revoke a label and still report

### DIFF
--- a/.github/workflows/dependency-approval.yml
+++ b/.github/workflows/dependency-approval.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
   statuses: write
 
 concurrency:
@@ -30,6 +30,18 @@ jobs:
           LABEL_NAME: ${{ github.event.label.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          # Revoking is `approved=false`; dropping the label is only cleanup, so a
+          # failure there must not abort the step before the status is posted.
+          revoke_approval() {
+            if ! gh api \
+              --method DELETE \
+              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/dependencies%3Aapproved"
+            then
+              echo "::warning::Could not remove the dependencies:approved label. Approval is still revoked for this head."
+            fi
+            approved=false
+          }
+
           pr="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
           files="$(
             gh api \
@@ -53,10 +65,7 @@ jobs:
           ' <<<"$pr")"
 
           if [ "$ACTION" = synchronize ] && [ "$approved" = true ]; then
-            gh api \
-              --method DELETE \
-              "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/dependencies%3Aapproved"
-            approved=false
+            revoke_approval
           elif [ "$ACTION" = labeled ] && [ "$LABEL_NAME" = dependencies:approved ]; then
             permission="$(
               gh api \
@@ -64,10 +73,7 @@ jobs:
                 --jq '.permission'
             )"
             if [[ ! "$permission" =~ ^(admin|maintain|write)$ ]]; then
-              gh api \
-                --method DELETE \
-                "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels/dependencies%3Aapproved"
-              approved=false
+              revoke_approval
             fi
           fi
 


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

## Summary

The `dependency approval` gate cannot revoke its own label, and the failure takes the whole status with it.

On `synchronize`, the workflow deletes `dependencies:approved` so that approval never carries across a
push. That DELETE returns `403 Resource not accessible by integration`, because removing a label from a
**pull request** needs `pull-requests: write` and the workflow declares `pull-requests: read`
([workflow syntax: permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions)
-- "`pull-requests: write` permits an action to add a label to a pull request"). `issues: write` does not
cover it; a PR's labels are governed by the pull-requests scope even though the endpoint lives under
`/issues`.

The step runs under `bash -e`, so the 403 aborts it before the `POST /statuses` at the bottom. The result
is the worst of both: the job goes red, no `dependency approval` status is posted at all, and nothing on
the PR says why.

Hit on #465 ([run 30419615896](https://github.com/pydantic/pydantic-ai-harness/actions/runs/30419615896)):

```
ACTION: synchronize
gh: Resource not accessible by integration (HTTP 403)
{"message":"Resource not accessible by integration",
 "documentation_url":"https://docs.github.com/rest/issues/labels#remove-a-label-from-an-issue",
 "status":"403"}
##[error]Process completed with exit code 1.
```

It stayed latent because it only fires when a PR already carries `dependencies:approved` at the moment a
push lands -- approve first, then push, and the gate breaks.

## Changes

**`pull-requests: read` -> `pull-requests: write`.** The actual fix. The workflow takes no checkout and
runs no pull-request code (the existing comment and the `dangerous-triggers` ignore both say so), so the
added scope is used for exactly one thing: dropping the label it already intends to drop.

**Label removal no longer aborts the step.** `approved=false` is what revokes approval; deleting the
label is cleanup that makes the PR reflect it. Those were coupled, so a cleanup failure could suppress
the verdict. Both call sites now go through one `revoke_approval` helper that warns on a failed delete
and keeps going, so the status is posted either way.

This is defense in depth rather than a second bug fix -- with the permission corrected the delete should
succeed. It matters because the failure mode is silent: a gate that cannot explain itself reads as a
broken PR, not a blocked one.

## Verification

No test harness exists for workflow shell, so I extracted the `run:` block and drove it under `bash -e`
against a stub `gh` that 403s on DELETE and records the status POST, with `ACTION=synchronize` and the
label present -- the exact shape of the #465 failure.

Before, the script dies on the DELETE:

```
gh: Resource not accessible by integration (HTTP 403)
EXIT=1
```

No status posted. After:

```
gh: Resource not accessible by integration (HTTP 403)
::warning::Could not remove the dependencies:approved label. Approval is still revoked for this head.
STATUS POSTED: ... -f state=failure -f context=dependency approval -f description=Maintainer must add dependencies:approved.
::error::A maintainer must add dependencies:approved because this PR changes pyproject.toml or uv.lock.
EXIT=1
```

Still red, as it should be -- but now it says why, and the approval is genuinely revoked. `check yaml`,
`yamlfmt`, `zizmor` and `codespell` all pass.

## Notes

The decision logic is untouched: what counts as a dependency file, who may approve, and the
approval-does-not-survive-a-push rule all behave exactly as before.

Worth a maintainer's eye: whether `issues: write` is still needed. I left it, since narrowing it is a
separate call from fixing the break, and this workflow only ever touches PRs.
