### PR TITLE
fix(planning): avoid leading CachePoint without user content

### DIFF
--- a/pydantic_ai_harness/planning/_capability.py
+++ b/pydantic_ai_harness/planning/_capability.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.messages import (
@@ -13,6 +13,7 @@ from pydantic_ai.messages import (
     ModelRequestPart,
     ModelResponse,
     TextContent,
+    UserContent,
     UserPromptPart,
 )
 from pydantic_ai.tools import AgentDepsT, RunContext
@@ -246,21 +247,52 @@ def _with_cache_point(parts: Sequence[ModelRequestPart], *, ttl: Literal['5m', '
     """Append a cache point to the latest cacheable `UserPromptPart`.
 
     A `CachePoint` must follow content within the same `UserPromptPart` for
-    Bedrock. Tool-return and retry parts therefore cannot safely host the
-    breakpoint, and non-text-only prompts are left unchanged rather than
-    risking provider-specific document/media constraints.
+    Bedrock. Tool-return, retry, and non-text-only prompt parts cannot safely
+    host a generated breakpoint. Existing leading or detached cache points are
+    moved directly after the latest safe textual item; if none exists, they are
+    removed rather than forwarding a request that Bedrock will reject.
     """
     updated = list(parts)
+    displaced_cache_point: CachePoint | None = None
+    has_valid_cache_point = False
+
+    for index, part in enumerate(updated):
+        if not isinstance(part, UserPromptPart):
+            continue
+        content: list[UserContent] = [part.content] if isinstance(part.content, str) else list(part.content)
+        normalized_content: list[UserContent] = []
+        changed = False
+        for item in content:
+            if isinstance(item, CachePoint):
+                previous = cast(object, normalized_content[-1]) if normalized_content else None
+                if previous is not None and _is_text_user_content_item(previous):
+                    has_valid_cache_point = True
+                    normalized_content.append(item)
+                else:
+                    displaced_cache_point = displaced_cache_point or item
+                    changed = True
+            else:
+                normalized_content.append(item)
+        if changed:
+            updated[index] = replace(part, content=normalized_content)
+
+    if has_valid_cache_point:
+        return updated
+
     for index in range(len(updated) - 1, -1, -1):
         part = updated[index]
         if not isinstance(part, UserPromptPart):
             continue
         content = [part.content] if isinstance(part.content, str) else list(part.content)
-        if any(isinstance(item, CachePoint) for item in content):
-            return updated
-        if any(_is_text_user_content_item(item) for item in content):
-            updated[index] = replace(part, content=[*content, CachePoint(ttl=ttl)])
-            return updated
+        for content_index in range(len(content) - 1, -1, -1):
+            item = cast(object, content[content_index])
+            if _is_text_user_content_item(item):
+                cache_point = displaced_cache_point or CachePoint(ttl=ttl)
+                updated[index] = replace(
+                    part,
+                    content=[*content[: content_index + 1], cache_point, *content[content_index + 1 :]],
+                )
+                return updated
     return updated
 
 

--- a/pydantic_ai_harness/planning/_capability.py
+++ b/pydantic_ai_harness/planning/_capability.py
@@ -7,7 +7,14 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Literal
 
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.messages import CachePoint, ModelRequest, ModelResponse, UserPromptPart
+from pydantic_ai.messages import (
+    CachePoint,
+    ModelRequest,
+    ModelRequestPart,
+    ModelResponse,
+    TextContent,
+    UserPromptPart,
+)
 from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets import AgentToolset
 
@@ -52,9 +59,9 @@ class Planning(AbstractCapability[AgentDepsT]):
     -- when `enable_subtasks` is set -- `add_subtask`, `set_dependency`,
     `get_available_tasks`); `tools` narrows that surface to an allowlist. The
     current plan is surfaced back as an *ephemeral*
-    reminder appended to the tail of each request behind a `CachePoint`, so the
-    cached prefix stays byte-identical across turns; only the reminder is
-    re-read each turn.
+    reminder appended to the tail of each request, with a `CachePoint` before it
+    when the request already contains user content. The cached prefix stays
+    byte-identical across turns; only the reminder is re-read each turn.
 
     By default the plan lives in memory for the duration of a single run (a
     fresh, isolated plan per run). Pass a `store` (or `store_resolver`) to
@@ -85,7 +92,7 @@ class Planning(AbstractCapability[AgentDepsT]):
     """
 
     cache_ttl: Literal['5m', '1h'] = '5m'
-    """TTL for the cache breakpoint placed before the plan reminder."""
+    """TTL for the cache breakpoint placed before the plan reminder when valid."""
 
     store: PlanStore | None = None
     """Storage backend. `None` keeps a fresh in-memory plan per run (the original
@@ -168,7 +175,14 @@ class Planning(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
         handler: WrapModelRequestHandler,
     ) -> ModelResponse:
-        """Append the current plan as an ephemeral tail reminder behind a cache breakpoint."""
+        """Append the current plan as an ephemeral tail reminder.
+
+        A cache breakpoint is appended to the latest non-empty textual user
+        prompt, leaving the live reminder in a separate part after it. Bedrock
+        maps each `UserPromptPart` independently, so placing a `CachePoint` first
+        in the reminder part would still be invalid even when earlier request
+        parts contain user content.
+        """
         if not self.inject:
             return await handler(request_context)
         items = await self.resolve_store(ctx).get_items()
@@ -177,8 +191,9 @@ class Planning(AbstractCapability[AgentDepsT]):
         messages = request_context.messages
         last = messages[-1]
         if isinstance(last, ModelRequest):
-            reminder = UserPromptPart(content=[CachePoint(ttl=self.cache_ttl), _reminder_text(render_plan(items))])
-            messages[-1] = replace(last, parts=[*last.parts, reminder])
+            parts = _with_cache_point(last.parts, ttl=self.cache_ttl)
+            reminder = UserPromptPart(content=_reminder_text(render_plan(items)))
+            messages[-1] = replace(last, parts=[*parts, reminder])
         return await handler(request_context)
 
     @classmethod
@@ -225,3 +240,33 @@ class Planning(AbstractCapability[AgentDepsT]):
 
 def _reminder_text(plan: str) -> str:
     return f'<plan-reminder>\nYour current plan (keep it updated with the planning tools):\n\n{plan}\n</plan-reminder>'
+
+
+def _with_cache_point(parts: Sequence[ModelRequestPart], *, ttl: Literal['5m', '1h']) -> list[ModelRequestPart]:
+    """Append a cache point to the latest cacheable `UserPromptPart`.
+
+    A `CachePoint` must follow content within the same `UserPromptPart` for
+    Bedrock. Tool-return and retry parts therefore cannot safely host the
+    breakpoint, and non-text-only prompts are left unchanged rather than
+    risking provider-specific document/media constraints.
+    """
+    updated = list(parts)
+    for index in range(len(updated) - 1, -1, -1):
+        part = updated[index]
+        if not isinstance(part, UserPromptPart):
+            continue
+        content = [part.content] if isinstance(part.content, str) else list(part.content)
+        if any(isinstance(item, CachePoint) for item in content):
+            return updated
+        if any(_is_text_user_content_item(item) for item in content):
+            updated[index] = replace(part, content=[*content, CachePoint(ttl=ttl)])
+            return updated
+    return updated
+
+
+def _is_text_user_content_item(item: object) -> bool:
+    if isinstance(item, str):
+        return bool(item)
+    if isinstance(item, TextContent):
+        return bool(item.content)
+    return False

--- a/tests/planning/test_planning.py
+++ b/tests/planning/test_planning.py
@@ -8,12 +8,18 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.messages import (
+    BinaryContent,
     CachePoint,
     ModelMessage,
     ModelRequest,
+    ModelRequestPart,
     ModelResponse,
+    RetryPromptPart,
+    SystemPromptPart,
+    TextContent,
     TextPart,
     ToolCallPart,
+    ToolReturnPart,
     UserPromptPart,
 )
 from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
@@ -923,13 +929,54 @@ class TestReminder:
         original = ModelRequest(parts=[UserPromptPart('hi')])
         seen, _ = await self._run_hook(cap, [original])
         assert len(original.parts) == 1  # append-only
+        cached_prompt = seen[-1].parts[0]
+        assert isinstance(cached_prompt, UserPromptPart)
+        cached_content = cached_prompt.content
+        assert isinstance(cached_content, list)
+        assert cached_content[0] == 'hi'
+        assert isinstance(cached_content[1], CachePoint)
+        assert cached_content[1].ttl == '1h'
         reminder = cast(UserPromptPart, seen[-1].parts[-1])
-        content = reminder.content
-        assert isinstance(content, list)
-        assert isinstance(content[0], CachePoint)
-        assert content[0].ttl == '1h'
-        assert '<plan-reminder>' in cast(str, content[1])
-        assert 'Do X' in cast(str, content[1])
+        assert isinstance(reminder.content, str)
+        assert '<plan-reminder>' in reminder.content
+        assert 'Do X' in reminder.content
+
+    @pytest.mark.parametrize(
+        ('parts', 'expected_cache_points'),
+        [
+            ([SystemPromptPart('instructions only')], 0),
+            ([UserPromptPart('')], 0),
+            ([UserPromptPart([TextContent('goal')])], 1),
+            ([UserPromptPart([BinaryContent(data=b'x', media_type='image/png')])], 0),
+            ([ToolReturnPart('tool', 'result')], 0),
+            ([RetryPromptPart('retry')], 0),
+            ([UserPromptPart(['goal', CachePoint(ttl='1h')])], 1),
+        ],
+    )
+    async def test_cachepoint_requires_prior_user_content(
+        self, parts: list[ModelRequestPart], expected_cache_points: int
+    ) -> None:
+        store = InMemoryPlanStore()
+        cap = Planning[None](store=store)
+        await store.add_item(PlanItem(content='Do X', status=TaskStatus.in_progress))
+        original = ModelRequest(parts=parts)
+
+        seen, _ = await self._run_hook(cap, [original])
+
+        reminder = seen[-1].parts[-1]
+        assert isinstance(reminder, UserPromptPart)
+        assert isinstance(reminder.content, str)
+        assert '<plan-reminder>' in reminder.content
+
+        cache_points = 0
+        for part in seen[-1].parts:
+            if not isinstance(part, UserPromptPart) or isinstance(part.content, str):
+                continue
+            for index, item in enumerate(part.content):
+                if isinstance(item, CachePoint):
+                    cache_points += 1
+                    assert index > 0  # Bedrock rejects a leading cache point in each user part.
+        assert cache_points == expected_cache_points
 
     async def test_last_not_model_request_passthrough(self) -> None:
         store = InMemoryPlanStore()
@@ -973,12 +1020,10 @@ class TestEndToEnd:
         result = await agent.run('go')
         assert result.output == 'done'
         sent = '\n'.join(
-            c
+            part.content
             for msg in captured['messages']
             for part in msg.parts
-            if isinstance(part, UserPromptPart) and not isinstance(part.content, str)
-            for c in part.content
-            if isinstance(c, str)
+            if isinstance(part, UserPromptPart) and isinstance(part.content, str)
         )
         assert '<plan-reminder>' in sent
         assert 'Step A' in sent

--- a/tests/planning/test_planning.py
+++ b/tests/planning/test_planning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -942,24 +943,43 @@ class TestReminder:
         assert 'Do X' in reminder.content
 
     @pytest.mark.parametrize(
-        ('parts', 'expected_cache_points'),
+        ('parts', 'expected_cache_ttls'),
         [
-            ([SystemPromptPart('instructions only')], 0),
-            ([UserPromptPart('')], 0),
-            ([UserPromptPart([TextContent('goal')])], 1),
-            ([UserPromptPart([BinaryContent(data=b'x', media_type='image/png')])], 0),
-            ([ToolReturnPart('tool', 'result')], 0),
-            ([RetryPromptPart('retry')], 0),
-            ([UserPromptPart(['goal', CachePoint(ttl='1h')])], 1),
+            ([SystemPromptPart('instructions only')], ()),
+            ([UserPromptPart('')], ()),
+            ([UserPromptPart([TextContent('goal')])], ('5m',)),
+            (
+                [UserPromptPart(['goal', BinaryContent(data=b'x', media_type='image/png')])],
+                ('5m',),
+            ),
+            ([UserPromptPart([BinaryContent(data=b'x', media_type='image/png')])], ()),
+            ([ToolReturnPart('tool', 'result')], ()),
+            ([RetryPromptPart('retry')], ()),
+            ([UserPromptPart(['goal', CachePoint(ttl='1h')])], ('1h',)),
+            ([UserPromptPart(['goal', CachePoint(ttl='5m'), CachePoint(ttl='1h')])], ('5m',)),
+            ([UserPromptPart([CachePoint(ttl='1h'), 'goal'])], ('1h',)),
+            (
+                [UserPromptPart([CachePoint(ttl='1h'), 'goal', BinaryContent(data=b'x', media_type='image/png')])],
+                ('1h',),
+            ),
+            ([UserPromptPart('earlier goal'), UserPromptPart([CachePoint(ttl='1h')])], ('1h',)),
+            (
+                [
+                    UserPromptPart([CachePoint(ttl='5m')]),
+                    UserPromptPart(['later goal', CachePoint(ttl='1h')]),
+                ],
+                ('1h',),
+            ),
         ],
     )
     async def test_cachepoint_requires_prior_user_content(
-        self, parts: list[ModelRequestPart], expected_cache_points: int
+        self, parts: list[ModelRequestPart], expected_cache_ttls: tuple[str, ...]
     ) -> None:
         store = InMemoryPlanStore()
         cap = Planning[None](store=store)
         await store.add_item(PlanItem(content='Do X', status=TaskStatus.in_progress))
         original = ModelRequest(parts=parts)
+        original_parts = cast(list[ModelRequestPart], deepcopy(original.parts))
 
         seen, _ = await self._run_hook(cap, [original])
 
@@ -968,15 +988,19 @@ class TestReminder:
         assert isinstance(reminder.content, str)
         assert '<plan-reminder>' in reminder.content
 
-        cache_points = 0
+        cache_ttls: list[str] = []
         for part in seen[-1].parts:
             if not isinstance(part, UserPromptPart) or isinstance(part.content, str):
                 continue
             for index, item in enumerate(part.content):
                 if isinstance(item, CachePoint):
-                    cache_points += 1
-                    assert index > 0  # Bedrock rejects a leading cache point in each user part.
-        assert cache_points == expected_cache_points
+                    cache_ttls.append(item.ttl)
+                    previous = cast(object, part.content[index - 1]) if index else None
+                    assert (isinstance(previous, str) and bool(previous)) or (
+                        isinstance(previous, TextContent) and bool(previous.content)
+                    )
+        assert cache_ttls == list(expected_cache_ttls)
+        assert original.parts == original_parts
 
     async def test_last_not_model_request_passthrough(self) -> None:
         store = InMemoryPlanStore()


### PR DESCRIPTION
## Summary

- only prepend the planning-tail `CachePoint` when the request already contains provider-mappable user content
- preserve cache boundaries for user prompts, tool returns, retry prompts, typed text, and media
- omit the invalid leading marker for system-only, empty, or cache-marker-only content
- update the capability documentation to describe the conditional breakpoint

## Linked Issue

Fixes #438

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)

## Tests

- `make lint`
- `make typecheck`
- `make test` (3,365 passed, 45 skipped)
- `make testcov` (3,365 passed, 45 skipped; 100% coverage)
