### PR TITLE
fix(code-mode): report unexpected session resets

### DIFF
--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -171,7 +171,7 @@ Printed output is limited to 10 MiB. Exceeding the limit makes `run_code` return
 
 ## REPL state
 
-State persists between `run_code` calls within the same agent run -- variables, imports, and function definitions carry over. Pass `restart: true` in the tool call to reset state.
+State persists between `run_code` calls within the same agent run -- variables, imports, and function definitions carry over. Pass `restart: true` in the tool call to reset state. If a worker crash or host-side execution failure invalidates the session, `run_code` returns a model retry that reports the reset; the next snippet must recreate any required state.
 
 ## Temporal durability
 

--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -187,7 +187,7 @@ Printed output is limited to 10 MiB. Exceeding the limit makes `run_code` return
 
 ## REPL state
 
-State persists between `run_code` calls within the same agent run -- variables, imports, and function definitions carry over. Pass `restart: true` in the tool call to reset state.
+State persists between `run_code` calls within the same agent run -- variables, imports, and function definitions carry over. Pass `restart: true` in the tool call to reset state. If a worker crash or host-side execution failure invalidates the session, `run_code` returns a model retry that reports the reset; the next snippet must recreate any required state.
 
 ## Temporal durability
 

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -662,6 +662,14 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             raise ModelRetry(
                 'The code crashed the sandbox worker and the session was reset. Revise the code and try again.'
             ) from e
+        except Exception as e:
+            # The session may have been invalidated by a host-side binding or protocol failure.
+            # Make the reset visible so the model can rebuild state on its next attempt.
+            run_state.reset()
+            raise ModelRetry(
+                'Code execution failed and the session was reset. '
+                'Re-import dependencies, recreate required state, and try again.'
+            ) from e
         except BaseException as e:
             # Convert a sandbox panic to a retry (see `is_sandbox_panic`);
             # interruptions re-raise unchanged after dropping the suspended session.

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -664,11 +664,15 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             ) from e
         except Exception as e:
             # The session may have been invalidated by a host-side binding or protocol failure.
-            # Make the reset visible so the model can rebuild state on its next attempt.
+            # Make the reset visible so the model can rebuild state on its next attempt. Include
+            # the error text: there is no Monty `display()` for host-side failures, and the cause
+            # chain is dropped once the retry becomes a prompt part, so this message is the only
+            # record of what failed for both the model and the transcript.
             run_state.reset()
+            error_text = f'{type(e).__name__}: {e}'
             raise ModelRetry(
-                'Code execution failed and the session was reset. '
-                'Re-import dependencies, recreate required state, and try again.'
+                'Code execution failed and the session was reset. Re-run any imports, recreate '
+                f'any state you need, and try again.\n{capture.prepend_to(error_text)}'
             ) from e
         except BaseException as e:
             # Convert a sandbox panic to a retry (see `is_sandbox_panic`);

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -1828,7 +1828,13 @@ class TestCodeMode:
             await wrapper.call_tool('run_code', {'code': 'x'}, ctx, run_code)
 
     async def test_unexpected_execution_error_reports_session_reset(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """An unexpected execution failure tells the model that the REPL state was dropped."""
+        """An unexpected execution failure tells the model that the REPL state was dropped.
+
+        No public code path raises a bare host-side exception on purpose, so the
+        executor is patched to fail the way a host-binding bug does (e.g.
+        pydantic/monty#631, which replaces the sandbox exception with a bare
+        `RuntimeError` when the traceback payload fails span validation).
+        """
 
         async def _fail(self: Any, state: Any) -> Any:
             raise RuntimeError('invalid exception payload')
@@ -1839,6 +1845,7 @@ class TestCodeMode:
         tools = await wrapper.get_tools(ctx)
         run_code = tools['run_code']
 
+        # Seed REPL state that the model would rely on in later feeds.
         await wrapper.call_tool('run_code', {'code': 'x = 1'}, ctx, run_code)
         with monkeypatch.context() as patcher:
             patcher.setattr('pydantic_ai_harness._monty_exec.MontyExecutor.run', _fail)
@@ -1846,6 +1853,7 @@ class TestCodeMode:
                 await wrapper.call_tool('run_code', {'code': 'x'}, ctx, run_code)
         # The retry message is the only record of the host-side error, so it must name it.
         assert 'RuntimeError: invalid exception payload' in str(exc_info.value)
+        # `x` is undefined in the fresh session's type check, proving the reset happened.
         with pytest.raises(ModelRetry, match='Type error in code'):
             await wrapper.call_tool('run_code', {'code': 'x'}, ctx, run_code)
 

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -1842,8 +1842,10 @@ class TestCodeMode:
         await wrapper.call_tool('run_code', {'code': 'x = 1'}, ctx, run_code)
         with monkeypatch.context() as patcher:
             patcher.setattr('pydantic_ai_harness._monty_exec.MontyExecutor.run', _fail)
-            with pytest.raises(ModelRetry, match='session was reset'):
+            with pytest.raises(ModelRetry, match='session was reset') as exc_info:
                 await wrapper.call_tool('run_code', {'code': 'x'}, ctx, run_code)
+        # The retry message is the only record of the host-side error, so it must name it.
+        assert 'RuntimeError: invalid exception payload' in str(exc_info.value)
         with pytest.raises(ModelRetry, match='Type error in code'):
             await wrapper.call_tool('run_code', {'code': 'x'}, ctx, run_code)
 

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -1827,6 +1827,26 @@ class TestCodeMode:
         with pytest.raises(ModelRetry, match='Type error in code'):
             await wrapper.call_tool('run_code', {'code': 'x'}, ctx, run_code)
 
+    async def test_unexpected_execution_error_reports_session_reset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unexpected execution failure tells the model that the REPL state was dropped."""
+
+        async def _fail(self: Any, state: Any) -> Any:
+            raise RuntimeError('invalid exception payload')
+
+        wrapper = CodeMode[None]().get_wrapper_toolset(_build_function_toolset(add))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        run_code = tools['run_code']
+
+        await wrapper.call_tool('run_code', {'code': 'x = 1'}, ctx, run_code)
+        with monkeypatch.context() as patcher:
+            patcher.setattr('pydantic_ai_harness._monty_exec.MontyExecutor.run', _fail)
+            with pytest.raises(ModelRetry, match='session was reset'):
+                await wrapper.call_tool('run_code', {'code': 'x'}, ctx, run_code)
+        with pytest.raises(ModelRetry, match='Type error in code'):
+            await wrapper.call_tool('run_code', {'code': 'x'}, ctx, run_code)
+
     async def test_cancellation_propagates_and_resets_session(self) -> None:
         """Cancellation drops the suspended session before propagating to the caller."""
         started = asyncio.Event()


### PR DESCRIPTION
## Summary

- report unexpected host-side execution failures to the model after resetting the invalid Code Mode session
- preserve existing sandbox-panic and interruption behavior
- add regression coverage for the silent state-loss path and document the reset contract

## Linked Issue

Closes #481

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)

## Motivation

A host-side Monty failure can leave the checkout finished and unusable. The existing generic exception path reset the session but re-raised the internal exception, so a subsequent model attempt could continue without knowing its persisted imports and variables were gone.

This converts ordinary unexpected execution exceptions into a `ModelRetry` that explicitly tells the model to recreate required state. Interruptions and other `BaseException` cases continue to propagate unchanged after cleanup.

## Verification

- `make lint`
- `make typecheck`
- `make test` (3,359 passed, 45 skipped)
- `make testcov` (100% statement and branch coverage)
- reproduced the original three-feed Monty failure and verified a model-visible reset notice followed by successful state reconstruction
