### PR TITLE
lint: enforce module-scope imports in tests via `PLC0415`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,10 +121,19 @@ target-version = 'py310'
 exclude = ['template']
 
 [tool.ruff.lint]
-extend-select = ['Q', 'RUF100', 'C90', 'UP', 'I', 'D', 'TID251']
+extend-select = ['Q', 'RUF100', 'C90', 'UP', 'I', 'D', 'TID251', 'PLC0415']
 
 [tool.ruff.lint.per-file-ignores]
 'tests/**/*.py' = ['D']
+# Deferred imports in the package are architectural, not convenience: `__getattr__`
+# lazy exports keep optional extras (pymongo, modal, ...) out of the base install,
+# some break an import cycle, and some defer a heavy data snapshot. PLC0415 cannot
+# tell those from an accidental function-scoped import, so it is off for the package
+# and enforced in tests, where every occurrence was accidental.
+'pydantic_ai_harness/**/*.py' = ['PLC0415']
+# `mcp` and `fastmcp` ship only with the `stackone` extra, so slim CI cannot import
+# them at module scope; these tests defer the import on purpose.
+'tests/stackone/**/*.py' = ['PLC0415']
 
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = 'single'

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import warnings as _warnings
 from collections.abc import AsyncIterator
+from dataclasses import replace as dc_replace
 from pathlib import Path
 from typing import Any, TypeVar
 from unittest.mock import MagicMock
@@ -23,19 +25,44 @@ from pydantic_ai import (
     Tool,
     ToolDefinition,
 )
-from pydantic_ai.exceptions import ModelRetry
-from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.capabilities import Capability, Instrumentation, ToolSearch
+from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
+from pydantic_ai.exceptions import ModelRetry, UserError
+from pydantic_ai.messages import (
+    BinaryContent,
+    InstructionPart,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    NativeToolReturnPart,
+    NativeToolSearchReturnPart,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    ToolSearchReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.messages import ToolReturn as ToolReturnMsg
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tool_manager import ParallelExecutionMode, ToolManager
+from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApproved, ToolDenied
+from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME, ToolSearchToolset, parse_discovered_tools
 from pydantic_ai.toolsets.abstract import ToolsetTool
+from pydantic_ai.toolsets.combined import CombinedToolset
 from pydantic_ai.toolsets.function import FunctionToolset
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RequestUsage, RunUsage
 from pydantic_core import SchemaValidator, core_schema
 from pydantic_monty import NOT_HANDLED, Monty, MountDir, OSAccess, OsFunction
 from typing_extensions import Never, TypedDict
 
 from pydantic_ai_harness import CodeMode
 from pydantic_ai_harness.code_mode import CodeModeToolset
+from pydantic_ai_harness.code_mode._capability import (
+    _extract_discovered_names,  # pyright: ignore[reportPrivateUsage]
+)
 from pydantic_ai_harness.code_mode._toolset import (  # pyright: ignore[reportPrivateUsage]
     _SEARCH_TOOLS_MODIFIER,
     _TOOL_SEARCH_ADDENDUM,
@@ -95,7 +122,6 @@ async def build_ctx(
     Use this for tests that call `call_tool` -- `CodeModeToolset` requires
     `ctx.tool_manager` to be set.
     """
-    from pydantic_ai.tool_manager import ToolManager
 
     await toolset.__aenter__()
     _entered_toolsets.append(toolset)
@@ -642,15 +668,6 @@ class TestCodeMode:
 
     async def test_agent_run_preserves_repl_between_code_calls(self) -> None:
         """Code Mode keeps one REPL across model steps in an agent run."""
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            ToolCallPart,
-            ToolReturnPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
 
         def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             response_count = sum(isinstance(message, ModelResponse) for message in messages)
@@ -779,7 +796,6 @@ class TestCodeMode:
 
     async def test_native_tool_named_run_code_raises_user_error(self) -> None:
         """A native tool named `run_code` raises UserError (reserved name)."""
-        from pydantic_ai.exceptions import UserError
 
         def run_code() -> str:
             """A tool that collides with the reserved name."""
@@ -794,7 +810,6 @@ class TestCodeMode:
 
     async def test_sandboxed_tool_named_run_code_raises_user_error(self) -> None:
         """A sandboxed tool named `run_code` raises UserError (conflicts with meta-tool)."""
-        from pydantic_ai.exceptions import UserError
 
         def run_code() -> str:
             """A tool that collides with the meta-tool name."""
@@ -1123,7 +1138,6 @@ class TestCodeMode:
         assert 'async def search' in description
 
         # Second call must not warn again.
-        import warnings as _warnings
 
         with _warnings.catch_warnings():
             _warnings.simplefilter('error')
@@ -1131,7 +1145,6 @@ class TestCodeMode:
 
     async def test_tool_with_return_schema_does_not_warn(self) -> None:
         """A sandboxed tool WITH a return_schema does not trigger the warning."""
-        import warnings as _warnings
 
         td = ToolDefinition(
             name='get_user',
@@ -1156,15 +1169,6 @@ class TestCodeMode:
         sandbox dispatches to a wrapped tool, and the second model turn observes the
         tool's return value before producing the final text output.
         """
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            ToolCallPart,
-            ToolReturnPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
 
         observed_tool_calls: list[str] = []
         observed_tool_returns: list[Any] = []
@@ -1228,7 +1232,6 @@ class TestCodeMode:
         `test_tool_search_toolset_deferred_tool_not_in_run_code`; this exercises the
         end-to-end path through `Agent`.)
         """
-        from pydantic_ai.capabilities import Capability
 
         capability = Capability[object](
             id='demo',
@@ -1423,7 +1426,6 @@ class TestCodeMode:
 
     async def test_tool_returning_tool_return_is_unwrapped(self) -> None:
         """A wrapped tool that returns a `ToolReturn` has its value unwrapped for the sandbox."""
-        from pydantic_ai.messages import ToolReturn as ToolReturnMsg
 
         def fancy() -> Any:
             """Return a ToolReturn with metadata."""
@@ -1445,7 +1447,6 @@ class TestCodeMode:
 
     async def test_approval_required_surfaces_as_model_retry(self) -> None:
         """Tools that raise ApprovalRequired inside the sandbox surface as ModelRetry."""
-        from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
 
         def needs_approval() -> str:
             """A tool that requires approval."""
@@ -1468,12 +1469,9 @@ class TestCodeMode:
         with the original denial message preserved in the trace.
         """
         try:
-            from pydantic_ai.capabilities import HandleDeferredToolCalls
+            from pydantic_ai.capabilities import HandleDeferredToolCalls  # noqa: PLC0415  # optional-version probe
         except ImportError:  # pragma: no cover -- only fires on floor-slim CI, which doesn't gate on coverage
             pytest.skip('Requires pydantic-ai-slim with `HandleDeferredToolCalls` (next release after 1.86.1)')
-
-        from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
-        from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDenied
 
         def needs_approval() -> str:
             """A tool that requires approval."""
@@ -1500,12 +1498,9 @@ class TestCodeMode:
         deferral after approval is *not* re-resolved -- it bubbles up to the caller.
         """
         try:
-            from pydantic_ai.capabilities import HandleDeferredToolCalls
+            from pydantic_ai.capabilities import HandleDeferredToolCalls  # noqa: PLC0415  # optional-version probe
         except ImportError:  # pragma: no cover -- only fires on floor-slim CI, which doesn't gate on coverage
             pytest.skip('Requires pydantic-ai-slim with `HandleDeferredToolCalls` (next release after 1.86.1)')
-
-        from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
-        from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApproved
 
         def always_needs_approval(ctx: RunContext[object]) -> str:
             """Raises `ApprovalRequired` every time, even after being approved."""
@@ -1568,7 +1563,6 @@ class TestCodeMode:
     async def test_tool_returning_binary_image_is_returned_directly(self) -> None:
         """A tool that returns BinaryContent passes through the sandbox and is
         returned as native multimodal content (not wrapped in a dict)."""
-        from pydantic_ai.messages import BinaryContent
 
         image_bytes = b'\x89PNG\r\n\x1a\n fake image data'
 
@@ -1591,7 +1585,6 @@ class TestCodeMode:
     async def test_tool_returning_binary_image_with_print_uses_list_format(self) -> None:
         """When print output accompanies a multimodal return, the result is a list
         so _split_content can extract the image for native delivery."""
-        from pydantic_ai.messages import BinaryContent
 
         image_bytes = b'\x89PNG fake'
 
@@ -1620,7 +1613,6 @@ class TestCodeMode:
     async def test_tool_returning_list_with_binary_image_and_print(self) -> None:
         """A list result containing multimodal items with print output gets flattened
         so _split_content can find each multimodal item at the top level."""
-        from pydantic_ai.messages import BinaryContent
 
         image_bytes = b'\x89PNG list'
 
@@ -1650,8 +1642,6 @@ class TestCodeMode:
     async def test_tool_returning_tool_return_with_binary_content(self) -> None:
         """A tool that wraps a BinaryContent in a ToolReturn has the image properly unwrapped
         and returned as native multimodal content."""
-        from pydantic_ai.messages import BinaryContent
-        from pydantic_ai.messages import ToolReturn as ToolReturnMsg
 
         image_bytes = b'\x89PNG wrapped'
 
@@ -1681,15 +1671,6 @@ class TestCodeMode:
     @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
     async def test_sandboxed_tool_calls_produce_otel_spans(self, capfire: CaptureLogfire) -> None:
         """Sandboxed tool calls dispatched through ToolManager produce OTel execute_tool spans."""
-        from pydantic_ai.capabilities import Instrumentation
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelResponse,
-            TextPart,
-            ToolCallPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
-        from pydantic_ai.models.instrumented import InstrumentationSettings
 
         call_count = 0
 
@@ -1917,7 +1898,6 @@ class TestCodeMode:
     async def test_sequential_tool_rendered_as_sync_and_resolved_inline(self) -> None:
         """A tool with `sequential=True` is rendered as `def` (sync) and
         resolved inline at FunctionSnapshot via `resume({'return_value': ...})`."""
-        from dataclasses import replace as dc_replace
 
         class _SeqToolset(AbstractToolset[object]):
             """Marks add as sequential; greet stays parallel."""
@@ -1978,7 +1958,6 @@ class TestCodeMode:
     async def test_sequential_tool_barrier_awaits_pending_parallel_tasks(self) -> None:
         """When a sequential tool is called while parallel tasks are pending,
         the pending tasks are awaited first (barrier) before dispatching."""
-        from dataclasses import replace as dc_replace
 
         class _SeqToolset(AbstractToolset[object]):
             def __init__(self) -> None:
@@ -2036,7 +2015,6 @@ class TestCodeMode:
 
     async def test_sequential_tool_error_surfaces_as_model_retry(self) -> None:
         """An error from a sequential tool (resolved inline) surfaces as ModelRetry."""
-        from dataclasses import replace as dc_replace
 
         class _SeqToolset(AbstractToolset[object]):
             def __init__(self) -> None:
@@ -2068,7 +2046,6 @@ class TestCodeMode:
     async def test_global_sequential_mode_forces_sequential_resolution(self) -> None:
         """When the parallel execution mode is `sequential`, tool calls inside the
         sandbox are resolved sequentially via FutureSnapshot. Signatures stay `async def`."""
-        from pydantic_ai.tool_manager import ToolManager
 
         wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(add))
         assert isinstance(wrapper, CodeModeToolset)
@@ -2094,9 +2071,6 @@ class TestCodeMode:
     async def test_global_sequential_overrides_per_tool_sequential(self) -> None:
         """When global sequential mode is active AND a tool has `sequential=True`,
         the tool is deferred (not resolved inline) and handled via FutureSnapshot."""
-        from dataclasses import replace as dc_replace
-
-        from pydantic_ai.tool_manager import ToolManager
 
         class _SeqToolset(AbstractToolset[object]):
             def __init__(self) -> None:
@@ -2157,8 +2131,6 @@ class TestToolSearchIntegration:
 
     async def test_search_tool_stays_native(self) -> None:
         """search_tools is kept as a native tool even with tools='all'."""
-        from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME
-        from pydantic_ai.toolsets.combined import CombinedToolset
 
         search_toolset = _StaticToolset([_search_tool_def()])
         func_toolset = _build_function_toolset(add)
@@ -2177,7 +2149,6 @@ class TestToolSearchIntegration:
 
     async def test_search_tools_description_appended(self) -> None:
         """search_tools description gets a modifier appended about run_code functions."""
-        from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME
 
         original_desc = 'There are additional tools. Search here.'
         toolset = _StaticToolset([_search_tool_def(description=original_desc)])
@@ -2221,7 +2192,6 @@ class TestToolSearchIntegration:
         pass-through so those flags reach `Model.prepare_request` unaltered. `search_tools`
         is native alongside `run_code`.
         """
-        from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME, ToolSearchToolset
 
         def later(x: int) -> str:
             """A deferred-loading tool."""
@@ -2245,8 +2215,6 @@ class TestToolSearchIntegration:
 
     async def test_tool_search_toolset_discovered_tool_in_run_code(self) -> None:
         """End-to-end: once `search_tools` has discovered the deferred tool, it folds into `run_code`."""
-        from pydantic_ai.messages import ModelMessage, ModelRequest, ToolSearchReturnPart
-        from pydantic_ai.toolsets._tool_search import ToolSearchToolset, parse_discovered_tools
 
         def later(x: int) -> str:
             """A deferred-loading tool."""
@@ -2288,7 +2256,6 @@ class TestToolSearchIntegration:
 
     def test_code_mode_ordering(self) -> None:
         """CodeMode declares ordering: outermost position, wraps ToolSearch."""
-        from pydantic_ai.capabilities._tool_search import ToolSearch
 
         ordering = CodeMode().get_ordering()
         assert ordering is not None
@@ -2327,8 +2294,6 @@ class TestDynamicCatalog:
         await toolset.get_tools(ctx)
         instructions = await toolset.get_instructions(ctx)
 
-        from pydantic_ai.messages import InstructionPart
-
         # No upstream instructions → the catalog is the only InstructionPart returned.
         assert isinstance(instructions, InstructionPart)
         assert 'async def add' in instructions.content
@@ -2336,7 +2301,6 @@ class TestDynamicCatalog:
         assert instructions.dynamic is True
 
     async def test_get_instructions_appends_to_upstream_string(self) -> None:
-        from pydantic_ai.messages import InstructionPart
 
         class _UpstreamToolset(FunctionToolset[object]):
             async def get_instructions(self, ctx: RunContext[object]) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
@@ -2355,7 +2319,6 @@ class TestDynamicCatalog:
         assert 'async def add' in instructions[1].content
 
     async def test_get_instructions_appends_to_upstream_sequence(self) -> None:
-        from pydantic_ai.messages import InstructionPart
 
         class _UpstreamToolset(FunctionToolset[object]):
             async def get_instructions(  # pyright: ignore[reportIncompatibleMethodOverride]
@@ -2449,7 +2412,6 @@ class TestDynamicCatalog:
     # -- discovery announcement: local search path ------------------------
 
     async def test_announce_on_local_search_return(self) -> None:
-        from pydantic_ai.messages import ModelRequest, SystemPromptPart, ToolCallPart
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -2471,7 +2433,6 @@ class TestDynamicCatalog:
 
     async def test_no_announce_when_disabled(self) -> None:
         """With `dynamic_catalog=False`, the hooks are inert even on a real search return."""
-        from pydantic_ai.messages import ToolCallPart
 
         cap = CodeMode[object]()
         ctx = build_run_context(None)
@@ -2485,7 +2446,6 @@ class TestDynamicCatalog:
         assert ctx.pending_messages == []
 
     async def test_announce_skipped_when_no_discoveries(self) -> None:
-        from pydantic_ai.messages import ToolCallPart
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -2500,7 +2460,6 @@ class TestDynamicCatalog:
 
     async def test_no_announce_for_non_search_tool(self) -> None:
         """`tool_kind != 'tool-search'` short-circuits before reading the result."""
-        from pydantic_ai.messages import ToolCallPart
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -2516,7 +2475,6 @@ class TestDynamicCatalog:
         assert ctx.pending_messages == []
 
     async def test_no_duplicate_announcement_for_same_tool(self) -> None:
-        from pydantic_ai.messages import ToolCallPart
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -2536,8 +2494,6 @@ class TestDynamicCatalog:
     # -- discovery announcement: native search path -----------------------
 
     async def test_announce_on_native_search_return_part(self) -> None:
-        from pydantic_ai.messages import ModelRequest, ModelResponse, NativeToolSearchReturnPart, SystemPromptPart
-        from pydantic_ai.usage import RequestUsage
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -2561,8 +2517,6 @@ class TestDynamicCatalog:
         assert isinstance(part, SystemPromptPart) and '`weather`' in part.content
 
     async def test_no_announce_for_unrelated_response_parts(self) -> None:
-        from pydantic_ai.messages import ModelResponse, NativeToolReturnPart, TextPart
-        from pydantic_ai.usage import RequestUsage
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -2588,9 +2542,6 @@ class TestDynamicCatalog:
         ],
     )
     def test_extract_discovered_names_handles_malformed(self, content: Any, expected: list[str]) -> None:
-        from pydantic_ai_harness.code_mode._capability import (
-            _extract_discovered_names,  # pyright: ignore[reportPrivateUsage]
-        )
 
         assert _extract_discovered_names(content) == expected
 
@@ -2607,20 +2558,6 @@ class TestDynamicCatalog:
              system content is no longer hoisted (pydantic/pydantic-ai#5509) — so the model
              sees the announcement inline and replies.
         """
-        from pydantic_ai.capabilities import ToolSearch
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelRequest,
-            ModelResponse,
-            SystemPromptPart,
-            TextPart,
-            ToolCallPart,
-            ToolReturnPart,
-            ToolSearchReturnPart,
-            UserPromptPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
-        from pydantic_ai.usage import RequestUsage
 
         captured_prompt_texts: list[list[str]] = []
         captured_descriptions: list[str] = []
@@ -2680,16 +2617,6 @@ class TestDynamicCatalog:
 
     async def test_run_code_calls_eager_tool_with_catalog_in_instructions(self) -> None:
         """An eager tool whose signature lives in instructions is still callable via `run_code`."""
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            ToolCallPart,
-            ToolReturnPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
-        from pydantic_ai.usage import RequestUsage
 
         def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             run_code_def = next(td for td in info.function_tools if td.name == 'run_code')
@@ -2951,7 +2878,6 @@ def _search_tool_def(description: str = 'Search for tools.') -> ToolDefinition:
     Carries `tool_kind='tool-search'`, matching what pydantic-ai emits (since 1.95.0);
     CodeMode routes it native off `tool_kind`, not its name.
     """
-    from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME
 
     return ToolDefinition(
         name=_SEARCH_TOOLS_NAME,

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -7,15 +7,25 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from opentelemetry.trace import NoOpTracer, Tracer
+from opentelemetry.trace import NoOpTracer, Tracer, get_tracer
+from pydantic_ai import Agent, Tool
+from pydantic_ai.capabilities import ToolSearch
 from pydantic_ai.messages import (
+    BinaryContent,
+    FilePart,
+    ImageUrl,
     LoadCapabilityCallPart,
     ModelMessage,
     ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
+    NativeToolCallPart,
+    NativeToolReturnPart,
+    RetryPromptPart,
     SystemPromptPart,
+    TextContent,
     TextPart,
+    ThinkingPart,
     ToolCallPart,
     ToolReturnPart,
     ToolSearchCallPart,
@@ -24,10 +34,14 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
 from pydantic_ai.usage import RunUsage
 
+import pydantic_ai_harness
+import pydantic_ai_harness.compaction as compaction
 from pydantic_ai_harness.compaction import (
     ClampOversizedMessages,
     ClearToolResults,
@@ -53,6 +67,7 @@ from pydantic_ai_harness.compaction._shared import (
     prepend_first_user_message,
 )
 from pydantic_ai_harness.compaction._summarizing_compaction import (
+    _DEFAULT_SUMMARY_PROMPT,
     _SUMMARY_PREFIX,
     _extract_previous_summary,
     _extract_system_prompts,
@@ -717,8 +732,6 @@ class TestExtractSystemPrompts:
 
 class TestExports:
     def test_exposed_under_submodule_only(self):
-        import pydantic_ai_harness
-        import pydantic_ai_harness.compaction as compaction
 
         names = [
             'SlidingWindowCompaction',
@@ -744,7 +757,6 @@ class TestUserPromptMultiModal:
     """Cover _user_prompt_text_for_counting and _user_prompt_text for non-string UserContent."""
 
     def test_estimate_with_text_content_parts(self):
-        from pydantic_ai.messages import TextContent
 
         part = UserPromptPart(content=[TextContent(content='hello')])
         msgs: list[ModelMessage] = [ModelRequest(parts=[part])]
@@ -759,7 +771,6 @@ class TestUserPromptMultiModal:
         assert estimate_token_count(msgs) == 2
 
     def test_format_with_text_content(self):
-        from pydantic_ai.messages import TextContent
 
         part = UserPromptPart(content=[TextContent(content='multi-part')])
         msgs: list[ModelMessage] = [ModelRequest(parts=[part])]
@@ -1859,7 +1870,6 @@ class TestSummarizingCompactionModel:
         assert mock_agent_instance.run.call_args.kwargs['usage'] is ctx.usage
 
     def test_default_prompt_has_structured_sections(self):
-        from pydantic_ai_harness.compaction._summarizing_compaction import _DEFAULT_SUMMARY_PROMPT
 
         for heading in (
             '## Intent',
@@ -2018,7 +2028,6 @@ class TestClampOversizedMessages:
 
     @pytest.mark.anyio
     async def test_request_messages_and_other_parts_untouched(self):
-        from pydantic_ai.messages import ThinkingPart
 
         big_user = _user('u' * 5_000)
         mixed = ModelResponse(parts=[ThinkingPart(content='t' * 5_000), TextPart(content='z' * 5_000)])
@@ -2064,8 +2073,6 @@ class TestPublicPath:
 
     @pytest.mark.anyio
     async def test_capabilities_wired_into_agent(self):
-        from pydantic_ai import Agent
-        from pydantic_ai.models.test import TestModel
 
         agent = Agent(
             TestModel(),
@@ -2076,8 +2083,6 @@ class TestPublicPath:
 
     @pytest.mark.anyio
     async def test_clamp_oversized_wired_into_agent(self):
-        from pydantic_ai import Agent
-        from pydantic_ai.models.test import TestModel
 
         agent = Agent(
             TestModel(),
@@ -2093,9 +2098,6 @@ class TestPublicPath:
         # `parse_discovered_tools`; blanking it to a string used to crash the *next*
         # request. Drive a multi-request run (search -> clear fires -> another request)
         # and assert it completes with discovery intact.
-        from pydantic_ai import Agent, Tool
-        from pydantic_ai.capabilities import ToolSearch
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
 
         def hidden_gem(x: int) -> int:
             return x + 1
@@ -2149,7 +2151,6 @@ class TestHelperBranchCoverage:
 
     def test_a_retry_and_a_thinking_block_are_counted(self):
         """Both are sent to the provider, and a run under load is where they appear."""
-        from pydantic_ai.messages import RetryPromptPart, ThinkingPart
 
         msgs: list[ModelMessage] = [
             ModelRequest(parts=[RetryPromptPart(content='r' * 400)]),
@@ -2162,7 +2163,6 @@ class TestHelperBranchCoverage:
 
     def test_a_provider_side_tool_call_and_its_result_are_counted(self):
         """A web search runs on the provider's side and its result still lands in the context."""
-        from pydantic_ai.messages import NativeToolCallPart, NativeToolReturnPart
 
         msgs: list[ModelMessage] = [
             ModelResponse(
@@ -2193,7 +2193,6 @@ class TestHelperBranchCoverage:
 
     def test_a_binary_part_is_not_counted_as_characters(self):
         """`FilePart` carries bytes; its length in characters would mean nothing."""
-        from pydantic_ai.messages import BinaryContent, FilePart
 
         msgs: list[ModelMessage] = [
             ModelResponse(parts=[FilePart(content=BinaryContent(data=b'\x00' * 4_000, media_type='image/png'))])
@@ -2202,7 +2201,6 @@ class TestHelperBranchCoverage:
         assert _format_messages(msgs) == ''
 
     def test_user_prompt_text_skips_non_text_content(self):
-        from pydantic_ai.messages import ImageUrl
 
         part = UserPromptPart(content=[ImageUrl(url='https://example.com/y.png'), 'hello'])
         msgs: list[ModelMessage] = [ModelRequest(parts=[part])]
@@ -2277,7 +2275,6 @@ def _make_ctx_with_tracer() -> Any:
     The `capfire` fixture configures the global OTel provider, so a tracer fetched from it
     captures the `compact_messages` span without needing a full instrumented `Agent` run.
     """
-    from opentelemetry.trace import get_tracer
 
     ctx = _make_ctx()
     ctx.tracer = get_tracer('test')
@@ -2294,9 +2291,6 @@ class TestCompactionSpan:
 
     @pytest.mark.anyio
     async def test_span_emitted_when_threshold_exceeded(self, capfire: CaptureLogfire) -> None:
-        from pydantic_ai import Agent
-        from pydantic_ai.models.instrumented import InstrumentationSettings
-        from pydantic_ai.models.test import TestModel
 
         agent: Agent[None, str] = Agent(
             TestModel(),
@@ -2319,9 +2313,6 @@ class TestCompactionSpan:
 
     @pytest.mark.anyio
     async def test_no_span_when_threshold_not_exceeded(self, capfire: CaptureLogfire) -> None:
-        from pydantic_ai import Agent
-        from pydantic_ai.models.instrumented import InstrumentationSettings
-        from pydantic_ai.models.test import TestModel
 
         agent: Agent[None, str] = Agent(
             TestModel(),
@@ -2379,7 +2370,6 @@ class TestCompactionSpan:
 
     @pytest.mark.anyio
     async def test_clamp_no_span_for_non_oversized_or_skipped_parts(self, capfire: CaptureLogfire) -> None:
-        from pydantic_ai.messages import ThinkingPart
 
         comp = ClampOversizedMessages(max_part_chars=1_000, clamp_tool_call_args=True)
         messages: list[ModelMessage] = [

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -8,7 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from opentelemetry.trace import NoOpTracer, Tracer
+from opentelemetry.trace import NoOpTracer, Tracer, get_tracer
 from pydantic_ai import Agent
 from pydantic_ai.messages import (
     ModelMessage,
@@ -24,6 +24,8 @@ from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
+import pydantic_ai_harness
+import pydantic_ai_harness.compaction as compaction
 from pydantic_ai_harness.compaction import (
     DEFAULT_CONTEXT_WINDOW,
     ClearToolResults,
@@ -959,7 +961,6 @@ class TestCompactNowSpan:
         return [s for s in capfire.exporter.exported_spans_as_dict() if s['name'] == 'compact_messages']
 
     async def test_emits_the_compaction_span(self, capfire: CaptureLogfire):
-        from opentelemetry.trace import get_tracer
 
         strategy: SlidingWindowCompaction[None] = SlidingWindowCompaction(max_tokens=1, keep_messages=2)
 
@@ -974,7 +975,6 @@ class TestCompactNowSpan:
 
     async def test_the_span_is_measured_with_the_tokenizer_it_was_given(self, capfire: CaptureLogfire):
         """Without it the manual path reports the heuristic where the in-run path reported a real count."""
-        from opentelemetry.trace import get_tracer
 
         strategy: SlidingWindowCompaction[None] = SlidingWindowCompaction(max_tokens=1, keep_messages=2)
         messages = _history(4)
@@ -986,7 +986,6 @@ class TestCompactNowSpan:
         assert attributes['compaction.tokens_before'] == characters, 'the 4-characters heuristic was used instead'
 
     async def test_no_span_when_the_history_is_unchanged(self, capfire: CaptureLogfire):
-        from opentelemetry.trace import get_tracer
 
         tiered: TieredCompaction[None] = TieredCompaction(
             tiers=[SlidingWindowCompaction(max_tokens=1, keep_messages=2)],
@@ -998,7 +997,6 @@ class TestCompactNowSpan:
         assert self._spans(capfire) == []
 
     async def test_the_span_names_the_focused_strategy(self, capfire: CaptureLogfire):
-        from opentelemetry.trace import get_tracer
 
         tiered: TieredCompaction[None] = TieredCompaction(
             tiers=[SlidingWindowCompaction(max_tokens=1, keep_messages=2)],
@@ -1037,8 +1035,6 @@ class TestWithFocus:
 
 class TestNewExports:
     def test_exposed_under_the_submodule_only(self):
-        import pydantic_ai_harness
-        import pydantic_ai_harness.compaction as compaction
 
         for name in ('ContextUsage', 'ReportContextUsage', 'compact_now', 'resolve_context_window'):
             assert hasattr(compaction, name)
@@ -1073,7 +1069,6 @@ class TestPositionalCompatibility:
         assert WarnNearLimits(10, 1_000, 2_000).max_total_tokens == 2_000
 
     def test_the_new_fields_stay_keyword_only(self):
-        import dataclasses
 
         cases = [
             (SlidingWindowCompaction, 'max_fraction'),

--- a/tests/compaction/test_deprecated_names.py
+++ b/tests/compaction/test_deprecated_names.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+import pydantic_ai_harness.compaction as compaction
 from pydantic_ai_harness import HarnessDeprecationWarning
 from pydantic_ai_harness.compaction import SlidingWindowCompaction, WarnNearLimits
 
@@ -12,18 +13,17 @@ def test_sliding_window_alias_warns_and_resolves() -> None:
     with pytest.warns(
         HarnessDeprecationWarning, match='renamed to `pydantic_ai_harness.compaction.SlidingWindowCompaction`'
     ):
-        from pydantic_ai_harness.compaction import SlidingWindow
+        from pydantic_ai_harness.compaction import SlidingWindow  # noqa: PLC0415  # importing is the assertion
     assert SlidingWindow is SlidingWindowCompaction
 
 
 def test_limit_warner_alias_warns_and_resolves() -> None:
     with pytest.warns(HarnessDeprecationWarning, match='renamed to `pydantic_ai_harness.compaction.WarnNearLimits`'):
-        from pydantic_ai_harness.compaction import LimitWarner
+        from pydantic_ai_harness.compaction import LimitWarner  # noqa: PLC0415  # importing is the assertion
     assert LimitWarner is WarnNearLimits
 
 
 def test_unknown_attribute_raises() -> None:
-    import pydantic_ai_harness.compaction as compaction
 
     with pytest.raises(AttributeError, match='has no attribute'):
         _ = compaction.DoesNotExist

--- a/tests/conversation_search/test_conversation_search.py
+++ b/tests/conversation_search/test_conversation_search.py
@@ -34,6 +34,7 @@ from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness.compaction import SlidingWindowCompaction, SummarizingCompaction
+from pydantic_ai_harness.compaction._summarizing_compaction import _SUMMARY_PREFIX
 from pydantic_ai_harness.conversation_search import (
     ConversationSearch,
     ConversationSearchToolset,
@@ -157,7 +158,6 @@ class TestSnapshotHistorySource:
         # compaction module's own constant makes this test fail the moment the two drift
         # apart. The cross-capability import is deliberately test-only; the source keeps a
         # local literal to avoid runtime coupling.
-        from pydantic_ai_harness.compaction._summarizing_compaction import _SUMMARY_PREFIX
 
         store = InMemoryStepStore()
         artifact = ModelRequest(parts=[SystemPromptPart(content=f'{_SUMMARY_PREFIX}older summarized context')])

--- a/tests/dynamic_workflow/test_dynamic_workflow.py
+++ b/tests/dynamic_workflow/test_dynamic_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import re
 from typing import Any
 
@@ -26,7 +27,9 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage, UsageLimits
 from pydantic_core import core_schema
+from pydantic_monty import Monty
 
+from pydantic_ai_harness._monty_exec import MontyExecutor
 from pydantic_ai_harness.code_mode import CodeMode
 from pydantic_ai_harness.dynamic_workflow import (
     DynamicWorkflow,
@@ -974,9 +977,6 @@ async def test_worker_crash_becomes_model_retry(monkeypatch: pytest.MonkeyPatch)
     # sub-agent results, not tear down the agent run. A tiny `request_timeout` plus an
     # infinite loop crashes the worker for real; `MontyCrashedError` cannot be constructed
     # or subclassed from Python, so injection is not an option.
-    import functools
-
-    from pydantic_monty import Monty
 
     monkeypatch.setattr(
         'pydantic_ai_harness.dynamic_workflow._toolset.Monty', functools.partial(Monty, request_timeout=0.5)
@@ -990,9 +990,6 @@ async def test_worker_crash_becomes_model_retry(monkeypatch: pytest.MonkeyPatch)
 async def test_worker_crash_after_budget_exhaustion_returns_terminal_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import functools
-
-    from pydantic_monty import Monty
 
     monkeypatch.setattr(
         'pydantic_ai_harness.dynamic_workflow._toolset.Monty', functools.partial(Monty, request_timeout=0.5)
@@ -1308,9 +1305,6 @@ async def test_cancellation_closes_unscheduled_coroutines() -> None:
     # In global-sequential mode (durable backends) deferred calls are kept as bare, unscheduled
     # coroutines. On cancellation those must be `close()`d, not cancelled -- covers the
     # coroutine branch of the executor's cleanup, unreachable through DynamicWorkflowToolset.
-    from pydantic_monty import Monty
-
-    from pydantic_ai_harness._monty_exec import MontyExecutor
 
     started = asyncio.Event()
 

--- a/tests/experimental/acp/test_acp.py
+++ b/tests/experimental/acp/test_acp.py
@@ -45,7 +45,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai.toolsets import CombinedToolset, FunctionToolset
 from pydantic_ai.usage import UsageLimits
 
 from pydantic_ai_harness import FileSystem, Shell
@@ -1139,7 +1139,6 @@ class TestPermission:
     def test_approval_names_come_from_function_toolsets_only(self) -> None:
         # A non-`FunctionToolset` session toolset cannot expose `requires_approval` without a live
         # run context, so it contributes nothing and its calls start `in_progress`.
-        from pydantic_ai.toolsets import CombinedToolset
 
         adapter: PydanticAIACPAgent[None, str] = PydanticAIACPAgent(_approval_agent([]))
         config: AcpSessionConfig[None] = AcpSessionConfig(deps=None, toolsets=[CombinedToolset([])])
@@ -2230,7 +2229,6 @@ class TestWorkspaceRooting:
     """A `session_config` factory roots `FileSystem` at the client's `cwd`, with absolute locations."""
 
     async def test_session_config_roots_filesystem_at_client_cwd(self, tmp_path: Path) -> None:
-        from pydantic_ai_harness.filesystem import FileSystem
 
         write = DeltaToolCall(name='write_file', json_args=json.dumps({'path': 'note.txt', 'content': 'hi'}))
         agent = Agent(_calls_tool_each_turn(write))  # the agent itself has no filesystem tools

--- a/tests/guardrails/test_deprecated_names.py
+++ b/tests/guardrails/test_deprecated_names.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 import pydantic_ai_harness
+import pydantic_ai_harness.guardrails as guardrails
 from pydantic_ai_harness import HarnessDeprecationWarning
 from pydantic_ai_harness.guardrails import (
     GuardrailResult,
@@ -16,7 +17,6 @@ from pydantic_ai_harness.guardrails import (
 
 
 def test_old_names_warn_and_resolve() -> None:
-    import pydantic_ai_harness.guardrails as guardrails
 
     expected = {
         'GuardResult': GuardrailResult,
@@ -44,7 +44,6 @@ def test_new_names_resolve_from_package_root_without_warning() -> None:
 
 
 def test_unknown_attribute_raises() -> None:
-    import pydantic_ai_harness.guardrails as guardrails
 
     with pytest.raises(AttributeError, match='has no attribute'):
         _ = guardrails.DoesNotExist

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -11,12 +11,15 @@ import stat
 from pathlib import Path
 
 import pytest
+import sniffio
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
+import pydantic_ai_harness
 from pydantic_ai_harness.localstack import LocalStack, LocalStackError, LocalStackToolset
+from pydantic_ai_harness.localstack import LocalStack as Exported
 
 from ._http_server import HttpResponse, http_server, unused_tcp_port
 
@@ -324,7 +327,6 @@ class TestLocalStackCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration(self) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -334,8 +336,6 @@ class TestLocalStackCapability:
         assert result.output == 'done'
 
     def test_exported_from_submodule(self) -> None:
-        import pydantic_ai_harness
-        from pydantic_ai_harness.localstack import LocalStack as Exported
 
         assert Exported is LocalStack
         # Capabilities are reached via their submodule, not the package root, so each keeps its own optional deps.
@@ -404,7 +404,6 @@ class TestContainerManagement:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration_manages_container(self, tmp_path: Path) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')

--- a/tests/media/conftest.py
+++ b/tests/media/conftest.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from pydantic_ai_harness.media import S3MediaStore
+
 if TYPE_CHECKING:
     from vcr.request import Request as VcrRequest  # pyright: ignore[reportMissingTypeStubs]
 
@@ -200,7 +202,6 @@ def s3_store(s3_credentials: dict[str, str]) -> Any:
     The key prefix is part of the URL path that lands in the cassette, so
     keep it stable across re-records.
     """
-    from pydantic_ai_harness.media import S3MediaStore
 
     return S3MediaStore(
         bucket=s3_credentials['bucket'],

--- a/tests/media/test_media.py
+++ b/tests/media/test_media.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypeGuard
 
+import httpx
 import pytest
 from httpx import AsyncClient, MockTransport, Request, Response
 from pydantic_ai.messages import (
@@ -35,7 +36,10 @@ from pydantic_ai_harness.media import (
     parse_media_uri,
     restore_media,
 )
-from pydantic_ai_harness.media._s3 import sign_request
+from pydantic_ai_harness.media._s3 import (
+    _canonical_uri,  # pyright: ignore[reportPrivateUsage]
+    sign_request,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -234,7 +238,6 @@ async def _restore_as_pre_pr_reader(node: dict[str, object], store: MediaStore) 
     The previous reader treats every marker as binary. Its missing-`uri` guard
     is left out because the markers under test always carry one.
     """
-    import base64
 
     uri_value = node.get('uri')
     assert isinstance(uri_value, str)
@@ -794,7 +797,6 @@ class TestS3MediaStoreWithMockTransport:
         Otherwise the signed canonical path and the path S3 receives diverge ->
         SignatureDoesNotMatch. The wire `raw_path` must equal `_canonical_uri(path)`.
         """
-        from pydantic_ai_harness.media._s3 import _canonical_uri  # pyright: ignore[reportPrivateUsage]
 
         captured: list[Request] = []
 
@@ -1041,7 +1043,6 @@ class TestS3MediaStoreWithMockTransport:
 
     async def test_no_client_branch_opens_one_per_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without `client=`, the store opens a fresh `httpx.AsyncClient` per call."""
-        import httpx
 
         captured: list[Request] = []
 

--- a/tests/media/test_mongo.py
+++ b/tests/media/test_mongo.py
@@ -14,7 +14,15 @@ from bson.binary import Binary
 from mongomock_motor import AsyncMongoMockClient
 from pymongo import AsyncMongoClient
 
-from pydantic_ai_harness.media import MediaContext, MediaStore, MongoMediaStore, media_uri_for, parse_media_uri
+import pydantic_ai_harness.media as media
+from pydantic_ai_harness.media import (
+    MediaContext,
+    MediaStore,
+    MongoMediaStore,
+    make_static_public_url,
+    media_uri_for,
+    parse_media_uri,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -257,7 +265,6 @@ class TestMongoMediaStorePublicUrl:
         assert await store.public_url(media_uri_for(b'x')) is None
 
     async def test_with_resolver_uses_it(self) -> None:
-        from pydantic_ai_harness.media import make_static_public_url
 
         store = MongoMediaStore(
             client=_mock_client(),
@@ -277,12 +284,10 @@ class TestMongoMediaStoreProtocol:
 
 class TestMediaLazyExport:
     def test_mongo_media_store_lazily_exported(self) -> None:
-        import pydantic_ai_harness.media as media
 
         assert media.MongoMediaStore is MongoMediaStore
 
     def test_unknown_attribute_raises(self) -> None:
-        import pydantic_ai_harness.media as media
 
         with pytest.raises(AttributeError, match='has no attribute'):
             _ = media.NoSuchStore  # type: ignore[attr-defined]

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -13,6 +13,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import Tracer
 from pydantic_ai import Agent, AgentSpec, DeferredToolRequests, ModelRetry, RunContext
 from pydantic_ai.capabilities import ToolSearch
+from pydantic_ai.durable_exec.temporal import TemporalDurability
 from pydantic_ai.messages import (
     ModelMessage,
     ModelMessagesTypeAdapter,
@@ -1381,7 +1382,6 @@ class TestTelemetryAndComposition:
 
     def test_temporal_durability_accepts_static_memory_toolset(self) -> None:
         pytest.importorskip('temporalio')
-        from pydantic_ai.durable_exec.temporal import TemporalDurability
 
         Agent(
             TestModel(),

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -13,7 +13,6 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import Tracer
 from pydantic_ai import Agent, AgentSpec, DeferredToolRequests, ModelRetry, RunContext
 from pydantic_ai.capabilities import ToolSearch
-from pydantic_ai.durable_exec.temporal import TemporalDurability
 from pydantic_ai.messages import (
     ModelMessage,
     ModelMessagesTypeAdapter,
@@ -1382,6 +1381,8 @@ class TestTelemetryAndComposition:
 
     def test_temporal_durability_accepts_static_memory_toolset(self) -> None:
         pytest.importorskip('temporalio')
+
+        from pydantic_ai.durable_exec.temporal import TemporalDurability  # noqa: PLC0415  # needs the temporal extra
 
         Agent(
             TestModel(),

--- a/tests/modal_sandbox/test_modal_sandbox.py
+++ b/tests/modal_sandbox/test_modal_sandbox.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 from typing import Protocol, TypeGuard, runtime_checkable
 
 import pytest
+import sniffio
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
@@ -16,6 +17,8 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import AbstractToolset
 from pydantic_ai.usage import RunUsage
 
+import pydantic_ai_harness
+import pydantic_ai_harness.modal_sandbox as modal_sandbox
 from pydantic_ai_harness.modal_sandbox import (
     ModalSandbox,
     ModalSandboxError,
@@ -23,6 +26,7 @@ from pydantic_ai_harness.modal_sandbox import (
     ModalSandboxTerminalError,
     ModalSandboxUnavailableError,
 )
+from pydantic_ai_harness.modal_sandbox import ModalSandbox as Exported
 
 from .fake_modal import FakeModal, FileInfo
 
@@ -776,9 +780,6 @@ class TestCapability:
         assert ModalSandbox(sandbox_id='sb-keep', max_command_timeout=600).max_command_timeout == 600
 
     def test_exported_from_capability_submodule(self) -> None:
-        import pydantic_ai_harness
-        import pydantic_ai_harness.modal_sandbox as modal_sandbox
-        from pydantic_ai_harness.modal_sandbox import ModalSandbox as Exported
 
         assert Exported is ModalSandbox
         assert 'ModalSandboxToolset' not in modal_sandbox.__all__
@@ -788,7 +789,6 @@ class TestCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration(self, fake_modal: FakeModal) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -800,7 +800,6 @@ class TestCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_can_call_run_command(self, fake_modal: FakeModal) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -828,7 +827,6 @@ class TestCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_context_does_not_create_an_unused_base_sandbox(self, fake_modal: FakeModal) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -847,7 +845,6 @@ class TestCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_run_failing_terminally_still_tears_down(self, fake_modal: FakeModal) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')

--- a/tests/pydantic_ai_docs/test_deprecated_names.py
+++ b/tests/pydantic_ai_docs/test_deprecated_names.py
@@ -31,7 +31,7 @@ def test_shim_warns_and_aliases_old_names() -> None:
 def test_fresh_import_warns() -> None:
     sys.modules.pop('pydantic_ai_harness.docs', None)
     with pytest.warns(HarnessDeprecationWarning, match=r'renamed to `pydantic_ai_harness\.pydantic_ai_docs`'):
-        import pydantic_ai_harness.docs
+        import pydantic_ai_harness.docs  # noqa: PLC0415  # importing is the assertion
 
     assert issubclass(pydantic_ai_harness.docs.PyaiDocs, PydanticAIDocs)
 
@@ -40,7 +40,7 @@ class TestPreRenameSpecCompatibility:
     def test_serialization_names(self) -> None:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            from pydantic_ai_harness.docs import PyaiDocs
+            from pydantic_ai_harness.docs import PyaiDocs  # noqa: PLC0415  # importing is the assertion
 
         assert PyaiDocs.get_serialization_name() == 'PyaiDocs'
         assert PydanticAIDocs.get_serialization_name() == 'PydanticAIDocs'
@@ -50,7 +50,7 @@ class TestPreRenameSpecCompatibility:
         # deprecated class through `custom_capability_types` must keep it loading.
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            from pydantic_ai_harness.docs import PyaiDocs
+            from pydantic_ai_harness.docs import PyaiDocs  # noqa: PLC0415  # importing is the assertion
 
         agent = Agent.from_spec(
             {'model': 'test', 'capabilities': [{'PyaiDocs': {}}]},
@@ -62,7 +62,7 @@ class TestPreRenameSpecCompatibility:
     def test_experimental_shim_exposes_the_same_class(self) -> None:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            from pydantic_ai_harness.docs import PyaiDocs
-            from pydantic_ai_harness.experimental.docs import PyaiDocs as experimental_pyai_docs
+            from pydantic_ai_harness.docs import PyaiDocs  # noqa: PLC0415  # importing is the assertion
+            from pydantic_ai_harness.experimental.docs import PyaiDocs as experimental_pyai_docs  # noqa: PLC0415
 
         assert experimental_pyai_docs is PyaiDocs

--- a/tests/repo_context/test_deprecated_names.py
+++ b/tests/repo_context/test_deprecated_names.py
@@ -13,6 +13,6 @@ from pydantic_ai_harness.repo_context import RepoContext
 def test_fresh_import_warns_and_aliases_old_path() -> None:
     sys.modules.pop('pydantic_ai_harness.context', None)
     with pytest.warns(HarnessDeprecationWarning, match=r'renamed to `pydantic_ai_harness\.repo_context`'):
-        import pydantic_ai_harness.context
+        import pydantic_ai_harness.context  # noqa: PLC0415  # importing is the assertion
 
     assert pydantic_ai_harness.context.RepoContext is RepoContext

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import signal
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -11,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import anyio
 import pytest
+import sniffio
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.models.test import TestModel
@@ -1163,7 +1165,6 @@ class TestShellCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration(self, tmp_path: Path) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -1213,8 +1214,6 @@ class TestKillProcessGroupEdgeCases:
 
         proc.wait = never_return
 
-        import signal
-
         kill_calls: list[tuple[int, int]] = []
 
         def fake_killpg(pgid: int, sig: int) -> None:
@@ -1250,8 +1249,6 @@ class TestKillProcessGroupEdgeCases:
             await anyio.sleep(999)
 
         proc.wait = never_return
-
-        import signal
 
         call_count = 0
 

--- a/tests/step_persistence/test_mongo.py
+++ b/tests/step_persistence/test_mongo.py
@@ -28,6 +28,7 @@ from pydantic_ai.models.test import TestModel
 from pymongo import AsyncMongoClient
 from pymongo.errors import DuplicateKeyError
 
+import pydantic_ai_harness.step_persistence as sp
 from pydantic_ai_harness.conversation_search import SnapshotHistorySource
 from pydantic_ai_harness.media import MongoMediaStore
 from pydantic_ai_harness.step_persistence import (
@@ -446,12 +447,10 @@ class TestMongoStepStoreMedia:
 
 class TestStepPersistenceLazyExport:
     def test_mongo_step_store_lazily_exported(self) -> None:
-        import pydantic_ai_harness.step_persistence as sp
 
         assert sp.MongoStepStore is MongoStepStore
 
     def test_unknown_attribute_raises(self) -> None:
-        import pydantic_ai_harness.step_persistence as sp
 
         with pytest.raises(AttributeError, match='has no attribute'):
             _ = sp.NoSuchStore  # type: ignore[attr-defined]

--- a/tests/step_persistence/test_sqlite_and_media.py
+++ b/tests/step_persistence/test_sqlite_and_media.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import base64
 import logging
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -85,7 +86,6 @@ class TestSqliteStepStoreProtocol:
             await store.register_run(RunRecord(run_id='r1'))
 
     async def test_list_runs_chronological(self, tmp_path: Path) -> None:
-        from datetime import datetime, timedelta, timezone
 
         store = SqliteStepStore(database=tmp_path / 'runs.db')
         base = datetime(2024, 1, 1, tzinfo=timezone.utc)

--- a/tests/step_persistence/test_step_persistence.py
+++ b/tests/step_persistence/test_step_persistence.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,7 @@ import pytest
 from pydantic_ai import Agent, CallToolsNode, ModelRequestNode, ModelRetry, RunContext
 from pydantic_ai._agent_graph import GraphAgentState  # pyright: ignore[reportPrivateUsage]
 from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.capabilities.abstract import AgentNode, NodeResult
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -44,10 +46,12 @@ from pydantic_ai_harness.step_persistence import (
     StepPersistence,
     StepStore,
     ToolEffectRecord,
+    annotate_tool_effect,
     continue_run,
     fork_run,
     is_provider_valid,
 )
+from pydantic_ai_harness.step_persistence._context import current_run_id
 from pydantic_ai_harness.step_persistence._store import _validate_id  # pyright: ignore[reportPrivateUsage]
 
 pytestmark = pytest.mark.anyio
@@ -1463,7 +1467,6 @@ class TestNonToolRetryPrompt:
 class TestListRunsChronologicalOrdering:
     async def test_in_memory_returns_started_at_order(self) -> None:
         """`InMemoryStepStore.list_runs` sorts by `started_at`, not insertion order."""
-        from datetime import datetime, timezone
 
         store = InMemoryStepStore()
         await store.register_run(RunRecord(run_id='z-newer', started_at=datetime(2026, 5, 24, 12, tzinfo=timezone.utc)))
@@ -1473,7 +1476,6 @@ class TestListRunsChronologicalOrdering:
 
     async def test_file_store_returns_started_at_order(self, tmp_path: Path) -> None:
         """`FileStepStore.list_runs` sorts by `started_at`, not by directory name."""
-        from datetime import datetime, timezone
 
         store = FileStepStore(tmp_path)
         # `a-new` is lexicographically first but chronologically last.
@@ -1486,7 +1488,6 @@ class TestListRunsChronologicalOrdering:
 class TestToolEffectMetadataPreservation:
     async def test_completed_preserves_idempotency_key_and_effect_summary(self) -> None:
         """Metadata written during the tool call survives the terminal `completed` record."""
-        from pydantic_ai_harness.step_persistence import annotate_tool_effect
 
         store = InMemoryStepStore()
         agent: Agent[object, str] = Agent(TestModel(), capabilities=[StepPersistence(store=store, run_id='r1')])
@@ -1511,7 +1512,6 @@ class TestToolEffectMetadataPreservation:
 
     async def test_failed_preserves_idempotency_key(self) -> None:
         """Metadata written before a tool raises still appears on the `failed` record."""
-        from pydantic_ai_harness.step_persistence import annotate_tool_effect
 
         store = InMemoryStepStore()
         agent: Agent[object, str] = Agent(TestModel(), capabilities=[StepPersistence(store=store, run_id='r1')])
@@ -1533,7 +1533,6 @@ class TestToolEffectMetadataPreservation:
 
     async def test_annotate_tool_effect_outside_step_persistence_is_a_noop(self) -> None:
         """No `current_run_id` → `annotate_tool_effect` returns without writing."""
-        from pydantic_ai_harness.step_persistence import annotate_tool_effect
 
         store = InMemoryStepStore()
         ctx = build_run_context(deps=None, run_id='r1')
@@ -1543,8 +1542,6 @@ class TestToolEffectMetadataPreservation:
 
     async def test_annotate_tool_effect_noop_when_prior_record_missing(self) -> None:
         """`current_run_id` set + ctx tool fields set, but no prior record → no-op."""
-        from pydantic_ai_harness.step_persistence import annotate_tool_effect
-        from pydantic_ai_harness.step_persistence._context import current_run_id
 
         store = InMemoryStepStore()
         ctx = RunContext[Any](
@@ -1994,8 +1991,6 @@ class TestLiveHistoryInvariant:
 
     async def test_node_boundary_messages_are_one_live_list(self) -> None:
         """All post-`UserPromptNode` boundaries expose the same list object, and it tracks the run."""
-        from pydantic_ai.capabilities import AbstractCapability
-        from pydantic_ai.capabilities.abstract import AgentNode, NodeResult
 
         seen: list[list[ModelMessage]] = []
 

--- a/tests/subagents/test_subagents.py
+++ b/tests/subagents/test_subagents.py
@@ -23,6 +23,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai.usage import UsageLimits
 
 from pydantic_ai_harness.subagents import SubAgent, SubAgents, SubAgentToolset
@@ -347,7 +348,6 @@ class TestDelegation:
         They are bound to capability instances registered in the parent run; sharing
         them is `shared_capabilities`' job (see the `_inherited_toolsets` docstring).
         """
-        from pydantic_ai.toolsets import FunctionToolset
 
         @dataclass
         class _ToolCapability(AbstractCapability[object]):

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,11 +1,13 @@
 import inspect
 from pathlib import Path
 
+import pydantic_ai.models
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
 
 import pydantic_ai_harness
+from pydantic_ai_harness import LLM_API_KEY_ENV_PATTERNS, FileSystem, Shell
 
 
 def test_import():
@@ -14,21 +16,18 @@ def test_import():
 
 
 def test_lazy_import_filesystem():
-    from pydantic_ai_harness import FileSystem
 
     assert inspect.isclass(FileSystem)
     assert hasattr(FileSystem, 'get_toolset')
 
 
 def test_lazy_import_shell():
-    from pydantic_ai_harness import Shell
 
     assert inspect.isclass(Shell)
     assert hasattr(Shell, 'get_toolset')
 
 
 def test_lazy_import_llm_api_key_env_patterns():
-    from pydantic_ai_harness import LLM_API_KEY_ENV_PATTERNS
 
     assert isinstance(LLM_API_KEY_ENV_PATTERNS, tuple)
     assert 'OPENAI_*' in LLM_API_KEY_ENV_PATTERNS
@@ -52,6 +51,5 @@ def test_tmp_dir_fixture(tmp_dir: Path):
 
 
 async def test_allow_model_requests(allow_model_requests: None):
-    import pydantic_ai.models
 
     assert pydantic_ai.models.ALLOW_MODEL_REQUESTS is True


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.
David: no line review. He asked for the lint rule after reviewing the inline imports in #514, and chose the full burn-down over a ratchet.

**Stacked on #514** (`media-marker-collision`), because that PR already hoists `tests/media/test_media.py`. Base retargets to `main` automatically when #514 merges. Review only the last commit.

## What this does

Adds `PLC0415` (`import-outside-top-level`) to the ruff config and clears the 146 existing test sites so it can be turned on.

Origin is the review thread on #514: a new test copied the inline-import habit from the file around it. That is how the pattern spreads, so the fix is a rule rather than one more hand-corrected file.

Net **-97 lines** across 23 files. Every hoisted import is a plain convenience import (`pydantic_ai.messages`, `TestModel`, `functools`, `datetime`) that had no reason to be deferred.

## What is deliberately *not* hoisted

Three exemptions, each for a different reason. None is a blanket "too hard".

**1. `pydantic_ai_harness/**` -- exempted in config.** All 31 source sites are architectural, not convenience: `__getattr__` lazy exports that keep optional extras (`pymongo`, `modal`) out of the base install, imports that break a cycle, and one deferred heavy data snapshot. PLC0415 cannot distinguish those from an accidental function-scoped import, so it is off for the package and enforced in tests, where every occurrence was accidental.

**2. `tests/stackone/**` -- exempted in config.** `mcp` and `fastmcp` ship only with the `stackone` extra. Hoisting their imports breaks the slim CI job outright -- I hit this on the first pass and reverted the package.

**3. Ten sites kept inline with `# noqa: PLC0415` and a reason.** Deprecation-shim tests where the import *is* what emits the warning under test (hoisting it would fire the warning at collection time, which `filterwarnings = ['error']` turns into a failure), plus two `try:` / `except ImportError` probes for an optional pydantic-ai version.

The exemptions are file-scoped rather than global, so the rule still fires everywhere else.

## Verification

`make lint`, `make typecheck` (pyright strict), and `make testcov` all pass -- full suite green at 100% branch coverage, no live services. `ruff check --select PLC0415 tests/` reports zero outside the exemptions.

The suite is the real check here: a hoist that changed import timing would surface as a failing deprecation or warning test, not as a lint error.

## Process note

Worth recording because it shaped the diff. My first two automated passes were wrong and were fully reverted:

1. Pass one picked the insertion point by scanning for the last line starting with `import`/`from`, which landed **inside an inline-snapshot string** holding a Python code sample.
2. Pass two walked the AST for any import outside `tree.body`, which over-collected module-level `if TYPE_CHECKING:` blocks that ruff never flagged, emptying the `if` and breaking syntax.

The final pass uses ruff's own JSON report to decide *which* imports move and the AST to decide *where* they land. Nothing from the earlier passes survives in this diff.

## Note on the dependency gate

This PR changes `pyproject.toml` -- that is where the ruff config lives, not a dependency change. The gate cannot tell the difference, so it needs `dependencies:approved`, added **after** the final push (the workflow strips the label on every `synchronize`).
