### PR TITLE
Fix Shell `max_output_chars` cap accounting

### DIFF
--- a/docs/shell.md
+++ b/docs/shell.md
@@ -64,7 +64,8 @@ denylist active -- `Shell()` alone is a working (if permissive) configuration.
 Output is labelled with `[stdout]` / `[stderr]` markers and an `[exit code: N]`
 line on non-zero exit. When it exceeds `max_output_chars` the **tail** is kept
 (the head is dropped), so errors, stack traces, and the `[stderr]` section --
-which all land at the end -- survive truncation.
+which all land at the end -- survive truncation. Background command status and
+exit metadata follow the captured output so they remain in the retained tail.
 
 ## Command controls
 

--- a/pydantic_ai_harness/_output.py
+++ b/pydantic_ai_harness/_output.py
@@ -3,6 +3,8 @@
 
 def truncate_tail(text: str, max_chars: int) -> str:
     """Limit text to `max_chars`, including an accurate truncation marker."""
+    if max_chars <= 0:  # pragma: no cover
+        raise ValueError('max_chars must be a positive integer.')
     if len(text) <= max_chars:
         return text
 
@@ -15,3 +17,10 @@ def truncate_tail(text: str, max_chars: int) -> str:
     if tail_chars == 0:
         return text[-max_chars:]
     return marker(tail_chars) + text[-tail_chars:]
+
+
+def truncate_head(text: str, max_chars: int) -> str:
+    """Limit control text to `max_chars`, keeping its identifying prefix."""
+    if max_chars <= 0:  # pragma: no cover
+        raise ValueError('max_chars must be a positive integer.')
+    return text[:max_chars]

--- a/pydantic_ai_harness/_output.py
+++ b/pydantic_ai_harness/_output.py
@@ -1,0 +1,17 @@
+"""Shared helpers for model-visible tool output."""
+
+
+def truncate_tail(text: str, max_chars: int) -> str:
+    """Limit text to `max_chars`, including an accurate truncation marker."""
+    if len(text) <= max_chars:
+        return text
+
+    def marker(tail_chars: int) -> str:
+        return f'[... output truncated, showing last {tail_chars} chars]\n'
+
+    tail_chars = max(0, max_chars - len(marker(max_chars)))
+    if tail_chars + 1 + len(marker(tail_chars + 1)) <= max_chars:
+        tail_chars += 1
+    if tail_chars == 0:
+        return text[-max_chars:]
+    return marker(tail_chars) + text[-tail_chars:]

--- a/pydantic_ai_harness/_output.py
+++ b/pydantic_ai_harness/_output.py
@@ -1,15 +1,12 @@
 """Shared helpers for model-visible tool output."""
 
 
-def truncate_tail(text: str, max_chars: int, *, preserve_prefix_chars: int = 0) -> str:
+def truncate_tail(text: str, max_chars: int) -> str:
     """Limit text to `max_chars`, including an accurate truncation marker."""
     if max_chars <= 0:
         return ''
     if len(text) <= max_chars:
         return text
-    if preserve_prefix_chars:
-        prefix_chars = min(preserve_prefix_chars, max_chars)
-        return text[:prefix_chars] + truncate_tail(text[preserve_prefix_chars:], max_chars - prefix_chars)
 
     def marker(tail_chars: int) -> str:
         return f'[... output truncated, showing last {tail_chars} chars]\n'

--- a/pydantic_ai_harness/_output.py
+++ b/pydantic_ai_harness/_output.py
@@ -2,7 +2,11 @@
 
 
 def truncate_tail(text: str, max_chars: int) -> str:
-    """Limit text to `max_chars`, including an accurate truncation marker."""
+    """Limit text to `max_chars`, keeping the tail.
+
+    The truncation marker counts toward the cap and reports the exact number
+    of retained chars. A cap too small to fit any marker returns a bare tail.
+    """
     if max_chars <= 0:  # pragma: no cover - callers validate the cap at construction
         return ''
     if len(text) <= max_chars:

--- a/pydantic_ai_harness/_output.py
+++ b/pydantic_ai_harness/_output.py
@@ -1,12 +1,15 @@
 """Shared helpers for model-visible tool output."""
 
 
-def truncate_tail(text: str, max_chars: int) -> str:
+def truncate_tail(text: str, max_chars: int, *, preserve_prefix_chars: int = 0) -> str:
     """Limit text to `max_chars`, including an accurate truncation marker."""
     if max_chars <= 0:
         return ''
     if len(text) <= max_chars:
         return text
+    if preserve_prefix_chars:
+        prefix_chars = min(preserve_prefix_chars, max_chars)
+        return text[:prefix_chars] + truncate_tail(text[preserve_prefix_chars:], max_chars - prefix_chars)
 
     def marker(tail_chars: int) -> str:
         return f'[... output truncated, showing last {tail_chars} chars]\n'

--- a/pydantic_ai_harness/_output.py
+++ b/pydantic_ai_harness/_output.py
@@ -3,7 +3,7 @@
 
 def truncate_tail(text: str, max_chars: int) -> str:
     """Limit text to `max_chars`, including an accurate truncation marker."""
-    if max_chars <= 0:
+    if max_chars <= 0:  # pragma: no cover - callers validate the cap at construction
         return ''
     if len(text) <= max_chars:
         return text

--- a/pydantic_ai_harness/_output.py
+++ b/pydantic_ai_harness/_output.py
@@ -3,8 +3,8 @@
 
 def truncate_tail(text: str, max_chars: int) -> str:
     """Limit text to `max_chars`, including an accurate truncation marker."""
-    if max_chars <= 0:  # pragma: no cover
-        raise ValueError('max_chars must be a positive integer.')
+    if max_chars <= 0:
+        return ''
     if len(text) <= max_chars:
         return text
 
@@ -21,6 +21,6 @@ def truncate_tail(text: str, max_chars: int) -> str:
 
 def truncate_head(text: str, max_chars: int) -> str:
     """Limit control text to `max_chars`, keeping its identifying prefix."""
-    if max_chars <= 0:  # pragma: no cover
-        raise ValueError('max_chars must be a positive integer.')
+    if max_chars <= 0:
+        return ''
     return text[:max_chars]

--- a/pydantic_ai_harness/_output.py
+++ b/pydantic_ai_harness/_output.py
@@ -17,10 +17,3 @@ def truncate_tail(text: str, max_chars: int) -> str:
     if tail_chars == 0:
         return text[-max_chars:]
     return marker(tail_chars) + text[-tail_chars:]
-
-
-def truncate_head(text: str, max_chars: int) -> str:
-    """Limit control text to `max_chars`, keeping its identifying prefix."""
-    if max_chars <= 0:
-        return ''
-    return text[:max_chars]

--- a/pydantic_ai_harness/localstack/_capability.py
+++ b/pydantic_ai_harness/localstack/_capability.py
@@ -66,7 +66,7 @@ class LocalStack(AbstractCapability[AgentDepsT]):
     """Default timeout in seconds for AWS CLI commands and the health check."""
 
     max_output_chars: int = 50_000
-    """Maximum characters of output returned to the model."""
+    """Maximum characters of output returned to the model. Must be positive."""
 
     aws_cli_path: str = 'aws'
     """Path or name of the AWS CLI executable (e.g. `aws` or `awslocal`)."""

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -17,7 +17,7 @@ from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 from typing_extensions import Self
 
-from pydantic_ai_harness._output import truncate_tail
+from pydantic_ai_harness._output import truncate_head, truncate_tail
 from pydantic_ai_harness.localstack._container import LocalStackContainer
 
 _HEALTH_PATH = '/_localstack/health'
@@ -295,8 +295,9 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
                     stderr=stderr_file,
                 )
             except FileNotFoundError:
-                return self._truncate(
-                    f'[error: AWS CLI {self._aws_cli_path!r} not found. Install the AWS CLI to use LocalStack tools.]'
+                return truncate_head(
+                    f'[error: AWS CLI {self._aws_cli_path!r} not found. Install the AWS CLI to use LocalStack tools.]',
+                    self._max_output_chars,
                 )
 
             try:
@@ -307,7 +308,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
                     proc.kill()
                     with anyio.CancelScope(shield=True):
                         await proc.wait()
-                    return self._truncate(f'[command timed out after {timeout}s]')
+                    return truncate_head(f'[command timed out after {timeout}s]', self._max_output_chars)
             finally:
                 await proc.aclose()
 
@@ -345,7 +346,9 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
             async with httpx.AsyncClient(timeout=self._default_timeout) as client:
                 response = await client.get(url)
         except httpx.HTTPError as e:
-            return self._truncate(f'[error: could not reach LocalStack at {url}: {e}]')
+            return truncate_head(f'[error: could not reach LocalStack at {url}: {e}]', self._max_output_chars)
         if response.status_code != 200:
-            return self._truncate(f'[error: LocalStack health check returned HTTP {response.status_code}]')
+            return truncate_head(
+                f'[error: LocalStack health check returned HTTP {response.status_code}]', self._max_output_chars
+            )
         return self._truncate(response.text)

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -7,6 +7,7 @@ import shlex
 import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlsplit
 
 import anyio
@@ -14,7 +15,7 @@ import httpx
 from pydantic_ai import RunContext
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import AgentDepsT
-from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset, ToolsetTool
 from typing_extensions import Self
 
 from pydantic_ai_harness._output import truncate_tail
@@ -132,6 +133,19 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
             startup_timeout=self._startup_timeout,
         )
 
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[AgentDepsT],
+        tool: ToolsetTool[AgentDepsT],
+    ) -> Any:
+        """Enforce the model-visible output cap at the tool dispatch seam."""
+        result = await super().call_tool(name, tool_args, ctx, tool)
+        if not isinstance(result, str):
+            return result
+        return truncate_tail(result, self._max_output_chars)
+
     def _host_port(self) -> int:
         """Host port to bind the container's edge port to, parsed from `endpoint_url`."""
         return urlsplit(self._endpoint_url).port or _DEFAULT_EDGE_PORT
@@ -241,14 +255,6 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         env['AWS_ENDPOINT_URL'] = self._endpoint_url
         return env
 
-    def _truncate(self, text: str) -> str:
-        """Truncate output to the configured cap, keeping the tail.
-
-        Errors and the `[stderr]` section land at the end, so the head is
-        dropped and as much of the tail as fits beside the marker is kept.
-        """
-        return truncate_tail(text, self._max_output_chars)
-
     async def aws_cli(self, command: str, *, timeout_seconds: float | None = None) -> str:
         """Run an AWS CLI command against the emulated AWS environment.
 
@@ -324,7 +330,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
             exit_code = proc.returncode
             if exit_code:
                 output = f'{output}\n[exit code: {exit_code}]'
-            return self._truncate(output)
+            return output
         finally:
             stdout_file.close()
             stderr_file.close()
@@ -348,4 +354,4 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
             return f'[error: could not reach LocalStack at {url}: {e}]'
         if response.status_code != 200:
             return f'[error: LocalStack health check returned HTTP {response.status_code}]'
-        return self._truncate(response.text)
+        return response.text

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -17,6 +17,7 @@ from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 from typing_extensions import Self
 
+from pydantic_ai_harness._output import truncate_tail
 from pydantic_ai_harness.localstack._container import LocalStackContainer
 
 _HEALTH_PATH = '/_localstack/health'
@@ -246,13 +247,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         Errors and the `[stderr]` section land at the end, so the head is
         dropped and the final `max_output_chars` are kept.
         """
-        if len(text) <= self._max_output_chars:
-            return text
-        marker = f'[... output truncated, showing last {self._max_output_chars} chars]\n'
-        tail_budget = self._max_output_chars - len(marker)
-        if tail_budget <= 0:
-            return text[-self._max_output_chars :]
-        return marker + text[-tail_budget:]
+        return truncate_tail(text, self._max_output_chars)
 
     async def aws_cli(self, command: str, *, timeout_seconds: float | None = None) -> str:
         """Run an AWS CLI command against the emulated AWS environment.
@@ -300,7 +295,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
                     stderr=stderr_file,
                 )
             except FileNotFoundError:
-                return (
+                return self._truncate(
                     f'[error: AWS CLI {self._aws_cli_path!r} not found. Install the AWS CLI to use LocalStack tools.]'
                 )
 
@@ -312,7 +307,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
                     proc.kill()
                     with anyio.CancelScope(shield=True):
                         await proc.wait()
-                    return f'[command timed out after {timeout}s]'
+                    return self._truncate(f'[command timed out after {timeout}s]')
             finally:
                 await proc.aclose()
 
@@ -324,12 +319,12 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
                 parts.append(f'[stdout]\n{stdout}')
             if stderr:
                 parts.append(f'[stderr]\n{stderr}')
-            output = self._truncate('\n'.join(parts) if parts else '(no output)')
+            output = '\n'.join(parts) if parts else '(no output)'
 
             exit_code = proc.returncode
             if exit_code:
-                return f'{output}\n[exit code: {exit_code}]'
-            return output
+                output = f'{output}\n[exit code: {exit_code}]'
+            return self._truncate(output)
         finally:
             stdout_file.close()
             stderr_file.close()
@@ -350,7 +345,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
             async with httpx.AsyncClient(timeout=self._default_timeout) as client:
                 response = await client.get(url)
         except httpx.HTTPError as e:
-            return f'[error: could not reach LocalStack at {url}: {e}]'
+            return self._truncate(f'[error: could not reach LocalStack at {url}: {e}]')
         if response.status_code != 200:
-            return f'[error: LocalStack health check returned HTTP {response.status_code}]'
+            return self._truncate(f'[error: LocalStack health check returned HTTP {response.status_code}]')
         return self._truncate(response.text)

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -140,7 +140,11 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
-        """Enforce the model-visible output cap at the tool dispatch seam."""
+        """Enforce the model-visible output cap at the tool dispatch seam.
+
+        Only `str` results are capped; a future tool returning rich content
+        (e.g. `ToolReturn`) needs this seam extended.
+        """
         result = await super().call_tool(name, tool_args, ctx, tool)
         if not isinstance(result, str):
             return result

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -245,7 +245,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         """Truncate output to the configured cap, keeping the tail.
 
         Errors and the `[stderr]` section land at the end, so the head is
-        dropped and the final `max_output_chars` are kept.
+        dropped and as much of the tail as fits beside the marker is kept.
         """
         return truncate_tail(text, self._max_output_chars)
 

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -17,7 +17,7 @@ from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 from typing_extensions import Self
 
-from pydantic_ai_harness._output import truncate_head, truncate_tail
+from pydantic_ai_harness._output import truncate_tail
 from pydantic_ai_harness.localstack._container import LocalStackContainer
 
 _HEALTH_PATH = '/_localstack/health'
@@ -295,9 +295,8 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
                     stderr=stderr_file,
                 )
             except FileNotFoundError:
-                return truncate_head(
-                    f'[error: AWS CLI {self._aws_cli_path!r} not found. Install the AWS CLI to use LocalStack tools.]',
-                    self._max_output_chars,
+                return (
+                    f'[error: AWS CLI {self._aws_cli_path!r} not found. Install the AWS CLI to use LocalStack tools.]'
                 )
 
             try:
@@ -308,7 +307,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
                     proc.kill()
                     with anyio.CancelScope(shield=True):
                         await proc.wait()
-                    return truncate_head(f'[command timed out after {timeout}s]', self._max_output_chars)
+                    return f'[command timed out after {timeout}s]'
             finally:
                 await proc.aclose()
 
@@ -346,9 +345,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
             async with httpx.AsyncClient(timeout=self._default_timeout) as client:
                 response = await client.get(url)
         except httpx.HTTPError as e:
-            return truncate_head(f'[error: could not reach LocalStack at {url}: {e}]', self._max_output_chars)
+            return f'[error: could not reach LocalStack at {url}: {e}]'
         if response.status_code != 200:
-            return truncate_head(
-                f'[error: LocalStack health check returned HTTP {response.status_code}]', self._max_output_chars
-            )
+            return f'[error: LocalStack health check returned HTTP {response.status_code}]'
         return self._truncate(response.text)

--- a/pydantic_ai_harness/shell/README.md
+++ b/pydantic_ai_harness/shell/README.md
@@ -43,7 +43,8 @@ print(result.output)
 Output is labelled with `[stdout]` / `[stderr]` markers and an `[exit code: N]`
 line on non-zero exit. When it exceeds `max_output_chars` the **tail** is kept
 (the head is dropped), so errors, stack traces, and the `[stderr]` section --
-which all land at the end -- survive truncation.
+which all land at the end -- survive truncation. Background command status and
+exit metadata follow the captured output so they remain in the retained tail.
 
 ## Command controls
 

--- a/pydantic_ai_harness/shell/_capability.py
+++ b/pydantic_ai_harness/shell/_capability.py
@@ -71,7 +71,7 @@ class Shell(AbstractCapability[AgentDepsT]):
     """Default timeout in seconds for command execution."""
 
     max_output_chars: int = 50_000
-    """Maximum characters of output returned to the model."""
+    """Maximum characters of output returned to the model. Must be positive."""
 
     persist_cwd: bool = False
     """If True, track cd commands and adjust the working directory for subsequent calls."""

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -67,17 +67,15 @@ def _is_interactive_command(command: str) -> bool:
 class _BackgroundProcess:
     """State for a background command using temp files for output."""
 
-    __slots__ = ('proc', 'command', 'stdout_path', 'stderr_path', 'finished', 'exit_code')
+    __slots__ = ('proc', 'stdout_path', 'stderr_path', 'finished', 'exit_code')
 
     def __init__(
         self,
         proc: anyio.abc.Process,
-        command: str,
         stdout_path: str,
         stderr_path: str,
     ) -> None:
         self.proc = proc
-        self.command = command
         self.stdout_path = stdout_path
         self.stderr_path = stderr_path
         self.finished = False
@@ -126,6 +124,8 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
 
         if self._allowed_commands and self._denied_commands:
             raise ValueError('Specify allowed_commands or denied_commands, not both.')
+        if max_output_chars <= 0:
+            raise ValueError('max_output_chars must be a positive integer.')
 
         self.add_function(self.run_command, name='run_command')
         self.add_function(self.start_command, name='start_command')
@@ -165,7 +165,9 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
 
         Tools place control metadata (status, exit code, `start_command`'s ID
         line) at the end of their responses, so keeping the tail preserves it
-        without any per-tool cases here.
+        without any per-tool cases here. Only `str` results are capped; a
+        future tool returning rich content (e.g. `ToolReturn`) needs this seam
+        extended.
         """
         result = await super().call_tool(name, tool_args, ctx, tool)
         if not isinstance(result, str):
@@ -429,7 +431,6 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
 
         bg = _BackgroundProcess(
             proc=proc,
-            command=command,
             stdout_path=stdout_file.name,
             stderr_path=stderr_file.name,
         )

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -161,9 +161,14 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         ctx: RunContext[AgentDepsT],
         tool: ToolsetTool[AgentDepsT],
     ) -> Any:
-        """Enforce the model-visible output cap at the tool dispatch seam."""
+        """Enforce the model-visible output cap at the tool dispatch seam.
+
+        Tools place control metadata (status, exit code, `start_command`'s ID
+        line) at the end of their responses, so keeping the tail preserves it
+        without any per-tool cases here.
+        """
         result = await super().call_tool(name, tool_args, ctx, tool)
-        if name == 'start_command' or not isinstance(result, str):
+        if not isinstance(result, str):
             return result
         return truncate_tail(result, self._max_output_chars)
 

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -22,6 +22,8 @@ from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 
+from pydantic_ai_harness._output import truncate_tail
+
 _IO_DRAIN_TIMEOUT: float = 2.0
 _KILL_GRACE_PERIOD: float = 2.0
 
@@ -124,6 +126,8 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
 
         if self._allowed_commands and self._denied_commands:
             raise ValueError('Specify allowed_commands or denied_commands, not both.')
+        if max_output_chars <= 0:
+            raise ValueError('max_output_chars must be a positive integer.')
 
         self.add_function(self.run_command, name='run_command')
         self.add_function(self.start_command, name='start_command')
@@ -222,10 +226,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         `[stderr]` section (which callers append last) -- lands at the end, so
         the head is dropped and the final `max_output_chars` are kept.
         """
-        if len(text) <= self._max_output_chars:
-            return text
-        marker = f'[... output truncated, showing last {self._max_output_chars} chars]\n'
-        return marker + text[-self._max_output_chars :]
+        return truncate_tail(text, self._max_output_chars)
 
     def _build_cwd_capture(self, command: str) -> tuple[str, Path | None]:
         """Wrap a command to record its final working directory out-of-band.
@@ -355,7 +356,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
                 with anyio.CancelScope(shield=True):
                     await proc.wait()
                     await self._drain_with_timeout(stdout_chunks, stderr_chunks, proc)
-                return f'[Command timed out after {timeout}s]'
+                return self._truncate(f'[Command timed out after {timeout}s]')
             finally:
                 await proc.aclose()
 
@@ -369,15 +370,14 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
                 parts.append(f'[stderr]\n{stderr}')
             output = '\n'.join(parts) if parts else '(no output)'
 
-            output = self._truncate(output)
             exit_code = proc.returncode if proc.returncode is not None else 0
 
             if cwd_file is not None and exit_code == 0:
                 self._apply_captured_cwd(cwd_file)
 
             if exit_code != 0:
-                return f'{output}\n[exit code: {exit_code}]'
-            return output
+                output = f'{output}\n[exit code: {exit_code}]'
+            return self._truncate(output)
         finally:
             if cwd_file is not None:
                 cwd_file.unlink(missing_ok=True)
@@ -464,7 +464,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         """
         bg = self._background.get(command_id)
         if bg is None:
-            return f'[Error: unknown command ID {command_id!r}]'
+            return self._truncate(f'[Error: unknown command ID {command_id!r}]')
 
         if not bg.finished and bg.proc.returncode is not None:
             bg.exit_code = bg.proc.returncode
@@ -482,11 +482,11 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
         if output_sections:
-            parts.append(self._truncate('\n'.join(output_sections)))
+            parts.append('\n'.join(output_sections))
         else:
             parts.append('(no output yet)')
 
-        return '\n'.join(parts)
+        return self._truncate('\n'.join(parts))
 
     async def stop_command(self, command_id: str) -> str:
         """Stop a background command and return its final output.
@@ -499,7 +499,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         """
         bg = self._background.get(command_id)
         if bg is None:
-            return f'[Error: unknown command ID {command_id!r}]'
+            return self._truncate(f'[Error: unknown command ID {command_id!r}]')
 
         if not bg.finished:
             await self._kill_process_group(bg.proc)
@@ -523,8 +523,8 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
         if output_sections:
-            parts.append(self._truncate('\n'.join(output_sections)))
+            parts.append('\n'.join(output_sections))
         else:
             parts.append('(no output)')
 
-        return '\n'.join(parts)
+        return self._truncate('\n'.join(parts))

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -22,7 +22,7 @@ from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 
-from pydantic_ai_harness._output import truncate_tail
+from pydantic_ai_harness._output import truncate_head, truncate_tail
 
 _IO_DRAIN_TIMEOUT: float = 2.0
 _KILL_GRACE_PERIOD: float = 2.0
@@ -228,6 +228,20 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         """
         return truncate_tail(text, self._max_output_chars)
 
+    def _join_metadata_and_output(self, metadata: list[str], output: str) -> str:
+        """Keep background-command metadata when there is room inside the output cap."""
+        prefix = '\n'.join(metadata)
+        combined = f'{prefix}\n{output}'
+        output_budget = self._max_output_chars - len(prefix) - 1
+        if output_budget <= 0:
+            return truncate_head(combined, self._max_output_chars)
+        return f'{prefix}\n{truncate_tail(output, output_budget)}'
+
+    def _unknown_command_error(self, command_id: str) -> str:
+        """Report an unknown ID without allowing its value to hide the error."""
+        message = f'[Error: unknown command ID {command_id!r}]'
+        return truncate_head(message, self._max_output_chars)
+
     def _build_cwd_capture(self, command: str) -> tuple[str, Path | None]:
         """Wrap a command to record its final working directory out-of-band.
 
@@ -356,7 +370,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
                 with anyio.CancelScope(shield=True):
                     await proc.wait()
                     await self._drain_with_timeout(stdout_chunks, stderr_chunks, proc)
-                return self._truncate(f'[Command timed out after {timeout}s]')
+                return truncate_head(f'[Command timed out after {timeout}s]', self._max_output_chars)
             finally:
                 await proc.aclose()
 
@@ -464,7 +478,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         """
         bg = self._background.get(command_id)
         if bg is None:
-            return self._truncate(f'[Error: unknown command ID {command_id!r}]')
+            return self._unknown_command_error(command_id)
 
         if not bg.finished and bg.proc.returncode is not None:
             bg.exit_code = bg.proc.returncode
@@ -481,12 +495,8 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
             output_sections.append(f'[stdout]\n{stdout}')
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
-        if output_sections:
-            parts.append('\n'.join(output_sections))
-        else:
-            parts.append('(no output yet)')
-
-        return self._truncate('\n'.join(parts))
+        output = '\n'.join(output_sections) if output_sections else '(no output yet)'
+        return self._join_metadata_and_output(parts, output)
 
     async def stop_command(self, command_id: str) -> str:
         """Stop a background command and return its final output.
@@ -499,7 +509,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         """
         bg = self._background.get(command_id)
         if bg is None:
-            return self._truncate(f'[Error: unknown command ID {command_id!r}]')
+            return self._unknown_command_error(command_id)
 
         if not bg.finished:
             await self._kill_process_group(bg.proc)
@@ -514,17 +524,18 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         del self._background[command_id]
         await bg.proc.aclose()
 
-        parts = [f'[stopped: {bg.command!r}]']
+        stopped = f'[stopped: {bg.command!r}]'
+        parts = [stopped]
         if bg.exit_code is not None:
-            parts.append(f'[exit code: {bg.exit_code}]')
+            exit_code = f'[exit code: {bg.exit_code}]'
+            stopped_budget = self._max_output_chars - len(exit_code) - 1
+            if stopped_budget >= len('[stopped:]'):
+                parts[0] = truncate_head(stopped, stopped_budget)
+            parts.append(exit_code)
         output_sections: list[str] = []
         if stdout:
             output_sections.append(f'[stdout]\n{stdout}')
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
-        if output_sections:
-            parts.append('\n'.join(output_sections))
-        else:
-            parts.append('(no output)')
-
-        return self._truncate('\n'.join(parts))
+        output = '\n'.join(output_sections) if output_sections else '(no output)'
+        return self._join_metadata_and_output(parts, output)

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -231,10 +231,9 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
     def _join_metadata_and_output(self, metadata: list[str], output: str) -> str:
         """Keep background-command metadata when there is room inside the output cap."""
         prefix = '\n'.join(metadata)
-        combined = f'{prefix}\n{output}'
         output_budget = self._max_output_chars - len(prefix) - 1
         if output_budget <= 0:
-            return truncate_head(combined, self._max_output_chars)
+            return truncate_head(f'{prefix}\n{output}', self._max_output_chars)
         return f'{prefix}\n{truncate_tail(output, output_budget)}'
 
     def _unknown_command_error(self, command_id: str) -> str:
@@ -534,6 +533,6 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
         output = '\n'.join(output_sections) if output_sections else '(no output)'
-        if len('\n'.join([*parts, output])) > self._max_output_chars:
+        if sum(len(part) for part in parts) + len(parts) + len(output) > self._max_output_chars:
             parts[0] = '[stopped]'
         return self._join_metadata_and_output(parts, output)

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -26,6 +26,7 @@ from pydantic_ai_harness._output import truncate_tail
 
 _IO_DRAIN_TIMEOUT: float = 2.0
 _KILL_GRACE_PERIOD: float = 2.0
+_CONTROL_PREFIX_RE = re.compile(r'\A(?:\[status:[^\n]*\]|\[stopped:[^\n]*\])\n(?:\[exit code:[^\n]*\]\n)?')
 
 _P = ParamSpec('_P')
 
@@ -165,7 +166,12 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         result = await super().call_tool(name, tool_args, ctx, tool)
         if name == 'start_command' or not isinstance(result, str):
             return result
-        return truncate_tail(result, self._max_output_chars)
+        control_prefix = _CONTROL_PREFIX_RE.match(result)
+        return truncate_tail(
+            result,
+            self._max_output_chars,
+            preserve_prefix_chars=control_prefix.end() if control_prefix else 0,
+        )
 
     def _resolve_env(self) -> dict[str, str] | None:
         """Compute the environment passed to spawned subprocesses.

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -26,7 +26,6 @@ from pydantic_ai_harness._output import truncate_tail
 
 _IO_DRAIN_TIMEOUT: float = 2.0
 _KILL_GRACE_PERIOD: float = 2.0
-_CONTROL_PREFIX_RE = re.compile(r'\A(?:\[status:[^\n]*\]|\[stopped:[^\n]*\])\n(?:\[exit code:[^\n]*\]\n)?')
 
 _P = ParamSpec('_P')
 
@@ -166,12 +165,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         result = await super().call_tool(name, tool_args, ctx, tool)
         if name == 'start_command' or not isinstance(result, str):
             return result
-        control_prefix = _CONTROL_PREFIX_RE.match(result)
-        return truncate_tail(
-            result,
-            self._max_output_chars,
-            preserve_prefix_chars=control_prefix.end() if control_prefix else 0,
-        )
+        return truncate_tail(result, self._max_output_chars)
 
     def _resolve_env(self) -> dict[str, str] | None:
         """Compute the environment passed to spawned subprocesses.
@@ -481,15 +475,14 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         stdout, stderr = self._read_bg_output(bg)
 
         status = 'finished' if bg.finished else 'running'
-        parts = [f'[status: {status}]']
-        if bg.finished and bg.exit_code is not None:
-            parts.append(f'[exit code: {bg.exit_code}]')
         output_sections: list[str] = []
         if stdout:
             output_sections.append(f'[stdout]\n{stdout}')
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
-        parts.append('\n'.join(output_sections) if output_sections else '(no output yet)')
+        parts = ['\n'.join(output_sections) if output_sections else '(no output yet)', f'[status: {status}]']
+        if bg.finished and bg.exit_code is not None:
+            parts.append(f'[exit code: {bg.exit_code}]')
         return '\n'.join(parts)
 
     async def stop_command(self, command_id: str) -> str:
@@ -518,13 +511,12 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         del self._background[command_id]
         await bg.proc.aclose()
 
-        parts = [f'[stopped: {bg.command!r}]']
-        if bg.exit_code is not None:
-            parts.append(f'[exit code: {bg.exit_code}]')
         output_sections: list[str] = []
         if stdout:
             output_sections.append(f'[stdout]\n{stdout}')
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
-        parts.append('\n'.join(output_sections) if output_sections else '(no output)')
+        parts = ['\n'.join(output_sections) if output_sections else '(no output)', '[stopped]']
+        if bg.exit_code is not None:
+            parts.append(f'[exit code: {bg.exit_code}]')
         return '\n'.join(parts)

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -224,7 +224,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
 
         The most useful output -- errors, stack traces, exit info, and the
         `[stderr]` section (which callers append last) -- lands at the end, so
-        the head is dropped and the final `max_output_chars` are kept.
+        the head is dropped and as much of the tail as fits beside the marker is kept.
         """
         return truncate_tail(text, self._max_output_chars)
 
@@ -527,15 +527,13 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         stopped = f'[stopped: {bg.command!r}]'
         parts = [stopped]
         if bg.exit_code is not None:
-            exit_code = f'[exit code: {bg.exit_code}]'
-            stopped_budget = self._max_output_chars - len(exit_code) - 1
-            if stopped_budget >= len('[stopped:]'):
-                parts[0] = truncate_head(stopped, stopped_budget)
-            parts.append(exit_code)
+            parts.append(f'[exit code: {bg.exit_code}]')
         output_sections: list[str] = []
         if stdout:
             output_sections.append(f'[stdout]\n{stdout}')
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
         output = '\n'.join(output_sections) if output_sections else '(no output)'
+        if len('\n'.join([*parts, output])) > self._max_output_chars:
+            parts[0] = '[stopped]'
         return self._join_metadata_and_output(parts, output)

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -126,8 +126,6 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
 
         if self._allowed_commands and self._denied_commands:
             raise ValueError('Specify allowed_commands or denied_commands, not both.')
-        if max_output_chars <= 0:
-            raise ValueError('max_output_chars must be a positive integer.')
 
         self.add_function(self.run_command, name='run_command')
         self.add_function(self.start_command, name='start_command')
@@ -228,7 +226,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         """
         return truncate_tail(text, self._max_output_chars)
 
-    def _join_metadata_and_output(self, metadata: list[str], output: str) -> str:
+    def _join_metadata_and_output(self, metadata: Sequence[str], output: str) -> str:
         """Keep background-command metadata when there is room inside the output cap."""
         prefix = '\n'.join(metadata)
         output_budget = self._max_output_chars - len(prefix) - 1
@@ -238,8 +236,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
 
     def _unknown_command_error(self, command_id: str) -> str:
         """Report an unknown ID without allowing its value to hide the error."""
-        message = f'[Error: unknown command ID {command_id!r}]'
-        return truncate_head(message, self._max_output_chars)
+        return truncate_head(f'[Error: unknown command ID {command_id!r}]', self._max_output_chars)
 
     def _build_cwd_capture(self, command: str) -> tuple[str, Path | None]:
         """Wrap a command to record its final working directory out-of-band.
@@ -523,8 +520,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         del self._background[command_id]
         await bg.proc.aclose()
 
-        stopped = f'[stopped: {bg.command!r}]'
-        parts = [stopped]
+        parts = [f'[stopped: {bg.command!r}]']
         if bg.exit_code is not None:
             parts.append(f'[exit code: {bg.exit_code}]')
         output_sections: list[str] = []
@@ -533,6 +529,6 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
         output = '\n'.join(output_sections) if output_sections else '(no output)'
-        if sum(len(part) for part in parts) + len(parts) + len(output) > self._max_output_chars:
+        if len('\n'.join([*parts, output])) > self._max_output_chars:
             parts[0] = '[stopped]'
         return self._join_metadata_and_output(parts, output)

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -233,7 +233,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         prefix = '\n'.join(metadata)
         output_budget = self._max_output_chars - len(prefix) - 1
         if output_budget <= 0:
-            return truncate_head(f'{prefix}\n{output}', self._max_output_chars)
+            return truncate_head(f'{prefix}\n', self._max_output_chars)
         return f'{prefix}\n{truncate_tail(output, output_budget)}'
 
     def _unknown_command_error(self, command_id: str) -> str:

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -20,9 +20,9 @@ import anyio.abc
 from pydantic_ai import RunContext
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import AgentDepsT
-from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset, ToolsetTool
 
-from pydantic_ai_harness._output import truncate_head, truncate_tail
+from pydantic_ai_harness._output import truncate_tail
 
 _IO_DRAIN_TIMEOUT: float = 2.0
 _KILL_GRACE_PERIOD: float = 2.0
@@ -154,6 +154,19 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
             denied_env_patterns=self._denied_env_patterns,
         )
 
+    async def call_tool(
+        self,
+        name: str,
+        tool_args: dict[str, Any],
+        ctx: RunContext[AgentDepsT],
+        tool: ToolsetTool[AgentDepsT],
+    ) -> Any:
+        """Enforce the model-visible output cap at the tool dispatch seam."""
+        result = await super().call_tool(name, tool_args, ctx, tool)
+        if name == 'start_command' or not isinstance(result, str):
+            return result
+        return truncate_tail(result, self._max_output_chars)
+
     def _resolve_env(self) -> dict[str, str] | None:
         """Compute the environment passed to spawned subprocesses.
 
@@ -216,27 +229,6 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
             raise PermissionError(f'Command {executable!r} is denied.')
         if self._allowed_commands and executable not in self._allowed_commands:
             raise PermissionError(f'Command {executable!r} is not in the allowed list.')
-
-    def _truncate(self, text: str) -> str:
-        """Truncate output to the configured cap, keeping the tail.
-
-        The most useful output -- errors, stack traces, exit info, and the
-        `[stderr]` section (which callers append last) -- lands at the end, so
-        the head is dropped and as much of the tail as fits beside the marker is kept.
-        """
-        return truncate_tail(text, self._max_output_chars)
-
-    def _join_metadata_and_output(self, metadata: Sequence[str], output: str) -> str:
-        """Keep background-command metadata when there is room inside the output cap."""
-        prefix = '\n'.join(metadata)
-        output_budget = self._max_output_chars - len(prefix) - 1
-        if output_budget <= 0:
-            return truncate_head(f'{prefix}\n', self._max_output_chars)
-        return f'{prefix}\n{truncate_tail(output, output_budget)}'
-
-    def _unknown_command_error(self, command_id: str) -> str:
-        """Report an unknown ID without allowing its value to hide the error."""
-        return truncate_head(f'[Error: unknown command ID {command_id!r}]', self._max_output_chars)
 
     def _build_cwd_capture(self, command: str) -> tuple[str, Path | None]:
         """Wrap a command to record its final working directory out-of-band.
@@ -366,7 +358,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
                 with anyio.CancelScope(shield=True):
                     await proc.wait()
                     await self._drain_with_timeout(stdout_chunks, stderr_chunks, proc)
-                return truncate_head(f'[Command timed out after {timeout}s]', self._max_output_chars)
+                return f'[Command timed out after {timeout}s]'
             finally:
                 await proc.aclose()
 
@@ -387,7 +379,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
 
             if exit_code != 0:
                 output = f'{output}\n[exit code: {exit_code}]'
-            return self._truncate(output)
+            return output
         finally:
             if cwd_file is not None:
                 cwd_file.unlink(missing_ok=True)
@@ -474,7 +466,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         """
         bg = self._background.get(command_id)
         if bg is None:
-            return self._unknown_command_error(command_id)
+            return f'[Error: unknown command ID {command_id!r}]'
 
         if not bg.finished and bg.proc.returncode is not None:
             bg.exit_code = bg.proc.returncode
@@ -491,8 +483,8 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
             output_sections.append(f'[stdout]\n{stdout}')
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
-        output = '\n'.join(output_sections) if output_sections else '(no output yet)'
-        return self._join_metadata_and_output(parts, output)
+        parts.append('\n'.join(output_sections) if output_sections else '(no output yet)')
+        return '\n'.join(parts)
 
     async def stop_command(self, command_id: str) -> str:
         """Stop a background command and return its final output.
@@ -505,7 +497,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         """
         bg = self._background.get(command_id)
         if bg is None:
-            return self._unknown_command_error(command_id)
+            return f'[Error: unknown command ID {command_id!r}]'
 
         if not bg.finished:
             await self._kill_process_group(bg.proc)
@@ -528,7 +520,5 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
             output_sections.append(f'[stdout]\n{stdout}')
         if stderr:
             output_sections.append(f'[stderr]\n{stderr}')
-        output = '\n'.join(output_sections) if output_sections else '(no output)'
-        if len('\n'.join([*parts, output])) > self._max_output_chars:
-            parts[0] = '[stopped]'
-        return self._join_metadata_and_output(parts, output)
+        parts.append('\n'.join(output_sections) if output_sections else '(no output)')
+        return '\n'.join(parts)

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -229,10 +229,19 @@ class TestAwsCli:
         result = await _toolset(aws_cli_path='/no/such/aws-binary').aws_cli('s3 ls')
         assert 'not found' in result
 
+    async def test_missing_cli_binary_respects_output_cap(self) -> None:
+        result = await _toolset(max_output_chars=10, aws_cli_path='/no/such/aws-binary').aws_cli('s3 ls')
+        assert result == '[error: AW'
+
     async def test_timeout(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'sleep 5')
         result = await _toolset(aws_cli_path=stub).aws_cli('s3 ls', timeout_seconds=0.3)
         assert 'timed out after 0.3s' in result
+
+    async def test_timeout_respects_output_cap(self, tmp_path: Path) -> None:
+        stub = _make_stub(tmp_path, 'sleep 5')
+        result = await _toolset(max_output_chars=10, aws_cli_path=stub).aws_cli('s3 ls', timeout_seconds=0.1)
+        assert result == '[command t'
 
     async def test_per_call_timeout_overrides_default(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'echo "$@"')
@@ -284,6 +293,11 @@ class TestLocalStackHealth:
             result = await _toolset(endpoint_url=server.endpoint_url).localstack_health()
         assert 'HTTP 503' in result
 
+    async def test_non_200_respects_output_cap(self) -> None:
+        with http_server([HttpResponse(503)]) as server:
+            result = await _toolset(endpoint_url=server.endpoint_url, max_output_chars=10).localstack_health()
+        assert result == '[error: Lo'
+
     async def test_at_size_limit_is_not_truncated(self) -> None:
         with http_server([HttpResponse(200, 'x' * 100)]) as server:
             result = await _toolset(endpoint_url=server.endpoint_url, max_output_chars=100).localstack_health()
@@ -300,6 +314,12 @@ class TestLocalStackHealth:
     async def test_connection_error(self) -> None:
         result = await _toolset(endpoint_url=f'http://localhost:{unused_tcp_port()}').localstack_health()
         assert 'could not reach LocalStack' in result
+
+    async def test_connection_error_respects_output_cap(self) -> None:
+        result = await _toolset(
+            endpoint_url=f'http://localhost:{unused_tcp_port()}', max_output_chars=10
+        ).localstack_health()
+        assert result == '[error: co'
 
 
 class TestLocalStackCapability:

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import stat
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pydantic_ai import Agent, RunContext
@@ -49,6 +50,25 @@ def _toolset(
     )
 
 
+def _run_context() -> RunContext[None]:
+    return RunContext[None](
+        deps=None,
+        model=TestModel(),
+        usage=RunUsage(),
+        prompt=None,
+        messages=[],
+        run_step=0,
+    )
+
+
+async def _call_localstack_tool(toolset: LocalStackToolset[None], name: str, **tool_args: Any) -> str:
+    ctx = _run_context()
+    tools = await toolset.get_tools(ctx)
+    result = await toolset.call_tool(name, tool_args, ctx, tools[name])
+    assert isinstance(result, str)
+    return result
+
+
 def _make_stub(tmp_path: Path, body: str) -> str:
     """Write an executable shell script standing in for the AWS CLI."""
     stub = tmp_path / 'fake-aws'
@@ -74,6 +94,28 @@ class TestConstruction:
     def test_non_positive_max_output_chars_rejected(self) -> None:
         with pytest.raises(ValueError, match='max_output_chars must be a positive integer.'):
             _toolset(max_output_chars=0)
+
+
+class TestOutputCap:
+    async def test_new_string_tool_is_capped_at_dispatch(self) -> None:
+        toolset = _toolset(max_output_chars=1)
+
+        def text() -> str:
+            return 'xx'
+
+        toolset.add_function(text)
+        assert await _call_localstack_tool(toolset, 'text') == 'x'
+
+    async def test_non_string_tool_result_is_unchanged(self) -> None:
+        toolset = _toolset(max_output_chars=1)
+
+        def number() -> int:
+            return 42
+
+        toolset.add_function(number)
+        ctx = _run_context()
+        tools = await toolset.get_tools(ctx)
+        assert await toolset.call_tool('number', {}, ctx, tools['number']) == 42
 
 
 class TestAwsCli:
@@ -241,19 +283,25 @@ class TestAwsCli:
 
     async def test_output_truncated(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'printf "%01000d" 0')
-        result = await _toolset(max_output_chars=100, aws_cli_path=stub).aws_cli('s3 ls')
+        result = await _call_localstack_tool(
+            _toolset(max_output_chars=100, aws_cli_path=stub), 'aws_cli', command='s3 ls'
+        )
         assert 'output truncated' in result
         assert len(result) <= 100
 
     async def test_truncation_respects_small_cap_without_marker(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'printf "%01000d" 0')
-        result = await _toolset(max_output_chars=10, aws_cli_path=stub).aws_cli('s3 ls')
+        result = await _call_localstack_tool(
+            _toolset(max_output_chars=10, aws_cli_path=stub), 'aws_cli', command='s3 ls'
+        )
         assert len(result) <= 10
         assert 'output truncated' not in result
 
     async def test_truncation_keeps_tail_and_marker_for_normal_cap(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'printf "HEAD"; printf "%0500dTAIL" 0')
-        result = await _toolset(max_output_chars=200, aws_cli_path=stub).aws_cli('s3 ls')
+        result = await _call_localstack_tool(
+            _toolset(max_output_chars=200, aws_cli_path=stub), 'aws_cli', command='s3 ls'
+        )
         assert len(result) == 200
         assert result.startswith('[... output truncated, showing last 153 chars]\n')
         assert result.endswith('TAIL')
@@ -261,7 +309,9 @@ class TestAwsCli:
 
     async def test_truncation_caps_complete_failure_response(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'printf "%0500d" 0; exit 7')
-        result = await _toolset(max_output_chars=200, aws_cli_path=stub).aws_cli('s3 ls')
+        result = await _call_localstack_tool(
+            _toolset(max_output_chars=200, aws_cli_path=stub), 'aws_cli', command='s3 ls'
+        )
         assert len(result) == 200
         assert result.startswith('[... output truncated, showing last 153 chars]\n')
         assert result.endswith('[exit code: 7]')
@@ -286,12 +336,16 @@ class TestLocalStackHealth:
 
     async def test_at_size_limit_is_not_truncated(self) -> None:
         with http_server([HttpResponse(200, 'x' * 100)]) as server:
-            result = await _toolset(endpoint_url=server.endpoint_url, max_output_chars=100).localstack_health()
+            result = await _call_localstack_tool(
+                _toolset(endpoint_url=server.endpoint_url, max_output_chars=100), 'localstack_health'
+            )
         assert result == 'x' * 100
 
     async def test_over_size_limit_keeps_tail(self) -> None:
         with http_server([HttpResponse(200, 'HEAD' + 'T' * 100)]) as server:
-            result = await _toolset(endpoint_url=server.endpoint_url, max_output_chars=100).localstack_health()
+            result = await _call_localstack_tool(
+                _toolset(endpoint_url=server.endpoint_url, max_output_chars=100), 'localstack_health'
+            )
         assert len(result) <= 100
         assert result.endswith('T')
         assert 'HEAD' not in result

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -229,19 +229,10 @@ class TestAwsCli:
         result = await _toolset(aws_cli_path='/no/such/aws-binary').aws_cli('s3 ls')
         assert 'not found' in result
 
-    async def test_missing_cli_binary_respects_output_cap(self) -> None:
-        result = await _toolset(max_output_chars=10, aws_cli_path='/no/such/aws-binary').aws_cli('s3 ls')
-        assert result == '[error: AW'
-
     async def test_timeout(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'sleep 5')
         result = await _toolset(aws_cli_path=stub).aws_cli('s3 ls', timeout_seconds=0.3)
         assert 'timed out after 0.3s' in result
-
-    async def test_timeout_respects_output_cap(self, tmp_path: Path) -> None:
-        stub = _make_stub(tmp_path, 'sleep 5')
-        result = await _toolset(max_output_chars=10, aws_cli_path=stub).aws_cli('s3 ls', timeout_seconds=0.1)
-        assert result == '[command t'
 
     async def test_per_call_timeout_overrides_default(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'echo "$@"')
@@ -293,11 +284,6 @@ class TestLocalStackHealth:
             result = await _toolset(endpoint_url=server.endpoint_url).localstack_health()
         assert 'HTTP 503' in result
 
-    async def test_non_200_respects_output_cap(self) -> None:
-        with http_server([HttpResponse(503)]) as server:
-            result = await _toolset(endpoint_url=server.endpoint_url, max_output_chars=10).localstack_health()
-        assert result == '[error: Lo'
-
     async def test_at_size_limit_is_not_truncated(self) -> None:
         with http_server([HttpResponse(200, 'x' * 100)]) as server:
             result = await _toolset(endpoint_url=server.endpoint_url, max_output_chars=100).localstack_health()
@@ -314,12 +300,6 @@ class TestLocalStackHealth:
     async def test_connection_error(self) -> None:
         result = await _toolset(endpoint_url=f'http://localhost:{unused_tcp_port()}').localstack_health()
         assert 'could not reach LocalStack' in result
-
-    async def test_connection_error_respects_output_cap(self) -> None:
-        result = await _toolset(
-            endpoint_url=f'http://localhost:{unused_tcp_port()}', max_output_chars=10
-        ).localstack_health()
-        assert result == '[error: co'
 
 
 class TestLocalStackCapability:

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -254,10 +254,17 @@ class TestAwsCli:
     async def test_truncation_keeps_tail_and_marker_for_normal_cap(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'printf "HEAD"; printf "%0500dTAIL" 0')
         result = await _toolset(max_output_chars=200, aws_cli_path=stub).aws_cli('s3 ls')
-        assert len(result) <= 200
-        assert 'output truncated' in result
+        assert len(result) == 200
+        assert result.startswith('[... output truncated, showing last 153 chars]\n')
         assert result.endswith('TAIL')
         assert 'HEAD' not in result
+
+    async def test_truncation_caps_complete_failure_response(self, tmp_path: Path) -> None:
+        stub = _make_stub(tmp_path, 'printf "%0500d" 0; exit 7')
+        result = await _toolset(max_output_chars=200, aws_cli_path=stub).aws_cli('s3 ls')
+        assert len(result) == 200
+        assert result.startswith('[... output truncated, showing last 153 chars]\n')
+        assert result.endswith('[exit code: 7]')
 
 
 class TestLocalStackHealth:

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -287,7 +287,7 @@ class TestAwsCli:
             _toolset(max_output_chars=100, aws_cli_path=stub), 'aws_cli', command='s3 ls'
         )
         assert 'output truncated' in result
-        assert len(result) <= 100
+        assert len(result) == 100
 
     async def test_truncation_respects_small_cap_without_marker(self, tmp_path: Path) -> None:
         stub = _make_stub(tmp_path, 'printf "%01000d" 0')

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -7,6 +7,7 @@ import shlex
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import anyio
@@ -77,6 +78,14 @@ def _run_context() -> RunContext[None]:
         messages=[],
         run_step=0,
     )
+
+
+async def _call_shell_tool(toolset: ShellToolset[None], name: str, **tool_args: Any) -> str:
+    ctx = _run_context()
+    tools = await toolset.get_tools(ctx)
+    result = await toolset.call_tool(name, tool_args, ctx, tools[name])
+    assert isinstance(result, str)
+    return result
 
 
 def _parse_command_id(result: str) -> str:
@@ -347,36 +356,6 @@ class TestCommandValidation:
         assert toolset._first_denied_operator('echo hi | cat') is None
 
 
-class TestTruncation:
-    def test_within_limit(self, toolset: ShellToolset[None]) -> None:
-        assert toolset._truncate('short') == 'short'
-
-    def test_exactly_at_limit_not_truncated(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=10)
-        result = ts._truncate('x' * 10)
-        assert result == 'x' * 10
-        assert 'truncated' not in result
-
-    def test_one_over_limit_truncated(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=10)
-        result = ts._truncate('x' * 11)
-        assert result == 'x' * 10
-
-    def test_keeps_tail_not_head(self, shell_dir: Path) -> None:
-        """The tail (where errors and the [stderr] section land) is preserved."""
-        ts = _shell_toolset(shell_dir, max_output_chars=20)
-        text = 'HEAD' + 'x' * 100 + 'TAIL_ERROR'
-        result = ts._truncate(text)
-        assert result.endswith('TAIL_ERROR')
-        assert 'HEAD' not in result
-        assert len(result) == 20
-
-    def test_truncation_marker_wording(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=50)
-        result = ts._truncate('x' * 100)
-        assert result == '[... output truncated, showing last 5 chars]\nxxxxx'
-
-
 class TestCwdCapture:
     """The persistent-cwd mechanism records `pwd` out-of-band via a private temp
     file, so command output can never spoof the tracked directory."""
@@ -490,14 +469,14 @@ class TestRunCommand:
 
     async def test_output_truncation(self, shell_dir: Path) -> None:
         ts = _shell_toolset(shell_dir, max_output_chars=50)
-        result = await ts.run_command(f'{sys.executable} -c "print(\'x\' * 200)"')
+        result = await _call_shell_tool(ts, 'run_command', command=f'{sys.executable} -c "print(\'x\' * 200)"')
         assert len(result) == 50
         assert 'truncated, showing last 5 chars' in result
 
     async def test_output_truncation_caps_complete_failure_response(self, shell_dir: Path) -> None:
         ts = _shell_toolset(shell_dir, max_output_chars=200)
         command = f'{sys.executable} -c "import sys; sys.stdout.write(\'x\' * 400); sys.exit(7)"'
-        result = await ts.run_command(command)
+        result = await _call_shell_tool(ts, 'run_command', command=command)
         assert len(result) == 200
         assert result.startswith('[... output truncated, showing last 153 chars]\n')
         assert result.endswith('[exit code: 7]')
@@ -560,16 +539,9 @@ class TestRunCommand:
         result = await ts.run_command('sleep 10')
         assert 'timed out after 0.5s' in result
 
-    async def test_timeout_respects_output_cap(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=10, default_timeout=0.1)
-        result = await ts.run_command('sleep 10')
-        assert len(result) == 10
-        assert result == '[Command t'
-
     async def test_zero_output_cap_returns_no_model_visible_output(self, shell_dir: Path) -> None:
         ts = _shell_toolset(shell_dir, max_output_chars=0)
-        assert await ts.run_command('echo hidden') == ''
-        assert await ts.check_command('unknown') == ''
+        assert await _call_shell_tool(ts, 'run_command', command='echo hidden') == ''
 
     async def test_custom_timeout_overrides_default(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -761,32 +733,17 @@ class TestProcessGroupKill:
 
 class TestBackgroundCommands:
     async def test_start_command_returns_id(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=50_000,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
-        result = await ts.start_command('sleep 100')
+        ts = _shell_toolset(shell_dir, max_output_chars=1)
+        result = await _call_shell_tool(ts, 'start_command', command='sleep 100')
         assert 'ID:' in result
         assert 'Started background command' in result
+        assert len(result) > 1
         command_id = _parse_command_id(result)
         await ts.stop_command(command_id)
 
     async def test_check_unknown_id(self, toolset: ShellToolset[None]) -> None:
         result = await toolset.check_command('nonexistent_id')
         assert 'unknown command ID' in result
-
-    async def test_unknown_id_responses_respect_output_cap(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=10)
-        check_result = await ts.check_command('a' * 100)
-        stop_result = await ts.stop_command('a' * 100)
-        assert check_result == '[Error: un'
-        assert stop_result == '[Error: un'
 
     async def test_stop_unknown_id(self, toolset: ShellToolset[None]) -> None:
         result = await toolset.stop_command('nonexistent_id')
@@ -838,46 +795,24 @@ class TestBackgroundCommands:
         await anyio.sleep(0.5)
 
         try:
-            check_result = await ts.check_command(command_id)
+            check_result = await _call_shell_tool(ts, 'check_command', command_id=command_id)
             assert len(check_result) == 200
-            assert check_result.startswith('[status: running]\n[... output truncated')
+            assert 'output truncated' in check_result
         finally:
-            stop_result = await ts.stop_command(command_id)
-        assert len(stop_result) <= 200
-        assert stop_result.startswith('[stopped]')
-        assert '[exit code:' in stop_result
+            stop_result = await _call_shell_tool(ts, 'stop_command', command_id=command_id)
+        assert len(stop_result) == 200
         assert 'output truncated' in stop_result
 
-    async def test_finished_background_metadata_survives_output_cap(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=200)
-        start_result = await ts.start_command("printf '%0400d' 0; exit 7")
-        command_id = _parse_command_id(start_result)
-        try:
-            with anyio.fail_after(5):
-                while True:
-                    check_result = await ts.check_command(command_id)
-                    if check_result.startswith('[status: finished]'):
-                        break
-                    await anyio.sleep(0.05)
-            assert len(check_result) == 200
-            assert check_result.startswith('[status: finished]\n[exit code: 7]\n[... output truncated')
-        finally:
-            stop_result = await ts.stop_command(command_id)
-        assert len(stop_result) <= 200
-        assert stop_result.startswith('[stopped]')
-        assert '[exit code: 7]' in stop_result
-        assert 'output truncated' in stop_result
+    async def test_non_string_tool_result_is_unchanged(self, shell_dir: Path) -> None:
+        ts = _shell_toolset(shell_dir, max_output_chars=1)
 
-    async def test_background_metadata_larger_than_output_cap(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=10)
-        start_result = await ts.start_command('sleep 30')
-        command_id = _parse_command_id(start_result)
-        try:
-            check_result = await ts.check_command(command_id)
-            assert check_result == '[status: r'
-        finally:
-            stop_result = await ts.stop_command(command_id)
-            assert stop_result == '[stopped]\n'
+        def number() -> int:
+            return 42
+
+        ts.add_function(number)
+        ctx = _run_context()
+        tools = await ts.get_tools(ctx)
+        assert await ts.call_tool('number', {}, ctx, tools['number']) == 42
 
     async def test_start_and_check_finished(self, shell_dir: Path) -> None:
         ts = ShellToolset(

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -666,6 +666,7 @@ class TestRunCommand:
         )
         result = await ts.run_command('sleep 10')
         assert len(result) == 10
+        assert result == '[Command t'
 
     async def test_custom_timeout_overrides_default(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -888,8 +889,10 @@ class TestBackgroundCommands:
             persist_cwd=False,
             allow_interactive=False,
         )
-        assert len(await ts.check_command('a' * 100)) == 10
-        assert len(await ts.stop_command('a' * 100)) == 10
+        check_result = await ts.check_command('a' * 100)
+        stop_result = await ts.stop_command('a' * 100)
+        assert check_result == '[Error: un'
+        assert stop_result == '[Error: un'
 
     async def test_stop_unknown_id(self, toolset: ShellToolset[None]) -> None:
         result = await toolset.stop_command('nonexistent_id')
@@ -947,16 +950,83 @@ class TestBackgroundCommands:
         )
         start_result = await ts.start_command("printf '%0400d' 0; sleep 30")
         command_id = _parse_command_id(start_result)
-        await anyio.sleep(0.2)
+        await anyio.sleep(0.5)
 
         try:
             check_result = await ts.check_command(command_id)
             assert len(check_result) == 200
-            assert check_result.startswith('[... output truncated, showing last 153 chars]\n')
+            assert check_result.startswith('[status: running]\n[... output truncated')
         finally:
             stop_result = await ts.stop_command(command_id)
-        assert len(stop_result) == 200
-        assert stop_result.startswith('[... output truncated, showing last 153 chars]\n')
+        assert len(stop_result) <= 200
+        assert stop_result.startswith('[stopped:')
+        assert '[exit code:' in stop_result
+        assert 'output truncated' in stop_result
+
+    async def test_finished_background_metadata_survives_output_cap(self, shell_dir: Path) -> None:
+        ts = ShellToolset(
+            cwd=shell_dir,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=10.0,
+            max_output_chars=200,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        start_result = await ts.start_command("printf '%0400d' 0; exit 7")
+        command_id = _parse_command_id(start_result)
+        await anyio.sleep(0.5)
+
+        check_result = await ts.check_command(command_id)
+        assert len(check_result) == 200
+        assert check_result.startswith('[status: finished]\n[exit code: 7]\n[... output truncated')
+
+        stop_result = await ts.stop_command(command_id)
+        assert len(stop_result) <= 200
+        assert stop_result.startswith('[stopped:')
+        assert '[exit code: 7]' in stop_result
+        assert 'output truncated' in stop_result
+
+    async def test_background_metadata_larger_than_output_cap(self, shell_dir: Path) -> None:
+        ts = ShellToolset(
+            cwd=shell_dir,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=10.0,
+            max_output_chars=10,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        start_result = await ts.start_command('sleep 30')
+        command_id = _parse_command_id(start_result)
+        try:
+            check_result = await ts.check_command(command_id)
+            assert check_result == '[status: r'
+        finally:
+            stop_result = await ts.stop_command(command_id)
+            assert stop_result == '[stopped: '
+
+    async def test_long_stopped_command_keeps_exit_code_within_cap(self, shell_dir: Path) -> None:
+        ts = ShellToolset(
+            cwd=shell_dir,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=10.0,
+            max_output_chars=200,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        start_result = await ts.start_command(f'exit 7 # {"x" * 400}')
+        command_id = _parse_command_id(start_result)
+        await anyio.sleep(0.5)
+
+        stop_result = await ts.stop_command(command_id)
+        assert len(stop_result) <= 200
+        assert stop_result.startswith('[stopped:')
+        assert stop_result.endswith('[exit code: 7]')
 
     async def test_start_and_check_finished(self, shell_dir: Path) -> None:
         ts = ShellToolset(

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -768,6 +768,7 @@ class TestBackgroundCommands:
         stop_result = await ts.stop_command(command_id)
         assert 'stopped' in stop_result
         assert 'hello_bg' in stop_result
+        assert stop_result.splitlines()[-2:] == ['[stopped]', '[exit code: 0]']
 
     async def test_start_and_check_running(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -785,6 +786,7 @@ class TestBackgroundCommands:
 
         check_result = await ts.check_command(command_id)
         assert 'running' in check_result
+        assert check_result.endswith('[status: running]')
 
         await ts.stop_command(command_id)
 
@@ -797,14 +799,15 @@ class TestBackgroundCommands:
         try:
             check_result = await _call_shell_tool(ts, 'check_command', command_id=command_id)
             assert len(check_result) == 200
-            assert check_result.startswith('[status: running]\n')
             assert 'output truncated' in check_result
+            assert check_result.endswith('[status: running]')
         finally:
             stop_result = await _call_shell_tool(ts, 'stop_command', command_id=command_id)
         assert len(stop_result) == 200
-        assert stop_result.startswith('[stopped:')
-        assert '\n[exit code:' in stop_result
         assert 'output truncated' in stop_result
+        stop_lines = stop_result.splitlines()
+        assert stop_lines[-2] == '[stopped]'
+        assert stop_lines[-1].startswith('[exit code:')
 
     async def test_new_string_tool_is_capped_at_dispatch(self, shell_dir: Path) -> None:
         ts = _shell_toolset(shell_dir, max_output_chars=1)
@@ -845,6 +848,7 @@ class TestBackgroundCommands:
         check_result = await ts.check_command(command_id)
         assert 'finished' in check_result
         assert 'done_quick' in check_result
+        assert check_result.splitlines()[-2:] == ['[status: finished]', '[exit code: 0]']
 
         await ts.stop_command(command_id)
 
@@ -1404,7 +1408,7 @@ class TestStopCommandAlreadyFinished:
 
         # stop_command should skip the kill branch and handle None exit_code
         result = await ts.stop_command(command_id)
-        assert '[stopped:' in result
+        assert result.endswith('[stopped]')
         assert '[exit code:' not in result
 
 

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -803,6 +803,15 @@ class TestBackgroundCommands:
         assert len(stop_result) == 200
         assert 'output truncated' in stop_result
 
+    async def test_new_string_tool_is_capped_at_dispatch(self, shell_dir: Path) -> None:
+        ts = _shell_toolset(shell_dir, max_output_chars=1)
+
+        def text() -> str:
+            return 'xx'
+
+        ts.add_function(text)
+        assert await _call_shell_tool(ts, 'text') == 'x'
+
     async def test_non_string_tool_result_is_unchanged(self, shell_dir: Path) -> None:
         ts = _shell_toolset(shell_dir, max_output_chars=1)
 

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -539,10 +539,6 @@ class TestRunCommand:
         result = await ts.run_command('sleep 10')
         assert 'timed out after 0.5s' in result
 
-    async def test_zero_output_cap_returns_no_model_visible_output(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=0)
-        assert await _call_shell_tool(ts, 'run_command', command='echo hidden') == ''
-
     async def test_custom_timeout_overrides_default(self, shell_dir: Path) -> None:
         ts = ShellToolset(
             cwd=shell_dir,
@@ -622,6 +618,12 @@ class TestRunCommand:
                 persist_cwd=False,
                 allow_interactive=False,
             )
+
+    def test_non_positive_max_output_chars_rejected(self, shell_dir: Path) -> None:
+        # Matches LocalStackToolset: a cap of 0 would blank every response,
+        # including start_command's ID line, leaving its process unstoppable.
+        with pytest.raises(ValueError, match='max_output_chars must be a positive integer.'):
+            _shell_toolset(shell_dir, max_output_chars=0)
 
     async def test_stdout_chunks_joined_cleanly(self, shell_dir: Path) -> None:
         ts = ShellToolset(

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -852,13 +852,17 @@ class TestBackgroundCommands:
         ts = _shell_toolset(shell_dir, max_output_chars=200)
         start_result = await ts.start_command("printf '%0400d' 0; exit 7")
         command_id = _parse_command_id(start_result)
-        await anyio.sleep(0.5)
-
-        check_result = await ts.check_command(command_id)
-        assert len(check_result) == 200
-        assert check_result.startswith('[status: finished]\n[exit code: 7]\n[... output truncated')
-
-        stop_result = await ts.stop_command(command_id)
+        try:
+            with anyio.fail_after(5):
+                while True:
+                    check_result = await ts.check_command(command_id)
+                    if check_result.startswith('[status: finished]'):
+                        break
+                    await anyio.sleep(0.05)
+            assert len(check_result) == 200
+            assert check_result.startswith('[status: finished]\n[exit code: 7]\n[... output truncated')
+        finally:
+            stop_result = await ts.stop_command(command_id)
         assert len(stop_result) <= 200
         assert stop_result.startswith('[stopped]')
         assert '[exit code: 7]' in stop_result

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -44,6 +44,24 @@ def _env_toolset(
     )
 
 
+def _shell_toolset(
+    shell_dir: Path,
+    *,
+    max_output_chars: int = 50_000,
+    default_timeout: float = 10.0,
+) -> ShellToolset[None]:
+    return ShellToolset(
+        cwd=shell_dir,
+        allowed_commands=[],
+        denied_commands=[],
+        denied_operators=[],
+        default_timeout=default_timeout,
+        max_output_chars=max_output_chars,
+        persist_cwd=False,
+        allow_interactive=False,
+    )
+
+
 def _read_env_var(name: str) -> str:
     """Shell command that prints an env var's value, or ABSENT if unset."""
     return f'{sys.executable} -c "import os; print(os.environ.get({name!r}, \'ABSENT\'))"'
@@ -209,19 +227,6 @@ class TestCommandValidation:
                 allow_interactive=False,
             )
 
-    def test_non_positive_max_output_chars_rejected(self, shell_dir: Path) -> None:
-        with pytest.raises(ValueError, match='max_output_chars must be a positive integer.'):
-            ShellToolset(
-                cwd=shell_dir,
-                allowed_commands=[],
-                denied_commands=[],
-                denied_operators=[],
-                default_timeout=10.0,
-                max_output_chars=0,
-                persist_cwd=False,
-                allow_interactive=False,
-            )
-
     async def test_interactive_blocked_by_default(self, toolset: ShellToolset[None]) -> None:
         with pytest.raises(PermissionError, match='Interactive commands'):
             toolset._check_command('vim file.txt')
@@ -346,75 +351,20 @@ class TestTruncation:
     def test_within_limit(self, toolset: ShellToolset[None]) -> None:
         assert toolset._truncate('short') == 'short'
 
-    def test_at_limit(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=10,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
-        result = ts._truncate('x' * 10)
-        assert result == 'x' * 10
-
-    def test_over_limit(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=10,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
-        result = ts._truncate('x' * 20)
-        assert result == 'x' * 10
-
     def test_exactly_at_limit_not_truncated(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=10,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=10)
         result = ts._truncate('x' * 10)
         assert result == 'x' * 10
         assert 'truncated' not in result
 
     def test_one_over_limit_truncated(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=10,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=10)
         result = ts._truncate('x' * 11)
         assert result == 'x' * 10
 
     def test_keeps_tail_not_head(self, shell_dir: Path) -> None:
         """The tail (where errors and the [stderr] section land) is preserved."""
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=20,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=20)
         text = 'HEAD' + 'x' * 100 + 'TAIL_ERROR'
         result = ts._truncate(text)
         assert result.endswith('TAIL_ERROR')
@@ -422,16 +372,7 @@ class TestTruncation:
         assert len(result) == 20
 
     def test_truncation_marker_wording(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=50,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=50)
         result = ts._truncate('x' * 100)
         assert result == '[... output truncated, showing last 5 chars]\nxxxxx'
 
@@ -548,47 +489,13 @@ class TestRunCommand:
         assert result == '(no output)'
 
     async def test_output_truncation(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=50,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=50)
         result = await ts.run_command(f'{sys.executable} -c "print(\'x\' * 200)"')
         assert len(result) == 50
         assert 'truncated, showing last 5 chars' in result
 
-    async def test_output_truncation_caps_complete_success_response(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=200,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
-        result = await ts.run_command(f'{sys.executable} -c "import sys; sys.stdout.write(\'x\' * 400)"')
-        assert len(result) == 200
-        assert result.startswith('[... output truncated, showing last 153 chars]\n')
-        assert result.endswith('x' * 153)
-
     async def test_output_truncation_caps_complete_failure_response(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=200,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=200)
         command = f'{sys.executable} -c "import sys; sys.stdout.write(\'x\' * 400); sys.exit(7)"'
         result = await ts.run_command(command)
         assert len(result) == 200
@@ -654,19 +561,15 @@ class TestRunCommand:
         assert 'timed out after 0.5s' in result
 
     async def test_timeout_respects_output_cap(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=0.1,
-            max_output_chars=10,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=10, default_timeout=0.1)
         result = await ts.run_command('sleep 10')
         assert len(result) == 10
         assert result == '[Command t'
+
+    async def test_zero_output_cap_returns_no_model_visible_output(self, shell_dir: Path) -> None:
+        ts = _shell_toolset(shell_dir, max_output_chars=0)
+        assert await ts.run_command('echo hidden') == ''
+        assert await ts.check_command('unknown') == ''
 
     async def test_custom_timeout_overrides_default(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -879,16 +782,7 @@ class TestBackgroundCommands:
         assert 'unknown command ID' in result
 
     async def test_unknown_id_responses_respect_output_cap(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=10,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=10)
         check_result = await ts.check_command('a' * 100)
         stop_result = await ts.stop_command('a' * 100)
         assert check_result == '[Error: un'
@@ -938,16 +832,7 @@ class TestBackgroundCommands:
         await ts.stop_command(command_id)
 
     async def test_check_and_stop_respect_output_cap(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=200,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=200)
         start_result = await ts.start_command("printf '%0400d' 0; sleep 30")
         command_id = _parse_command_id(start_result)
         await anyio.sleep(0.5)
@@ -964,16 +849,7 @@ class TestBackgroundCommands:
         assert 'output truncated' in stop_result
 
     async def test_finished_background_metadata_survives_output_cap(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=200,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=200)
         start_result = await ts.start_command("printf '%0400d' 0; exit 7")
         command_id = _parse_command_id(start_result)
         await anyio.sleep(0.5)
@@ -989,16 +865,7 @@ class TestBackgroundCommands:
         assert 'output truncated' in stop_result
 
     async def test_background_metadata_larger_than_output_cap(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=10,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
+        ts = _shell_toolset(shell_dir, max_output_chars=10)
         start_result = await ts.start_command('sleep 30')
         command_id = _parse_command_id(start_result)
         try:
@@ -1007,26 +874,6 @@ class TestBackgroundCommands:
         finally:
             stop_result = await ts.stop_command(command_id)
             assert stop_result == '[stopped]\n'
-
-    async def test_long_stopped_command_keeps_exit_code_within_cap(self, shell_dir: Path) -> None:
-        ts = ShellToolset(
-            cwd=shell_dir,
-            allowed_commands=[],
-            denied_commands=[],
-            denied_operators=[],
-            default_timeout=10.0,
-            max_output_chars=200,
-            persist_cwd=False,
-            allow_interactive=False,
-        )
-        start_result = await ts.start_command(f'printf "TAIL_ERROR"; exit 7 # {"x" * 400}')
-        command_id = _parse_command_id(start_result)
-        await anyio.sleep(0.5)
-
-        stop_result = await ts.stop_command(command_id)
-        assert len(stop_result) <= 200
-        assert stop_result.startswith('[stopped]\n[exit code: 7]')
-        assert stop_result.endswith('TAIL_ERROR')
 
     async def test_start_and_check_finished(self, shell_dir: Path) -> None:
         ts = ShellToolset(

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -733,12 +733,22 @@ class TestProcessGroupKill:
 
 class TestBackgroundCommands:
     async def test_start_command_returns_id(self, shell_dir: Path) -> None:
-        ts = _shell_toolset(shell_dir, max_output_chars=1)
+        ts = _shell_toolset(shell_dir)
         result = await _call_shell_tool(ts, 'start_command', command='sleep 100')
         assert 'ID:' in result
         assert 'Started background command' in result
-        assert len(result) > 1
         command_id = _parse_command_id(result)
+        await ts.stop_command(command_id)
+
+    async def test_start_command_long_echo_is_capped_keeping_id(self, shell_dir: Path) -> None:
+        # The command echo is subject to the cap like any other output; the ID
+        # line is the tail, so truncation keeps it usable for check/stop calls.
+        ts = _shell_toolset(shell_dir, max_output_chars=80)
+        result = await _call_shell_tool(ts, 'start_command', command='true ' + 'x' * 200)
+        assert len(result) == 80
+        assert 'output truncated' in result
+        command_id = _parse_command_id(result)
+        assert len(command_id) == 12
         await ts.stop_command(command_id)
 
     async def test_check_unknown_id(self, toolset: ShellToolset[None]) -> None:

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -959,7 +959,7 @@ class TestBackgroundCommands:
         finally:
             stop_result = await ts.stop_command(command_id)
         assert len(stop_result) <= 200
-        assert stop_result.startswith('[stopped:')
+        assert stop_result.startswith('[stopped]')
         assert '[exit code:' in stop_result
         assert 'output truncated' in stop_result
 
@@ -984,7 +984,7 @@ class TestBackgroundCommands:
 
         stop_result = await ts.stop_command(command_id)
         assert len(stop_result) <= 200
-        assert stop_result.startswith('[stopped:')
+        assert stop_result.startswith('[stopped]')
         assert '[exit code: 7]' in stop_result
         assert 'output truncated' in stop_result
 
@@ -1006,7 +1006,7 @@ class TestBackgroundCommands:
             assert check_result == '[status: r'
         finally:
             stop_result = await ts.stop_command(command_id)
-            assert stop_result == '[stopped: '
+            assert stop_result == '[stopped]\n'
 
     async def test_long_stopped_command_keeps_exit_code_within_cap(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -1019,14 +1019,14 @@ class TestBackgroundCommands:
             persist_cwd=False,
             allow_interactive=False,
         )
-        start_result = await ts.start_command(f'exit 7 # {"x" * 400}')
+        start_result = await ts.start_command(f'printf "TAIL_ERROR"; exit 7 # {"x" * 400}')
         command_id = _parse_command_id(start_result)
         await anyio.sleep(0.5)
 
         stop_result = await ts.stop_command(command_id)
         assert len(stop_result) <= 200
-        assert stop_result.startswith('[stopped:')
-        assert stop_result.endswith('[exit code: 7]')
+        assert stop_result.startswith('[stopped]\n[exit code: 7]')
+        assert stop_result.endswith('TAIL_ERROR')
 
     async def test_start_and_check_finished(self, shell_dir: Path) -> None:
         ts = ShellToolset(

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -209,6 +209,19 @@ class TestCommandValidation:
                 allow_interactive=False,
             )
 
+    def test_non_positive_max_output_chars_rejected(self, shell_dir: Path) -> None:
+        with pytest.raises(ValueError, match='max_output_chars must be a positive integer.'):
+            ShellToolset(
+                cwd=shell_dir,
+                allowed_commands=[],
+                denied_commands=[],
+                denied_operators=[],
+                default_timeout=10.0,
+                max_output_chars=0,
+                persist_cwd=False,
+                allow_interactive=False,
+            )
+
     async def test_interactive_blocked_by_default(self, toolset: ShellToolset[None]) -> None:
         with pytest.raises(PermissionError, match='Interactive commands'):
             toolset._check_command('vim file.txt')
@@ -359,8 +372,7 @@ class TestTruncation:
             allow_interactive=False,
         )
         result = ts._truncate('x' * 20)
-        assert result.endswith('x' * 10)
-        assert 'truncated, showing last 10 chars' in result
+        assert result == 'x' * 10
 
     def test_exactly_at_limit_not_truncated(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -389,8 +401,7 @@ class TestTruncation:
             allow_interactive=False,
         )
         result = ts._truncate('x' * 11)
-        assert result.endswith('x' * 10)
-        assert 'truncated, showing last 10 chars' in result
+        assert result == 'x' * 10
 
     def test_keeps_tail_not_head(self, shell_dir: Path) -> None:
         """The tail (where errors and the [stderr] section land) is preserved."""
@@ -408,7 +419,7 @@ class TestTruncation:
         result = ts._truncate(text)
         assert result.endswith('TAIL_ERROR')
         assert 'HEAD' not in result
-        assert 'truncated' in result
+        assert len(result) == 20
 
     def test_truncation_marker_wording(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -417,12 +428,12 @@ class TestTruncation:
             denied_commands=[],
             denied_operators=[],
             default_timeout=10.0,
-            max_output_chars=10,
+            max_output_chars=50,
             persist_cwd=False,
             allow_interactive=False,
         )
-        result = ts._truncate('x' * 20)
-        assert 'output truncated, showing last 10 chars' in result
+        result = ts._truncate('x' * 100)
+        assert result == '[... output truncated, showing last 5 chars]\nxxxxx'
 
 
 class TestCwdCapture:
@@ -548,7 +559,41 @@ class TestRunCommand:
             allow_interactive=False,
         )
         result = await ts.run_command(f'{sys.executable} -c "print(\'x\' * 200)"')
-        assert 'truncated, showing last 50 chars' in result
+        assert len(result) == 50
+        assert 'truncated, showing last 5 chars' in result
+
+    async def test_output_truncation_caps_complete_success_response(self, shell_dir: Path) -> None:
+        ts = ShellToolset(
+            cwd=shell_dir,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=10.0,
+            max_output_chars=200,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        result = await ts.run_command(f'{sys.executable} -c "import sys; sys.stdout.write(\'x\' * 400)"')
+        assert len(result) == 200
+        assert result.startswith('[... output truncated, showing last 153 chars]\n')
+        assert result.endswith('x' * 153)
+
+    async def test_output_truncation_caps_complete_failure_response(self, shell_dir: Path) -> None:
+        ts = ShellToolset(
+            cwd=shell_dir,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=10.0,
+            max_output_chars=200,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        command = f'{sys.executable} -c "import sys; sys.stdout.write(\'x\' * 400); sys.exit(7)"'
+        result = await ts.run_command(command)
+        assert len(result) == 200
+        assert result.startswith('[... output truncated, showing last 153 chars]\n')
+        assert result.endswith('[exit code: 7]')
 
     async def test_persist_cwd(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -607,6 +652,20 @@ class TestRunCommand:
         )
         result = await ts.run_command('sleep 10')
         assert 'timed out after 0.5s' in result
+
+    async def test_timeout_respects_output_cap(self, shell_dir: Path) -> None:
+        ts = ShellToolset(
+            cwd=shell_dir,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=0.1,
+            max_output_chars=10,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        result = await ts.run_command('sleep 10')
+        assert len(result) == 10
 
     async def test_custom_timeout_overrides_default(self, shell_dir: Path) -> None:
         ts = ShellToolset(
@@ -818,6 +877,20 @@ class TestBackgroundCommands:
         result = await toolset.check_command('nonexistent_id')
         assert 'unknown command ID' in result
 
+    async def test_unknown_id_responses_respect_output_cap(self, shell_dir: Path) -> None:
+        ts = ShellToolset(
+            cwd=shell_dir,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=10.0,
+            max_output_chars=10,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        assert len(await ts.check_command('a' * 100)) == 10
+        assert len(await ts.stop_command('a' * 100)) == 10
+
     async def test_stop_unknown_id(self, toolset: ShellToolset[None]) -> None:
         result = await toolset.stop_command('nonexistent_id')
         assert 'unknown command ID' in result
@@ -860,6 +933,30 @@ class TestBackgroundCommands:
         assert 'running' in check_result
 
         await ts.stop_command(command_id)
+
+    async def test_check_and_stop_respect_output_cap(self, shell_dir: Path) -> None:
+        ts = ShellToolset(
+            cwd=shell_dir,
+            allowed_commands=[],
+            denied_commands=[],
+            denied_operators=[],
+            default_timeout=10.0,
+            max_output_chars=200,
+            persist_cwd=False,
+            allow_interactive=False,
+        )
+        start_result = await ts.start_command("printf '%0400d' 0; sleep 30")
+        command_id = _parse_command_id(start_result)
+        await anyio.sleep(0.2)
+
+        try:
+            check_result = await ts.check_command(command_id)
+            assert len(check_result) == 200
+            assert check_result.startswith('[... output truncated, showing last 153 chars]\n')
+        finally:
+            stop_result = await ts.stop_command(command_id)
+        assert len(stop_result) == 200
+        assert stop_result.startswith('[... output truncated, showing last 153 chars]\n')
 
     async def test_start_and_check_finished(self, shell_dir: Path) -> None:
         ts = ShellToolset(

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -797,10 +797,13 @@ class TestBackgroundCommands:
         try:
             check_result = await _call_shell_tool(ts, 'check_command', command_id=command_id)
             assert len(check_result) == 200
+            assert check_result.startswith('[status: running]\n')
             assert 'output truncated' in check_result
         finally:
             stop_result = await _call_shell_tool(ts, 'stop_command', command_id=command_id)
         assert len(stop_result) == 200
+        assert stop_result.startswith('[stopped:')
+        assert '\n[exit code:' in stop_result
         assert 'output truncated' in stop_result
 
     async def test_new_string_tool_is_capped_at_dispatch(self, shell_dir: Path) -> None:


### PR DESCRIPTION
## Summary

- Enforce model-visible string output limits once at each toolset's dispatch boundary instead of in individual command branches.
- Count the truncation marker inside `max_output_chars` and report the retained tail length accurately.
- Share the tail-truncation primitive between Shell and LocalStack.
- Place Shell background status and exit metadata after captured output, and use a bounded `[stopped]` trailer.

### Boundary notes

- Every string result crossing `ShellToolset.call_tool` or `LocalStackToolset.call_tool` is capped, with no per-tool cases: tools registered in the future are covered automatically.
- Tools place control metadata (status, exit code, `start_command`'s ID line) at the end of their responses, so tail truncation preserves it. This is the one convention a new tool must follow; the cap itself cannot be missed.
- `run_command`, `start_command`, `check_command`, `stop_command`, `aws_cli`, and `localstack_health` contain no manual truncation calls.
- Very small caps can retain only part of a control trailer because the truthful truncation marker counts toward the same strict cap. `ShellToolset` now rejects a non-positive `max_output_chars` at construction (matching `LocalStackToolset`), since a cap that blanks `start_command`'s ID line would start a process the model can never stop.

### Compatibility

- Public signatures, imports, dependencies, constructor defaults, and configuration formats are unchanged.
- Direct Python calls to `ShellToolset` and `LocalStackToolset` tool methods now return their complete result; the documented cap is enforced on output crossing tool dispatch to the model.
- `check_command` and `stop_command` now place captured output before status and exit metadata. `stop_command` returns `[stopped]` instead of echoing the original command.
- A `start_command` response longer than the cap is now truncated (previously unbounded); the trailing ID line survives because the tail is kept.
- `ShellToolset` now raises `ValueError` for `max_output_chars <= 0`, where it previously accepted any value.
- Consumers that depend on direct-method capping or exact background response strings will observe these behavioral changes. Normal agent tool calls remain strictly bounded by `max_output_chars`.

## Linked Issue

Closes #482

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior and structural enforcement
- [x] `make lint && make typecheck && make test` passes locally
- [x] `make testcov` reports 100% branch coverage
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)
