### PR TITLE
INT-102: Add E2B sandbox capability with Logfire tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ uv add "pydantic-ai-harness[modal]"             # ModalSandbox (adds the Modal S
 uv add "pydantic-ai-harness[logfire]"           # ManagedPrompt (Logfire-managed prompts)
 uv add "pydantic-ai-harness[exa]"               # ExaSearch + ExaAgent (web research via the Exa API)
 uv add "pydantic-ai-harness[acp]"               # ACP (serve an agent to editors over the Agent Client Protocol)
+uv add pydantic-ai-harness "e2b>=2.34.0"        # E2BSandbox (adds the E2B SDK separately)
 ```
 
 The `code-mode` extra is also supported as an alias.
@@ -152,6 +153,7 @@ We studied leading coding agents, agent frameworks, and Claw-style assistants to
 | | **Shell** | Execute commands with allowlists, denylists, and timeouts | :white_check_mark: [Docs](pydantic_ai_harness/shell/) | [pydantic-ai-backend](https://github.com/vstorm-co/pydantic-ai-backend) (vstorm&#8209;co) |
 | | **LocalStack** | Environment-backed AWS emulator with AWS CLI tools and optional Docker lifecycle | :white_check_mark: [Docs](pydantic_ai_harness/localstack/) | |
 | | **Modal sandbox** | Run commands and manage files in an isolated [Modal](https://modal.com) cloud sandbox | :white_check_mark: [Docs](pydantic_ai_harness/modal_sandbox/) | |
+| | **E2B sandbox** | Run commands and manage files in an isolated [E2B](https://e2b.dev) cloud sandbox with Logfire spans | :white_check_mark: [Docs](pydantic_ai_harness/e2b_sandbox/) | |
 | | **Repo context injection** | Auto-load CLAUDE.md/AGENTS.md and repo structure | :white_check_mark: [Docs](pydantic_ai_harness/context/) | [pydantic-deep](https://github.com/vstorm-co/pydantic-deepagents) (vstorm&#8209;co) |
 | | **Docs lookup** | On-demand `read_pyai_docs` tool for Pydantic AI docs | :white_check_mark: [Docs](pydantic_ai_harness/docs/) | |
 | | **Web research** | Web search returning relevant page excerpts, full single-page retrieval, and opt-in deep search with cited answers, backed by [Exa](https://exa.ai) | :white_check_mark: [Docs](pydantic_ai_harness/exa/) | |

--- a/docs/e2b-sandbox.md
+++ b/docs/e2b-sandbox.md
@@ -1,0 +1,251 @@
+---
+title: E2B Sandbox
+description: Give a Pydantic AI agent an E2B cloud sandbox with bounded command and file tools.
+---
+
+# E2B Sandbox
+
+`E2BSandbox` gives a Pydantic AI agent an isolated cloud computer for running
+model-generated commands and working with files. Use it for coding, tests, data
+processing, and other workloads that should not execute on the application host.
+
+Every agent run gets a fresh [E2B sandbox](https://e2b.dev/docs) by default. The
+capability also supports attaching to an existing sandbox or injecting a session
+that the application keeps open across several runs.
+
+## Quick start
+
+Install Harness and the E2B Python SDK, then set an E2B API key:
+
+```bash
+uv add pydantic-ai-harness "e2b>=2.34.0"
+export E2B_API_KEY=...
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[E2BSandbox(template='base')],
+)
+
+result = agent.run_sync('Create a Python script that prints the first ten primes and run it.')
+print(result.output)
+```
+
+The capability contributes four tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `run_command` | Run a Bash command and return labelled, bounded stdout and stderr. |
+| `read_file` | Stream a UTF-8 text file with bounded memory and line paging. |
+| `write_file` | Write UTF-8 text to a file. |
+| `list_directory` | List directory entries, marking directories with `/`. |
+
+A non-zero command exit is reported to the model instead of raised. Recoverable
+service and filesystem errors become `ModelRetry`; an expired or missing
+sandbox raises `E2BSandboxUnavailableError`, and rejected credentials raise
+`E2BSandboxAuthError`.
+
+## Logfire
+
+E2B lifecycle and tool operations use the active Pydantic AI OpenTelemetry
+tracer. With Pydantic AI instrumentation enabled, Logfire shows:
+
+- `e2b.sandbox.create`, `e2b.sandbox.connect`, and `e2b.sandbox.kill`
+- `e2b.sandbox.run_command`, `read_file`, `write_file`, and `list_directory`
+- sandbox ID, template, lifecycle mode, outcome, exit code, timeout, truncation,
+  file size, and directory entry count
+
+Harness does not add commands, paths, file contents, stdout, or stderr to its
+`e2b.*` span attributes. Pydantic AI's own tool spans can include tool arguments
+and results, so set `include_content=False` when those values must stay out of
+telemetry:
+
+```python
+import logfire
+from pydantic_ai import Agent
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+logfire.configure()
+logfire.instrument_pydantic_ai(include_content=False)
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[E2BSandbox()],
+)
+```
+
+Without Pydantic AI instrumentation, capability-managed sessions use the run's
+no-op tracer and the added operation spans have negligible overhead.
+
+## Lifecycle
+
+The default mode is **owned**. A new sandbox is created as the run enters the
+toolset and killed when the run exits, even if the model never calls a sandbox
+tool. `sandbox_timeout` is the E2B-side lifetime backstop.
+
+Attach to a sandbox managed elsewhere by ID:
+
+```python
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+capability = E2BSandbox(sandbox_id='sbx_existing')
+```
+
+The capability connects for each run and leaves the sandbox running afterward.
+Creation settings such as `template`, `env`, and `sandbox_timeout` cannot be
+combined with `sandbox_id`.
+
+Inject a session to reuse one sandbox across runs while controlling its lifetime:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox, E2BSandboxSession
+
+async with E2BSandboxSession(template='base', sandbox_timeout=1800) as session:
+    agent = Agent(
+        'anthropic:claude-sonnet-4-6',
+        capabilities=[E2BSandbox(session=session, max_command_timeout=600)],
+    )
+    await agent.run('Install the project dependencies.')
+    await agent.run('Run the test suite in the same sandbox.')
+```
+
+The injected session must already be open. The capability uses it but never
+opens or kills it. Reused sandboxes share one filesystem and process space, so
+do not use the same session for overlapping runs that require isolation.
+
+## Output and memory bounds
+
+The E2B Python SDK buffers a command's output in the command handle. Harness
+therefore captures stdout and stderr inside the sandbox with a bounded tail
+before the SDK receives them. Each stream retains at most `max_output_bytes`,
+then the model-facing result applies `max_output_bytes` and `max_output_lines`
+again. Truncation is marked and stream labels are preserved.
+
+This capture wrapper requires Bash, `setsid`, `mkfifo`, `wc`, `tee`, and GNU
+`tail`. E2B's standard `base` template supplies them. Custom templates must
+retain those programs.
+
+`read_file` checks metadata and then streams at most `max_read_bytes + 1` bytes,
+so a file that grows after the metadata check still cannot create an unbounded
+client buffer. Large files are refused with a hint to slice them using
+`run_command`. `list_directory` materializes E2B's complete listing before it
+truncates the displayed result.
+
+## Timeouts and cancellation
+
+`default_command_timeout` applies when the model omits `timeout_seconds`.
+`max_command_timeout` caps model-supplied values. In owned mode a command cannot
+outlive `sandbox_timeout`; attached or injected modes use a 300-second ceiling
+unless `max_command_timeout` is set explicitly.
+
+When E2B reports a timeout or the client wait is cancelled, Harness makes
+best-effort attempts to kill both the command's process group and its E2B command
+handle. Exiting an owned session also kills the whole sandbox. The E2B async SDK
+uses asyncio internally, so real E2B runs require an asyncio event loop.
+
+## Configuration
+
+```python
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+E2BSandbox(
+    template=None,
+    sandbox_id=None,
+    session=None,
+    sandbox_timeout=300,
+    workdir='/home/user',
+    env=None,
+    metadata=None,
+    allow_internet_access=True,
+    default_command_timeout=60.0,
+    max_command_timeout=None,
+    max_output_bytes=50 * 1024,
+    max_output_lines=2000,
+    max_read_bytes=5 * 1024 * 1024,
+    instructions=None,
+)
+```
+
+Settings used only for creation cannot be combined with `sandbox_id` or an
+injected `session`; those conflicts fail during capability construction.
+
+## Composition
+
+Do not combine `E2BSandbox` with another unprefixed capability that provides
+`run_command`, `read_file`, `write_file`, or `list_directory`. Pydantic AI
+rejects duplicate tool names. Use `PrefixTools` and custom instructions when an
+agent needs both:
+
+```python
+from pydantic_ai.capabilities import PrefixTools
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+sandbox = PrefixTools(
+    wrapped=E2BSandbox(
+        instructions='Use the e2b_-prefixed tools for work in the E2B sandbox.',
+    ),
+    prefix='e2b',
+)
+```
+
+## Agent specs
+
+Register `E2BSandbox` as a custom capability type when loading an agent spec:
+
+```yaml
+model: anthropic:claude-sonnet-4-6
+capabilities:
+  - E2BSandbox:
+      template: base
+      sandbox_timeout: 600
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[E2BSandbox])
+```
+
+## Lower-level session
+
+`E2BSandboxSession` is public for applications that need explicit lifecycle and
+byte-oriented access:
+
+```python
+from pydantic_ai_harness.e2b_sandbox import E2BSandboxSession
+
+async with E2BSandboxSession(template='base') as session:
+    result = await session.exec('echo hello', timeout=30, max_output_bytes=50 * 1024)
+    print(result.stdout, result.returncode)
+```
+
+## API reference
+
+- [E2B Python SDK](https://github.com/e2b-dev/E2B/tree/main/packages/python-sdk)
+- [Pydantic AI Logfire integration](/ai/logfire/)
+- [Pydantic AI capabilities](/ai/core-concepts/capabilities/)
+- [E2B Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/e2b_sandbox/)
+- [Pydantic AI Harness version policy](index.md#version-policy)
+
+The API may change between releases while Pydantic AI Harness is on 0.x
+versions.
+
+::: pydantic_ai_harness.e2b_sandbox.E2BSandbox
+
+::: pydantic_ai_harness.e2b_sandbox.E2BSandboxSession
+
+::: pydantic_ai_harness.e2b_sandbox.E2BSandboxExecResult
+
+::: pydantic_ai_harness.e2b_sandbox.E2BSandboxError
+
+::: pydantic_ai_harness.e2b_sandbox.E2BSandboxTerminalError
+
+::: pydantic_ai_harness.e2b_sandbox.E2BSandboxAuthError
+
+::: pydantic_ai_harness.e2b_sandbox.E2BSandboxUnavailableError

--- a/pydantic_ai_harness/_sandbox_tool_output.py
+++ b/pydantic_ai_harness/_sandbox_tool_output.py
@@ -1,7 +1,7 @@
-"""Presentation helpers for Modal sandbox file and command output.
+"""Presentation helpers for remote sandbox file and command output.
 
-Pure formatting stays separate from the Modal I/O layer so output behavior can be
-tested without provisioning a sandbox.
+Pure formatting stays separate from provider I/O so output behavior can be tested
+without provisioning a sandbox.
 
 `read_file`-style tools want `render_file_window` (line-addressable, head-first, with a
 continuation offset). Free-form command output wants `truncate_output` (tail-first, so
@@ -55,10 +55,10 @@ def _tail_bytes(line: str, max_bytes: int) -> str:
 def guard_read_size(size_bytes: int, *, max_bytes: int) -> None:
     """Refuse to read a file larger than `max_bytes`, pointing the model at shell tools.
 
-    A `read_file`-style tool loads the whole file before windowing it, so an oversized
-    file would transfer and decode in full just to return a small slice. This is provider
-    agnostic: the caller supplies the size (however its backend reports it) and the policy
-    lives here so every backend refuses the same way.
+    A `read_file`-style tool should not transfer or decode an oversized file just to
+    return a small slice. This is provider agnostic: the caller supplies the size
+    (however its backend reports it) and the policy lives here so every backend refuses
+    the same way. Providers should still bound the actual read to handle a growth race.
 
     Raises:
         ModelRetry: if the file is too large, telling the model to read part of it instead.

--- a/pydantic_ai_harness/e2b_sandbox/README.md
+++ b/pydantic_ai_harness/e2b_sandbox/README.md
@@ -1,0 +1,233 @@
+# E2B Sandbox
+
+`E2BSandbox` gives a Pydantic AI agent an isolated cloud computer for running
+model-generated commands and working with files. Use it for coding, tests, data
+processing, and other workloads that should not execute on the application host.
+
+Every agent run gets a fresh [E2B sandbox](https://e2b.dev/docs) by default. The
+capability also supports attaching to an existing sandbox or injecting a session
+that the application keeps open across several runs.
+
+## Quick start
+
+Install Harness and the E2B Python SDK, then set an E2B API key:
+
+```bash
+uv add pydantic-ai-harness "e2b>=2.34.0"
+export E2B_API_KEY=...
+```
+
+Add the capability to an agent:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[E2BSandbox(template='base')],
+)
+
+result = agent.run_sync('Create a Python script that prints the first ten primes and run it.')
+print(result.output)
+```
+
+The capability contributes four tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `run_command` | Run a Bash command and return labelled, bounded stdout and stderr. |
+| `read_file` | Stream a UTF-8 text file with bounded memory and line paging. |
+| `write_file` | Write UTF-8 text to a file. |
+| `list_directory` | List directory entries, marking directories with `/`. |
+
+A non-zero command exit is reported to the model instead of raised. Recoverable
+service and filesystem errors become `ModelRetry`; an expired or missing
+sandbox raises `E2BSandboxUnavailableError`, and rejected credentials raise
+`E2BSandboxAuthError`.
+
+## Logfire
+
+E2B lifecycle and tool operations use the active Pydantic AI OpenTelemetry
+tracer. With Pydantic AI instrumentation enabled, Logfire shows:
+
+- `e2b.sandbox.create`, `e2b.sandbox.connect`, and `e2b.sandbox.kill`
+- `e2b.sandbox.run_command`, `read_file`, `write_file`, and `list_directory`
+- sandbox ID, template, lifecycle mode, outcome, exit code, timeout, truncation,
+  file size, and directory entry count
+
+Harness does not add commands, paths, file contents, stdout, or stderr to its
+`e2b.*` span attributes. Pydantic AI's own tool spans can include tool arguments
+and results, so set `include_content=False` when those values must stay out of
+telemetry:
+
+```python
+import logfire
+from pydantic_ai import Agent
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+logfire.configure()
+logfire.instrument_pydantic_ai(include_content=False)
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[E2BSandbox()],
+)
+```
+
+Without Pydantic AI instrumentation, capability-managed sessions use the run's
+no-op tracer and the added operation spans have negligible overhead.
+
+## Lifecycle
+
+The default mode is **owned**. A new sandbox is created as the run enters the
+toolset and killed when the run exits, even if the model never calls a sandbox
+tool. `sandbox_timeout` is the E2B-side lifetime backstop.
+
+Attach to a sandbox managed elsewhere by ID:
+
+```python
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+capability = E2BSandbox(sandbox_id='sbx_existing')
+```
+
+The capability connects for each run and leaves the sandbox running afterward.
+Creation settings such as `template`, `env`, and `sandbox_timeout` cannot be
+combined with `sandbox_id`.
+
+Inject a session to reuse one sandbox across runs while controlling its lifetime:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox, E2BSandboxSession
+
+async with E2BSandboxSession(template='base', sandbox_timeout=1800) as session:
+    agent = Agent(
+        'anthropic:claude-sonnet-4-6',
+        capabilities=[E2BSandbox(session=session, max_command_timeout=600)],
+    )
+    await agent.run('Install the project dependencies.')
+    await agent.run('Run the test suite in the same sandbox.')
+```
+
+The injected session must already be open. The capability uses it but never
+opens or kills it. Reused sandboxes share one filesystem and process space, so
+do not use the same session for overlapping runs that require isolation.
+
+## Output and memory bounds
+
+The E2B Python SDK buffers a command's output in the command handle. Harness
+therefore captures stdout and stderr inside the sandbox with a bounded tail
+before the SDK receives them. Each stream retains at most `max_output_bytes`,
+then the model-facing result applies `max_output_bytes` and `max_output_lines`
+again. Truncation is marked and stream labels are preserved.
+
+This capture wrapper requires Bash, `setsid`, `mkfifo`, `wc`, `tee`, and GNU
+`tail`. E2B's standard `base` template supplies them. Custom templates must
+retain those programs.
+
+`read_file` checks metadata and then streams at most `max_read_bytes + 1` bytes,
+so a file that grows after the metadata check still cannot create an unbounded
+client buffer. Large files are refused with a hint to slice them using
+`run_command`. `list_directory` materializes E2B's complete listing before it
+truncates the displayed result.
+
+## Timeouts and cancellation
+
+`default_command_timeout` applies when the model omits `timeout_seconds`.
+`max_command_timeout` caps model-supplied values. In owned mode a command cannot
+outlive `sandbox_timeout`; attached or injected modes use a 300-second ceiling
+unless `max_command_timeout` is set explicitly.
+
+When E2B reports a timeout or the client wait is cancelled, Harness makes
+best-effort attempts to kill both the command's process group and its E2B command
+handle. Exiting an owned session also kills the whole sandbox. The E2B async SDK
+uses asyncio internally, so real E2B runs require an asyncio event loop.
+
+## Configuration
+
+```python
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+E2BSandbox(
+    template=None,                    # E2B template name/id; None uses E2B's default
+    sandbox_id=None,                  # attach instead of creating a sandbox
+    session=None,                     # caller-owned, already-open E2BSandboxSession
+    sandbox_timeout=300,              # owned sandbox lifetime in seconds
+    workdir='/home/user',             # command cwd and base for relative file paths
+    env=None,                         # environment variables for owned sandboxes
+    metadata=None,                    # E2B metadata for owned sandboxes
+    allow_internet_access=True,       # network access for owned sandboxes
+    default_command_timeout=60.0,     # default per-command timeout
+    max_command_timeout=None,         # hard per-command ceiling
+    max_output_bytes=50 * 1024,       # retained payload per stream or file result
+    max_output_lines=2000,            # retained lines per stream or file result
+    max_read_bytes=5 * 1024 * 1024,   # streamed file-read memory bound
+    instructions=None,                # None: defaults; '': disabled; str: custom
+)
+```
+
+## Composition
+
+Do not combine `E2BSandbox` with another unprefixed capability that provides
+`run_command`, `read_file`, `write_file`, or `list_directory`. Pydantic AI
+rejects duplicate tool names. Use `PrefixTools` and custom instructions when an
+agent needs both:
+
+```python
+from pydantic_ai.capabilities import PrefixTools
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+sandbox = PrefixTools(
+    wrapped=E2BSandbox(
+        instructions='Use the e2b_-prefixed tools for work in the E2B sandbox.',
+    ),
+    prefix='e2b',
+)
+```
+
+Prefixing changes tool names but does not rewrite default instructions.
+
+## Agent specs
+
+Register `E2BSandbox` as a custom capability type when loading an agent spec:
+
+```yaml
+model: anthropic:claude-sonnet-4-6
+capabilities:
+  - E2BSandbox:
+      template: base
+      sandbox_timeout: 600
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.e2b_sandbox import E2BSandbox
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[E2BSandbox])
+```
+
+## Lower-level session
+
+`E2BSandboxSession` is public for applications that need explicit lifecycle and
+byte-oriented access:
+
+```python
+from pydantic_ai_harness.e2b_sandbox import E2BSandboxSession
+
+async with E2BSandboxSession(template='base') as session:
+    result = await session.exec('echo hello', timeout=30, max_output_bytes=50 * 1024)
+    print(result.stdout, result.returncode)
+```
+
+## Further reading
+
+- [E2B Python SDK](https://github.com/e2b-dev/E2B/tree/main/packages/python-sdk)
+- [Pydantic AI Logfire integration](https://ai.pydantic.dev/logfire/)
+- [Pydantic AI capabilities](https://ai.pydantic.dev/capabilities/)
+- [E2B Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/e2b_sandbox/)
+- [Pydantic AI Harness version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy)
+
+The API may change between releases while Pydantic AI Harness is on 0.x
+versions.

--- a/pydantic_ai_harness/e2b_sandbox/__init__.py
+++ b/pydantic_ai_harness/e2b_sandbox/__init__.py
@@ -1,0 +1,21 @@
+"""E2B sandbox capability and lower-level caller-owned session."""
+
+from pydantic_ai_harness.e2b_sandbox._capability import E2BSandbox
+from pydantic_ai_harness.e2b_sandbox._session import (
+    E2BSandboxAuthError,
+    E2BSandboxError,
+    E2BSandboxExecResult,
+    E2BSandboxSession,
+    E2BSandboxTerminalError,
+    E2BSandboxUnavailableError,
+)
+
+__all__ = [
+    'E2BSandbox',
+    'E2BSandboxAuthError',
+    'E2BSandboxError',
+    'E2BSandboxExecResult',
+    'E2BSandboxSession',
+    'E2BSandboxTerminalError',
+    'E2BSandboxUnavailableError',
+]

--- a/pydantic_ai_harness/e2b_sandbox/_capability.py
+++ b/pydantic_ai_harness/e2b_sandbox/_capability.py
@@ -1,0 +1,199 @@
+"""E2B sandbox capability that gives agents an isolated cloud computer."""
+
+from __future__ import annotations
+
+import math
+import posixpath
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.toolsets import AgentToolset
+
+from pydantic_ai_harness._sandbox_tool_output import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
+from pydantic_ai_harness.e2b_sandbox._session import (
+    DEFAULT_SANDBOX_TIMEOUT,
+    DEFAULT_WORKDIR,
+    E2BSandboxSession,
+)
+from pydantic_ai_harness.e2b_sandbox._toolset import E2BSandboxToolset
+
+_DEFAULT_MAX_READ_BYTES = 5 * 1024 * 1024
+
+_OWNED_INSTRUCTIONS = (
+    'You have an E2B sandbox: an isolated, ephemeral cloud computer. Use `run_command` to run '
+    'Bash commands, and `read_file` / `write_file` / `list_directory` to manage files. '
+    'A command times out after {default_timeout}s unless you pass `timeout_seconds` '
+    '(up to {max_timeout}s). The sandbox is reset between runs, so persist anything important elsewhere.'
+)
+
+_REUSED_INSTRUCTIONS = (
+    'You have an E2B sandbox: an isolated cloud computer. Use `run_command` to run Bash commands, '
+    'and `read_file` / `write_file` / `list_directory` to manage files. A command times out after '
+    '{default_timeout}s unless you pass `timeout_seconds` (up to {max_timeout}s). This sandbox '
+    'persists across runs, so files from earlier runs can still be present.'
+)
+
+
+@dataclass(kw_only=True)
+class E2BSandbox(AbstractCapability[AgentDepsT]):
+    """Access to an isolated cloud sandbox powered by [E2B](https://e2b.dev).
+
+    Each agent run gets a fresh sandbox by default. Set `sandbox_id` to attach to a
+    sandbox managed elsewhere, or pass an open `E2BSandboxSession` whose lifetime you
+    manage. Command and file operations emit content-free OpenTelemetry spans through
+    the active Pydantic AI tracer, so they appear in Logfire when the agent is instrumented.
+    """
+
+    template: str | None = None
+    """E2B template name or id for newly created sandboxes. None uses E2B's default."""
+
+    sandbox_id: str | None = None
+    """Attach to an existing sandbox instead of creating one. It will not be killed."""
+
+    session: E2BSandboxSession | None = None
+    """Use a caller-owned, already-open session without opening or closing it."""
+
+    sandbox_timeout: int = DEFAULT_SANDBOX_TIMEOUT
+    """Maximum lifetime in seconds for an owned sandbox."""
+
+    workdir: str = DEFAULT_WORKDIR
+    """Absolute working directory for commands and relative file paths."""
+
+    env: Mapping[str, str] | None = None
+    """Environment variables applied when creating an owned sandbox."""
+
+    metadata: Mapping[str, str] | None = None
+    """E2B metadata applied when creating an owned sandbox."""
+
+    allow_internet_access: bool = True
+    """Whether an owned sandbox may access the internet."""
+
+    default_command_timeout: float = 60.0
+    """Default maximum runtime in seconds for one command."""
+
+    max_command_timeout: int | None = None
+    """Hard per-command ceiling. Reused sandboxes default to 300 seconds."""
+
+    max_output_bytes: int = DEFAULT_MAX_BYTES
+    """Maximum stdout, stderr, or file-read payload retained in UTF-8 bytes."""
+
+    max_output_lines: int = DEFAULT_MAX_LINES
+    """Maximum payload lines returned by each command stream or file tool."""
+
+    max_read_bytes: int = _DEFAULT_MAX_READ_BYTES
+    """Maximum file size streamed into client memory by `read_file`."""
+
+    instructions: str | None = None
+    """Model instructions. None uses mode-aware defaults; an empty string disables them."""
+
+    def __post_init__(self) -> None:
+        """Validate limits and reject settings ignored by the selected lifecycle mode."""
+        self._validate_configuration()
+        if self.env is not None:
+            self.env = dict(self.env)
+        if self.metadata is not None:
+            self.metadata = dict(self.metadata)
+
+        if self.session is not None:
+            conflicts = self._non_default_owned_settings()
+            if self.sandbox_id is not None:
+                conflicts.append('sandbox_id')
+            if conflicts:
+                raise ValueError(
+                    f'{", ".join(conflicts)} cannot be combined with `session`, which already owns '
+                    'the sandbox and its configuration.'
+                )
+            return
+
+        if self.sandbox_id is not None:
+            conflicts = self._non_default_creation_settings()
+            if conflicts:
+                raise ValueError(
+                    f'{", ".join(conflicts)} only apply when creating a sandbox, but `sandbox_id` attaches '
+                    'to an existing one. Remove them, or drop `sandbox_id` to create a sandbox.'
+                )
+            return
+
+        ceiling = self.max_command_timeout
+        if ceiling is not None and ceiling > self.sandbox_timeout:
+            raise ValueError(
+                f'max_command_timeout ({ceiling}) cannot exceed sandbox_timeout '
+                f'({self.sandbox_timeout}) for an owned sandbox.'
+            )
+
+    def _validate_configuration(self) -> None:
+        for name, value in (
+            ('sandbox_timeout', self.sandbox_timeout),
+            ('max_output_bytes', self.max_output_bytes),
+            ('max_output_lines', self.max_output_lines),
+            ('max_read_bytes', self.max_read_bytes),
+        ):
+            if type(value) is not int or value <= 0:
+                raise ValueError(f'{name} must be a positive integer, got {value!r}.')
+
+        timeout = self.default_command_timeout
+        if type(timeout) is bool or not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError(f'default_command_timeout must be a positive finite number, got {timeout!r}.')
+
+        ceiling = self.max_command_timeout
+        if ceiling is not None and (type(ceiling) is not int or ceiling <= 0):
+            raise ValueError(f'max_command_timeout must be a positive integer or None, got {ceiling!r}.')
+        if not self.workdir or not posixpath.isabs(self.workdir):
+            raise ValueError(f'workdir must be an absolute sandbox path, got {self.workdir!r}.')
+        if type(self.allow_internet_access) is not bool:
+            raise ValueError(f'allow_internet_access must be a boolean, got {self.allow_internet_access!r}.')
+        if self.instructions is not None and type(self.instructions) is not str:
+            raise ValueError(f'instructions must be a string or None, got {self.instructions!r}.')
+
+    def _non_default_creation_settings(self) -> list[str]:
+        return [
+            name
+            for name, value, default in (
+                ('template', self.template, None),
+                ('sandbox_timeout', self.sandbox_timeout, DEFAULT_SANDBOX_TIMEOUT),
+                ('env', self.env, None),
+                ('metadata', self.metadata, None),
+                ('allow_internet_access', self.allow_internet_access, True),
+            )
+            if value != default
+        ]
+
+    def _non_default_owned_settings(self) -> list[str]:
+        return [
+            *self._non_default_creation_settings(),
+            *(['workdir'] if self.workdir != DEFAULT_WORKDIR else []),
+        ]
+
+    def get_instructions(self) -> str | None:
+        """Describe the configured sandbox lifecycle and deadlines to the model."""
+        if self.instructions is not None:
+            return self.instructions or None
+        reused = self.sandbox_id is not None or self.session is not None
+        template = _REUSED_INSTRUCTIONS if reused else _OWNED_INSTRUCTIONS
+        ceiling = (
+            self.max_command_timeout
+            if self.max_command_timeout is not None
+            else (DEFAULT_SANDBOX_TIMEOUT if reused else self.sandbox_timeout)
+        )
+        default_timeout = min(max(1, math.ceil(self.default_command_timeout)), ceiling)
+        return template.format(default_timeout=default_timeout, max_timeout=ceiling)
+
+    def get_toolset(self) -> AgentToolset[AgentDepsT]:
+        """Build the model-facing E2B toolset."""
+        return E2BSandboxToolset[AgentDepsT](
+            template=self.template,
+            sandbox_id=self.sandbox_id,
+            sandbox_timeout=self.sandbox_timeout,
+            workdir=self.workdir,
+            default_command_timeout=self.default_command_timeout,
+            max_command_timeout=self.max_command_timeout,
+            max_output_bytes=self.max_output_bytes,
+            max_output_lines=self.max_output_lines,
+            max_read_bytes=self.max_read_bytes,
+            env=self.env,
+            metadata=self.metadata,
+            allow_internet_access=self.allow_internet_access,
+            session=self.session,
+        )

--- a/pydantic_ai_harness/e2b_sandbox/_session.py
+++ b/pydantic_ai_harness/e2b_sandbox/_session.py
@@ -1,0 +1,620 @@
+"""Lifecycle and I/O for an E2B sandbox.
+
+External assumptions last verified 2026-07-24:
+
+* `AsyncSandbox.create`, `connect`, and `kill` provide the owned/attached lifecycle:
+  https://github.com/e2b-dev/E2B/blob/main/packages/python-sdk/e2b/sandbox_async/main.py
+* foreground command results buffer all output, so bounded command capture must happen
+  inside the sandbox before the SDK receives it:
+  https://github.com/e2b-dev/E2B/blob/main/packages/python-sdk/e2b/sandbox_async/commands/command_handle.py
+* the default `base` template contains Bash, GNU coreutils, and `setsid` (util-linux),
+  which the bounded capture wrapper uses:
+  https://github.com/e2b-dev/E2B/blob/main/templates/base/e2b.Dockerfile
+
+Re-check these sources before changing lifecycle, command, or template assumptions.
+"""
+
+from __future__ import annotations
+
+import importlib
+import posixpath
+import shlex
+import warnings
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Literal, Protocol, overload, runtime_checkable
+from uuid import uuid4
+
+import anyio
+import anyio.lowlevel
+from opentelemetry import trace
+from opentelemetry.trace import Tracer
+from typing_extensions import Self
+
+DEFAULT_SANDBOX_TIMEOUT = 300
+DEFAULT_WORKDIR = '/home/user'
+
+_CREATE_TIMEOUT = 120
+_TEARDOWN_TIMEOUT = 30
+_INTERNAL_COMMAND_TIMEOUT = 10
+_TIMEOUT_EXIT_CODE = 124
+
+_MISSING_E2B = (
+    "The 'e2b' package is required for E2BSandbox. Install it alongside Harness with "
+    '`uv add pydantic-ai-harness "e2b>=2.34.0"`.'
+)
+_AUTH_MESSAGE = 'E2B rejected the credentials. Set a valid E2B_API_KEY in the environment.'
+
+
+class _CommandResult(Protocol):  # pragma: no cover - structural typing only
+    stdout: str
+    stderr: str
+    exit_code: int
+    error: str | None
+
+
+@runtime_checkable
+class _CommandFailure(Protocol):  # pragma: no cover - structural typing only
+    stdout: str
+    stderr: str
+    exit_code: int
+    error: str | None
+
+
+class _CommandHandle(Protocol):  # pragma: no cover - structural typing only
+    pid: int
+
+    async def wait(self) -> _CommandResult: ...
+
+    async def kill(self) -> bool: ...
+
+
+class _Commands(Protocol):  # pragma: no cover - structural typing only
+    @overload
+    async def run(
+        self,
+        command: str,
+        *,
+        background: Literal[True],
+        cwd: str | None = None,
+        timeout: float | None = 60,
+    ) -> _CommandHandle: ...
+
+    @overload
+    async def run(
+        self,
+        command: str,
+        *,
+        background: Literal[False] | None = None,
+        cwd: str | None = None,
+        timeout: float | None = 60,
+    ) -> _CommandResult: ...
+
+
+class _FileType(Protocol):  # pragma: no cover - structural typing only
+    value: str
+
+
+class _EntryInfo(Protocol):  # pragma: no cover - structural typing only
+    name: str
+    path: str
+    type: _FileType | None
+    size: int
+
+
+class _AsyncFileStream(Protocol):  # pragma: no cover - structural typing only
+    def __aiter__(self) -> AsyncIterator[bytes]: ...
+
+    async def __aenter__(self) -> Self: ...
+
+    async def __aexit__(self, *args: object) -> None: ...
+
+
+class _Filesystem(Protocol):  # pragma: no cover - structural typing only
+    async def get_info(self, path: str) -> _EntryInfo: ...
+
+    @overload
+    async def read(self, path: str, format: Literal['bytes']) -> bytearray: ...
+
+    @overload
+    async def read(
+        self,
+        path: str,
+        format: Literal['stream'],
+        *,
+        stream_idle_timeout: float | None = None,
+    ) -> _AsyncFileStream: ...
+
+    async def write(self, path: str, data: str | bytes) -> object: ...
+
+    async def list(self, path: str, depth: int | None = 1) -> list[_EntryInfo]: ...
+
+    async def remove(self, path: str) -> None: ...
+
+
+class _AsyncSandbox(Protocol):  # pragma: no cover - structural typing only
+    sandbox_id: str
+    commands: _Commands
+    files: _Filesystem
+
+    async def kill(self) -> bool: ...
+
+
+class _AsyncSandboxFactory(Protocol):  # pragma: no cover - structural typing only
+    async def create(
+        self,
+        template: str | None = None,
+        timeout: int | None = None,
+        metadata: dict[str, str] | None = None,
+        envs: dict[str, str] | None = None,
+        secure: bool = True,
+        allow_internet_access: bool = True,
+    ) -> _AsyncSandbox: ...
+
+    async def connect(self, sandbox_id: str, timeout: int | None = None) -> _AsyncSandbox: ...
+
+
+@runtime_checkable
+class _E2BModule(Protocol):  # pragma: no cover - structural typing only
+    AsyncSandbox: _AsyncSandboxFactory
+    AuthenticationException: type[Exception]
+    CommandExitException: type[Exception]
+    FileNotFoundException: type[Exception]
+    SandboxException: type[Exception]
+    SandboxNotFoundException: type[Exception]
+    TimeoutException: type[Exception]
+
+
+def _load_e2b() -> _E2BModule:
+    try:
+        module: ModuleType = importlib.import_module('e2b')
+    except ImportError as e:
+        raise E2BSandboxError(_MISSING_E2B) from e
+    if not isinstance(module, _E2BModule):  # pragma: no cover - incompatible third-party package
+        raise E2BSandboxError('The installed `e2b` package does not expose the expected async sandbox API.')
+    return module
+
+
+class E2BSandboxError(RuntimeError):
+    """Base class for failures reported by the E2B sandbox integration."""
+
+
+class E2BSandboxTerminalError(E2BSandboxError):
+    """A sandbox failure that a model retry cannot repair."""
+
+
+class E2BSandboxUnavailableError(E2BSandboxTerminalError):
+    """The E2B sandbox does not exist or is no longer running."""
+
+
+class E2BSandboxAuthError(E2BSandboxTerminalError):
+    """E2B rejected the configured credentials."""
+
+
+class _E2BSandboxReadTooLargeError(E2BSandboxError):
+    def __init__(self, *, size_bytes: int, max_bytes: int) -> None:
+        self.size_bytes = size_bytes
+        self.max_bytes = max_bytes
+        super().__init__(f'File grew beyond the {max_bytes}-byte read limit.')
+
+
+@dataclass(frozen=True, kw_only=True)
+class E2BSandboxExecResult:
+    """The bounded outcome of running a command in an E2B sandbox."""
+
+    stdout: str
+    stderr: str
+    returncode: int
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+    timed_out: bool = False
+    applied_timeout: int | None = None
+
+
+def _capture_wrapper(temp_dir: str, max_output_bytes: int) -> str:
+    """Build a Bash wrapper that retains a bounded tail and counts total bytes."""
+    command_path = shlex.quote(posixpath.join(temp_dir, 'command.sh'))
+    stdout_path = shlex.quote(posixpath.join(temp_dir, 'stdout'))
+    stderr_path = shlex.quote(posixpath.join(temp_dir, 'stderr'))
+    stdout_stream = shlex.quote(posixpath.join(temp_dir, 'stdout.stream'))
+    stderr_stream = shlex.quote(posixpath.join(temp_dir, 'stderr.stream'))
+    stdout_count_stream = shlex.quote(posixpath.join(temp_dir, 'stdout.count.stream'))
+    stderr_count_stream = shlex.quote(posixpath.join(temp_dir, 'stderr.count.stream'))
+    stdout_count = shlex.quote(posixpath.join(temp_dir, 'stdout.count'))
+    stderr_count = shlex.quote(posixpath.join(temp_dir, 'stderr.count'))
+    limit = str(max_output_bytes)
+    return f"""#!/bin/bash
+set +e
+mkfifo {stdout_stream} {stderr_stream} {stdout_count_stream} {stderr_count_stream} || exit 125
+wc -c < {stdout_count_stream} > {stdout_count} &
+stdout_count_pid=$!
+tee {stdout_count_stream} < {stdout_stream} | tail -c {limit} > {stdout_path} &
+stdout_capture_pid=$!
+wc -c < {stderr_count_stream} > {stderr_count} &
+stderr_count_pid=$!
+tee {stderr_count_stream} < {stderr_stream} | tail -c {limit} > {stderr_path} &
+stderr_capture_pid=$!
+/bin/bash {command_path} > {stdout_stream} 2> {stderr_stream}
+command_status=$?
+wait "$stdout_capture_pid" "$stderr_capture_pid" "$stdout_count_pid" "$stderr_count_pid"
+capture_status=$?
+if [ "$capture_status" -ne 0 ]; then
+  exit 125
+fi
+exit "$command_status"
+"""
+
+
+class E2BSandboxSession:
+    """Async context manager that creates or attaches to an E2B sandbox.
+
+    Owned sessions create a sandbox on enter and kill it on exit. Attached
+    sessions connect to `sandbox_id` and leave it running. The E2B async SDK uses
+    `asyncio.create_task` for command handles, so this session requires asyncio.
+    """
+
+    def __init__(
+        self,
+        *,
+        template: str | None = None,
+        sandbox_id: str | None = None,
+        sandbox_timeout: int = DEFAULT_SANDBOX_TIMEOUT,
+        workdir: str = DEFAULT_WORKDIR,
+        env: Mapping[str, str] | None = None,
+        metadata: Mapping[str, str] | None = None,
+        allow_internet_access: bool = True,
+        tracer: Tracer | None = None,
+    ) -> None:
+        if type(sandbox_timeout) is not int or sandbox_timeout <= 0:
+            raise ValueError(f'sandbox_timeout must be a positive integer, got {sandbox_timeout!r}.')
+        if not workdir or not posixpath.isabs(workdir):
+            raise ValueError(f'workdir must be an absolute sandbox path, got {workdir!r}.')
+        if type(allow_internet_access) is not bool:
+            raise ValueError(f'allow_internet_access must be a boolean, got {allow_internet_access!r}.')
+        if sandbox_id is not None:
+            conflicts = [
+                name
+                for name, value, default in (
+                    ('template', template, None),
+                    ('sandbox_timeout', sandbox_timeout, DEFAULT_SANDBOX_TIMEOUT),
+                    ('env', env, None),
+                    ('metadata', metadata, None),
+                    ('allow_internet_access', allow_internet_access, True),
+                )
+                if value != default
+            ]
+            if conflicts:
+                raise ValueError(
+                    f'{", ".join(conflicts)} only apply when creating a sandbox, but `sandbox_id` attaches '
+                    'to an existing one. Remove them, or drop `sandbox_id` to create a sandbox.'
+                )
+        self._template = template
+        self._sandbox_id = sandbox_id
+        self._sandbox_timeout = sandbox_timeout
+        self._workdir = workdir
+        self._env = dict(env) if env is not None else None
+        self._metadata = dict(metadata) if metadata is not None else None
+        self._allow_internet_access = allow_internet_access
+        self._tracer = tracer or trace.get_tracer('pydantic_ai_harness.e2b_sandbox')
+        self._sandbox: _AsyncSandbox | None = None
+
+    @property
+    def sandbox_id(self) -> str | None:
+        """The running sandbox id, or None while the session is closed."""
+        return self._sandbox.sandbox_id if self._sandbox is not None else None
+
+    @property
+    def template(self) -> str | None:
+        """The configured template for an owned sandbox."""
+        return self._template
+
+    @property
+    def mode(self) -> Literal['owned', 'attached']:
+        """Whether this session owns the sandbox lifecycle."""
+        return 'attached' if self._sandbox_id is not None else 'owned'
+
+    @property
+    def workdir(self) -> str:
+        """Working directory shared by command and relative file operations."""
+        return self._workdir
+
+    async def __aenter__(self) -> Self:
+        """Create or connect to the configured sandbox."""
+        if self._sandbox is not None:
+            raise E2BSandboxError(
+                'The session is already open; exit it before entering again. '
+                'Use a separate session per concurrent context.'
+            )
+        operation = 'connect' if self._sandbox_id is not None else 'create'
+        with self._tracer.start_as_current_span(f'e2b.sandbox.{operation}') as span:
+            span.set_attribute('e2b.sandbox.mode', self.mode)
+            if self._template is not None:
+                span.set_attribute('e2b.sandbox.template', self._template)
+            try:
+                with anyio.CancelScope(shield=True):
+                    with anyio.move_on_after(_CREATE_TIMEOUT):
+                        self._sandbox = await self._open_sandbox()
+            except Exception as e:
+                error = self._operation_error(e, f'Could not {operation} E2B sandbox')
+                span.set_attribute('e2b.outcome', 'error')
+                span.set_attribute('e2b.exception_type', type(e).__name__)
+                raise error from e
+            if self._sandbox is None:
+                span.set_attribute('e2b.outcome', 'timeout')
+                raise E2BSandboxError(
+                    f'E2B sandbox {operation} did not complete within {_CREATE_TIMEOUT}s; '
+                    'the E2B control plane may be unreachable.'
+                )
+            span.set_attribute('e2b.sandbox.id', self._sandbox.sandbox_id)
+            span.set_attribute('e2b.outcome', 'success')
+        try:
+            await anyio.lowlevel.checkpoint()
+        except BaseException as e:
+            await self.__aexit__(type(e), e, e.__traceback__)
+            raise
+        return self
+
+    async def _open_sandbox(self) -> _AsyncSandbox:
+        e2b = _load_e2b()
+        if self._sandbox_id is not None:
+            return await e2b.AsyncSandbox.connect(self._sandbox_id)
+        return await e2b.AsyncSandbox.create(
+            template=self._template,
+            timeout=self._sandbox_timeout,
+            metadata=self._metadata,
+            envs=self._env,
+            secure=True,
+            allow_internet_access=self._allow_internet_access,
+        )
+
+    async def __aexit__(self, *args: object) -> None:
+        """Kill an owned sandbox; leave an attached sandbox running."""
+        body_failed = bool(args and args[0] is not None)
+        try:
+            await self.close()
+        except E2BSandboxError as e:
+            if not body_failed:
+                raise
+            warnings.warn(f'Could not clean up the owned E2B sandbox: {e}', RuntimeWarning, stacklevel=2)
+
+    async def close(self) -> None:
+        """Close the session, preserving sandbox identity when owned cleanup fails."""
+        sandbox = self._sandbox
+        if sandbox is None:
+            return
+        if self._sandbox_id is not None:
+            self._sandbox = None
+            return
+        with self._tracer.start_as_current_span('e2b.sandbox.kill') as span:
+            span.set_attribute('e2b.sandbox.id', sandbox.sandbox_id)
+            span.set_attribute('e2b.sandbox.mode', 'owned')
+            try:
+                with anyio.CancelScope(shield=True):
+                    with anyio.fail_after(_TEARDOWN_TIMEOUT):
+                        await sandbox.kill()
+            except Exception as e:
+                span.set_attribute('e2b.outcome', 'error')
+                span.set_attribute('e2b.exception_type', type(e).__name__)
+                raise self._operation_error(e, 'Could not kill the owned E2B sandbox') from e
+            span.set_attribute('e2b.outcome', 'success')
+            self._sandbox = None
+
+    def _require_sandbox(self) -> _AsyncSandbox:
+        if self._sandbox is None:
+            raise E2BSandboxError('The E2B sandbox session is not open.')
+        return self._sandbox
+
+    def _operation_error(self, e: Exception, context: str) -> E2BSandboxError:
+        if isinstance(e, E2BSandboxError):
+            return e
+        e2b = _load_e2b()
+        if isinstance(e, e2b.AuthenticationException):
+            return E2BSandboxAuthError(_AUTH_MESSAGE)
+        if isinstance(e, e2b.SandboxNotFoundException):
+            sandbox_id = self.sandbox_id or self._sandbox_id
+            suffix = f' {sandbox_id!r}' if sandbox_id is not None else ''
+            return E2BSandboxUnavailableError(f'The E2B sandbox{suffix} is no longer available.')
+        return E2BSandboxError(f'{context}: {type(e).__name__}: {e}')
+
+    def _resolve(self, path: str) -> str:
+        if posixpath.isabs(path):
+            return posixpath.normpath(path)
+        return posixpath.normpath(posixpath.join(self._workdir, path))
+
+    async def exec(
+        self,
+        command: str,
+        *,
+        timeout: int,
+        max_output_bytes: int,
+    ) -> E2BSandboxExecResult:
+        """Run a command with bounded stdout/stderr capture inside the sandbox."""
+        if type(timeout) is not int or timeout <= 0:
+            raise ValueError(f'timeout must be a positive integer, got {timeout!r}.')
+        if type(max_output_bytes) is not int or max_output_bytes <= 0:
+            raise ValueError(f'max_output_bytes must be a positive integer, got {max_output_bytes!r}.')
+        try:
+            command.encode('utf-8')
+        except UnicodeEncodeError as e:
+            raise E2BSandboxError('Command contains characters that cannot be encoded as UTF-8.') from e
+
+        sandbox = self._require_sandbox()
+        e2b = _load_e2b()
+        temp_dir = f'/tmp/pydantic-ai-harness-{uuid4().hex}'
+        command_path = posixpath.join(temp_dir, 'command.sh')
+        wrapper_path = posixpath.join(temp_dir, 'capture.sh')
+        handle: _CommandHandle | None = None
+        sdk_stdout = ''
+        sdk_stderr = ''
+        returncode = 0
+        timed_out = False
+
+        try:
+            await sandbox.files.write(command_path, command)
+            await sandbox.files.write(wrapper_path, _capture_wrapper(temp_dir, max_output_bytes))
+            run = f'exec setsid /bin/bash {shlex.quote(wrapper_path)}'
+            handle = await sandbox.commands.run(run, background=True, cwd=self._workdir, timeout=timeout)
+            try:
+                result = await handle.wait()
+                returncode = result.exit_code
+                sdk_stdout = result.stdout
+                sdk_stderr = result.stderr
+            except Exception as e:
+                if isinstance(e, e2b.CommandExitException):
+                    if not isinstance(e, _CommandFailure):  # pragma: no cover - incompatible SDK exception
+                        raise E2BSandboxError('E2B returned an incomplete command failure.') from e
+                    returncode = e.exit_code
+                    sdk_stdout = e.stdout
+                    sdk_stderr = e.stderr
+                elif isinstance(e, e2b.TimeoutException):
+                    timed_out = True
+                    returncode = _TIMEOUT_EXIT_CODE
+                    await self._kill_command(handle)
+                else:
+                    raise self._operation_error(e, 'Could not read the E2B command result') from e
+        except BaseException as e:
+            if handle is not None and not timed_out:
+                await self._kill_command(handle)
+            with anyio.CancelScope(shield=True):
+                await self._remove_temp_dir(temp_dir)
+            if isinstance(e, Exception) and not isinstance(e, E2BSandboxError):
+                raise self._operation_error(e, 'Could not run E2B sandbox command') from e
+            raise
+
+        try:
+            stdout, stdout_truncated = await self._read_capture(
+                temp_dir,
+                'stdout',
+                max_output_bytes,
+                incomplete_ok=timed_out,
+            )
+            stderr, stderr_truncated = await self._read_capture(
+                temp_dir,
+                'stderr',
+                max_output_bytes,
+                incomplete_ok=timed_out,
+            )
+        except Exception as e:
+            raise self._operation_error(e, 'Could not read bounded E2B command output') from e
+        finally:
+            await self._remove_temp_dir(temp_dir)
+
+        if sdk_stdout:
+            stdout = f'{stdout}\n{sdk_stdout}' if stdout else sdk_stdout
+        if sdk_stderr:
+            stderr = f'{stderr}\n{sdk_stderr}' if stderr else sdk_stderr
+        return E2BSandboxExecResult(
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
+            timed_out=timed_out,
+            applied_timeout=timeout,
+        )
+
+    async def _kill_command(self, handle: _CommandHandle) -> None:
+        sandbox = self._require_sandbox()
+        with anyio.CancelScope(shield=True):
+            with anyio.move_on_after(_INTERNAL_COMMAND_TIMEOUT):
+                try:
+                    await sandbox.commands.run(
+                        f'kill -KILL -- -{handle.pid}',
+                        cwd=self._workdir,
+                        timeout=_INTERNAL_COMMAND_TIMEOUT,
+                    )
+                except Exception:
+                    pass
+            with anyio.move_on_after(_INTERNAL_COMMAND_TIMEOUT):
+                try:
+                    await handle.kill()
+                except Exception:
+                    pass
+
+    async def _read_capture(
+        self,
+        temp_dir: str,
+        stream: str,
+        max_output_bytes: int,
+        *,
+        incomplete_ok: bool,
+    ) -> tuple[str, bool]:
+        sandbox = self._require_sandbox()
+        e2b = _load_e2b()
+        try:
+            data = bytes(await sandbox.files.read(posixpath.join(temp_dir, stream), 'bytes'))
+        except Exception as e:
+            if incomplete_ok and isinstance(e, e2b.FileNotFoundException):
+                return '', False
+            raise
+        bounded = data[-max_output_bytes:]
+        decoded = bounded.decode('utf-8', errors='replace')
+        try:
+            count_data = bytes(await sandbox.files.read(posixpath.join(temp_dir, f'{stream}.count'), 'bytes'))
+        except Exception as e:
+            if incomplete_ok and isinstance(e, e2b.FileNotFoundException):
+                return decoded, len(data) >= max_output_bytes
+            raise
+        try:
+            total_bytes = int(count_data.decode().strip())
+        except (UnicodeDecodeError, ValueError) as e:
+            if incomplete_ok:
+                return decoded, len(data) >= max_output_bytes
+            raise E2BSandboxError(f'E2B command {stream} byte count was invalid.') from e
+        return decoded, total_bytes > len(bounded)
+
+    async def _remove_temp_dir(self, temp_dir: str) -> None:
+        with anyio.CancelScope(shield=True):
+            with anyio.move_on_after(_INTERNAL_COMMAND_TIMEOUT):
+                try:
+                    await self._require_sandbox().files.remove(temp_dir)
+                except Exception:
+                    pass
+
+    async def file_size(self, path: str) -> int:
+        """Return the size of a sandbox file without reading it."""
+        try:
+            return (await self._require_sandbox().files.get_info(self._resolve(path))).size
+        except Exception as e:
+            raise self._operation_error(e, f'Could not inspect sandbox file {path!r}') from e
+
+    async def read_bytes(self, path: str, *, max_bytes: int) -> bytes:
+        """Stream a file into a bounded buffer."""
+        if type(max_bytes) is not int or max_bytes <= 0:
+            raise ValueError(f'max_bytes must be a positive integer, got {max_bytes!r}.')
+        target = self._resolve(path)
+        try:
+            stream = await self._require_sandbox().files.read(
+                target,
+                'stream',
+                stream_idle_timeout=_INTERNAL_COMMAND_TIMEOUT,
+            )
+            data = bytearray()
+            async with stream:
+                async for chunk in stream:
+                    remaining = max_bytes + 1 - len(data)
+                    if remaining > 0:  # pragma: no branch - we raise as soon as max_bytes + 1 is retained
+                        data.extend(chunk[:remaining])
+                    if len(data) > max_bytes:
+                        raise _E2BSandboxReadTooLargeError(size_bytes=len(data), max_bytes=max_bytes)
+            return bytes(data)
+        except _E2BSandboxReadTooLargeError:
+            raise
+        except Exception as e:
+            raise self._operation_error(e, f'Could not read sandbox file {path!r}') from e
+
+    async def write_bytes(self, path: str, data: bytes) -> None:
+        """Write bytes to a sandbox file, creating parent directories."""
+        try:
+            await self._require_sandbox().files.write(self._resolve(path), data)
+        except Exception as e:
+            raise self._operation_error(e, f'Could not write sandbox file {path!r}') from e
+
+    async def list_files(self, path: str) -> list[tuple[str, bool]]:
+        """List a sandbox directory as `(name, is_dir)` pairs."""
+        try:
+            entries = await self._require_sandbox().files.list(self._resolve(path), depth=1)
+        except Exception as e:
+            raise self._operation_error(e, f'Could not list sandbox directory {path!r}') from e
+        return [(entry.name, entry.type is not None and entry.type.value == 'dir') for entry in entries]

--- a/pydantic_ai_harness/e2b_sandbox/_toolset.py
+++ b/pydantic_ai_harness/e2b_sandbox/_toolset.py
@@ -1,0 +1,309 @@
+"""E2B sandbox tools and their Pydantic AI observability."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Annotated, Literal
+
+from opentelemetry import trace
+from opentelemetry.trace import Span, Tracer
+from pydantic import Field
+from pydantic_ai import RunContext
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
+from typing_extensions import Self
+
+from pydantic_ai_harness._sandbox_tool_output import guard_read_size, render_file_window, truncate_output
+from pydantic_ai_harness.e2b_sandbox._session import (
+    DEFAULT_SANDBOX_TIMEOUT,
+    E2BSandboxError,
+    E2BSandboxSession,
+    E2BSandboxTerminalError,
+)
+
+
+class E2BSandboxToolset(FunctionToolset[AgentDepsT]):
+    """Give an agent per-run E2B command and file tools."""
+
+    def __init__(
+        self,
+        *,
+        template: str | None,
+        sandbox_id: str | None,
+        sandbox_timeout: int,
+        workdir: str,
+        default_command_timeout: float,
+        max_command_timeout: int | None,
+        max_output_bytes: int,
+        max_output_lines: int,
+        max_read_bytes: int,
+        env: Mapping[str, str] | None = None,
+        metadata: Mapping[str, str] | None = None,
+        allow_internet_access: bool = True,
+        session: E2BSandboxSession | None = None,
+        _tracer: Tracer | None = None,
+        _run_scoped: bool = False,
+    ) -> None:
+        super().__init__(id='e2b_sandbox')
+        self._template = template
+        self._sandbox_id = sandbox_id
+        self._sandbox_timeout = sandbox_timeout
+        self._workdir = workdir
+        self._default_command_timeout = default_command_timeout
+        self._max_command_timeout = max_command_timeout
+        self._max_output_bytes = max_output_bytes
+        self._max_output_lines = max_output_lines
+        self._max_read_bytes = max_read_bytes
+        self._env = dict(env) if env is not None else None
+        self._metadata = dict(metadata) if metadata is not None else None
+        self._allow_internet_access = allow_internet_access
+        self._external_session = session
+        self._tracer = _tracer
+        self._session: E2BSandboxSession | None = None
+        self._run_scoped = _run_scoped
+
+        self.add_function(self.run_command, name='run_command')
+        self.add_function(self.read_file, name='read_file')
+        self.add_function(self.write_file, name='write_file')
+        self.add_function(self.list_directory, name='list_directory')
+
+    async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
+        """Return a fresh toolset so each run owns an isolated session."""
+        return E2BSandboxToolset[AgentDepsT](
+            template=self._template,
+            sandbox_id=self._sandbox_id,
+            sandbox_timeout=self._sandbox_timeout,
+            workdir=self._workdir,
+            default_command_timeout=self._default_command_timeout,
+            max_command_timeout=self._max_command_timeout,
+            max_output_bytes=self._max_output_bytes,
+            max_output_lines=self._max_output_lines,
+            max_read_bytes=self._max_read_bytes,
+            env=self._env,
+            metadata=self._metadata,
+            allow_internet_access=self._allow_internet_access,
+            session=self._external_session,
+            _tracer=ctx.tracer,
+            _run_scoped=True,
+        )
+
+    async def __aenter__(self) -> Self:
+        """Open the run-owned session or validate an injected one."""
+        if not self._run_scoped:
+            return self
+        if self._external_session is not None:
+            if self._external_session.sandbox_id is None:
+                raise E2BSandboxError(
+                    'The injected session is not open. Enter it with `async with session:` before running the agent.'
+                )
+            self._session = self._external_session
+            return self
+        session = E2BSandboxSession(
+            template=self._template,
+            sandbox_id=self._sandbox_id,
+            sandbox_timeout=self._sandbox_timeout,
+            workdir=self._workdir,
+            env=self._env,
+            metadata=self._metadata,
+            allow_internet_access=self._allow_internet_access,
+            tracer=self._tracer,
+        )
+        await session.__aenter__()
+        self._session = session
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Close only a session owned by this run."""
+        session = self._session
+        self._session = None
+        if session is not None and self._external_session is None:
+            await session.__aexit__(*args)
+
+    def _require_session(self) -> E2BSandboxSession:
+        if self._session is None:
+            raise E2BSandboxError('The E2B sandbox session is not open.')
+        return self._session
+
+    def _mode(self) -> Literal['owned', 'attached', 'injected']:
+        if self._external_session is not None:
+            return 'injected'
+        return 'attached' if self._sandbox_id is not None else 'owned'
+
+    def _operation_tracer(self) -> Tracer:
+        return self._tracer or trace.get_tracer('pydantic_ai_harness.e2b_sandbox')
+
+    def _set_span_base(self, span: Span, session: E2BSandboxSession, operation: str) -> None:
+        sandbox_id = session.sandbox_id
+        span.set_attribute('e2b.operation', operation)
+        span.set_attribute('e2b.sandbox.mode', self._mode())
+        if sandbox_id is not None:  # pragma: no branch - tools require an open session
+            span.set_attribute('e2b.sandbox.id', sandbox_id)
+        if session.template is not None:
+            span.set_attribute('e2b.sandbox.template', session.template)
+
+    def _command_timeout(self, timeout_seconds: float | None) -> int:
+        if timeout_seconds is not None and (not math.isfinite(timeout_seconds) or timeout_seconds <= 0):
+            raise ModelRetry(f'timeout_seconds must be greater than 0, got {timeout_seconds}.')
+        requested = timeout_seconds if timeout_seconds is not None else self._default_command_timeout
+        reused = self._external_session is not None or self._sandbox_id is not None
+        ceiling = (
+            self._max_command_timeout
+            if self._max_command_timeout is not None
+            else (DEFAULT_SANDBOX_TIMEOUT if reused else self._sandbox_timeout)
+        )
+        return min(max(1, math.ceil(requested)), ceiling)
+
+    def _truncate_stream(self, text: str, already_truncated: bool) -> str:
+        return truncate_output(
+            text,
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+            direction='tail',
+            already_truncated=already_truncated,
+        )
+
+    async def run_command(
+        self,
+        command: str,
+        *,
+        timeout_seconds: float | None = None,
+    ) -> str:
+        """Run a Bash command in the sandbox and return bounded output.
+
+        Args:
+            command: The Bash command to run.
+            timeout_seconds: Maximum seconds to wait (default: the configured timeout).
+
+        Returns:
+            Labelled stdout/stderr output, with timeout or non-zero exit status.
+        """
+        session = self._require_session()
+        timeout = self._command_timeout(timeout_seconds)
+        with self._operation_tracer().start_as_current_span('e2b.sandbox.run_command') as span:
+            self._set_span_base(span, session, 'run_command')
+            span.set_attribute('e2b.command.timeout_seconds', timeout)
+            try:
+                result = await session.exec(command, timeout=timeout, max_output_bytes=self._max_output_bytes)
+            except E2BSandboxTerminalError:
+                span.set_attribute('e2b.outcome', 'terminal_error')
+                raise
+            except E2BSandboxError as e:
+                span.set_attribute('e2b.outcome', 'retry')
+                raise ModelRetry(str(e))
+
+            span.set_attribute('e2b.command.exit_code', result.returncode)
+            span.set_attribute('e2b.command.stdout_truncated', result.stdout_truncated)
+            span.set_attribute('e2b.command.stderr_truncated', result.stderr_truncated)
+            if result.timed_out:
+                span.set_attribute('e2b.outcome', 'timeout')
+            elif result.returncode:
+                span.set_attribute('e2b.outcome', 'nonzero_exit')
+            else:
+                span.set_attribute('e2b.outcome', 'success')
+
+        parts: list[str] = []
+        if result.stdout:
+            parts.append(f'[stdout]\n{self._truncate_stream(result.stdout, result.stdout_truncated)}')
+        if result.stderr:
+            parts.append(f'[stderr]\n{self._truncate_stream(result.stderr, result.stderr_truncated)}')
+        output = '\n'.join(parts) if parts else '(no output)'
+        if result.timed_out:
+            return f'{output}\n[timed out after {result.applied_timeout}s]'
+        if result.returncode:
+            return f'{output}\n[exit code: {result.returncode}]'
+        return output
+
+    async def read_file(
+        self,
+        path: str,
+        *,
+        offset: Annotated[int | None, Field(description='Line number to start reading from (1-indexed)')] = None,
+        limit: Annotated[int | None, Field(description='Maximum number of lines to read')] = None,
+    ) -> str:
+        """Read a UTF-8 file, with line paging and bounded memory.
+
+        Args:
+            path: Sandbox path, relative to the configured working directory when needed.
+            offset: Line number to start reading from (1-indexed).
+            limit: Maximum number of lines to read.
+        """
+        session = self._require_session()
+        with self._operation_tracer().start_as_current_span('e2b.sandbox.read_file') as span:
+            self._set_span_base(span, session, 'read_file')
+            try:
+                guard_read_size(await session.file_size(path), max_bytes=self._max_read_bytes)
+                data = await session.read_bytes(path, max_bytes=self._max_read_bytes)
+                guard_read_size(len(data), max_bytes=self._max_read_bytes)
+                output = render_file_window(
+                    data,
+                    offset=offset,
+                    limit=limit,
+                    max_lines=self._max_output_lines,
+                    max_bytes=self._max_output_bytes,
+                )
+            except E2BSandboxTerminalError:
+                span.set_attribute('e2b.outcome', 'terminal_error')
+                raise
+            except ModelRetry:
+                span.set_attribute('e2b.outcome', 'retry')
+                raise
+            except E2BSandboxError as e:
+                span.set_attribute('e2b.outcome', 'retry')
+                raise ModelRetry(f'Could not read {path!r}: {e}')
+            span.set_attribute('e2b.outcome', 'success')
+            span.set_attribute('e2b.file.size_bytes', len(data))
+        return output
+
+    async def write_file(self, path: str, content: str) -> str:
+        """Write UTF-8 text to a sandbox file.
+
+        Args:
+            path: Sandbox path, relative to the configured working directory when needed.
+            content: Text to write.
+        """
+        session = self._require_session()
+        try:
+            data = content.encode('utf-8')
+        except UnicodeEncodeError:
+            raise ModelRetry('content contains characters that cannot be encoded as UTF-8 (unpaired surrogates).')
+        with self._operation_tracer().start_as_current_span('e2b.sandbox.write_file') as span:
+            self._set_span_base(span, session, 'write_file')
+            try:
+                await session.write_bytes(path, data)
+            except E2BSandboxTerminalError:
+                span.set_attribute('e2b.outcome', 'terminal_error')
+                raise
+            except E2BSandboxError as e:
+                span.set_attribute('e2b.outcome', 'retry')
+                raise ModelRetry(f'Could not write {path!r}: {e}')
+            span.set_attribute('e2b.outcome', 'success')
+            span.set_attribute('e2b.file.size_bytes', len(data))
+        return f'Wrote {len(data)} bytes to {path!r}.'
+
+    async def list_directory(self, path: str = '.') -> str:
+        """List sandbox directory entries, with directories ending in `/`.
+
+        Args:
+            path: Sandbox path, relative to the configured working directory when needed.
+        """
+        session = self._require_session()
+        with self._operation_tracer().start_as_current_span('e2b.sandbox.list_directory') as span:
+            self._set_span_base(span, session, 'list_directory')
+            try:
+                entries = await session.list_files(path)
+            except E2BSandboxTerminalError:
+                span.set_attribute('e2b.outcome', 'terminal_error')
+                raise
+            except E2BSandboxError as e:
+                span.set_attribute('e2b.outcome', 'retry')
+                raise ModelRetry(f'Could not list {path!r}: {e}')
+            span.set_attribute('e2b.outcome', 'success')
+            span.set_attribute('e2b.file.entry_count', len(entries))
+        if not entries:
+            return '(empty)'
+        names = [f'{name}/' if is_dir else name for name, is_dir in sorted(entries)]
+        return truncate_output(
+            '\n'.join(names), max_lines=self._max_output_lines, max_bytes=self._max_output_bytes, direction='head'
+        )

--- a/pydantic_ai_harness/modal_sandbox/_capability.py
+++ b/pydantic_ai_harness/modal_sandbox/_capability.py
@@ -10,6 +10,7 @@ from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AgentToolset
 
+from pydantic_ai_harness._sandbox_tool_output import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
 from pydantic_ai_harness.modal_sandbox._session import (
     DEFAULT_APP_NAME as _DEFAULT_APP_NAME,
 )
@@ -22,7 +23,6 @@ from pydantic_ai_harness.modal_sandbox._session import (
 from pydantic_ai_harness.modal_sandbox._session import (
     ModalSandboxSession,
 )
-from pydantic_ai_harness.modal_sandbox._tool_output import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
 from pydantic_ai_harness.modal_sandbox._toolset import ModalSandboxToolset
 
 # read_file pulls the whole file into memory before windowing it, so cap how large a file

--- a/pydantic_ai_harness/modal_sandbox/_toolset.py
+++ b/pydantic_ai_harness/modal_sandbox/_toolset.py
@@ -13,12 +13,12 @@ from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 from typing_extensions import Self
 
+from pydantic_ai_harness._sandbox_tool_output import guard_read_size, render_file_window, truncate_output
 from pydantic_ai_harness.modal_sandbox._session import (
     ModalSandboxError,
     ModalSandboxSession,
     ModalSandboxTerminalError,
 )
-from pydantic_ai_harness.modal_sandbox._tool_output import guard_read_size, render_file_window, truncate_output
 
 
 class ModalSandboxToolset(FunctionToolset[AgentDepsT]):

--- a/tests/e2b_sandbox/__init__.py
+++ b/tests/e2b_sandbox/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the E2B sandbox capability."""

--- a/tests/e2b_sandbox/conftest.py
+++ b/tests/e2b_sandbox/conftest.py
@@ -1,0 +1,29 @@
+"""Fixtures that keep E2B sandbox unit tests off the real service."""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Iterator
+
+import pytest
+
+from .fake_e2b import FakeE2B
+
+
+class _PoisonedE2B(types.ModuleType):
+    def __getattr__(self, name: str) -> object:  # pragma: no cover - unit-test tripwire
+        raise AssertionError('An E2B unit test touched the real SDK. Use the `fake_e2b` fixture.')
+
+
+@pytest.fixture(autouse=True)
+def _no_real_e2b(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setitem(sys.modules, 'e2b', _PoisonedE2B('e2b'))
+    yield
+
+
+@pytest.fixture
+def fake_e2b(monkeypatch: pytest.MonkeyPatch) -> Iterator[FakeE2B]:
+    control = FakeE2B()
+    monkeypatch.setitem(sys.modules, 'e2b', control.module)
+    yield control

--- a/tests/e2b_sandbox/fake_e2b.py
+++ b/tests/e2b_sandbox/fake_e2b.py
@@ -1,0 +1,379 @@
+"""In-memory E2B async SDK fake used by sandbox capability tests."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+import types
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal, overload
+
+import anyio
+from typing_extensions import Self
+
+
+class AuthenticationException(Exception):
+    """Fake E2B authentication failure."""
+
+
+class SandboxException(Exception):
+    """Fake generic E2B failure."""
+
+
+class SandboxNotFoundException(SandboxException):
+    """Fake missing E2B sandbox failure."""
+
+
+class FileNotFoundException(SandboxException):
+    """Fake missing E2B file failure."""
+
+
+class TimeoutException(SandboxException):
+    """Fake command timeout."""
+
+
+class CommandExitException(SandboxException):
+    """Fake non-zero command result."""
+
+    def __init__(self, stdout: str, stderr: str, exit_code: int) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+        self.error = f'exit status {exit_code}'
+        super().__init__(self.error)
+
+
+@dataclass(frozen=True)
+class FakeCreateCall:
+    template: str | None
+    timeout: int | None
+    metadata: dict[str, str] | None
+    envs: dict[str, str] | None
+    secure: bool
+    allow_internet_access: bool
+
+
+@dataclass(frozen=True)
+class FakeCommandCall:
+    command: str
+    background: bool
+    cwd: str | None
+    timeout: float | None
+
+
+@dataclass(frozen=True)
+class FakeCommandResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class FakeFileType:
+    value: str
+
+
+@dataclass(frozen=True)
+class FakeEntryInfo:
+    name: str
+    path: str
+    type: FakeFileType | None
+    size: int
+
+
+class FakeFileStream:
+    """Async byte stream whose chunking is configurable."""
+
+    def __init__(self, data: bytes, chunk_size: int) -> None:
+        self._data = data
+        self._chunk_size = chunk_size
+        self._index = 0
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._index >= len(self._data):
+            raise StopAsyncIteration
+        chunk = self._data[self._index : self._index + self._chunk_size]
+        self._index += self._chunk_size
+        return chunk
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+class FakeCommandHandle:
+    """Background command handle matching the portion Harness consumes."""
+
+    def __init__(
+        self,
+        control: FakeE2B,
+        *,
+        result: FakeCommandResult,
+        wait_error: Exception | None,
+    ) -> None:
+        self._control = control
+        self._result = result
+        self._wait_error = wait_error
+        self.pid = 4242
+        self.killed = False
+
+    async def wait(self) -> FakeCommandResult:
+        if self._wait_error is not None:
+            raise self._wait_error
+        if self._result.exit_code:
+            raise CommandExitException(
+                self._control.sdk_stdout,
+                self._control.sdk_stderr,
+                self._result.exit_code,
+            )
+        return self._result
+
+    async def kill(self) -> bool:
+        self.killed = True
+        if self._control.handle_kill_error is not None:
+            raise self._control.handle_kill_error
+        return True
+
+
+class FakeFilesystem:
+    """Dictionary-backed E2B filesystem."""
+
+    def __init__(self, control: FakeE2B) -> None:
+        self._control = control
+        self.files: dict[str, bytes] = {}
+        self.stat_sizes: dict[str, int] = {}
+        self.listings: dict[str, list[FakeEntryInfo]] = {}
+        self.removed: list[str] = []
+
+    async def get_info(self, path: str) -> FakeEntryInfo:
+        if self._control.info_error is not None:
+            raise self._control.info_error
+        if path not in self.files and path not in self.stat_sizes:
+            raise FileNotFoundException(path)
+        size = self.stat_sizes.get(path, len(self.files.get(path, b'')))
+        return FakeEntryInfo(posixpath.basename(path), path, FakeFileType('file'), size)
+
+    @overload
+    async def read(self, path: str, format: Literal['bytes']) -> bytearray: ...  # pragma: no cover
+
+    @overload
+    async def read(
+        self,
+        path: str,
+        format: Literal['stream'],
+        *,
+        stream_idle_timeout: float | None = None,
+    ) -> FakeFileStream: ...  # pragma: no cover
+
+    async def read(
+        self,
+        path: str,
+        format: Literal['bytes', 'stream'],
+        *,
+        stream_idle_timeout: float | None = None,
+    ) -> bytearray | FakeFileStream:
+        del stream_idle_timeout
+        if self._control.read_error is not None:
+            raise self._control.read_error
+        try:
+            data = self.files[path]
+        except KeyError as e:
+            raise FileNotFoundException(path) from e
+        if format == 'bytes':
+            return bytearray(data)
+        return FakeFileStream(data, self._control.file_chunk_size)
+
+    async def write(self, path: str, data: str | bytes) -> object:
+        if self._control.write_error is not None:
+            raise self._control.write_error
+        self.files[path] = data.encode() if isinstance(data, str) else data
+        return object()
+
+    async def list(self, path: str, depth: int | None = 1) -> list[FakeEntryInfo]:
+        del depth
+        if self._control.list_error is not None:
+            raise self._control.list_error
+        return list(self.listings.get(path, []))
+
+    async def remove(self, path: str) -> None:
+        self.removed.append(path)
+        if self._control.remove_error is not None:
+            raise self._control.remove_error
+        for target in [target for target in self.files if target == path or target.startswith(f'{path}/')]:
+            del self.files[target]
+
+
+class FakeCommands:
+    """Command manager that simulates Harness's capture wrapper."""
+
+    def __init__(self, sandbox: FakeSandbox, control: FakeE2B) -> None:
+        self._sandbox = sandbox
+        self._control = control
+        self.calls: list[FakeCommandCall] = []
+        self.handles: list[FakeCommandHandle] = []
+
+    @overload
+    async def run(
+        self,
+        command: str,
+        *,
+        background: Literal[True],
+        cwd: str | None = None,
+        timeout: float | None = 60,
+    ) -> FakeCommandHandle: ...  # pragma: no cover
+
+    @overload
+    async def run(
+        self,
+        command: str,
+        *,
+        background: Literal[False] | None = None,
+        cwd: str | None = None,
+        timeout: float | None = 60,
+    ) -> FakeCommandResult: ...  # pragma: no cover
+
+    async def run(
+        self,
+        command: str,
+        *,
+        background: bool | None = None,
+        cwd: str | None = None,
+        timeout: float | None = 60,
+    ) -> FakeCommandHandle | FakeCommandResult:
+        is_background = background is True
+        self.calls.append(FakeCommandCall(command, is_background, cwd, timeout))
+        if self._control.run_error is not None:
+            raise self._control.run_error
+        if not is_background:
+            if self._control.kill_process_error is not None:
+                raise self._control.kill_process_error
+            return FakeCommandResult('', '', 0)
+
+        wrapper_path = command.rsplit(' ', 1)[-1]
+        temp_dir = posixpath.dirname(wrapper_path)
+        command_text = self._sandbox.files.files[f'{temp_dir}/command.sh'].decode()
+        wrapper = self._sandbox.files.files[wrapper_path].decode()
+        match = re.search(r'tail -c (\d+)', wrapper)
+        if match is None:  # pragma: no cover - asserts Harness's private wrapper contract
+            raise AssertionError('Harness capture wrapper did not contain a byte limit')
+        byte_limit = int(match.group(1))
+        stdout, stderr, exit_code = self._control.responder(command_text, int(timeout or 0))
+        if not self._control.omit_capture:
+            self._write_capture(temp_dir, 'stdout', stdout, byte_limit)
+            self._write_capture(temp_dir, 'stderr', stderr, byte_limit)
+        result = FakeCommandResult(
+            self._control.sdk_stdout,
+            self._control.sdk_stderr,
+            exit_code,
+            None if exit_code == 0 else f'exit status {exit_code}',
+        )
+        handle = FakeCommandHandle(self._control, result=result, wait_error=self._control.wait_error)
+        self.handles.append(handle)
+        return handle
+
+    def _write_capture(self, temp_dir: str, stream: str, text: str, byte_limit: int) -> None:
+        data = text.encode()
+        self._sandbox.files.files[f'{temp_dir}/{stream}'] = data[-byte_limit:]
+        count = b'invalid' if self._control.invalid_count else str(len(data)).encode()
+        if not self._control.omit_count:
+            self._sandbox.files.files[f'{temp_dir}/{stream}.count'] = count
+
+
+class FakeSandbox:
+    """Fake async sandbox instance."""
+
+    def __init__(self, control: FakeE2B, sandbox_id: str) -> None:
+        self._control = control
+        self.sandbox_id = sandbox_id
+        self.files = FakeFilesystem(control)
+        self.commands = FakeCommands(self, control)
+        self.kill_calls = 0
+
+    async def kill(self) -> bool:
+        self.kill_calls += 1
+        if self._control.kill_hangs:
+            await anyio.sleep_forever()
+        if self._control.kill_error is not None:
+            raise self._control.kill_error
+        return True
+
+
+class FakeAsyncSandboxFactory:
+    """Fake `AsyncSandbox` class methods."""
+
+    def __init__(self, control: FakeE2B) -> None:
+        self._control = control
+
+    async def create(
+        self,
+        template: str | None = None,
+        timeout: int | None = None,
+        metadata: dict[str, str] | None = None,
+        envs: dict[str, str] | None = None,
+        secure: bool = True,
+        allow_internet_access: bool = True,
+    ) -> FakeSandbox:
+        self._control.create_calls.append(
+            FakeCreateCall(template, timeout, metadata, envs, secure, allow_internet_access)
+        )
+        if self._control.create_hangs:
+            await anyio.sleep_forever()
+        if self._control.create_error is not None:
+            raise self._control.create_error
+        sandbox = FakeSandbox(self._control, f'sbx-{len(self._control.sandboxes) + 1}')
+        self._control.sandboxes.append(sandbox)
+        return sandbox
+
+    async def connect(self, sandbox_id: str, timeout: int | None = None) -> FakeSandbox:
+        self._control.connect_calls.append((sandbox_id, timeout))
+        if self._control.connect_error is not None:
+            raise self._control.connect_error
+        sandbox = FakeSandbox(self._control, sandbox_id)
+        self._control.sandboxes.append(sandbox)
+        return sandbox
+
+
+class FakeE2B:
+    """Control surface plus a module-shaped E2B SDK fake."""
+
+    def __init__(self) -> None:
+        self.sandboxes: list[FakeSandbox] = []
+        self.create_calls: list[FakeCreateCall] = []
+        self.connect_calls: list[tuple[str, int | None]] = []
+        self.responder: Callable[[str, int], tuple[str, str, int]] = lambda command, timeout: ('', '', 0)
+        self.create_error: Exception | None = None
+        self.connect_error: Exception | None = None
+        self.kill_error: Exception | None = None
+        self.kill_hangs = False
+        self.create_hangs = False
+        self.run_error: Exception | None = None
+        self.kill_process_error: Exception | None = None
+        self.wait_error: Exception | None = None
+        self.handle_kill_error: Exception | None = None
+        self.write_error: Exception | None = None
+        self.read_error: Exception | None = None
+        self.info_error: Exception | None = None
+        self.list_error: Exception | None = None
+        self.remove_error: Exception | None = None
+        self.omit_capture = False
+        self.omit_count = False
+        self.invalid_count = False
+        self.sdk_stdout = ''
+        self.sdk_stderr = ''
+        self.file_chunk_size = 4
+
+        self.module = types.ModuleType('e2b')
+        setattr(self.module, 'AsyncSandbox', FakeAsyncSandboxFactory(self))
+        setattr(self.module, 'AuthenticationException', AuthenticationException)
+        setattr(self.module, 'CommandExitException', CommandExitException)
+        setattr(self.module, 'FileNotFoundException', FileNotFoundException)
+        setattr(self.module, 'SandboxException', SandboxException)
+        setattr(self.module, 'SandboxNotFoundException', SandboxNotFoundException)
+        setattr(self.module, 'TimeoutException', TimeoutException)

--- a/tests/e2b_sandbox/test_e2b_sandbox.py
+++ b/tests/e2b_sandbox/test_e2b_sandbox.py
@@ -1,0 +1,454 @@
+"""Tests for E2BSandbox through its public capability API."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import AsyncGenerator, Mapping
+from contextlib import asynccontextmanager
+from typing import Protocol, TypeGuard, runtime_checkable
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import NoOpTracer, Tracer
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import AbstractToolset
+from pydantic_ai.usage import RunUsage
+from typing_extensions import Self
+
+from pydantic_ai_harness.e2b_sandbox import (
+    E2BSandbox,
+    E2BSandboxAuthError,
+    E2BSandboxError,
+    E2BSandboxSession,
+    E2BSandboxUnavailableError,
+)
+
+from .fake_e2b import (
+    AuthenticationException,
+    FakeE2B,
+    FakeEntryInfo,
+    FakeFileType,
+    SandboxException,
+    SandboxNotFoundException,
+    TimeoutException,
+)
+
+
+@runtime_checkable
+class _E2BSandboxTools(Protocol):  # pragma: no cover - structural typing only
+    async def __aenter__(self) -> Self: ...
+
+    async def __aexit__(self, *args: object) -> None: ...
+
+    async def run_command(self, command: str, *, timeout_seconds: float | None = None) -> str: ...
+
+    async def read_file(self, path: str, *, offset: int | None = None, limit: int | None = None) -> str: ...
+
+    async def write_file(self, path: str, content: str) -> str: ...
+
+    async def list_directory(self, path: str = '.') -> str: ...
+
+
+def _is_abstract_toolset(value: object) -> TypeGuard[AbstractToolset[None]]:
+    return isinstance(value, AbstractToolset)
+
+
+def _run_context(*, tracer: Tracer | None = None) -> RunContext[None]:
+    return RunContext[None](
+        deps=None,
+        model=TestModel(),
+        usage=RunUsage(),
+        prompt=None,
+        messages=[],
+        run_step=0,
+        tracer=tracer or NoOpTracer(),
+    )
+
+
+@asynccontextmanager
+async def _toolset(
+    *,
+    sandbox_id: str | None = None,
+    template: str | None = None,
+    sandbox_timeout: int = 300,
+    workdir: str = '/home/user',
+    default_command_timeout: float = 30.0,
+    max_command_timeout: int | None = None,
+    max_output_bytes: int = 50_000,
+    max_output_lines: int = 2000,
+    max_read_bytes: int = 5 * 1024 * 1024,
+    env: Mapping[str, str] | None = None,
+    metadata: Mapping[str, str] | None = None,
+    allow_internet_access: bool = True,
+    session: E2BSandboxSession | None = None,
+    tracer: Tracer | None = None,
+) -> AsyncGenerator[_E2BSandboxTools]:
+    toolset = E2BSandbox[None](
+        template=template,
+        sandbox_id=sandbox_id,
+        sandbox_timeout=sandbox_timeout,
+        workdir=workdir,
+        default_command_timeout=default_command_timeout,
+        max_command_timeout=max_command_timeout,
+        max_output_bytes=max_output_bytes,
+        max_output_lines=max_output_lines,
+        max_read_bytes=max_read_bytes,
+        env=env,
+        metadata=metadata,
+        allow_internet_access=allow_internet_access,
+        session=session,
+    ).get_toolset()
+    if not _is_abstract_toolset(toolset):  # pragma: no cover - capability contract
+        raise AssertionError('E2BSandbox must return an AbstractToolset')
+    run_toolset = await toolset.for_run(_run_context(tracer=tracer))
+    if not isinstance(run_toolset, _E2BSandboxTools):  # pragma: no cover - capability contract
+        raise AssertionError('E2BSandbox toolset is missing its public tools')
+    async with run_toolset:
+        yield run_toolset
+
+
+class TestRunCommand:
+    async def test_stdout_stderr_nonzero_and_no_output(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.responder = lambda command, timeout: ('out\n', 'err\n', 2)
+        async with _toolset() as tools:
+            assert await tools.run_command('false') == ('[stdout]\nout\n[stderr]\nerr\n[exit code: 2]')
+            fake_e2b.responder = lambda command, timeout: ('', '', 0)
+            assert await tools.run_command('true') == '(no output)'
+
+    async def test_timeout_is_reported_and_killed(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.responder = lambda command, timeout: ('partial\n', '', 0)
+        fake_e2b.wait_error = TimeoutException('deadline')
+        async with _toolset() as tools:
+            result = await tools.run_command('sleep 99', timeout_seconds=2)
+        assert result == '[stdout]\npartial\n[timed out after 2s]'
+        assert fake_e2b.sandboxes[0].commands.handles[0].killed is True
+
+    async def test_timeout_rounds_and_clamps(self, fake_e2b: FakeE2B) -> None:
+        async with _toolset(sandbox_timeout=20, default_command_timeout=4.1) as tools:
+            await tools.run_command('default')
+            await tools.run_command('fractional', timeout_seconds=0.2)
+            await tools.run_command('clamped', timeout_seconds=100)
+        timeouts = [call.timeout for call in fake_e2b.sandboxes[0].commands.calls if call.background]
+        assert timeouts == [5, 1, 20]
+
+    async def test_owned_default_ceiling_tracks_longer_sandbox_lifetime(self, fake_e2b: FakeE2B) -> None:
+        async with _toolset(sandbox_timeout=600) as tools:
+            await tools.run_command('long', timeout_seconds=500)
+        command = next(call for call in fake_e2b.sandboxes[0].commands.calls if call.background)
+        assert command.timeout == 500
+
+    async def test_explicit_ceiling_for_reused_sandbox(self, fake_e2b: FakeE2B) -> None:
+        async with _toolset(sandbox_id='sbx-existing', max_command_timeout=600) as tools:
+            await tools.run_command('long', timeout_seconds=900)
+        command = next(call for call in fake_e2b.sandboxes[0].commands.calls if call.background)
+        assert command.timeout == 600
+        assert fake_e2b.sandboxes[0].kill_calls == 0
+
+    @pytest.mark.parametrize('timeout', [0.0, -1.0, float('inf'), float('nan')])
+    async def test_bad_model_timeout_retries(self, fake_e2b: FakeE2B, timeout: float) -> None:
+        async with _toolset() as tools:
+            with pytest.raises(ModelRetry, match='greater than 0'):
+                await tools.run_command('echo', timeout_seconds=timeout)
+        assert fake_e2b.sandboxes[0].commands.calls == []
+
+    async def test_output_is_bounded_per_stream_and_by_lines(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.responder = lambda command, timeout: (
+            'A' * 100 + 'END',
+            'first\nsecond\nthird',
+            0,
+        )
+        async with _toolset(max_output_bytes=20, max_output_lines=1) as tools:
+            result = await tools.run_command('flood')
+        assert result.startswith('[stdout]\n[... output truncated')
+        assert 'END' in result
+        assert '[stderr]\n[... output truncated to the last 1 lines ...]\nthird' in result
+
+    async def test_recoverable_and_terminal_errors(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.run_error = SandboxException('transient')
+        async with _toolset() as tools:
+            with pytest.raises(ModelRetry, match='transient'):
+                await tools.run_command('echo')
+        fake_e2b.run_error = SandboxNotFoundException('gone')
+        async with _toolset() as tools:
+            with pytest.raises(E2BSandboxUnavailableError):
+                await tools.run_command('echo')
+
+    async def test_unentered_base_toolset_rejected(self) -> None:
+        toolset = E2BSandbox[None]().get_toolset()
+        assert isinstance(toolset, _E2BSandboxTools)
+        async with toolset:
+            with pytest.raises(E2BSandboxError, match='session is not open'):
+                await toolset.run_command('echo')
+
+
+class TestFiles:
+    async def test_read_write_and_list(self, fake_e2b: FakeE2B) -> None:
+        async with _toolset() as tools:
+            assert await tools.write_file('notes.txt', 'alpha\nbeta\ngamma') == ("Wrote 16 bytes to 'notes.txt'.")
+            assert await tools.read_file('notes.txt', offset=2, limit=1) == (
+                'beta\n\n[1 more lines in file. Use offset=3 to continue.]'
+            )
+            fake_e2b.sandboxes[0].files.listings['/home/user'] = [
+                FakeEntryInfo('z.txt', '/home/user/z.txt', FakeFileType('file'), 1),
+                FakeEntryInfo('src', '/home/user/src', FakeFileType('dir'), 0),
+            ]
+            assert await tools.list_directory() == 'src/\nz.txt'
+
+    async def test_empty_and_truncated_directory(self, fake_e2b: FakeE2B) -> None:
+        async with _toolset(max_output_lines=1) as tools:
+            assert await tools.list_directory() == '(empty)'
+            fake_e2b.sandboxes[0].files.listings['/home/user'] = [
+                FakeEntryInfo('a', '/home/user/a', FakeFileType('file'), 1),
+                FakeEntryInfo('b', '/home/user/b', FakeFileType('file'), 1),
+            ]
+            assert (await tools.list_directory()).startswith('a\n[... output truncated')
+
+    async def test_read_refuses_large_file_and_growth_race(self, fake_e2b: FakeE2B) -> None:
+        async with _toolset(max_read_bytes=5) as tools:
+            fake_e2b.sandboxes[0].files.stat_sizes['/large'] = 6
+            with pytest.raises(ModelRetry, match='over the 5B read limit'):
+                await tools.read_file('/large')
+            fake_e2b.sandboxes[0].files.stat_sizes['/growing'] = 5
+            fake_e2b.sandboxes[0].files.files['/growing'] = b'123456'
+            with pytest.raises(ModelRetry, match='grew beyond'):
+                await tools.read_file('/growing')
+
+    async def test_binary_and_unpaired_surrogate_retry(self, fake_e2b: FakeE2B) -> None:
+        async with _toolset() as tools:
+            fake_e2b.sandboxes[0].files.files['/binary'] = b'\xff'
+            with pytest.raises(ModelRetry, match='not valid UTF-8'):
+                await tools.read_file('/binary')
+            with pytest.raises(ModelRetry, match='unpaired surrogates'):
+                await tools.write_file('/x', '\ud800')
+
+    @pytest.mark.parametrize(
+        ('operation', 'match'),
+        [
+            ('read', 'Could not read'),
+            ('write', 'Could not write'),
+            ('list', 'Could not list'),
+        ],
+    )
+    async def test_recoverable_file_errors(self, fake_e2b: FakeE2B, operation: str, match: str) -> None:
+        setattr(fake_e2b, f'{operation}_error', SandboxException('transient'))
+        async with _toolset() as tools:
+            if operation == 'read':
+                fake_e2b.sandboxes[0].files.files['/x'] = b'x'
+            with pytest.raises(ModelRetry, match=match):
+                if operation == 'read':
+                    await tools.read_file('/x')
+                elif operation == 'write':
+                    await tools.write_file('/x', 'x')
+                else:
+                    await tools.list_directory('/x')
+
+    @pytest.mark.parametrize('operation', ['read', 'write', 'list'])
+    async def test_terminal_file_errors(self, fake_e2b: FakeE2B, operation: str) -> None:
+        error = SandboxNotFoundException('gone')
+        if operation == 'read':
+            fake_e2b.info_error = error
+        else:
+            setattr(fake_e2b, f'{operation}_error', error)
+        async with _toolset() as tools:
+            with pytest.raises(E2BSandboxUnavailableError):
+                if operation == 'read':
+                    await tools.read_file('/x')
+                elif operation == 'write':
+                    await tools.write_file('/x', 'x')
+                else:
+                    await tools.list_directory('/x')
+
+
+class TestLifecycleAndTracing:
+    async def test_injected_open_session_is_reused(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession(template='python') as session:
+            async with _toolset(session=session) as tools:
+                assert await tools.run_command('true') == '(no output)'
+            assert fake_e2b.sandboxes[0].kill_calls == 0
+        assert fake_e2b.sandboxes[0].kill_calls == 1
+
+    async def test_injected_session_must_be_open(self) -> None:
+        session = E2BSandboxSession()
+        toolset = E2BSandbox[None](session=session).get_toolset()
+        assert _is_abstract_toolset(toolset)
+        run_toolset = await toolset.for_run(_run_context())
+        with pytest.raises(E2BSandboxError, match='injected session is not open'):
+            async with run_toolset:
+                pass  # pragma: no cover
+
+    async def test_spans_have_identity_outcomes_and_no_content(self, fake_e2b: FakeE2B) -> None:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        tracer = provider.get_tracer('e2b-test')
+        fake_e2b.responder = lambda command, timeout: ('secret output', '', 3)
+        async with _toolset(template='python', tracer=tracer) as tools:
+            await tools.run_command('secret command')
+
+        spans = {span.name: span for span in exporter.get_finished_spans()}
+        assert set(spans) == {
+            'e2b.sandbox.create',
+            'e2b.sandbox.run_command',
+            'e2b.sandbox.kill',
+        }
+        command_span = spans['e2b.sandbox.run_command']
+        assert command_span.attributes is not None
+        assert command_span.attributes['e2b.sandbox.id'] == 'sbx-1'
+        assert command_span.attributes['e2b.sandbox.template'] == 'python'
+        assert command_span.attributes['e2b.sandbox.mode'] == 'owned'
+        assert command_span.attributes['e2b.outcome'] == 'nonzero_exit'
+        assert command_span.attributes['e2b.command.exit_code'] == 3
+        assert 'secret' not in repr(command_span.attributes)
+
+    @pytest.mark.parametrize(
+        ('error', 'outcome'),
+        [
+            (SandboxException('transient'), 'retry'),
+            (AuthenticationException('bad key'), 'terminal_error'),
+        ],
+    )
+    async def test_error_span_outcomes(self, fake_e2b: FakeE2B, error: Exception, outcome: str) -> None:
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        fake_e2b.run_error = error
+        with pytest.raises((ModelRetry, E2BSandboxAuthError)):
+            async with _toolset(tracer=provider.get_tracer('test')) as tools:
+                await tools.run_command('echo')
+        span = next(span for span in exporter.get_finished_spans() if span.name == 'e2b.sandbox.run_command')
+        assert span.attributes is not None
+        assert span.attributes['e2b.outcome'] == outcome
+
+
+class TestCapability:
+    def test_defaults_exports_and_keyword_only(self) -> None:
+        cap = E2BSandbox()
+        assert cap.template is None
+        assert cap.sandbox_timeout == 300
+        assert cap.workdir == '/home/user'
+        assert cap.default_command_timeout == 60.0
+        assert isinstance(cap.get_toolset(), AbstractToolset)
+        assert E2BSandbox.get_serialization_name() == 'E2BSandbox'
+        assert all(
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY
+            for parameter in inspect.signature(E2BSandbox).parameters.values()
+        )
+
+        import pydantic_ai_harness
+        import pydantic_ai_harness.e2b_sandbox as e2b_sandbox
+
+        assert 'E2BSandbox' in e2b_sandbox.__all__
+        assert 'E2BSandboxSession' in e2b_sandbox.__all__
+        assert 'E2BSandboxToolset' not in e2b_sandbox.__all__
+        assert 'E2BSandbox' not in pydantic_ai_harness.__all__
+
+    @pytest.mark.parametrize(
+        ('name', 'value'),
+        [
+            ('sandbox_timeout', 0),
+            ('max_output_bytes', True),
+            ('max_output_lines', -1),
+            ('max_read_bytes', 0),
+            ('default_command_timeout', 0),
+            ('default_command_timeout', float('nan')),
+            ('default_command_timeout', float('inf')),
+            ('max_command_timeout', 0),
+            ('workdir', 'relative'),
+            ('allow_internet_access', 'yes'),
+            ('instructions', 123),
+        ],
+    )
+    def test_invalid_configuration(self, name: str, value: object) -> None:
+        with pytest.raises(ValueError, match=name):
+            E2BSandbox(**{name: value})  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        ('kwargs', 'expected'),
+        [
+            ({'template': 'python'}, 'template'),
+            ({'sandbox_timeout': 600}, 'sandbox_timeout'),
+            ({'env': {'A': 'b'}}, 'env'),
+            ({'metadata': {'A': 'b'}}, 'metadata'),
+            ({'allow_internet_access': False}, 'allow_internet_access'),
+        ],
+    )
+    def test_attach_rejects_create_only_settings(self, kwargs: dict[str, object], expected: str) -> None:
+        with pytest.raises(ValueError, match=expected):
+            E2BSandbox(sandbox_id='sbx', **kwargs)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        ('kwargs', 'expected'),
+        [
+            ({'sandbox_id': 'sbx'}, 'sandbox_id'),
+            ({'template': 'python'}, 'template'),
+            ({'workdir': '/project'}, 'workdir'),
+        ],
+    )
+    def test_injected_rejects_other_lifecycle_settings(self, kwargs: dict[str, object], expected: str) -> None:
+        with pytest.raises(ValueError, match=expected):
+            E2BSandbox(session=E2BSandboxSession(), **kwargs)  # type: ignore[arg-type]
+
+    def test_owned_ceiling_cannot_outlive_sandbox(self) -> None:
+        with pytest.raises(ValueError, match='cannot exceed sandbox_timeout'):
+            E2BSandbox(sandbox_timeout=10, max_command_timeout=11)
+        assert E2BSandbox(sandbox_id='sbx', max_command_timeout=600).max_command_timeout == 600
+
+    def test_mapping_inputs_are_copied(self) -> None:
+        env = {'A': 'one'}
+        metadata = {'task': 'test'}
+        cap = E2BSandbox(env=env, metadata=metadata)
+        env['A'] = 'two'
+        metadata['task'] = 'changed'
+        assert cap.env == {'A': 'one'}
+        assert cap.metadata == {'task': 'test'}
+
+    def test_mode_aware_instructions_and_override(self) -> None:
+        owned = E2BSandbox(default_command_timeout=4.1, sandbox_timeout=20).get_instructions()
+        reused = E2BSandbox(
+            sandbox_id='sbx',
+            default_command_timeout=500,
+            max_command_timeout=600,
+        ).get_instructions()
+        injected = E2BSandbox(session=E2BSandboxSession()).get_instructions()
+        assert owned is not None and 'after 5s' in owned and 'up to 20s' in owned
+        assert reused is not None and 'after 500s' in reused and 'persists across runs' in reused
+        assert injected is not None and 'persists across runs' in injected
+        assert E2BSandbox(instructions='Custom').get_instructions() == 'Custom'
+        assert E2BSandbox(instructions='').get_instructions() is None
+
+    @pytest.mark.anyio(backends=['asyncio'])
+    async def test_agent_can_call_command(self, fake_e2b: FakeE2B) -> None:
+        import sniffio
+
+        if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
+            pytest.skip('Agent.run() requires asyncio')
+        fake_e2b.responder = lambda command, timeout: ('hello\n', '', 0)
+
+        def call_then_finish(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            del info
+            if not any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+                return ModelResponse(
+                    parts=[ToolCallPart('run_command', {'command': 'echo hello'}, tool_call_id='run-1')]
+                )
+            return ModelResponse(parts=[TextPart('done')])
+
+        agent: Agent[None, str] = Agent(
+            FunctionModel(call_then_finish),
+            capabilities=[E2BSandbox()],
+        )
+        result = await agent.run('run a command')
+        assert result.output == 'done'
+        returns = [
+            part.content
+            for message in result.all_messages()
+            for part in message.parts
+            if isinstance(part, ToolReturnPart)
+        ]
+        assert returns == ['[stdout]\nhello']
+        assert fake_e2b.sandboxes[0].kill_calls == 1

--- a/tests/e2b_sandbox/test_session.py
+++ b/tests/e2b_sandbox/test_session.py
@@ -1,0 +1,368 @@
+"""Tests for the public E2B sandbox session."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import anyio
+import pytest
+
+from pydantic_ai_harness.e2b_sandbox import (
+    E2BSandboxAuthError,
+    E2BSandboxError,
+    E2BSandboxSession,
+    E2BSandboxUnavailableError,
+)
+
+from .fake_e2b import (
+    AuthenticationException,
+    FakeE2B,
+    FakeEntryInfo,
+    FakeFileType,
+    SandboxException,
+    SandboxNotFoundException,
+    TimeoutException,
+)
+
+
+class TestLifecycle:
+    async def test_owned_create_and_kill(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession(
+            template='python-data',
+            sandbox_timeout=120,
+            workdir='/workspace',
+            env={'TOKEN': 'secret'},
+            metadata={'task': 'test'},
+            allow_internet_access=False,
+        ) as session:
+            assert session.sandbox_id == 'sbx-1'
+            assert session.template == 'python-data'
+            assert session.mode == 'owned'
+            assert session.workdir == '/workspace'
+        assert fake_e2b.create_calls == [
+            fake_e2b.create_calls[0].__class__(
+                'python-data',
+                120,
+                {'task': 'test'},
+                {'TOKEN': 'secret'},
+                True,
+                False,
+            )
+        ]
+        assert fake_e2b.sandboxes[0].kill_calls == 1
+        assert session.sandbox_id is None
+
+    async def test_attach_leaves_sandbox_running(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession(sandbox_id='sbx-existing', workdir='/project') as session:
+            assert session.sandbox_id == 'sbx-existing'
+            assert session.mode == 'attached'
+        assert fake_e2b.connect_calls == [('sbx-existing', None)]
+        assert fake_e2b.sandboxes[0].kill_calls == 0
+        assert session.sandbox_id is None
+
+    async def test_close_before_enter_is_safe(self) -> None:
+        session = E2BSandboxSession()
+        assert session.sandbox_id is None
+        await session.close()
+        await session.__aexit__(None, None, None)
+
+    async def test_enter_twice_rejected(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='already open'):
+                await session.__aenter__()
+        assert len(fake_e2b.sandboxes) == 1
+
+    async def test_cancel_after_create_still_kills(self, fake_e2b: FakeE2B) -> None:
+        session = E2BSandboxSession()
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            await session.__aenter__()
+        assert fake_e2b.sandboxes[0].kill_calls == 1
+        assert session.sandbox_id is None
+
+    async def test_create_timeout_is_bounded(self, fake_e2b: FakeE2B, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr('pydantic_ai_harness.e2b_sandbox._session._CREATE_TIMEOUT', 0.01)
+        fake_e2b.create_hangs = True
+        with anyio.fail_after(2):
+            with pytest.raises(E2BSandboxError, match='did not complete within'):
+                async with E2BSandboxSession():
+                    pass  # pragma: no cover
+
+    async def test_kill_timeout_preserves_identity(self, fake_e2b: FakeE2B, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr('pydantic_ai_harness.e2b_sandbox._session._TEARDOWN_TIMEOUT', 0.01)
+        session = E2BSandboxSession()
+        await session.__aenter__()
+        fake_e2b.kill_hangs = True
+        with pytest.raises(E2BSandboxError, match='Could not kill'):
+            await session.close()
+        assert session.sandbox_id == 'sbx-1'
+        fake_e2b.kill_hangs = False
+        await session.close()
+        assert session.sandbox_id is None
+
+    async def test_cleanup_failure_warns_during_body_error(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.kill_error = SandboxException('kill failed')
+        with pytest.warns(RuntimeWarning, match='Could not clean up'):
+            with pytest.raises(RuntimeError, match='body failed'):
+                async with E2BSandboxSession():
+                    raise RuntimeError('body failed')
+
+    async def test_cleanup_failure_raises_after_clean_body(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.kill_error = SandboxException('kill failed')
+        with pytest.raises(E2BSandboxError, match='Could not kill'):
+            async with E2BSandboxSession():
+                pass
+
+
+class TestConfigurationAndErrors:
+    @pytest.mark.parametrize('value', [0, -1, True])
+    def test_invalid_sandbox_timeout(self, value: int) -> None:
+        with pytest.raises(ValueError, match='positive integer'):
+            E2BSandboxSession(sandbox_timeout=value)
+
+    @pytest.mark.parametrize('value', ['', 'relative'])
+    def test_invalid_workdir(self, value: str) -> None:
+        with pytest.raises(ValueError, match='absolute sandbox path'):
+            E2BSandboxSession(workdir=value)
+
+    def test_invalid_allow_internet_access(self) -> None:
+        with pytest.raises(ValueError, match='allow_internet_access'):
+            E2BSandboxSession(allow_internet_access='yes')  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        ('kwargs', 'expected'),
+        [
+            ({'template': 'custom'}, 'template'),
+            ({'sandbox_timeout': 600}, 'sandbox_timeout'),
+            ({'env': {'A': 'b'}}, 'env'),
+            ({'metadata': {'A': 'b'}}, 'metadata'),
+            ({'allow_internet_access': False}, 'allow_internet_access'),
+        ],
+    )
+    def test_attach_rejects_create_only_settings(self, kwargs: dict[str, object], expected: str) -> None:
+        with pytest.raises(ValueError, match=expected):
+            E2BSandboxSession(sandbox_id='sbx', **kwargs)  # type: ignore[arg-type]
+
+    async def test_missing_sdk_has_install_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_import = importlib.import_module
+
+        def fail_e2b(name: str, package: str | None = None) -> types.ModuleType:
+            if name == 'e2b':
+                raise ImportError('missing')
+            return real_import(name, package)  # pragma: no cover - only E2B is requested by the subject
+
+        monkeypatch.delitem(sys.modules, 'e2b', raising=False)
+        monkeypatch.setattr(importlib, 'import_module', fail_e2b)
+        with pytest.raises(E2BSandboxError, match='e2b.*package is required'):
+            async with E2BSandboxSession():
+                pass  # pragma: no cover
+
+    async def test_incompatible_sdk_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, 'e2b', types.ModuleType('e2b'))
+        with pytest.raises(E2BSandboxError, match='does not expose the expected'):
+            async with E2BSandboxSession():
+                pass  # pragma: no cover
+
+    @pytest.mark.parametrize(
+        ('error', 'error_type', 'match'),
+        [
+            (AuthenticationException('bad key'), E2BSandboxAuthError, 'valid E2B_API_KEY'),
+            (SandboxNotFoundException('gone'), E2BSandboxUnavailableError, 'no longer available'),
+            (SandboxException('control plane'), E2BSandboxError, 'control plane'),
+        ],
+    )
+    async def test_create_errors_are_classified(
+        self,
+        fake_e2b: FakeE2B,
+        error: Exception,
+        error_type: type[E2BSandboxError],
+        match: str,
+    ) -> None:
+        fake_e2b.create_error = error
+        with pytest.raises(error_type, match=match):
+            async with E2BSandboxSession():
+                pass  # pragma: no cover
+
+    async def test_missing_attached_id_is_named(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.connect_error = SandboxNotFoundException('gone')
+        with pytest.raises(E2BSandboxUnavailableError, match="'sbx-missing'"):
+            async with E2BSandboxSession(sandbox_id='sbx-missing'):
+                pass  # pragma: no cover
+
+
+class TestExec:
+    async def test_success_and_bounded_tail(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.responder = lambda command, timeout: ('A' * 20 + 'END', 'warning', 0)
+        async with E2BSandboxSession(workdir='/project') as session:
+            result = await session.exec('echo hello', timeout=7, max_output_bytes=10)
+            command_call = fake_e2b.sandboxes[0].commands.calls[0]
+            assert command_call.cwd == '/project'
+            assert command_call.timeout == 7
+        assert result.stdout == 'A' * 7 + 'END'
+        assert result.stderr == 'warning'
+        assert result.stdout_truncated is True
+        assert result.stderr_truncated is False
+        assert result.returncode == 0
+        assert result.applied_timeout == 7
+        assert fake_e2b.sandboxes[0].files.removed
+
+    async def test_nonzero_exit_and_sdk_diagnostics(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.responder = lambda command, timeout: ('out', 'err', 9)
+        fake_e2b.sdk_stdout = 'wrapper out'
+        fake_e2b.sdk_stderr = 'wrapper err'
+        async with E2BSandboxSession() as session:
+            result = await session.exec('exit 9', timeout=3, max_output_bytes=100)
+        assert result.stdout == 'out\nwrapper out'
+        assert result.stderr == 'err\nwrapper err'
+        assert result.returncode == 9
+        assert result.timed_out is False
+
+    async def test_timeout_kills_process_group_and_handle(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.responder = lambda command, timeout: ('partial', '', 0)
+        fake_e2b.wait_error = TimeoutException('deadline')
+        fake_e2b.invalid_count = True
+        fake_e2b.kill_process_error = SandboxException('already gone')
+        fake_e2b.handle_kill_error = SandboxException('already gone')
+        async with E2BSandboxSession() as session:
+            result = await session.exec('sleep 99', timeout=2, max_output_bytes=100)
+        assert result.timed_out is True
+        assert result.returncode == 124
+        assert result.stdout == 'partial'
+        assert fake_e2b.sandboxes[0].commands.handles[0].killed is True
+
+    async def test_timeout_without_capture_returns_empty(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.wait_error = TimeoutException('deadline')
+        fake_e2b.omit_capture = True
+        async with E2BSandboxSession() as session:
+            result = await session.exec('sleep 99', timeout=2, max_output_bytes=100)
+        assert result.stdout == result.stderr == ''
+        assert result.timed_out is True
+
+    async def test_timeout_without_count_returns_available_tail(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.responder = lambda command, timeout: ('partial', '', 0)
+        fake_e2b.wait_error = TimeoutException('deadline')
+        fake_e2b.omit_count = True
+        async with E2BSandboxSession() as session:
+            result = await session.exec('sleep 99', timeout=2, max_output_bytes=100)
+        assert result.stdout == 'partial'
+        assert result.stdout_truncated is False
+
+    async def test_missing_capture_on_completed_command_is_an_error(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.omit_capture = True
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='Could not read bounded'):
+                await session.exec('true', timeout=2, max_output_bytes=100)
+
+    async def test_missing_count_on_completed_command_is_an_error(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.omit_count = True
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='Could not read bounded'):
+                await session.exec('true', timeout=2, max_output_bytes=100)
+
+    async def test_run_and_wait_failures_are_wrapped(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.run_error = SandboxException('run failed')
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='Could not run.*run failed'):
+                await session.exec('echo', timeout=2, max_output_bytes=100)
+        fake_e2b.run_error = None
+        fake_e2b.wait_error = SandboxException('wait failed')
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='Could not read.*wait failed'):
+                await session.exec('echo', timeout=2, max_output_bytes=100)
+
+    async def test_invalid_capture_count_is_wrapped(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.invalid_count = True
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='byte count was invalid'):
+                await session.exec('echo', timeout=2, max_output_bytes=100)
+
+    async def test_capture_read_failure_is_wrapped(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.read_error = SandboxException('read failed')
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='Could not read bounded.*read failed'):
+                await session.exec('echo', timeout=2, max_output_bytes=100)
+
+    async def test_temp_remove_failure_is_best_effort(self, fake_e2b: FakeE2B) -> None:
+        fake_e2b.remove_error = SandboxException('remove failed')
+        async with E2BSandboxSession() as session:
+            assert (await session.exec('true', timeout=2, max_output_bytes=100)).returncode == 0
+
+    @pytest.mark.parametrize(
+        ('kwargs', 'match'),
+        [
+            ({'timeout': 0, 'max_output_bytes': 10}, 'timeout'),
+            ({'timeout': 1, 'max_output_bytes': 0}, 'max_output_bytes'),
+        ],
+    )
+    async def test_invalid_limits(self, fake_e2b: FakeE2B, kwargs: dict[str, int], match: str) -> None:
+        async with E2BSandboxSession() as session:
+            with pytest.raises(ValueError, match=match):
+                await session.exec('true', **kwargs)
+
+    async def test_unpaired_surrogate_command_rejected(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='cannot be encoded'):
+                await session.exec('\ud800', timeout=1, max_output_bytes=10)
+
+    async def test_exec_before_enter_rejected(self) -> None:
+        with pytest.raises(E2BSandboxError, match='session is not open'):
+            await E2BSandboxSession().exec('true', timeout=1, max_output_bytes=10)
+
+
+class TestFiles:
+    async def test_file_operations_and_relative_paths(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession(workdir='/project') as session:
+            await session.write_bytes('notes.txt', b'abcdef')
+            assert await session.file_size('notes.txt') == 6
+            assert await session.read_bytes('notes.txt', max_bytes=6) == b'abcdef'
+            fake_e2b.sandboxes[0].files.listings['/project'] = [
+                FakeEntryInfo('z.txt', '/project/z.txt', FakeFileType('file'), 1),
+                FakeEntryInfo('src', '/project/src', FakeFileType('dir'), 0),
+                FakeEntryInfo('unknown', '/project/unknown', None, 0),
+            ]
+            assert await session.list_files('.') == [
+                ('z.txt', False),
+                ('src', True),
+                ('unknown', False),
+            ]
+
+    async def test_stream_read_stops_over_limit(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession() as session:
+            fake_e2b.sandboxes[0].files.files['/big'] = b'abcdefgh'
+            with pytest.raises(E2BSandboxError, match='grew beyond'):
+                await session.read_bytes('/big', max_bytes=5)
+
+    async def test_invalid_stream_limit(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession() as session:
+            with pytest.raises(ValueError, match='max_bytes'):
+                await session.read_bytes('/x', max_bytes=0)
+
+    async def test_missing_file_is_wrapped(self, fake_e2b: FakeE2B) -> None:
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match='Could not inspect'):
+                await session.file_size('/missing')
+
+    @pytest.mark.parametrize(
+        ('operation', 'match'),
+        [
+            ('info', 'Could not inspect'),
+            ('read', 'Could not read'),
+            ('write', 'Could not write'),
+            ('list', 'Could not list'),
+        ],
+    )
+    async def test_file_errors_are_wrapped(self, fake_e2b: FakeE2B, operation: str, match: str) -> None:
+        error = SandboxException(f'{operation} failed')
+        setattr(fake_e2b, f'{operation}_error', error)
+        async with E2BSandboxSession() as session:
+            with pytest.raises(E2BSandboxError, match=match):
+                if operation == 'info':
+                    await session.file_size('/x')
+                elif operation == 'read':
+                    await session.read_bytes('/x', max_bytes=10)
+                elif operation == 'write':
+                    await session.write_bytes('/x', b'x')
+                else:
+                    await session.list_files('/x')

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -117,6 +117,7 @@ _CAPABILITY_PAGE_META = {
     'managed-prompt.md': ('logfire', 'Managed Prompt'),
     'memory.md': ('memory', 'Memory'),
     'modal-sandbox.md': ('modal_sandbox', 'Modal Sandbox'),
+    'e2b-sandbox.md': ('e2b_sandbox', 'E2B Sandbox'),
     'context.md': ('context', 'Context'),
     'pydantic-ai-docs.md': ('docs', 'Pydantic AI Docs'),
     'exa-search.md': ('exa', 'Exa Search'),


### PR DESCRIPTION
## Summary

- add an `E2BSandbox` capability with owned, attached, and caller-managed session lifecycles
- expose bounded `run_command`, `read_file`, `write_file`, and `list_directory` tools
- emit E2B lifecycle and operation spans through the active Pydantic AI tracer for Logfire
- move the Modal output-formatting helpers to a provider-neutral sandbox module
- add provider documentation, agent integration tests, and a fake E2B SDK test seam

## Why

Pydantic AI Harness has a Modal sandbox provider but no E2B provider. This adds an E2B-backed option with equivalent lifecycle and tool semantics, while preserving the observability expected from Pydantic AI and Logfire.

The implementation was compared with Modal, Open SWE, LangChain E2B, and Mastra sandbox adapters. E2B's Python command handle retains complete stdout and stderr even when callbacks are used, so this implementation performs bounded tail capture inside the sandbox before the SDK receives command output.

## Behavior

- owned mode creates one sandbox per agent run and kills it on exit
- attached mode connects by sandbox ID and leaves the sandbox running
- injected mode reuses an already-open `E2BSandboxSession` without owning its lifecycle
- command timeouts trigger bounded, best-effort process-group and command-handle cleanup
- file reads use metadata preflight plus a streaming `max_read_bytes + 1` bound
- terminal authentication and missing-sandbox failures propagate instead of causing model retry loops

The custom `e2b.*` spans include sandbox identity, lifecycle mode, outcomes, timeouts, exit codes, truncation flags, file sizes, and directory entry counts. They do not include commands, paths, file contents, stdout, or stderr. The docs show `include_content=False` for suppressing content on Pydantic AI's own tool spans as well.

## Dependency note

The repository contribution policy says external PRs must not change `pyproject.toml` or `uv.lock`. The E2B SDK is therefore loaded dynamically and documented as a separate install:

```bash
uv add pydantic-ai-harness "e2b>=2.34.0"
```

A maintainer-approved package extra can be added separately if desired.

## Validation

- `ruff format --check`
- `ruff check`
- strict `pyright`
- 3,259 tests passed, 37 skipped
- 100% statement and branch coverage across the repository
- dynamic SDK contract checked against E2B Python SDK 2.34.0

No authenticated E2B control-plane request was made during validation.
