### PR TITLE
docs(agent_docs): record where operational policy lives

### DIFF
--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -122,6 +122,26 @@ warnings where practical.
   editors, and stack traces (`modal_sandbox` is the reference; `filesystem` is
   0-based pending migration).
 
+### Policy Lives In The Pluggable Component
+
+When a capability takes a dependency behind a `Protocol` -- `PlanStore`,
+`MemoryStore`, a client, a sandbox -- retry, fallback and degradation policy
+belongs to the implementation of that protocol, not to fields on the capability.
+
+The capability's job is to state what it does when the dependency fails, and to
+keep the protocol small enough to wrap. A caller who wants
+degraded-but-alive behavior writes a wrapping implementation; that is what the
+protocol is for. The alternative is a capability that grows one `on_x_error=`
+field per dependency and ends up owning behavior it cannot test end to end.
+
+Worked example: `planning`'s tail reminder reads its `PlanStore` on every model
+request, so a store that raises fails the run. `Planning` has no error-handling
+knob; the README documents the behavior and sketches a wrapping store instead.
+
+This is the same boundary as `core-boundary.md`, one level down: there, harness
+does not reimplement core semantics; here, a capability does not reimplement its
+dependency's operational policy.
+
 ## Composition Checks
 
 Before treating a capability as done, check how it composes with:

--- a/agent_docs/index.md
+++ b/agent_docs/index.md
@@ -18,6 +18,9 @@ For any code change:
   or CLI: `capability-authoring.md` "External-Service Assumptions And Refresh"
 - New or changed tests: `testing-capabilities.md`
 - Unsure whether behavior belongs in harness or Pydantic AI core: `core-boundary.md`
+- Adding a retry, fallback or error-handling field to a capability that takes a
+  pluggable dependency: `capability-authoring.md` "Policy Lives In The Pluggable
+  Component"
 - Review, pre-PR check, or final self-check: `review-checklist.md`
 - Commands/parsers, processes/containers, network endpoints, resource cleanup,
   output limits, or CI trust boundaries: `review-checklist.md` "Executable


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David gave the direction; he has not reviewed the wording in detail.

Adds a short subsection to `agent_docs/capability-authoring.md` under API Design, plus a routing line in `agent_docs/index.md`.

**The rule:** when a capability takes a dependency behind a `Protocol` -- `PlanStore`, `MemoryStore`, a client, a sandbox -- retry, fallback and degradation policy belongs to the implementation of that protocol, not to fields on the capability. The capability states what it does when the dependency fails and keeps the protocol small enough to wrap; a caller who wants degraded-but-alive behavior writes a wrapping implementation.

**Why write it down.** The reflex on any "the store went down and killed my run" report is to add an `on_x_error=` field. That is behavior the capability cannot test end to end, and it multiplies once per dependency. It came up concretely in the `Planning` review (#404): the tail reminder reads its `PlanStore` on every model request, so a dead store aborts the run. That stays the behavior -- documented, with a wrapping store as the escape hatch -- rather than becoming a ninth field on the capability.

It is the same boundary as `core-boundary.md`, one level down: there, harness does not reimplement core semantics; here, a capability does not reimplement its dependency's operational policy.

Docs only -- no code, no dependency changes.
