### PR TITLE
fix(media): decode URL-safe binary payloads

### DIFF
--- a/pydantic_ai_harness/media/_walker.py
+++ b/pydantic_ai_harness/media/_walker.py
@@ -136,7 +136,7 @@ async def _maybe_externalize_binary(
     # `_is_binary_part` already verified `data` is a string; the cast is safe.
     data_value = node['data']
     assert isinstance(data_value, str)
-    raw = base64.b64decode(data_value)
+    raw = base64.urlsafe_b64decode(data_value)
     if len(raw) < threshold_bytes:
         return None
     media_type_value = node.get('media_type')

--- a/tests/media/test_media.py
+++ b/tests/media/test_media.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 from datetime import datetime, timezone
@@ -10,6 +11,8 @@ from typing import TypeGuard
 
 import pytest
 from httpx import AsyncClient, MockTransport, Request, Response
+from pydantic_ai import ModelMessagesTypeAdapter
+from pydantic_ai.messages import BinaryContent, ModelMessage, ModelRequest, UserPromptPart
 
 from pydantic_ai_harness.media import (
     DiskMediaStore,
@@ -261,6 +264,28 @@ class TestExternalizeRestoreWalker:
         restored_text = _json.dumps(restored)
         assert '"kind": "binary"' in restored_text
         assert b64_payload in restored_text  # bytes restored exactly
+
+    async def test_binary_round_trip_accepts_pydantic_urlsafe_base64(self, tmp_path: Path) -> None:
+        payload = bytes(range(256)) * 500
+        messages: list[ModelMessage] = [
+            ModelRequest(
+                parts=[UserPromptPart(content=[BinaryContent(data=payload, media_type='application/octet-stream')])]
+            )
+        ]
+        node: object = json.loads(ModelMessagesTypeAdapter.dump_json(messages))
+        store = DiskMediaStore(tmp_path)
+
+        externalized = await externalize_media(node, media_store=store, threshold_bytes=64 * 1024)
+        restored = await restore_media(externalized, media_store=store)
+        [restored_message] = ModelMessagesTypeAdapter.validate_python(restored)
+        assert isinstance(restored_message, ModelRequest)
+        [restored_part] = restored_message.parts
+        assert isinstance(restored_part, UserPromptPart)
+        assert not isinstance(restored_part.content, str)
+        [restored_binary] = restored_part.content
+        assert isinstance(restored_binary, BinaryContent)
+
+        assert restored_binary.data == payload
 
     async def test_binary_restore_reuses_write_context(self, tmp_path: Path) -> None:
         """A context-dependent storage key is found with the binary media type."""
@@ -561,7 +586,6 @@ class TestExternalizeRestoreWalker:
         import json as _json
 
         from pydantic_ai.messages import (
-            ModelMessage,
             ModelMessagesTypeAdapter,
             ModelRequest,
             TextContent,


### PR DESCRIPTION
## Summary

Pydantic serializes `BinaryContent.data` with the URL-safe base64 alphabet. The media walker decoded that value with the standard base64 decoder, which could raise `Incorrect padding` or return corrupted bytes when the payload contained `-` or `_`.

This change uses `base64.urlsafe_b64decode`, which accepts Pydantic's URL-safe encoding while remaining compatible with standard base64. The regression test serializes high-entropy `BinaryContent` through Pydantic, externalizes and restores it through the public media API, validates the restored messages, and compares the recovered bytes.

## Linked Issue

Fixes #511

## Verification

- Focused regression before the fix: failed with `binascii.Error: Incorrect padding`
- Focused regression after the fix: `1 passed`
- Media module: `82 passed, 1 skipped`
- `make lint`: passed
- `make typecheck`: `0 errors, 0 warnings, 0 informations`
- `make test`: `3893 passed, 47 skipped`
- `make testcov`: `3893 passed, 47 skipped`; 100% statement and branch coverage

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added for the corrected behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks
