### PR TITLE
Add Scheduling capability and ScheduleRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ We studied leading coding agents, agent frameworks, and Claw-style assistants to
 | | **Tool error recovery** | Retry failed tool calls with backoff and budget | :construction: [PR&nbsp;#171](https://github.com/pydantic/pydantic-ai-harness/pull/171) | |
 | **Reasoning** | **Adaptive reasoning** | Adjust thinking effort based on task complexity | :construction: [PR&nbsp;#174](https://github.com/pydantic/pydantic-ai-harness/pull/174) | |
 | | **Current time** | Inject current date/time into system prompt | :construction: [PR&nbsp;#170](https://github.com/pydantic/pydantic-ai-harness/pull/170) | |
+| **Autonomy** | **Scheduling** | Model-managed schedules -- cron, intervals, one-shots -- executed by an in-process runner with results delivered to your callback | :white_check_mark: [Docs](pydantic_ai_harness/scheduling/) | |
 
 > Packages by [vstorm-co](https://github.com/vstorm-co) are endorsed by the Pydantic AI team. We're working with them to upstream some of their implementations into this repo.
 

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -28,6 +28,7 @@
       { "label": "Managed Prompt", "slug": "managed-prompt" },
       { "label": "LocalStack", "slug": "localstack" },
       { "label": "StackOne", "slug": "stackone" },
+      { "label": "Scheduling", "slug": "scheduling" },
       { "label": "Skills", "slug": "skills" },
       { "label": "ACP", "slug": "acp" }
     ]

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -64,6 +64,7 @@ Naive datetimes and cron expressions are interpreted in the schedule's IANA time
 - **At most once.** A schedule's next occurrence is advanced and saved before the agent runs, so a crash mid-run skips an occurrence instead of running it twice.
 - **No automatic retry.** A failed run records `last_error` and the schedule keeps its next occurrence; for recurring work, the next occurrence is the retry.
 - **No overlap.** A schedule still running when it comes due again is skipped, never run concurrently with itself.
+- **One runner per store.** At-most-once and no-overlap hold within a single runner process. Two runners sharing a store can both claim the same occurrence.
 - **No backlog replay.** A recurring schedule overdue beyond `misfire_grace` (default 10 minutes) runs once now and continues from the next future occurrence. An overdue one-shot is recorded as `missed` instead of running hours late. Resuming a paused schedule continues from its next future occurrence.
 - **Bounded runs.** `max_runs` counts attempts; when reached, the schedule completes. `run_timeout` and per-schedule or runner-wide `usage_limits` cap each run's wall-clock time and spend.
 - Empty output is a success, not an error.
@@ -79,8 +80,8 @@ from pydantic_ai_harness.scheduling import ScheduleResult
 
 
 async def deliver(result: ScheduleResult) -> None:
-    if result.schedule.deliver_to == 'slack:#eng':
-        await post_to_slack(result.output)
+    target = result.schedule.deliver_to or 'stdout'
+    print(f'[{target}] {result.schedule.name}: {result.output}')
 ```
 
 ## Scheduled runs cannot schedule
@@ -90,6 +91,8 @@ Inside a scheduled run, the scheduling tools and instructions are absent. A sche
 ## Driving the runner from outside
 
 `tick()` claims and executes everything due, then returns. Call it from system cron, a workflow engine, or serverless infrastructure instead of keeping `run_until_stopped()` alive:
+
+Invocations must not overlap for a given store; schedule the external trigger accordingly.
 
 ```python
 from pydantic_ai import Agent

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,126 @@
+---
+title: Scheduling
+description: Let an agent schedule work -- cron, intervals, one-shots -- and run it on time, delivering results to a callback you own.
+---
+
+# Scheduling
+
+Let an agent schedule work, and run that work on time.
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/scheduling/)
+
+> The API may change between releases. Breaking changes ship deprecation warnings where practical.
+
+`Scheduling` gives the model tools to create and manage schedules. `ScheduleRunner` executes them: when a schedule is due, it runs the agent with the schedule's prompt and hands the outcome to your callback.
+
+## Usage
+
+Install the extra (only cron expressions need it; interval and one-shot schedules work without it):
+
+```bash
+pip install 'pydantic-ai-harness[scheduling]'
+```
+
+Attach the capability, then run the runner:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.scheduling import ScheduleResult, ScheduleRunner, Scheduling, SqliteScheduleStore
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[Scheduling(store=SqliteScheduleStore('schedules.db'))],
+)
+
+
+def show(result: ScheduleResult) -> None:
+    print(f'{result.schedule.name}: {result.status}')
+
+
+async def main():
+    await agent.run('Every weekday at 9am, summarize our open pull requests.')
+
+    runner = ScheduleRunner(agent, deps=None, on_result=show)
+    await runner.run_until_stopped()
+```
+
+The model calls `create_schedule` with a name, a prompt, and a schedule string. The runner claims due schedules once per `tick_interval` (default 60 seconds) and executes each one as a fresh, isolated agent run.
+
+You can also create schedules from code: build a `Schedule` and `add` it to the store the runner reads.
+
+## Schedule forms
+
+| Form | Example | Runs |
+|---|---|---|
+| `every <N><m\|h\|d>` | `every 30m` | repeatedly, on a fixed interval |
+| `in <N><m\|h\|d>` | `in 2h` | once, that far from now |
+| ISO 8601 datetime | `2026-09-01T09:00` | once, at that time |
+| Five-field cron | `0 9 * * MON-FRI` | repeatedly, per the expression |
+
+Naive datetimes and cron expressions are interpreted in the schedule's IANA timezone (`Scheduling(timezone=...)`, UTC by default). Cron occurrences keep their wall-clock hour across DST transitions.
+
+## Execution semantics
+
+- **At most once.** A schedule's next occurrence is advanced and saved before the agent runs, so a crash mid-run skips an occurrence instead of running it twice.
+- **No automatic retry.** A failed run records `last_error` and the schedule keeps its next occurrence; for recurring work, the next occurrence is the retry.
+- **No overlap.** A schedule still running when it comes due again is skipped, never run concurrently with itself.
+- **No backlog replay.** A recurring schedule overdue beyond `misfire_grace` (default 10 minutes) runs once now and continues from the next future occurrence. An overdue one-shot is recorded as `missed` instead of running hours late. Resuming a paused schedule continues from its next future occurrence.
+- **Bounded runs.** `max_runs` counts attempts; when reached, the schedule completes. `run_timeout` and per-schedule or runner-wide `usage_limits` cap each run's wall-clock time and spend.
+- Empty output is a success, not an error.
+
+## Delivering results
+
+Every outcome is stored on the schedule (`last_status`, `last_output`, `last_error`) and passed to `on_result`, sync or async. A callback that raises is recorded as `last_delivery_error`; it never fails the run.
+
+`deliver_to` is an opaque hint. The harness does not interpret it; your callback routes on it:
+
+```python
+from pydantic_ai_harness.scheduling import ScheduleResult
+
+
+async def deliver(result: ScheduleResult) -> None:
+    if result.schedule.deliver_to == 'slack:#eng':
+        await post_to_slack(result.output)
+```
+
+## Scheduled runs cannot schedule
+
+Inside a scheduled run, the scheduling tools and instructions are absent. A scheduled prompt cannot create, change, or trigger schedules, so it cannot replicate itself.
+
+## Driving the runner from outside
+
+`tick()` claims and executes everything due, then returns. Call it from system cron, a workflow engine, or serverless infrastructure instead of keeping `run_until_stopped()` alive:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.scheduling import ScheduleRunner, Scheduling, SqliteScheduleStore
+
+store = SqliteScheduleStore('schedules.db')
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[Scheduling(store=store)])
+
+
+async def main():
+    await ScheduleRunner(agent, deps=None, store=store).tick()
+```
+
+Durability capabilities on the agent compose transparently: scheduled runs execute like any other run.
+
+## Agent spec
+
+```yaml
+capabilities:
+  - Scheduling: {backend: sqlite, database: schedules.db, timezone: Europe/Berlin}
+```
+
+Load it with `Agent.from_spec(..., custom_capability_types=[Scheduling])`.
+
+## See also
+
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
+- [Subagents](subagents.md) -- another capability that runs prompts as fresh, isolated agent runs
+
+## API reference
+
+::: pydantic_ai_harness.scheduling.Scheduling
+
+::: pydantic_ai_harness.scheduling.ScheduleRunner

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -64,7 +64,7 @@ Naive datetimes and cron expressions are interpreted in the schedule's IANA time
 - **At most once.** A schedule's next occurrence is advanced and saved before the agent runs, so a crash mid-run skips an occurrence instead of running it twice.
 - **No automatic retry.** A failed run records `last_error` and the schedule keeps its next occurrence; for recurring work, the next occurrence is the retry.
 - **No overlap.** A schedule still running when it comes due again is skipped, never run concurrently with itself.
-- **One runner per store.** At-most-once and no-overlap hold within a single runner process. Two runners sharing a store can both claim the same occurrence.
+- **One runner per store.** At-most-once and no-overlap hold within a single runner process. Two runners sharing a store can both claim the same occurrence. The store carries no per-user scoping: every schedule belongs to the agent's principal, so give each tenant its own store.
 - **No backlog replay.** A recurring schedule overdue beyond `misfire_grace` (default 10 minutes) runs once now and continues from the next future occurrence. An overdue one-shot is recorded as `missed` instead of running hours late. Resuming a paused schedule continues from its next future occurrence.
 - **Bounded runs.** `max_runs` counts attempts; when reached, the schedule completes. `run_timeout` and per-schedule or runner-wide `usage_limits` cap each run's wall-clock time and spend.
 - Empty output is a success, not an error.

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -24,6 +24,8 @@ pip install 'pydantic-ai-harness[scheduling]'
 Attach the capability, then run the runner:
 
 ```python
+import asyncio
+
 from pydantic_ai import Agent
 from pydantic_ai_harness.scheduling import ScheduleResult, ScheduleRunner, Scheduling, SqliteScheduleStore
 
@@ -42,6 +44,9 @@ async def main():
 
     runner = ScheduleRunner(agent, deps=None, on_result=show)
     await runner.run_until_stopped()
+
+
+asyncio.run(main())
 ```
 
 The model calls `create_schedule` with a name, a prompt, and a schedule string. The runner claims due schedules once per `tick_interval` (default 60 seconds) and executes each one as a fresh, isolated agent run.
@@ -84,9 +89,15 @@ async def deliver(result: ScheduleResult) -> None:
     print(f'[{target}] {result.schedule.name}: {result.output}')
 ```
 
-## Scheduled runs cannot schedule
+## Scheduling tools inside scheduled runs
 
-Inside a scheduled run, the scheduling tools and instructions are absent. A scheduled prompt cannot create, change, or trigger schedules, so it cannot replicate itself.
+Inside a scheduled run, this capability's scheduling tools and instructions are absent. The application can still expose other tools that write to the same store, so this guard only prevents access through `Scheduling` itself.
+
+## Custom stores and concurrent writers
+
+`Schedule.version` is store bookkeeping for optimistic concurrency control. A `ScheduleStore.save()` implementation replaces a record only when the supplied version matches the stored version, persists it with `version + 1`, raises `ScheduleConflictError` for a stale version, and raises `ValueError` for an unknown id. Writers re-read and retry after conflicts so updates apply to current state.
+
+Use one runner per store. Versioned saves protect concurrent tool and runner updates within that design, but do not coordinate claims across runner processes.
 
 ## Driving the runner from outside
 
@@ -95,6 +106,8 @@ Inside a scheduled run, the scheduling tools and instructions are absent. A sche
 Invocations must not overlap for a given store; schedule the external trigger accordingly.
 
 ```python
+import asyncio
+
 from pydantic_ai import Agent
 from pydantic_ai_harness.scheduling import ScheduleRunner, Scheduling, SqliteScheduleStore
 
@@ -104,6 +117,9 @@ agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[Scheduling(store=stor
 
 async def main():
     await ScheduleRunner(agent, deps=None, store=store).tick()
+
+
+asyncio.run(main())
 ```
 
 Durability capabilities on the agent compose transparently: scheduled runs execute like any other run.

--- a/pydantic_ai_harness/scheduling/README.md
+++ b/pydantic_ai_harness/scheduling/README.md
@@ -59,7 +59,7 @@ Naive datetimes and cron expressions are interpreted in the schedule's IANA time
 - **At most once.** A schedule's next occurrence is advanced and saved before the agent runs, so a crash mid-run skips an occurrence instead of running it twice.
 - **No automatic retry.** A failed run records `last_error` and the schedule keeps its next occurrence; for recurring work, the next occurrence is the retry.
 - **No overlap.** A schedule still running when it comes due again is skipped, never run concurrently with itself.
-- **One runner per store.** At-most-once and no-overlap hold within a single runner process. Two runners sharing a store can both claim the same occurrence.
+- **One runner per store.** At-most-once and no-overlap hold within a single runner process. Two runners sharing a store can both claim the same occurrence. The store carries no per-user scoping: every schedule belongs to the agent's principal, so give each tenant its own store.
 - **No backlog replay.** A recurring schedule overdue beyond `misfire_grace` (default 10 minutes) runs once now and continues from the next future occurrence. An overdue one-shot is recorded as `missed` instead of running hours late. Resuming a paused schedule continues from its next future occurrence.
 - **Bounded runs.** `max_runs` counts attempts; when reached, the schedule completes. `run_timeout` and per-schedule or runner-wide `usage_limits` cap each run's wall-clock time and spend.
 - Empty output is a success, not an error.

--- a/pydantic_ai_harness/scheduling/README.md
+++ b/pydantic_ai_harness/scheduling/README.md
@@ -19,6 +19,8 @@ pip install 'pydantic-ai-harness[scheduling]'
 Attach the capability, then run the runner:
 
 ```python
+import asyncio
+
 from pydantic_ai import Agent
 from pydantic_ai_harness.scheduling import ScheduleResult, ScheduleRunner, Scheduling, SqliteScheduleStore
 
@@ -37,6 +39,9 @@ async def main():
 
     runner = ScheduleRunner(agent, deps=None, on_result=show)
     await runner.run_until_stopped()
+
+
+asyncio.run(main())
 ```
 
 The model calls `create_schedule` with a name, a prompt, and a schedule string. The runner claims due schedules once per `tick_interval` (default 60 seconds) and executes each one as a fresh, isolated agent run.
@@ -79,9 +84,15 @@ async def deliver(result: ScheduleResult) -> None:
     print(f'[{target}] {result.schedule.name}: {result.output}')
 ```
 
-## Scheduled runs cannot schedule
+## Scheduling tools inside scheduled runs
 
-Inside a scheduled run, the scheduling tools and instructions are absent. A scheduled prompt cannot create, change, or trigger schedules, so it cannot replicate itself.
+Inside a scheduled run, this capability's scheduling tools and instructions are absent. The application can still expose other tools that write to the same store, so this guard only prevents access through `Scheduling` itself.
+
+## Custom stores and concurrent writers
+
+`Schedule.version` is store bookkeeping for optimistic concurrency control. A `ScheduleStore.save()` implementation replaces a record only when the supplied version matches the stored version, persists it with `version + 1`, raises `ScheduleConflictError` for a stale version, and raises `ValueError` for an unknown id. Writers re-read and retry after conflicts so updates apply to current state.
+
+Use one runner per store. Versioned saves protect concurrent tool and runner updates within that design, but do not coordinate claims across runner processes.
 
 ## Driving the runner from outside
 
@@ -90,6 +101,8 @@ Inside a scheduled run, the scheduling tools and instructions are absent. A sche
 Invocations must not overlap for a given store; schedule the external trigger accordingly.
 
 ```python
+import asyncio
+
 from pydantic_ai import Agent
 from pydantic_ai_harness.scheduling import ScheduleRunner, Scheduling, SqliteScheduleStore
 
@@ -99,6 +112,9 @@ agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[Scheduling(store=stor
 
 async def main():
     await ScheduleRunner(agent, deps=None, store=store).tick()
+
+
+asyncio.run(main())
 ```
 
 Durability capabilities on the agent compose transparently: scheduled runs execute like any other run.

--- a/pydantic_ai_harness/scheduling/README.md
+++ b/pydantic_ai_harness/scheduling/README.md
@@ -1,0 +1,110 @@
+# Scheduling
+
+Let an agent schedule work, and run that work on time.
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/scheduling/)
+
+> The API may change between releases. Breaking changes ship deprecation warnings where practical.
+
+`Scheduling` gives the model tools to create and manage schedules. `ScheduleRunner` executes them: when a schedule is due, it runs the agent with the schedule's prompt and hands the outcome to your callback.
+
+## Usage
+
+Install the extra (only cron expressions need it; interval and one-shot schedules work without it):
+
+```bash
+pip install 'pydantic-ai-harness[scheduling]'
+```
+
+Attach the capability, then run the runner:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.scheduling import ScheduleResult, ScheduleRunner, Scheduling, SqliteScheduleStore
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    capabilities=[Scheduling(store=SqliteScheduleStore('schedules.db'))],
+)
+
+
+def show(result: ScheduleResult) -> None:
+    print(f'{result.schedule.name}: {result.status}')
+
+
+async def main():
+    await agent.run('Every weekday at 9am, summarize our open pull requests.')
+
+    runner = ScheduleRunner(agent, deps=None, on_result=show)
+    await runner.run_until_stopped()
+```
+
+The model calls `create_schedule` with a name, a prompt, and a schedule string. The runner claims due schedules once per `tick_interval` (default 60 seconds) and executes each one as a fresh, isolated agent run.
+
+You can also create schedules from code: build a `Schedule` and `add` it to the store the runner reads.
+
+## Schedule forms
+
+| Form | Example | Runs |
+|---|---|---|
+| `every <N><m\|h\|d>` | `every 30m` | repeatedly, on a fixed interval |
+| `in <N><m\|h\|d>` | `in 2h` | once, that far from now |
+| ISO 8601 datetime | `2026-09-01T09:00` | once, at that time |
+| Five-field cron | `0 9 * * MON-FRI` | repeatedly, per the expression |
+
+Naive datetimes and cron expressions are interpreted in the schedule's IANA timezone (`Scheduling(timezone=...)`, UTC by default). Cron occurrences keep their wall-clock hour across DST transitions.
+
+## Execution semantics
+
+- **At most once.** A schedule's next occurrence is advanced and saved before the agent runs, so a crash mid-run skips an occurrence instead of running it twice.
+- **No automatic retry.** A failed run records `last_error` and the schedule keeps its next occurrence; for recurring work, the next occurrence is the retry.
+- **No overlap.** A schedule still running when it comes due again is skipped, never run concurrently with itself.
+- **No backlog replay.** A recurring schedule overdue beyond `misfire_grace` (default 10 minutes) runs once now and continues from the next future occurrence. An overdue one-shot is recorded as `missed` instead of running hours late. Resuming a paused schedule continues from its next future occurrence.
+- **Bounded runs.** `max_runs` counts attempts; when reached, the schedule completes. `run_timeout` and per-schedule or runner-wide `usage_limits` cap each run's wall-clock time and spend.
+- Empty output is a success, not an error.
+
+## Delivering results
+
+Every outcome is stored on the schedule (`last_status`, `last_output`, `last_error`) and passed to `on_result`, sync or async. A callback that raises is recorded as `last_delivery_error`; it never fails the run.
+
+`deliver_to` is an opaque hint. The harness does not interpret it; your callback routes on it:
+
+```python
+from pydantic_ai_harness.scheduling import ScheduleResult
+
+
+async def deliver(result: ScheduleResult) -> None:
+    if result.schedule.deliver_to == 'slack:#eng':
+        await post_to_slack(result.output)
+```
+
+## Scheduled runs cannot schedule
+
+Inside a scheduled run, the scheduling tools and instructions are absent. A scheduled prompt cannot create, change, or trigger schedules, so it cannot replicate itself.
+
+## Driving the runner from outside
+
+`tick()` claims and executes everything due, then returns. Call it from system cron, a workflow engine, or serverless infrastructure instead of keeping `run_until_stopped()` alive:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.scheduling import ScheduleRunner, Scheduling, SqliteScheduleStore
+
+store = SqliteScheduleStore('schedules.db')
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[Scheduling(store=store)])
+
+
+async def main():
+    await ScheduleRunner(agent, deps=None, store=store).tick()
+```
+
+Durability capabilities on the agent compose transparently: scheduled runs execute like any other run.
+
+## Agent spec
+
+```yaml
+capabilities:
+  - Scheduling: {backend: sqlite, database: schedules.db, timezone: Europe/Berlin}
+```
+
+Load it with `Agent.from_spec(..., custom_capability_types=[Scheduling])`.

--- a/pydantic_ai_harness/scheduling/README.md
+++ b/pydantic_ai_harness/scheduling/README.md
@@ -59,6 +59,7 @@ Naive datetimes and cron expressions are interpreted in the schedule's IANA time
 - **At most once.** A schedule's next occurrence is advanced and saved before the agent runs, so a crash mid-run skips an occurrence instead of running it twice.
 - **No automatic retry.** A failed run records `last_error` and the schedule keeps its next occurrence; for recurring work, the next occurrence is the retry.
 - **No overlap.** A schedule still running when it comes due again is skipped, never run concurrently with itself.
+- **One runner per store.** At-most-once and no-overlap hold within a single runner process. Two runners sharing a store can both claim the same occurrence.
 - **No backlog replay.** A recurring schedule overdue beyond `misfire_grace` (default 10 minutes) runs once now and continues from the next future occurrence. An overdue one-shot is recorded as `missed` instead of running hours late. Resuming a paused schedule continues from its next future occurrence.
 - **Bounded runs.** `max_runs` counts attempts; when reached, the schedule completes. `run_timeout` and per-schedule or runner-wide `usage_limits` cap each run's wall-clock time and spend.
 - Empty output is a success, not an error.
@@ -74,8 +75,8 @@ from pydantic_ai_harness.scheduling import ScheduleResult
 
 
 async def deliver(result: ScheduleResult) -> None:
-    if result.schedule.deliver_to == 'slack:#eng':
-        await post_to_slack(result.output)
+    target = result.schedule.deliver_to or 'stdout'
+    print(f'[{target}] {result.schedule.name}: {result.output}')
 ```
 
 ## Scheduled runs cannot schedule
@@ -85,6 +86,8 @@ Inside a scheduled run, the scheduling tools and instructions are absent. A sche
 ## Driving the runner from outside
 
 `tick()` claims and executes everything due, then returns. Call it from system cron, a workflow engine, or serverless infrastructure instead of keeping `run_until_stopped()` alive:
+
+Invocations must not overlap for a given store; schedule the external trigger accordingly.
 
 ```python
 from pydantic_ai import Agent

--- a/pydantic_ai_harness/scheduling/__init__.py
+++ b/pydantic_ai_harness/scheduling/__init__.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pydantic_ai_harness.scheduling._capability import Scheduling
 from pydantic_ai_harness.scheduling._runner import ScheduleRunner
-from pydantic_ai_harness.scheduling._store import InMemoryScheduleStore, ScheduleStore, SqliteScheduleStore
+from pydantic_ai_harness.scheduling._store import (
+    InMemoryScheduleStore,
+    ScheduleConflictError,
+    ScheduleStore,
+    SqliteScheduleStore,
+)
 from pydantic_ai_harness.scheduling._types import (
     CronTrigger,
     IntervalTrigger,
@@ -22,6 +27,7 @@ __all__ = [
     'IntervalTrigger',
     'OnceTrigger',
     'Schedule',
+    'ScheduleConflictError',
     'ScheduleResult',
     'ScheduleResultCallback',
     'ScheduleRunner',

--- a/pydantic_ai_harness/scheduling/__init__.py
+++ b/pydantic_ai_harness/scheduling/__init__.py
@@ -1,0 +1,33 @@
+"""Scheduled agent execution with pluggable storage and result delivery."""
+
+from __future__ import annotations
+
+from pydantic_ai_harness.scheduling._capability import Scheduling
+from pydantic_ai_harness.scheduling._runner import ScheduleRunner
+from pydantic_ai_harness.scheduling._store import InMemoryScheduleStore, ScheduleStore, SqliteScheduleStore
+from pydantic_ai_harness.scheduling._types import (
+    CronTrigger,
+    IntervalTrigger,
+    OnceTrigger,
+    Schedule,
+    ScheduleResult,
+    ScheduleResultCallback,
+    ScheduleTrigger,
+    parse_schedule,
+)
+
+__all__ = [
+    'CronTrigger',
+    'InMemoryScheduleStore',
+    'IntervalTrigger',
+    'OnceTrigger',
+    'Schedule',
+    'ScheduleResult',
+    'ScheduleResultCallback',
+    'ScheduleRunner',
+    'ScheduleStore',
+    'ScheduleTrigger',
+    'Scheduling',
+    'SqliteScheduleStore',
+    'parse_schedule',
+]

--- a/pydantic_ai_harness/scheduling/_capability.py
+++ b/pydantic_ai_harness/scheduling/_capability.py
@@ -1,0 +1,113 @@
+"""The `Scheduling` capability for model-managed scheduled runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+from zoneinfo import ZoneInfo
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.tools import AgentDepsT, RunContext
+
+from pydantic_ai_harness.scheduling._runner import scheduled_run_var
+from pydantic_ai_harness.scheduling._store import InMemoryScheduleStore, ScheduleStore, SqliteScheduleStore
+from pydantic_ai_harness.scheduling._toolset import SchedulingToolset
+
+if TYPE_CHECKING:
+    from pydantic_ai.agent.abstract import AgentInstructions
+
+_DEFAULT_GUIDANCE = (
+    'Use `create_schedule`, `list_schedules`, `get_schedule`, `update_schedule`, `pause_schedule`, '
+    '`resume_schedule`, `delete_schedule`, and `run_schedule_now` to manage scheduled work. Schedule strings accept '
+    '`every <N><m|h|d>`, `in <N><m|h|d>`, ISO 8601 datetimes, or five-field cron expressions. Schedules only '
+    'execute while the application runs a `ScheduleRunner`.'
+)
+
+
+@dataclass
+class Scheduling(AbstractCapability[AgentDepsT]):
+    """Model-managed schedules backed by a shared `ScheduleStore`.
+
+    The default store is a fresh `InMemoryScheduleStore` owned by this capability
+    instance. Pass an explicit store when schedules must persist across process
+    restarts or be shared with separately constructed runners.
+    """
+
+    store: ScheduleStore | None = None
+    """Storage backend. `None` creates a fresh in-memory store for this instance."""
+
+    timezone: str = 'UTC'
+    """Default IANA timezone for schedules created by the tools."""
+
+    guidance: str | None = None
+    """Static scheduling guidance for the system prompt.
+
+    Three states make opting out explicit:
+
+    - `None` uses the built-in guidance.
+    - `''` provides no guidance.
+    - Any other string replaces the built-in guidance verbatim.
+
+    Treating `None` as an opt-out would leave no explicit way to request the
+    default and could turn a configuration value resolving to `None` into an
+    unintended omission.
+    """
+
+    def __post_init__(self) -> None:
+        """Validate configuration and create the instance-owned default store."""
+        try:
+            ZoneInfo(self.timezone)
+        except (KeyError, ValueError) as exc:
+            raise ValueError(f'Unknown IANA timezone: {self.timezone!r}') from exc
+        if self.store is None:
+            self.store = InMemoryScheduleStore()
+
+    @property
+    def resolved_store(self) -> ScheduleStore:
+        """Return the store owned or provided by this capability."""
+        if self.store is None:  # pragma: no cover - `__post_init__` resolves this field
+            raise RuntimeError('Scheduling store was not initialized.')
+        return self.store
+
+    def get_toolset(self) -> SchedulingToolset[AgentDepsT]:
+        """Provide the recursion-guarded `scheduling` toolset."""
+        return SchedulingToolset(self)
+
+    def get_instructions(self) -> AgentInstructions[AgentDepsT] | None:
+        """Provide scheduling guidance outside scheduled runs."""
+
+        def instructions(ctx: RunContext[AgentDepsT]) -> str | None:
+            del ctx
+            if scheduled_run_var.get() is not None:
+                return None
+            if self.guidance is not None:
+                return self.guidance or None
+            return _DEFAULT_GUIDANCE
+
+        return instructions
+
+    @classmethod
+    def from_spec(
+        cls,
+        *,
+        backend: Literal['memory', 'sqlite'] = 'memory',
+        database: str = '.agent-schedules.db',
+        timezone: str = 'UTC',
+        guidance: str | None = None,
+    ) -> Scheduling[AgentDepsT]:
+        """Construct `Scheduling` from serializable options."""
+        if backend != 'sqlite' and database != '.agent-schedules.db':
+            raise ValueError('database is only valid with backend="sqlite"')
+        if backend == 'memory':
+            store: ScheduleStore | None = None
+        elif backend == 'sqlite':
+            store = SqliteScheduleStore(database)
+        else:
+            # Spec values arrive from YAML or JSON before the `Literal` can protect this branch.
+            raise ValueError(f"Unknown scheduling backend {backend!r}; expected 'memory' or 'sqlite'.")
+        return cls(store=store, timezone=timezone, guidance=guidance)
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        """Return the agent-spec serialization name."""
+        return 'Scheduling'

--- a/pydantic_ai_harness/scheduling/_runner.py
+++ b/pydantic_ai_harness/scheduling/_runner.py
@@ -246,6 +246,8 @@ class ScheduleRunner(Generic[AgentDepsT]):
         infrastructure.
         """
         reference = now or datetime.now(timezone.utc)
+        if reference.utcoffset() is None:
+            raise ValueError('now must be timezone-aware')
         results: list[ScheduleResult] = []
         claims = await self._claim_due(reference)
         async with anyio.create_task_group() as task_group:

--- a/pydantic_ai_harness/scheduling/_runner.py
+++ b/pydantic_ai_harness/scheduling/_runner.py
@@ -1,0 +1,254 @@
+"""In-process execution loop for due schedules."""
+
+from __future__ import annotations
+
+import inspect
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Generic, Literal
+
+import anyio
+from pydantic_ai.agent import AbstractAgent
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.usage import UsageLimits
+
+from pydantic_ai_harness.scheduling._store import ScheduleStore
+from pydantic_ai_harness.scheduling._types import (
+    CronTrigger,
+    IntervalTrigger,
+    OnceTrigger,
+    Schedule,
+    ScheduleResult,
+    ScheduleResultCallback,
+    next_run_time,
+)
+
+scheduled_run_var: ContextVar[str | None] = ContextVar('scheduled_run', default=None)
+"""Id of the schedule running in the current context, or `None`."""
+
+
+@dataclass(frozen=True)
+class _Claim:
+    schedule: Schedule
+    execute: bool
+    claimed_at: datetime
+
+
+class ScheduleRunner(Generic[AgentDepsT]):
+    """Execute due schedules against an agent.
+
+    A runner assumes exclusive ownership of its store. Occurrences are advanced
+    before agent execution for at-most-once behavior, and `stop()` drains runs
+    already in flight before `run_until_stopped()` returns.
+    """
+
+    def __init__(
+        self,
+        agent: AbstractAgent[AgentDepsT, Any],
+        *,
+        deps: AgentDepsT,
+        store: ScheduleStore | None = None,
+        on_result: ScheduleResultCallback | None = None,
+        tick_interval: float = 60.0,
+        misfire_grace: timedelta = timedelta(minutes=10),
+        run_timeout: float | None = None,
+        usage_limits: UsageLimits | None = None,
+    ) -> None:
+        """Initialize a schedule runner.
+
+        Args:
+            agent: Agent used for each isolated scheduled run.
+            deps: Dependencies passed to every agent run.
+            store: Schedule store, or `None` to find the agent's `Scheduling` store.
+            on_result: Optional sync or async outcome callback.
+            tick_interval: Seconds between claims in the continuous loop.
+            misfire_grace: Maximum lateness before one-shot schedules are missed.
+            run_timeout: Optional wall-clock limit for one agent run.
+            usage_limits: Default usage limits for schedules without their own limits.
+
+        Raises:
+            ValueError: If configuration is invalid or no unambiguous store can be found.
+        """
+        if tick_interval <= 0:
+            raise ValueError('tick_interval must be greater than zero')
+        if misfire_grace < timedelta(0):
+            raise ValueError('misfire_grace must not be negative')
+        if run_timeout is not None and run_timeout <= 0:
+            raise ValueError('run_timeout must be greater than zero')
+        self._agent = agent
+        self._store = store or self._store_from_agent(agent)
+        self._deps = deps
+        self._on_result = on_result
+        self._tick_interval = tick_interval
+        self._misfire_grace = misfire_grace
+        self._run_timeout = run_timeout
+        self._usage_limits = usage_limits
+        self._running: set[str] = set()
+        self._stop_event = anyio.Event()
+
+    @staticmethod
+    def _store_from_agent(agent: AbstractAgent[AgentDepsT, Any]) -> ScheduleStore:
+        from pydantic_ai_harness.scheduling._capability import Scheduling
+
+        found: ScheduleStore | None = None
+        multiple = False
+
+        def inspect_capability(capability: AbstractCapability[AgentDepsT]) -> None:
+            nonlocal found, multiple
+            if isinstance(capability, Scheduling):
+                if found is not None:
+                    multiple = True
+                else:
+                    found = capability.resolved_store
+
+        agent.root_capability.apply(inspect_capability)
+        if multiple:
+            raise ValueError('The agent has multiple Scheduling capabilities; pass `store=` explicitly.')
+        if found is None:
+            raise ValueError('No Scheduling capability was found on the agent; pass `store=` explicitly.')
+        return found
+
+    async def _claim_due(self, now: datetime) -> list[_Claim]:
+        claims: list[_Claim] = []
+        for schedule in await self._store.list():
+            due_at = schedule.next_run_at
+            if not schedule.enabled or due_at is None or due_at > now or schedule.id in self._running:
+                continue
+            self._running.add(schedule.id)
+            try:
+                overdue = now - due_at > self._misfire_grace
+                if overdue and isinstance(schedule.trigger, OnceTrigger):
+                    schedule.next_run_at = None
+                    schedule.last_status = 'missed'
+                    schedule.last_error = 'The runner was not running within the allowed grace period.'
+                    await self._store.save(schedule)
+                    claims.append(_Claim(schedule, execute=False, claimed_at=now))
+                    continue
+
+                if isinstance(schedule.trigger, (CronTrigger, IntervalTrigger)):
+                    schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+                else:
+                    schedule.next_run_at = None
+                schedule.runs_completed += 1
+                if schedule.max_runs is not None and schedule.runs_completed >= schedule.max_runs:
+                    schedule.next_run_at = None
+                await self._store.save(schedule)
+                claims.append(_Claim(schedule, execute=True, claimed_at=now))
+            except BaseException:
+                self._running.discard(schedule.id)
+                raise
+        return claims
+
+    async def _deliver(self, result: ScheduleResult) -> None:
+        if self._on_result is None:
+            return
+        result.schedule.last_delivery_error = None
+        try:
+            callback_result = self._on_result(result)
+            if inspect.isawaitable(callback_result):
+                await callback_result
+        except Exception as exc:
+            result.schedule.last_delivery_error = f'{type(exc).__name__}: {exc}'[:1000]
+        await self._store.save(result.schedule)
+
+    async def _execute(self, claim: _Claim) -> ScheduleResult:
+        schedule = claim.schedule
+        started_at = datetime.now(timezone.utc)
+        try:
+            if not claim.execute:
+                finished_at = datetime.now(timezone.utc)
+                result = ScheduleResult(
+                    schedule=schedule,
+                    status='missed',
+                    output=None,
+                    error=schedule.last_error,
+                    started_at=started_at,
+                    finished_at=finished_at,
+                    usage=None,
+                )
+                await self._deliver(result)
+                return result
+
+            token = scheduled_run_var.set(schedule.id)
+            try:
+                run = self._agent.run(
+                    schedule.prompt,
+                    deps=self._deps,
+                    usage_limits=schedule.usage_limits or self._usage_limits,
+                )
+                if self._run_timeout is None:
+                    agent_result = await run
+                else:
+                    with anyio.fail_after(self._run_timeout):
+                        agent_result = await run
+            except Exception as exc:
+                status: Literal['success', 'error', 'missed'] = 'error'
+                output = None
+                error = f'{type(exc).__name__}: {exc}'[:1000]
+                usage = None
+            else:
+                status = 'success'
+                output = str(agent_result.output)
+                error = None
+                usage = agent_result.usage
+            finally:
+                scheduled_run_var.reset(token)
+
+            schedule.last_run_at = claim.claimed_at
+            schedule.last_status = status
+            schedule.last_output = output if status == 'success' else schedule.last_output
+            schedule.last_error = error
+            await self._store.save(schedule)
+            result = ScheduleResult(
+                schedule=schedule,
+                status=status,
+                output=output,
+                error=error,
+                started_at=started_at,
+                finished_at=datetime.now(timezone.utc),
+                usage=usage,
+            )
+            await self._deliver(result)
+            return result
+        finally:
+            self._running.discard(schedule.id)
+
+    async def _execute_collect(self, claim: _Claim, results: list[ScheduleResult]) -> None:
+        results.append(await self._execute(claim))
+
+    async def tick(self, now: datetime | None = None) -> list[ScheduleResult]:
+        """Claim and concurrently execute schedules due at `now`.
+
+        This method does not require the continuous runner loop, so an external
+        scheduler can drive it from system cron, a workflow engine, or serverless
+        infrastructure.
+
+        Args:
+            now: UTC-aware claim time override for deterministic callers and tests.
+
+        Returns:
+            Results from every occurrence claimed by this tick.
+        """
+        reference = now or datetime.now(timezone.utc)
+        results: list[ScheduleResult] = []
+        claims = await self._claim_due(reference)
+        async with anyio.create_task_group() as task_group:
+            for claim in claims:
+                task_group.start_soon(self._execute_collect, claim, results)
+        return results
+
+    async def run_until_stopped(self) -> None:
+        """Claim on each interval until stopped, then drain in-flight runs."""
+        async with anyio.create_task_group() as task_group:
+            while not self._stop_event.is_set():
+                claims = await self._claim_due(datetime.now(timezone.utc))
+                for claim in claims:
+                    task_group.start_soon(self._execute, claim)
+                with anyio.move_on_after(self._tick_interval):
+                    await self._stop_event.wait()
+
+    def stop(self) -> None:
+        """Request an idempotent graceful stop of the continuous loop."""
+        self._stop_event.set()

--- a/pydantic_ai_harness/scheduling/_runner.py
+++ b/pydantic_ai_harness/scheduling/_runner.py
@@ -15,7 +15,7 @@ from pydantic_ai.capabilities import AbstractCapability, WrapperCapability
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.usage import UsageLimits
 
-from pydantic_ai_harness.scheduling._store import ScheduleStore
+from pydantic_ai_harness.scheduling._store import ScheduleConflictError, ScheduleStore
 from pydantic_ai_harness.scheduling._types import (
     CronTrigger,
     IntervalTrigger,
@@ -29,6 +29,8 @@ from pydantic_ai_harness.scheduling._types import (
 scheduled_run_var: ContextVar[str | None] = ContextVar('scheduled_run', default=None)
 """Id of the schedule running in the current context, or `None`."""
 
+_SAVE_ATTEMPTS = 3
+
 
 @dataclass(frozen=True)
 class _Claim:
@@ -40,7 +42,7 @@ class _Claim:
 class ScheduleRunner(Generic[AgentDepsT]):
     """Execute due schedules against an agent.
 
-    A runner assumes exclusive ownership of its store. Occurrences are advanced
+    A runner assumes no other runner uses its store. Occurrences are advanced
     before agent execution for at-most-once behavior, and `stop()` drains runs
     already in flight before `run_until_stopped()` returns.
     """
@@ -99,59 +101,72 @@ class ScheduleRunner(Generic[AgentDepsT]):
             raise ValueError('No Scheduling capability was found on the agent; pass `store=` explicitly.')
         return found[0].resolved_store
 
-    async def _claim_due(self, now: datetime) -> list[_Claim]:
-        claims: list[_Claim] = []
-        try:
-            for schedule in await self._store.list():
-                due_at = schedule.next_run_at
-                if not schedule.enabled or due_at is None or due_at > now:
-                    continue
+    async def _claim(self, schedule: Schedule, now: datetime) -> _Claim | None:
+        for attempt in range(_SAVE_ATTEMPTS):
+            due_at = schedule.next_run_at
+            if not schedule.enabled or due_at is None or due_at > now:
+                return None
+
+            execute = True
+            should_start = True
+            if schedule.max_runs is not None and schedule.runs_completed >= schedule.max_runs:
+                schedule.next_run_at = None
+                execute = False
+                should_start = False
+            elif schedule.id in self._running:
+                if isinstance(schedule.trigger, (CronTrigger, IntervalTrigger)):  # pragma: no branch
+                    schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+                    execute = False
+                    should_start = False
+                else:  # pragma: no cover - a one-shot cannot become due again while its only run is in flight
+                    return None
+            elif now - due_at > self._misfire_grace and isinstance(schedule.trigger, OnceTrigger):
+                schedule.next_run_at = None
+                schedule.last_status = 'missed'
+                schedule.last_error = 'The runner was not running within the allowed grace period.'
+                execute = False
+            else:
+                if isinstance(schedule.trigger, (CronTrigger, IntervalTrigger)):
+                    schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+                else:
+                    schedule.next_run_at = None
+                schedule.runs_completed += 1
                 if schedule.max_runs is not None and schedule.runs_completed >= schedule.max_runs:
                     schedule.next_run_at = None
-                    await self._store.save(schedule)
-                    continue
-                if schedule.id in self._running:
-                    if isinstance(schedule.trigger, (CronTrigger, IntervalTrigger)):  # pragma: no branch
-                        schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
-                        await self._store.save(schedule)
-                    continue
-                self._running.add(schedule.id)
-                try:
-                    overdue = now - due_at > self._misfire_grace
-                    if overdue and isinstance(schedule.trigger, OnceTrigger):
-                        schedule.next_run_at = None
-                        schedule.last_status = 'missed'
-                        schedule.last_error = 'The runner was not running within the allowed grace period.'
-                        await self._store.save(schedule)
-                        claims.append(_Claim(schedule, execute=False, claimed_at=now))
-                        continue
 
-                    if isinstance(schedule.trigger, (CronTrigger, IntervalTrigger)):
-                        schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
-                    else:
-                        schedule.next_run_at = None
-                    schedule.runs_completed += 1
-                    if schedule.max_runs is not None and schedule.runs_completed >= schedule.max_runs:
-                        schedule.next_run_at = None
-                    await self._store.save(schedule)
-                    claims.append(_Claim(schedule, execute=True, claimed_at=now))
-                except BaseException:
-                    self._running.discard(schedule.id)
+            try:
+                await self._store.save(schedule)
+            except ScheduleConflictError:
+                if attempt == _SAVE_ATTEMPTS - 1:
                     raise
-        except BaseException:
-            for claim in claims:
-                self._running.discard(claim.schedule.id)
-            raise
-        return claims
+                refreshed = await self._store.get(schedule.id)
+                if refreshed is None:
+                    return None
+                schedule = refreshed
+                continue
+
+            if should_start:
+                self._running.add(schedule.id)
+                return _Claim(schedule, execute=execute, claimed_at=now)
+            return None
+        raise AssertionError('unreachable')  # pragma: no cover
 
     async def _apply_outcome(self, schedule_id: str, fallback: Schedule, apply: Callable[[Schedule], None]) -> Schedule:
-        """Re-read so outcome fields preserve concurrent edits and a deleted schedule stays deleted."""
-        current = await self._store.get(schedule_id)
-        target = current if current is not None else fallback
-        apply(target)
-        if current is not None:
-            await self._store.save(target)
-        return target
+        """Retry against fresh state so outcome fields compose with concurrent edits."""
+        for attempt in range(_SAVE_ATTEMPTS):
+            current = await self._store.get(schedule_id)
+            target = current if current is not None else fallback
+            apply(target)
+            if current is None:
+                return target
+            try:
+                await self._store.save(target)
+            except ScheduleConflictError:
+                if attempt == _SAVE_ATTEMPTS - 1:
+                    raise
+                continue
+            return target
+        raise AssertionError('unreachable')  # pragma: no cover
 
     async def _deliver(self, result: ScheduleResult) -> None:
         if self._on_result is None:
@@ -249,21 +264,36 @@ class ScheduleRunner(Generic[AgentDepsT]):
         if reference.utcoffset() is None:
             raise ValueError('now must be timezone-aware')
         results: list[ScheduleResult] = []
-        claims = await self._claim_due(reference)
+        sweep_error: Exception | None = None
         async with anyio.create_task_group() as task_group:
-            for claim in claims:
-                task_group.start_soon(self._execute_collect, claim, results)
+            try:
+                for schedule in await self._store.list():
+                    claim = await self._claim(schedule, reference)
+                    if claim is not None:
+                        task_group.start_soon(self._execute_collect, claim, results)
+            except Exception as exc:
+                sweep_error = exc
+        if sweep_error is not None:
+            raise sweep_error
         return results
 
     async def run_until_stopped(self) -> None:
         """Claim on each interval until stopped, then drain in-flight runs."""
+        sweep_error: Exception | None = None
         async with anyio.create_task_group() as task_group:
             while not self._stop_event.is_set():
-                claims = await self._claim_due(datetime.now(timezone.utc))
-                for claim in claims:
-                    task_group.start_soon(self._execute, claim)
+                try:
+                    for schedule in await self._store.list():
+                        claim = await self._claim(schedule, datetime.now(timezone.utc))
+                        if claim is not None:
+                            task_group.start_soon(self._execute, claim)
+                except Exception as exc:
+                    sweep_error = exc
+                    break
                 with anyio.move_on_after(self._tick_interval):
                     await self._stop_event.wait()
+        if sweep_error is not None:
+            raise sweep_error
 
     def stop(self) -> None:
         """Request an idempotent graceful stop of the continuous loop."""

--- a/pydantic_ai_harness/scheduling/_runner.py
+++ b/pydantic_ai_harness/scheduling/_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -10,7 +11,7 @@ from typing import Any, Generic, Literal
 
 import anyio
 from pydantic_ai.agent import AbstractAgent
-from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.capabilities import AbstractCapability, WrapperCapability
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.usage import UsageLimits
 
@@ -58,18 +59,9 @@ class ScheduleRunner(Generic[AgentDepsT]):
     ) -> None:
         """Initialize a schedule runner.
 
-        Args:
-            agent: Agent used for each isolated scheduled run.
-            deps: Dependencies passed to every agent run.
-            store: Schedule store, or `None` to find the agent's `Scheduling` store.
-            on_result: Optional sync or async outcome callback.
-            tick_interval: Seconds between claims in the continuous loop.
-            misfire_grace: Maximum lateness before one-shot schedules are missed.
-            run_timeout: Optional wall-clock limit for one agent run.
-            usage_limits: Default usage limits for schedules without their own limits.
-
-        Raises:
-            ValueError: If configuration is invalid or no unambiguous store can be found.
+        Store resolution falls back to the agent's `Scheduling` capability. `misfire_grace`
+        bounds how late an occurrence may fire, and `usage_limits` is the default when a
+        schedule has none.
         """
         if tick_interval <= 0:
             raise ValueError('tick_interval must be greater than zero')
@@ -78,7 +70,7 @@ class ScheduleRunner(Generic[AgentDepsT]):
         if run_timeout is not None and run_timeout <= 0:
             raise ValueError('run_timeout must be greater than zero')
         self._agent = agent
-        self._store = store or self._store_from_agent(agent)
+        self._store = store if store is not None else self._store_from_agent(agent)
         self._deps = deps
         self._on_result = on_result
         self._tick_interval = tick_interval
@@ -92,66 +84,91 @@ class ScheduleRunner(Generic[AgentDepsT]):
     def _store_from_agent(agent: AbstractAgent[AgentDepsT, Any]) -> ScheduleStore:
         from pydantic_ai_harness.scheduling._capability import Scheduling
 
-        found: ScheduleStore | None = None
-        multiple = False
+        found: list[Scheduling[AgentDepsT]] = []
 
         def inspect_capability(capability: AbstractCapability[AgentDepsT]) -> None:
-            nonlocal found, multiple
-            if isinstance(capability, Scheduling):
-                if found is not None:
-                    multiple = True
-                else:
-                    found = capability.resolved_store
+            while isinstance(capability, WrapperCapability):
+                capability = capability.wrapped
+            if isinstance(capability, Scheduling) and all(match is not capability for match in found):
+                found.append(capability)
 
         agent.root_capability.apply(inspect_capability)
-        if multiple:
+        if len(found) > 1:
             raise ValueError('The agent has multiple Scheduling capabilities; pass `store=` explicitly.')
-        if found is None:
+        if not found:
             raise ValueError('No Scheduling capability was found on the agent; pass `store=` explicitly.')
-        return found
+        return found[0].resolved_store
 
     async def _claim_due(self, now: datetime) -> list[_Claim]:
         claims: list[_Claim] = []
-        for schedule in await self._store.list():
-            due_at = schedule.next_run_at
-            if not schedule.enabled or due_at is None or due_at > now or schedule.id in self._running:
-                continue
-            self._running.add(schedule.id)
-            try:
-                overdue = now - due_at > self._misfire_grace
-                if overdue and isinstance(schedule.trigger, OnceTrigger):
-                    schedule.next_run_at = None
-                    schedule.last_status = 'missed'
-                    schedule.last_error = 'The runner was not running within the allowed grace period.'
-                    await self._store.save(schedule)
-                    claims.append(_Claim(schedule, execute=False, claimed_at=now))
+        try:
+            for schedule in await self._store.list():
+                due_at = schedule.next_run_at
+                if not schedule.enabled or due_at is None or due_at > now:
                     continue
-
-                if isinstance(schedule.trigger, (CronTrigger, IntervalTrigger)):
-                    schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
-                else:
-                    schedule.next_run_at = None
-                schedule.runs_completed += 1
                 if schedule.max_runs is not None and schedule.runs_completed >= schedule.max_runs:
                     schedule.next_run_at = None
-                await self._store.save(schedule)
-                claims.append(_Claim(schedule, execute=True, claimed_at=now))
-            except BaseException:
-                self._running.discard(schedule.id)
-                raise
+                    await self._store.save(schedule)
+                    continue
+                if schedule.id in self._running:
+                    if isinstance(schedule.trigger, (CronTrigger, IntervalTrigger)):  # pragma: no branch
+                        schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+                        await self._store.save(schedule)
+                    continue
+                self._running.add(schedule.id)
+                try:
+                    overdue = now - due_at > self._misfire_grace
+                    if overdue and isinstance(schedule.trigger, OnceTrigger):
+                        schedule.next_run_at = None
+                        schedule.last_status = 'missed'
+                        schedule.last_error = 'The runner was not running within the allowed grace period.'
+                        await self._store.save(schedule)
+                        claims.append(_Claim(schedule, execute=False, claimed_at=now))
+                        continue
+
+                    if isinstance(schedule.trigger, (CronTrigger, IntervalTrigger)):
+                        schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+                    else:
+                        schedule.next_run_at = None
+                    schedule.runs_completed += 1
+                    if schedule.max_runs is not None and schedule.runs_completed >= schedule.max_runs:
+                        schedule.next_run_at = None
+                    await self._store.save(schedule)
+                    claims.append(_Claim(schedule, execute=True, claimed_at=now))
+                except BaseException:
+                    self._running.discard(schedule.id)
+                    raise
+        except BaseException:
+            for claim in claims:
+                self._running.discard(claim.schedule.id)
+            raise
         return claims
+
+    async def _apply_outcome(self, schedule_id: str, fallback: Schedule, apply: Callable[[Schedule], None]) -> Schedule:
+        """Re-read so outcome fields preserve concurrent edits and a deleted schedule stays deleted."""
+        current = await self._store.get(schedule_id)
+        target = current if current is not None else fallback
+        apply(target)
+        if current is not None:
+            await self._store.save(target)
+        return target
 
     async def _deliver(self, result: ScheduleResult) -> None:
         if self._on_result is None:
             return
-        result.schedule.last_delivery_error = None
+        delivery_error: str | None = None
         try:
             callback_result = self._on_result(result)
             if inspect.isawaitable(callback_result):
                 await callback_result
         except Exception as exc:
-            result.schedule.last_delivery_error = f'{type(exc).__name__}: {exc}'[:1000]
-        await self._store.save(result.schedule)
+            delivery_error = f'{type(exc).__name__}: {exc}'[:1000]
+
+        def apply_delivery(schedule: Schedule) -> None:
+            schedule.last_delivery_error = delivery_error
+            result.schedule.last_delivery_error = delivery_error
+
+        await self._apply_outcome(result.schedule.id, result.schedule, apply_delivery)
 
     async def _execute(self, claim: _Claim) -> ScheduleResult:
         schedule = claim.schedule
@@ -196,13 +213,16 @@ class ScheduleRunner(Generic[AgentDepsT]):
             finally:
                 scheduled_run_var.reset(token)
 
-            schedule.last_run_at = claim.claimed_at
-            schedule.last_status = status
-            schedule.last_output = output if status == 'success' else schedule.last_output
-            schedule.last_error = error
-            await self._store.save(schedule)
+            def apply_outcome(target: Schedule) -> None:
+                target.last_run_at = claim.claimed_at
+                target.last_status = status
+                target.last_error = error
+                if status == 'success':
+                    target.last_output = output
+
+            updated = await self._apply_outcome(schedule.id, schedule, apply_outcome)
             result = ScheduleResult(
-                schedule=schedule,
+                schedule=updated,
                 status=status,
                 output=output,
                 error=error,
@@ -224,12 +244,6 @@ class ScheduleRunner(Generic[AgentDepsT]):
         This method does not require the continuous runner loop, so an external
         scheduler can drive it from system cron, a workflow engine, or serverless
         infrastructure.
-
-        Args:
-            now: UTC-aware claim time override for deterministic callers and tests.
-
-        Returns:
-            Results from every occurrence claimed by this tick.
         """
         reference = now or datetime.now(timezone.utc)
         results: list[ScheduleResult] = []

--- a/pydantic_ai_harness/scheduling/_store.py
+++ b/pydantic_ai_harness/scheduling/_store.py
@@ -88,7 +88,8 @@ class SqliteScheduleStore:
     """File-backed SQLite schedule storage.
 
     Empty and `:memory:` databases are unsupported because each operation uses a fresh connection.
-    Blocking SQLite work runs in a worker thread under one process-local lock.
+    Blocking SQLite work runs in a worker thread. The version check runs inside the `UPDATE`
+    statement itself, so it holds across store instances and processes sharing one database file.
     """
 
     def __init__(self, database: str = '.agent-schedules.db', *, table: str = 'schedules') -> None:
@@ -110,7 +111,8 @@ class SqliteScheduleStore:
             try:
                 connection.execute(
                     f'CREATE TABLE IF NOT EXISTS "{self._table}" '
-                    '(seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT UNIQUE NOT NULL, data TEXT NOT NULL)'
+                    '(seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT UNIQUE NOT NULL, '
+                    'data TEXT NOT NULL, version INTEGER NOT NULL DEFAULT 0)'
                 )
                 connection.commit()
             except BaseException:
@@ -124,8 +126,8 @@ class SqliteScheduleStore:
             connection = self._connect()
             try:
                 connection.execute(
-                    f'INSERT INTO "{self._table}" (id, data) VALUES (?, ?)',
-                    (schedule.id, schedule.model_dump_json()),
+                    f'INSERT INTO "{self._table}" (id, data, version) VALUES (?, ?, ?)',
+                    (schedule.id, schedule.model_dump_json(), schedule.version),
                 )
                 connection.commit()
             except sqlite3.IntegrityError as exc:
@@ -155,17 +157,16 @@ class SqliteScheduleStore:
         with self._lock:
             connection = self._connect()
             try:
-                row = connection.execute(f'SELECT data FROM "{self._table}" WHERE id = ?', (schedule.id,)).fetchone()
-                if row is None:
-                    raise ValueError(f'Unknown schedule id {schedule.id!r}.')
-                stored = Schedule.model_validate_json(str(row[0]))
-                if schedule.version != stored.version:
-                    raise ScheduleConflictError(f'Schedule {schedule.id!r} changed since it was read.')
                 bumped = schedule.model_copy(update={'version': schedule.version + 1}, deep=True)
-                connection.execute(
-                    f'UPDATE "{self._table}" SET data = ? WHERE id = ?',
-                    (bumped.model_dump_json(), schedule.id),
+                cursor = connection.execute(
+                    f'UPDATE "{self._table}" SET data = ?, version = ? WHERE id = ? AND version = ?',
+                    (bumped.model_dump_json(), bumped.version, schedule.id, schedule.version),
                 )
+                if cursor.rowcount == 0:
+                    row = connection.execute(f'SELECT 1 FROM "{self._table}" WHERE id = ?', (schedule.id,)).fetchone()
+                    if row is None:
+                        raise ValueError(f'Unknown schedule id {schedule.id!r}.')
+                    raise ScheduleConflictError(f'Schedule {schedule.id!r} changed since it was read.')
                 connection.commit()
             finally:
                 connection.close()

--- a/pydantic_ai_harness/scheduling/_store.py
+++ b/pydantic_ai_harness/scheduling/_store.py
@@ -19,8 +19,8 @@ class ScheduleStore(Protocol):
     """Async whole-record storage for schedules.
 
     Use one runner per store. The protocol's read-modify-write operations are
-    not atomic across processes; a backend with claim or compare-and-swap
-    semantics can provide multi-process coordination later.
+    not atomic, so concurrent writers such as a second runner or tool calls
+    while a run is in flight can interleave with last-write-wins results.
     """
 
     async def add(self, schedule: Schedule) -> Schedule:
@@ -81,16 +81,17 @@ class InMemoryScheduleStore:
 class SqliteScheduleStore:
     """File-backed SQLite schedule storage.
 
-    `:memory:` is unsupported because each operation uses a fresh connection.
+    Empty and `:memory:` databases are unsupported because each operation uses a fresh connection.
     Blocking SQLite work runs in a worker thread under one process-local lock.
     """
 
     def __init__(self, database: str = '.agent-schedules.db', *, table: str = 'schedules') -> None:
         if not _VALID_TABLE_RE.fullmatch(table):
             raise ValueError(f'invalid table name: {table!r}')
-        if database == ':memory:':
+        if database in ('', ':memory:'):
             raise ValueError(
-                "SqliteScheduleStore does not support ':memory:'; use InMemoryScheduleStore or a file-backed database."
+                "SqliteScheduleStore does not support empty or ':memory:' databases; "
+                'use InMemoryScheduleStore or a file-backed database.'
             )
         self._database = database
         self._table = table

--- a/pydantic_ai_harness/scheduling/_store.py
+++ b/pydantic_ai_harness/scheduling/_store.py
@@ -107,11 +107,15 @@ class SqliteScheduleStore:
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self._database)
         if not self._ready:
-            connection.execute(
-                f'CREATE TABLE IF NOT EXISTS "{self._table}" '
-                '(seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT UNIQUE NOT NULL, data TEXT NOT NULL)'
-            )
-            connection.commit()
+            try:
+                connection.execute(
+                    f'CREATE TABLE IF NOT EXISTS "{self._table}" '
+                    '(seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT UNIQUE NOT NULL, data TEXT NOT NULL)'
+                )
+                connection.commit()
+            except BaseException:
+                connection.close()
+                raise
             self._ready = True
         return connection
 

--- a/pydantic_ai_harness/scheduling/_store.py
+++ b/pydantic_ai_harness/scheduling/_store.py
@@ -14,13 +14,16 @@ from pydantic_ai_harness.scheduling._types import Schedule
 _VALID_TABLE_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]{0,62}')
 
 
+class ScheduleConflictError(Exception):
+    """Raised when a schedule save uses a stale version."""
+
+
 @runtime_checkable
 class ScheduleStore(Protocol):
     """Async whole-record storage for schedules.
 
-    Use one runner per store. The protocol's read-modify-write operations are
-    not atomic, so concurrent writers such as a second runner or tool calls
-    while a run is in flight can interleave with last-write-wins results.
+    Use one runner per store. Writers must re-read and retry when `save` raises
+    `ScheduleConflictError` because another writer changed the record.
     """
 
     async def add(self, schedule: Schedule) -> Schedule:
@@ -36,7 +39,7 @@ class ScheduleStore(Protocol):
         ...  # pragma: no cover
 
     async def save(self, schedule: Schedule) -> None:
-        """Replace an existing schedule, raising `ValueError` for an unknown id."""
+        """Replace a matching version with `version + 1`, or raise on conflict or unknown id."""
         ...  # pragma: no cover
 
     async def remove(self, schedule_id: str) -> bool:
@@ -68,10 +71,13 @@ class InMemoryScheduleStore:
         return [schedule.model_copy(deep=True) for schedule in self._schedules.values()]
 
     async def save(self, schedule: Schedule) -> None:
-        """Replace an existing schedule with a deep copy."""
-        if schedule.id not in self._schedules:
+        """Replace a matching version with a bumped deep copy."""
+        stored = self._schedules.get(schedule.id)
+        if stored is None:
             raise ValueError(f'Unknown schedule id {schedule.id!r}.')
-        self._schedules[schedule.id] = schedule.model_copy(deep=True)
+        if schedule.version != stored.version:
+            raise ScheduleConflictError(f'Schedule {schedule.id!r} changed since it was read.')
+        self._schedules[schedule.id] = schedule.model_copy(update={'version': schedule.version + 1}, deep=True)
 
     async def remove(self, schedule_id: str) -> bool:
         """Remove a schedule and return whether it existed."""
@@ -102,7 +108,7 @@ class SqliteScheduleStore:
         connection = sqlite3.connect(self._database)
         if not self._ready:
             connection.execute(
-                f'CREATE TABLE IF NOT EXISTS {self._table} '
+                f'CREATE TABLE IF NOT EXISTS "{self._table}" '
                 '(seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT UNIQUE NOT NULL, data TEXT NOT NULL)'
             )
             connection.commit()
@@ -114,7 +120,7 @@ class SqliteScheduleStore:
             connection = self._connect()
             try:
                 connection.execute(
-                    f'INSERT INTO {self._table} (id, data) VALUES (?, ?)',
+                    f'INSERT INTO "{self._table}" (id, data) VALUES (?, ?)',
                     (schedule.id, schedule.model_dump_json()),
                 )
                 connection.commit()
@@ -127,7 +133,7 @@ class SqliteScheduleStore:
         with self._lock:
             connection = self._connect()
             try:
-                row = connection.execute(f'SELECT data FROM {self._table} WHERE id = ?', (schedule_id,)).fetchone()
+                row = connection.execute(f'SELECT data FROM "{self._table}" WHERE id = ?', (schedule_id,)).fetchone()
             finally:
                 connection.close()
         return None if row is None else Schedule.model_validate_json(str(row[0]))
@@ -136,7 +142,7 @@ class SqliteScheduleStore:
         with self._lock:
             connection = self._connect()
             try:
-                rows = connection.execute(f'SELECT data FROM {self._table} ORDER BY seq').fetchall()
+                rows = connection.execute(f'SELECT data FROM "{self._table}" ORDER BY seq').fetchall()
             finally:
                 connection.close()
         return [Schedule.model_validate_json(str(row[0])) for row in rows]
@@ -145,12 +151,17 @@ class SqliteScheduleStore:
         with self._lock:
             connection = self._connect()
             try:
-                cursor = connection.execute(
-                    f'UPDATE {self._table} SET data = ? WHERE id = ?',
-                    (schedule.model_dump_json(), schedule.id),
-                )
-                if cursor.rowcount == 0:
+                row = connection.execute(f'SELECT data FROM "{self._table}" WHERE id = ?', (schedule.id,)).fetchone()
+                if row is None:
                     raise ValueError(f'Unknown schedule id {schedule.id!r}.')
+                stored = Schedule.model_validate_json(str(row[0]))
+                if schedule.version != stored.version:
+                    raise ScheduleConflictError(f'Schedule {schedule.id!r} changed since it was read.')
+                bumped = schedule.model_copy(update={'version': schedule.version + 1}, deep=True)
+                connection.execute(
+                    f'UPDATE "{self._table}" SET data = ? WHERE id = ?',
+                    (bumped.model_dump_json(), schedule.id),
+                )
                 connection.commit()
             finally:
                 connection.close()
@@ -159,7 +170,7 @@ class SqliteScheduleStore:
         with self._lock:
             connection = self._connect()
             try:
-                cursor = connection.execute(f'DELETE FROM {self._table} WHERE id = ?', (schedule_id,))
+                cursor = connection.execute(f'DELETE FROM "{self._table}" WHERE id = ?', (schedule_id,))
                 connection.commit()
                 return cursor.rowcount > 0
             finally:
@@ -179,7 +190,7 @@ class SqliteScheduleStore:
         return await anyio.to_thread.run_sync(self._list_sync)
 
     async def save(self, schedule: Schedule) -> None:
-        """Replace an existing persisted schedule."""
+        """Replace a matching persisted version with a bumped version."""
         await anyio.to_thread.run_sync(self._save_sync, schedule)
 
     async def remove(self, schedule_id: str) -> bool:

--- a/pydantic_ai_harness/scheduling/_store.py
+++ b/pydantic_ai_harness/scheduling/_store.py
@@ -1,0 +1,186 @@
+"""Storage backends for scheduled agent runs."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import threading
+from typing import Protocol, runtime_checkable
+
+import anyio.to_thread
+
+from pydantic_ai_harness.scheduling._types import Schedule
+
+_VALID_TABLE_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]{0,62}')
+
+
+@runtime_checkable
+class ScheduleStore(Protocol):
+    """Async whole-record storage for schedules.
+
+    Use one runner per store. The protocol's read-modify-write operations are
+    not atomic across processes; a backend with claim or compare-and-swap
+    semantics can provide multi-process coordination later.
+    """
+
+    async def add(self, schedule: Schedule) -> Schedule:
+        """Store a new schedule, raising `ValueError` for a duplicate id."""
+        ...  # pragma: no cover
+
+    async def get(self, schedule_id: str) -> Schedule | None:
+        """Return one schedule by id, or `None`."""
+        ...  # pragma: no cover
+
+    async def list(self) -> list[Schedule]:
+        """Return schedules in insertion order."""
+        ...  # pragma: no cover
+
+    async def save(self, schedule: Schedule) -> None:
+        """Replace an existing schedule, raising `ValueError` for an unknown id."""
+        ...  # pragma: no cover
+
+    async def remove(self, schedule_id: str) -> bool:
+        """Remove a schedule and return whether it existed."""
+        ...  # pragma: no cover
+
+
+class InMemoryScheduleStore:
+    """Insertion-ordered process-local schedule storage."""
+
+    def __init__(self) -> None:
+        self._schedules: dict[str, Schedule] = {}
+
+    async def add(self, schedule: Schedule) -> Schedule:
+        """Store a deep copy of a new schedule."""
+        if schedule.id in self._schedules:
+            raise ValueError(f'A schedule with id {schedule.id!r} already exists.')
+        stored = schedule.model_copy(deep=True)
+        self._schedules[schedule.id] = stored
+        return stored.model_copy(deep=True)
+
+    async def get(self, schedule_id: str) -> Schedule | None:
+        """Return a deep copy of one schedule, or `None`."""
+        schedule = self._schedules.get(schedule_id)
+        return None if schedule is None else schedule.model_copy(deep=True)
+
+    async def list(self) -> list[Schedule]:
+        """Return deep copies of schedules in insertion order."""
+        return [schedule.model_copy(deep=True) for schedule in self._schedules.values()]
+
+    async def save(self, schedule: Schedule) -> None:
+        """Replace an existing schedule with a deep copy."""
+        if schedule.id not in self._schedules:
+            raise ValueError(f'Unknown schedule id {schedule.id!r}.')
+        self._schedules[schedule.id] = schedule.model_copy(deep=True)
+
+    async def remove(self, schedule_id: str) -> bool:
+        """Remove a schedule and return whether it existed."""
+        return self._schedules.pop(schedule_id, None) is not None
+
+
+class SqliteScheduleStore:
+    """File-backed SQLite schedule storage.
+
+    `:memory:` is unsupported because each operation uses a fresh connection.
+    Blocking SQLite work runs in a worker thread under one process-local lock.
+    """
+
+    def __init__(self, database: str = '.agent-schedules.db', *, table: str = 'schedules') -> None:
+        if not _VALID_TABLE_RE.fullmatch(table):
+            raise ValueError(f'invalid table name: {table!r}')
+        if database == ':memory:':
+            raise ValueError(
+                "SqliteScheduleStore does not support ':memory:'; use InMemoryScheduleStore or a file-backed database."
+            )
+        self._database = database
+        self._table = table
+        self._lock = threading.Lock()
+        self._ready = False
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._database)
+        if not self._ready:
+            connection.execute(
+                f'CREATE TABLE IF NOT EXISTS {self._table} '
+                '(seq INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT UNIQUE NOT NULL, data TEXT NOT NULL)'
+            )
+            connection.commit()
+            self._ready = True
+        return connection
+
+    def _add_sync(self, schedule: Schedule) -> None:
+        with self._lock:
+            connection = self._connect()
+            try:
+                connection.execute(
+                    f'INSERT INTO {self._table} (id, data) VALUES (?, ?)',
+                    (schedule.id, schedule.model_dump_json()),
+                )
+                connection.commit()
+            except sqlite3.IntegrityError as exc:
+                raise ValueError(f'A schedule with id {schedule.id!r} already exists.') from exc
+            finally:
+                connection.close()
+
+    def _get_sync(self, schedule_id: str) -> Schedule | None:
+        with self._lock:
+            connection = self._connect()
+            try:
+                row = connection.execute(f'SELECT data FROM {self._table} WHERE id = ?', (schedule_id,)).fetchone()
+            finally:
+                connection.close()
+        return None if row is None else Schedule.model_validate_json(str(row[0]))
+
+    def _list_sync(self) -> list[Schedule]:
+        with self._lock:
+            connection = self._connect()
+            try:
+                rows = connection.execute(f'SELECT data FROM {self._table} ORDER BY seq').fetchall()
+            finally:
+                connection.close()
+        return [Schedule.model_validate_json(str(row[0])) for row in rows]
+
+    def _save_sync(self, schedule: Schedule) -> None:
+        with self._lock:
+            connection = self._connect()
+            try:
+                cursor = connection.execute(
+                    f'UPDATE {self._table} SET data = ? WHERE id = ?',
+                    (schedule.model_dump_json(), schedule.id),
+                )
+                if cursor.rowcount == 0:
+                    raise ValueError(f'Unknown schedule id {schedule.id!r}.')
+                connection.commit()
+            finally:
+                connection.close()
+
+    def _remove_sync(self, schedule_id: str) -> bool:
+        with self._lock:
+            connection = self._connect()
+            try:
+                cursor = connection.execute(f'DELETE FROM {self._table} WHERE id = ?', (schedule_id,))
+                connection.commit()
+                return cursor.rowcount > 0
+            finally:
+                connection.close()
+
+    async def add(self, schedule: Schedule) -> Schedule:
+        """Persist a new schedule and return a detached copy."""
+        await anyio.to_thread.run_sync(self._add_sync, schedule)
+        return schedule.model_copy(deep=True)
+
+    async def get(self, schedule_id: str) -> Schedule | None:
+        """Return one persisted schedule by id, or `None`."""
+        return await anyio.to_thread.run_sync(self._get_sync, schedule_id)
+
+    async def list(self) -> list[Schedule]:
+        """Return persisted schedules in insertion order."""
+        return await anyio.to_thread.run_sync(self._list_sync)
+
+    async def save(self, schedule: Schedule) -> None:
+        """Replace an existing persisted schedule."""
+        await anyio.to_thread.run_sync(self._save_sync, schedule)
+
+    async def remove(self, schedule_id: str) -> bool:
+        """Remove a persisted schedule and return whether it existed."""
+        return await anyio.to_thread.run_sync(self._remove_sync, schedule_id)

--- a/pydantic_ai_harness/scheduling/_toolset.py
+++ b/pydantic_ai_harness/scheduling/_toolset.py
@@ -19,6 +19,7 @@ from pydantic_ai_harness.scheduling._types import (
     OnceTrigger,
     Schedule,
     ScheduleTrigger,
+    new_schedule_id,
     next_run_time,
     parse_schedule,
 )
@@ -173,8 +174,16 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
             )
         except ValueError as exc:
             raise ModelRetry(f'Invalid schedule: {exc}') from exc
-        await self._capability.resolved_store.add(created)
-        return f'Schedule created.\n{_render_schedule(created, full=False)}'
+        for attempt in range(_SAVE_ATTEMPTS):
+            try:
+                await self._capability.resolved_store.add(created)
+            except ValueError as exc:
+                if attempt == _SAVE_ATTEMPTS - 1:
+                    raise ModelRetry('Could not store the schedule under a fresh id. Try again.') from exc
+                created = created.model_copy(update={'id': new_schedule_id()})
+                continue
+            return f'Schedule created.\n{_render_schedule(created, full=False)}'
+        raise AssertionError('unreachable')  # pragma: no cover
 
     async def list_schedules(self, ctx: RunContext[AgentDepsT]) -> str:
         """List all schedules without prompt or output bodies."""
@@ -279,7 +288,10 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
             schedule.enabled = True
             if schedule.next_run_at is not None:
                 now = datetime.now(datetime_timezone.utc)
-                schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+                next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+                if next_run_at is None:
+                    raise ModelRetry('This schedule expired while paused. Create a new schedule instead.')
+                schedule.next_run_at = next_run_at
             if not await self._save_or_retry(schedule, attempt):
                 continue
             return f'Schedule {schedule.id} resumed.\n{_render_schedule(schedule, full=False)}'

--- a/pydantic_ai_harness/scheduling/_toolset.py
+++ b/pydantic_ai_harness/scheduling/_toolset.py
@@ -1,0 +1,270 @@
+"""Model-facing CRUD tools for the `Scheduling` capability."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone as datetime_timezone
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.toolsets import FunctionToolset, ToolsetTool
+
+from pydantic_ai_harness.scheduling._runner import scheduled_run_var
+from pydantic_ai_harness.scheduling._types import (
+    CronTrigger,
+    IntervalTrigger,
+    OnceTrigger,
+    Schedule,
+    ScheduleTrigger,
+    next_run_time,
+    parse_schedule,
+)
+
+if TYPE_CHECKING:
+    from pydantic_ai_harness.scheduling._capability import Scheduling
+
+CREATE_SCHEDULE_DESCRIPTION = (
+    'Create a schedule for a prompt. Schedule text accepts `every 30m`, `every 2h`, '
+    '`in 15m`, an ISO 8601 datetime, or a five-field cron expression.'
+)
+LIST_SCHEDULES_DESCRIPTION = 'List schedules without expanding their prompt or output bodies.'
+GET_SCHEDULE_DESCRIPTION = 'Get one schedule by id, including its prompt and most recent successful output.'
+UPDATE_SCHEDULE_DESCRIPTION = 'Update selected fields of an existing schedule by id.'
+PAUSE_SCHEDULE_DESCRIPTION = 'Pause a schedule so the runner will not claim it.'
+RESUME_SCHEDULE_DESCRIPTION = 'Resume a schedule from its next future occurrence without replaying a backlog.'
+DELETE_SCHEDULE_DESCRIPTION = 'Delete a schedule permanently by id.'
+RUN_SCHEDULE_NOW_DESCRIPTION = 'Queue an enabled schedule for execution on the next runner tick.'
+
+
+def _trigger_display(trigger: ScheduleTrigger) -> str:
+    if isinstance(trigger, CronTrigger):
+        return trigger.expr
+    if isinstance(trigger, IntervalTrigger):
+        seconds = int(trigger.every.total_seconds())
+        if seconds % 86_400 == 0:
+            return f'every {seconds // 86_400}d'
+        if seconds % 3_600 == 0:
+            return f'every {seconds // 3_600}h'
+        return f'every {seconds // 60}m'
+    return trigger.at.isoformat()
+
+
+def _render_schedule(schedule: Schedule, *, full: bool) -> str:
+    next_run = (
+        'none'
+        if schedule.next_run_at is None
+        else schedule.next_run_at.astimezone(ZoneInfo(schedule.timezone)).isoformat()
+    )
+    lines = [
+        f'id: {schedule.id}',
+        f'name: {schedule.name}',
+        f'status: {schedule.status}',
+        f'schedule: {_trigger_display(schedule.trigger)}',
+        f'next run ({schedule.timezone}): {next_run}',
+    ]
+    if schedule.last_status is not None:
+        lines.append(f'last status: {schedule.last_status}')
+    if schedule.last_error is not None:
+        lines.append(f'last error: {schedule.last_error}')
+    if schedule.last_delivery_error is not None:
+        lines.append(f'last delivery error: {schedule.last_delivery_error}')
+    if full:
+        lines.extend(
+            [
+                f'deliver to: {schedule.deliver_to or "none"}',
+                f'max runs: {schedule.max_runs if schedule.max_runs is not None else "none"}',
+                f'runs completed: {schedule.runs_completed}',
+                f'prompt: {schedule.prompt}',
+                f'last output: {schedule.last_output if schedule.last_output is not None else "none"}',
+            ]
+        )
+    return '\n'.join(lines)
+
+
+class SchedulingToolset(FunctionToolset[AgentDepsT]):
+    """CRUD tools over a `Scheduling` capability's shared store."""
+
+    def __init__(self, capability: Scheduling[AgentDepsT]) -> None:
+        super().__init__(id='scheduling')
+        self._capability = capability
+        self.add_function(self.create_schedule, description=CREATE_SCHEDULE_DESCRIPTION)
+        self.add_function(self.list_schedules, description=LIST_SCHEDULES_DESCRIPTION)
+        self.add_function(self.get_schedule, description=GET_SCHEDULE_DESCRIPTION)
+        self.add_function(self.update_schedule, description=UPDATE_SCHEDULE_DESCRIPTION)
+        self.add_function(self.pause_schedule, description=PAUSE_SCHEDULE_DESCRIPTION)
+        self.add_function(self.resume_schedule, description=RESUME_SCHEDULE_DESCRIPTION)
+        self.add_function(self.delete_schedule, description=DELETE_SCHEDULE_DESCRIPTION)
+        self.add_function(self.run_schedule_now, description=RUN_SCHEDULE_NOW_DESCRIPTION)
+
+    async def get_tools(self, ctx: RunContext[AgentDepsT]) -> dict[str, ToolsetTool[AgentDepsT]]:
+        """Hide scheduling tools while a scheduled prompt is running."""
+        if scheduled_run_var.get() is not None:
+            return {}
+        return await super().get_tools(ctx)
+
+    async def _known_or_retry(self, schedule_id: str) -> Schedule:
+        schedule = await self._capability.resolved_store.get(schedule_id)
+        if schedule is not None:
+            return schedule
+        known = ', '.join(item.id for item in await self._capability.resolved_store.list()) or '(none)'
+        raise ModelRetry(f'Unknown schedule id {schedule_id!r}. Known ids: {known}.')
+
+    @staticmethod
+    def _parse(text: str, *, timezone: str) -> ScheduleTrigger:
+        try:
+            return parse_schedule(text, timezone=timezone)
+        except (ImportError, ValueError) as exc:
+            raise ModelRetry(f'Invalid schedule: {exc}') from exc
+
+    @staticmethod
+    def _validate_combination(trigger: ScheduleTrigger, max_runs: int | None) -> None:
+        if isinstance(trigger, OnceTrigger) and max_runs is not None:
+            raise ModelRetry('`max_runs` is only valid for recurring schedules; remove it for a one-shot schedule.')
+
+    async def create_schedule(
+        self,
+        ctx: RunContext[AgentDepsT],
+        name: str,
+        prompt: str,
+        schedule: str,
+        deliver_to: str | None = None,
+        max_runs: int | None = None,
+    ) -> str:
+        """Create a schedule.
+
+        Args:
+            ctx: Framework-provided run context.
+            name: Short human-readable name.
+            prompt: Self-contained prompt executed on every occurrence.
+            schedule: Compact schedule text.
+            deliver_to: Optional opaque routing hint for the result callback.
+            max_runs: Optional attempt limit for a recurring schedule.
+        """
+        del ctx
+        trigger = self._parse(schedule, timezone=self._capability.timezone)
+        self._validate_combination(trigger, max_runs)
+        now = datetime.now(datetime_timezone.utc)
+        next_run_at = next_run_time(trigger, after=now, timezone=self._capability.timezone)
+        if isinstance(trigger, OnceTrigger) and next_run_at is None:
+            raise ModelRetry('Cannot create this schedule because that time is in the past. Choose a future time.')
+        try:
+            created = Schedule(
+                name=name,
+                prompt=prompt,
+                trigger=trigger,
+                timezone=self._capability.timezone,
+                deliver_to=deliver_to,
+                max_runs=max_runs,
+                next_run_at=next_run_at,
+            )
+        except ValueError as exc:
+            raise ModelRetry(f'Invalid schedule: {exc}') from exc
+        await self._capability.resolved_store.add(created)
+        return f'Schedule created.\n{_render_schedule(created, full=False)}'
+
+    async def list_schedules(self, ctx: RunContext[AgentDepsT]) -> str:
+        """List all schedules without prompt or output bodies."""
+        del ctx
+        schedules = await self._capability.resolved_store.list()
+        if not schedules:
+            return 'No schedules.'
+        return '\n\n'.join(_render_schedule(schedule, full=False) for schedule in schedules)
+
+    async def get_schedule(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
+        """Get a schedule's full details.
+
+        Args:
+            ctx: Framework-provided run context.
+            schedule_id: Id returned by a schedule listing or creation.
+        """
+        del ctx
+        return _render_schedule(await self._known_or_retry(schedule_id), full=True)
+
+    async def update_schedule(
+        self,
+        ctx: RunContext[AgentDepsT],
+        schedule_id: str,
+        name: str | None = None,
+        prompt: str | None = None,
+        schedule: str | None = None,
+        deliver_to: str | None = None,
+        max_runs: int | None = None,
+    ) -> str:
+        """Update the provided non-`None` schedule fields.
+
+        Args:
+            ctx: Framework-provided run context.
+            schedule_id: Id of the schedule to update.
+            name: Replacement name.
+            prompt: Replacement prompt.
+            schedule: Replacement compact schedule text.
+            deliver_to: Replacement opaque routing hint.
+            max_runs: Replacement recurring attempt limit.
+        """
+        del ctx
+        existing = await self._known_or_retry(schedule_id)
+        trigger = existing.trigger if schedule is None else self._parse(schedule, timezone=existing.timezone)
+        resulting_max_runs = existing.max_runs if max_runs is None else max_runs
+        self._validate_combination(trigger, resulting_max_runs)
+        updates: dict[str, object] = {}
+        if name is not None:
+            updates['name'] = name
+        if prompt is not None:
+            updates['prompt'] = prompt
+        if deliver_to is not None:
+            updates['deliver_to'] = deliver_to
+        if max_runs is not None:
+            updates['max_runs'] = max_runs
+        if schedule is not None:
+            now = datetime.now(datetime_timezone.utc)
+            next_run_at = next_run_time(trigger, after=now, timezone=existing.timezone)
+            if isinstance(trigger, OnceTrigger) and next_run_at is None:
+                raise ModelRetry('Cannot update this schedule because that time is in the past. Choose a future time.')
+            updates.update(trigger=trigger, next_run_at=next_run_at)
+            if trigger != existing.trigger:
+                updates['runs_completed'] = 0
+        try:
+            data = existing.model_dump()
+            data.update(updates)
+            updated = Schedule.model_validate(data)
+        except ValueError as exc:
+            raise ModelRetry(f'Invalid schedule update: {exc}') from exc
+        await self._capability.resolved_store.save(updated)
+        return f'Schedule updated.\n{_render_schedule(updated, full=False)}'
+
+    async def pause_schedule(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
+        """Pause a schedule by id."""
+        del ctx
+        schedule = await self._known_or_retry(schedule_id)
+        schedule.enabled = False
+        await self._capability.resolved_store.save(schedule)
+        return f'Schedule {schedule.id} paused.'
+
+    async def resume_schedule(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
+        """Resume from the next occurrence after now instead of replaying a backlog."""
+        del ctx
+        schedule = await self._known_or_retry(schedule_id)
+        now = datetime.now(datetime_timezone.utc)
+        schedule.enabled = True
+        schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+        await self._capability.resolved_store.save(schedule)
+        return f'Schedule {schedule.id} resumed.\n{_render_schedule(schedule, full=False)}'
+
+    async def delete_schedule(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
+        """Delete a schedule by id."""
+        del ctx
+        schedule = await self._known_or_retry(schedule_id)
+        await self._capability.resolved_store.remove(schedule_id)
+        return f"Schedule {schedule.id} ('{schedule.name}') deleted."
+
+    async def run_schedule_now(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
+        """Queue an enabled schedule for the next runner tick."""
+        del ctx
+        schedule = await self._known_or_retry(schedule_id)
+        if not schedule.enabled:
+            raise ModelRetry('This schedule is paused. Resume it before queuing an immediate run.')
+        schedule.next_run_at = datetime.now(datetime_timezone.utc)
+        await self._capability.resolved_store.save(schedule)
+        return f'Schedule {schedule.id} queued for the next runner tick.'

--- a/pydantic_ai_harness/scheduling/_toolset.py
+++ b/pydantic_ai_harness/scheduling/_toolset.py
@@ -12,6 +12,7 @@ from pydantic_ai.tools import AgentDepsT, RunContext
 from pydantic_ai.toolsets import FunctionToolset, ToolsetTool
 
 from pydantic_ai_harness.scheduling._runner import scheduled_run_var
+from pydantic_ai_harness.scheduling._store import ScheduleConflictError
 from pydantic_ai_harness.scheduling._types import (
     CronTrigger,
     IntervalTrigger,
@@ -36,6 +37,8 @@ PAUSE_SCHEDULE_DESCRIPTION = 'Pause a schedule so the runner will not claim it.'
 RESUME_SCHEDULE_DESCRIPTION = 'Resume a schedule from its next future occurrence without replaying a backlog.'
 DELETE_SCHEDULE_DESCRIPTION = 'Delete a schedule permanently by id.'
 RUN_SCHEDULE_NOW_DESCRIPTION = 'Queue an enabled schedule for execution on the next runner tick.'
+_SAVE_ATTEMPTS = 3
+_CONFLICT_RETRY_MESSAGE = 'The schedule changed while this update was being applied. Try again.'
 
 
 def _trigger_display(trigger: ScheduleTrigger) -> str:
@@ -110,6 +113,15 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
             return schedule
         known = ', '.join(item.id for item in await self._capability.resolved_store.list()) or '(none)'
         raise ModelRetry(f'Unknown schedule id {schedule_id!r}. Known ids: {known}.')
+
+    async def _save_or_retry(self, schedule: Schedule, attempt: int) -> bool:
+        try:
+            await self._capability.resolved_store.save(schedule)
+        except ScheduleConflictError as exc:
+            if attempt == _SAVE_ATTEMPTS - 1:
+                raise ModelRetry(_CONFLICT_RETRY_MESSAGE) from exc
+            return False
+        return True
 
     @staticmethod
     def _parse(text: str, *, timezone: str) -> ScheduleTrigger:
@@ -200,64 +212,78 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
             name: Replacement name.
             prompt: Replacement prompt.
             schedule: Replacement compact schedule text.
-            deliver_to: Replacement opaque routing hint.
-            max_runs: Replacement recurring attempt limit.
+            deliver_to: Replacement routing hint; an empty string clears it.
+            max_runs: Replacement recurring attempt limit; zero removes the limit.
         """
         del ctx
-        existing = await self._known_or_retry(schedule_id)
-        if schedule is not None and existing.next_run_at is None:
-            raise ModelRetry('This schedule is completed. Create a new schedule instead.')
-        trigger = existing.trigger if schedule is None else self._parse(schedule, timezone=existing.timezone)
-        resulting_max_runs = existing.max_runs if max_runs is None else max_runs
-        self._validate_combination(trigger, resulting_max_runs)
-        updates: dict[str, object] = {}
-        if name is not None:
-            updates['name'] = name
-        if prompt is not None:
-            updates['prompt'] = prompt
-        if deliver_to is not None:
-            updates['deliver_to'] = deliver_to
-        if max_runs is not None:
-            updates['max_runs'] = max_runs
-        if schedule is not None:
-            now = datetime.now(datetime_timezone.utc)
-            next_run_at = next_run_time(trigger, after=now, timezone=existing.timezone)
-            if isinstance(trigger, OnceTrigger) and next_run_at is None:
-                raise ModelRetry('Cannot update this schedule because that time is in the past. Choose a future time.')
-            updates.update(trigger=trigger, next_run_at=next_run_at)
-            if trigger != existing.trigger:
-                updates['runs_completed'] = 0
-        try:
-            data = existing.model_dump()
-            data.update(updates)
-            updated = Schedule.model_validate(data)
-        except ValueError as exc:
-            raise ModelRetry(f'Invalid schedule update: {exc}') from exc
-        if updated.max_runs is not None and updated.runs_completed >= updated.max_runs:
-            updated.next_run_at = None
-        await self._capability.resolved_store.save(updated)
-        return f'Schedule updated.\n{_render_schedule(updated, full=False)}'
+        for attempt in range(_SAVE_ATTEMPTS):
+            existing = await self._known_or_retry(schedule_id)
+            if schedule is not None and existing.next_run_at is None:
+                raise ModelRetry('This schedule is completed. Create a new schedule instead.')
+            trigger = existing.trigger if schedule is None else self._parse(schedule, timezone=existing.timezone)
+            inherited_limit_on_once = schedule is not None and isinstance(trigger, OnceTrigger) and max_runs is None
+            resulting_max_runs = None if max_runs == 0 or inherited_limit_on_once else max_runs
+            if max_runs is None and not inherited_limit_on_once:
+                resulting_max_runs = existing.max_runs
+            self._validate_combination(trigger, resulting_max_runs)
+            updates: dict[str, object] = {}
+            if name is not None:
+                updates['name'] = name
+            if prompt is not None:
+                updates['prompt'] = prompt
+            if deliver_to is not None:
+                updates['deliver_to'] = deliver_to or None
+            if max_runs is not None or inherited_limit_on_once:
+                updates['max_runs'] = resulting_max_runs
+            if schedule is not None:
+                now = datetime.now(datetime_timezone.utc)
+                next_run_at = next_run_time(trigger, after=now, timezone=existing.timezone)
+                if isinstance(trigger, OnceTrigger) and next_run_at is None:
+                    raise ModelRetry(
+                        'Cannot update this schedule because that time is in the past. Choose a future time.'
+                    )
+                updates.update(trigger=trigger, next_run_at=next_run_at)
+                if trigger != existing.trigger:
+                    updates['runs_completed'] = 0
+            try:
+                data = existing.model_dump()
+                data.update(updates)
+                updated = Schedule.model_validate(data)
+            except ValueError as exc:
+                raise ModelRetry(f'Invalid schedule update: {exc}') from exc
+            if updated.max_runs is not None and updated.runs_completed >= updated.max_runs:
+                updated.next_run_at = None
+            if not await self._save_or_retry(updated, attempt):
+                continue
+            return f'Schedule updated.\n{_render_schedule(updated, full=False)}'
+        raise AssertionError('unreachable')  # pragma: no cover
 
     async def pause_schedule(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
         """Pause a schedule by id."""
         del ctx
-        schedule = await self._known_or_retry(schedule_id)
-        schedule.enabled = False
-        await self._capability.resolved_store.save(schedule)
-        return f'Schedule {schedule.id} paused.'
+        for attempt in range(_SAVE_ATTEMPTS):
+            schedule = await self._known_or_retry(schedule_id)
+            schedule.enabled = False
+            if not await self._save_or_retry(schedule, attempt):
+                continue
+            return f'Schedule {schedule.id} paused.'
+        raise AssertionError('unreachable')  # pragma: no cover
 
     async def resume_schedule(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
         """Resume from the next occurrence after now instead of replaying a backlog."""
         del ctx
-        schedule = await self._known_or_retry(schedule_id)
-        if schedule.enabled:
-            raise ModelRetry('This schedule is not paused.')
-        schedule.enabled = True
-        if schedule.next_run_at is not None:
-            now = datetime.now(datetime_timezone.utc)
-            schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
-        await self._capability.resolved_store.save(schedule)
-        return f'Schedule {schedule.id} resumed.\n{_render_schedule(schedule, full=False)}'
+        for attempt in range(_SAVE_ATTEMPTS):
+            schedule = await self._known_or_retry(schedule_id)
+            if schedule.enabled:
+                raise ModelRetry('This schedule is not paused.')
+            schedule.enabled = True
+            if schedule.next_run_at is not None:
+                now = datetime.now(datetime_timezone.utc)
+                schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+            if not await self._save_or_retry(schedule, attempt):
+                continue
+            return f'Schedule {schedule.id} resumed.\n{_render_schedule(schedule, full=False)}'
+        raise AssertionError('unreachable')  # pragma: no cover
 
     async def delete_schedule(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
         """Delete a schedule by id."""
@@ -269,11 +295,14 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
     async def run_schedule_now(self, ctx: RunContext[AgentDepsT], schedule_id: str) -> str:
         """Queue an enabled schedule for the next runner tick."""
         del ctx
-        schedule = await self._known_or_retry(schedule_id)
-        if not schedule.enabled:
-            raise ModelRetry('This schedule is paused. Resume it before queuing an immediate run.')
-        if schedule.next_run_at is None:
-            raise ModelRetry('This schedule is completed. Create a new schedule instead.')
-        schedule.next_run_at = datetime.now(datetime_timezone.utc)
-        await self._capability.resolved_store.save(schedule)
-        return f'Schedule {schedule.id} queued for the next runner tick.'
+        for attempt in range(_SAVE_ATTEMPTS):
+            schedule = await self._known_or_retry(schedule_id)
+            if not schedule.enabled:
+                raise ModelRetry('This schedule is paused. Resume it before queuing an immediate run.')
+            if schedule.next_run_at is None:
+                raise ModelRetry('This schedule is completed. Create a new schedule instead.')
+            schedule.next_run_at = datetime.now(datetime_timezone.utc)
+            if not await self._save_or_retry(schedule, attempt):
+                continue
+            return f'Schedule {schedule.id} queued for the next runner tick.'
+        raise AssertionError('unreachable')  # pragma: no cover

--- a/pydantic_ai_harness/scheduling/_toolset.py
+++ b/pydantic_ai_harness/scheduling/_toolset.py
@@ -231,6 +231,8 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
             updated = Schedule.model_validate(data)
         except ValueError as exc:
             raise ModelRetry(f'Invalid schedule update: {exc}') from exc
+        if updated.max_runs is not None and updated.runs_completed >= updated.max_runs:
+            updated.next_run_at = None
         await self._capability.resolved_store.save(updated)
         return f'Schedule updated.\n{_render_schedule(updated, full=False)}'
 
@@ -246,9 +248,12 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
         """Resume from the next occurrence after now instead of replaying a backlog."""
         del ctx
         schedule = await self._known_or_retry(schedule_id)
-        now = datetime.now(datetime_timezone.utc)
+        if schedule.enabled:
+            raise ModelRetry('This schedule is not paused.')
         schedule.enabled = True
-        schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
+        if schedule.next_run_at is not None:
+            now = datetime.now(datetime_timezone.utc)
+            schedule.next_run_at = next_run_time(schedule.trigger, after=now, timezone=schedule.timezone)
         await self._capability.resolved_store.save(schedule)
         return f'Schedule {schedule.id} resumed.\n{_render_schedule(schedule, full=False)}'
 
@@ -265,6 +270,8 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
         schedule = await self._known_or_retry(schedule_id)
         if not schedule.enabled:
             raise ModelRetry('This schedule is paused. Resume it before queuing an immediate run.')
+        if schedule.next_run_at is None:
+            raise ModelRetry('This schedule is completed. Create a new schedule instead.')
         schedule.next_run_at = datetime.now(datetime_timezone.utc)
         await self._capability.resolved_store.save(schedule)
         return f'Schedule {schedule.id} queued for the next runner tick.'

--- a/pydantic_ai_harness/scheduling/_toolset.py
+++ b/pydantic_ai_harness/scheduling/_toolset.py
@@ -205,6 +205,8 @@ class SchedulingToolset(FunctionToolset[AgentDepsT]):
         """
         del ctx
         existing = await self._known_or_retry(schedule_id)
+        if schedule is not None and existing.next_run_at is None:
+            raise ModelRetry('This schedule is completed. Create a new schedule instead.')
         trigger = existing.trigger if schedule is None else self._parse(schedule, timezone=existing.timezone)
         resulting_max_runs = existing.max_runs if max_runs is None else max_runs
         self._validate_combination(trigger, resulting_max_runs)

--- a/pydantic_ai_harness/scheduling/_types.py
+++ b/pydantic_ai_harness/scheduling/_types.py
@@ -58,7 +58,7 @@ class CronTrigger(BaseModel):
 
 
 class IntervalTrigger(BaseModel):
-    """A recurring fixed interval of at least one minute."""
+    """A recurring fixed interval from one minute through 365 days."""
 
     kind: Literal['interval'] = 'interval'
     every: timedelta
@@ -66,9 +66,11 @@ class IntervalTrigger(BaseModel):
     @field_validator('every')
     @classmethod
     def validate_every(cls, value: timedelta) -> timedelta:
-        """Reject intervals below the runner's supported cadence."""
+        """Reject intervals outside the runner's supported cadence."""
         if value < timedelta(minutes=1):
             raise ValueError('Interval schedules must run at least every 1 minute.')
+        if value > timedelta(days=365):
+            raise ValueError('Interval schedules cannot exceed 365 days. Use a cron expression for longer cadences.')
         return value
 
 
@@ -103,13 +105,16 @@ def parse_schedule(text: str, *, timezone: str = 'UTC', now: datetime | None = N
     value = text.strip()
     match = _DURATION_RE.fullmatch(value)
     if match is not None:
-        duration = _duration(int(match.group('count')), match.group('unit'))
-        if match.group('form').lower() == 'every':
-            return IntervalTrigger(every=duration)
-        reference = now or datetime.now(tz=ZoneInfo(timezone))
-        if reference.tzinfo is None:
-            reference = reference.replace(tzinfo=ZoneInfo(timezone))
-        return OnceTrigger(at=reference + duration)
+        try:
+            duration = _duration(int(match.group('count')), match.group('unit'))
+            if match.group('form').lower() == 'every':
+                return IntervalTrigger(every=duration)
+            reference = now or datetime.now(tz=ZoneInfo(timezone))
+            if reference.tzinfo is None:
+                reference = reference.replace(tzinfo=ZoneInfo(timezone))
+            return OnceTrigger(at=reference + duration)
+        except OverflowError as exc:
+            raise ValueError('Duration is too large.') from exc
 
     # Only a leading date marks an ISO datetime: a bare `T` also appears in cron day and
     # month names such as `TUE` or `OCT`.

--- a/pydantic_ai_harness/scheduling/_types.py
+++ b/pydantic_ai_harness/scheduling/_types.py
@@ -146,6 +146,8 @@ class Schedule(BaseModel):
     """A persisted scheduled agent run."""
 
     id: str = Field(default_factory=lambda: uuid4().hex[:12])
+    version: int = 0
+    """Store-managed revision used for optimistic concurrency control."""
     name: str
     prompt: str
     trigger: ScheduleTrigger

--- a/pydantic_ai_harness/scheduling/_types.py
+++ b/pydantic_ai_harness/scheduling/_types.py
@@ -96,19 +96,8 @@ def parse_schedule(text: str, *, timezone: str = 'UTC', now: datetime | None = N
 
     Accepted forms are `every <N><m|h|d>`, `in <N><m|h|d>`, an ISO 8601
     datetime, or a five-field cron expression. A naive ISO datetime is
-    interpreted in `timezone`.
-
-    Args:
-        text: Schedule text to parse.
-        timezone: IANA timezone for naive datetimes and cron schedules.
-        now: Current time override used by relative one-shot schedules.
-
-    Returns:
-        The parsed trigger.
-
-    Raises:
-        ValueError: If the timezone or schedule text is invalid.
-        ImportError: If a cron expression is used without the scheduling extra.
+    interpreted in `timezone`. Cron expressions raise `ImportError` when the
+    scheduling extra is not installed.
     """
     timezone = _validate_timezone(timezone)
     value = text.strip()

--- a/pydantic_ai_harness/scheduling/_types.py
+++ b/pydantic_ai_harness/scheduling/_types.py
@@ -1,0 +1,202 @@
+"""Types and schedule parsing for the `Scheduling` capability."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable, Iterator
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from datetime import timezone as datetime_timezone
+from typing import Annotated, Literal
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from pydantic import AwareDatetime, BaseModel, Field, field_validator
+from pydantic_ai.usage import RunUsage, UsageLimits
+
+_DURATION_RE = re.compile(r'(?P<form>every|in)\s+(?P<count>\d+)(?P<unit>[mhd])', re.IGNORECASE)
+_DATE_PREFIX_RE = re.compile(r'\d{4}-\d{2}-\d{2}')
+_PARSE_ERROR = (
+    'Schedule must be one of: every <N><m|h|d>, in <N><m|h|d>, an ISO 8601 datetime, or a 5-field cron expression.'
+)
+_INSTALL_HINT = 'Install scheduling support with `pip install pydantic-ai-harness[scheduling]`.'
+
+
+def _cron_sim(expr: str, start: datetime) -> Iterator[datetime]:
+    try:
+        from cronsim import CronSim
+    except ImportError as exc:
+        raise ImportError(_INSTALL_HINT) from exc
+    return CronSim(expr, start)
+
+
+def _validate_timezone(value: str) -> str:
+    try:
+        ZoneInfo(value)
+    except (KeyError, ValueError) as exc:
+        raise ValueError(f'Unknown IANA timezone: {value!r}') from exc
+    return value
+
+
+class CronTrigger(BaseModel):
+    """A recurring five-field cron expression."""
+
+    kind: Literal['cron'] = 'cron'
+    expr: str
+
+    @field_validator('expr')
+    @classmethod
+    def validate_expr(cls, value: str) -> str:
+        """Validate the cron expression using `cronsim`."""
+        try:
+            _cron_sim(value, datetime.now(datetime_timezone.utc))
+        except ImportError:
+            raise
+        except Exception as exc:
+            raise ValueError(str(exc)) from exc
+        return value
+
+
+class IntervalTrigger(BaseModel):
+    """A recurring fixed interval of at least one minute."""
+
+    kind: Literal['interval'] = 'interval'
+    every: timedelta
+
+    @field_validator('every')
+    @classmethod
+    def validate_every(cls, value: timedelta) -> timedelta:
+        """Reject intervals below the runner's supported cadence."""
+        if value < timedelta(minutes=1):
+            raise ValueError('Interval schedules must run at least every 1 minute.')
+        return value
+
+
+class OnceTrigger(BaseModel):
+    """A one-shot execution at an aware datetime."""
+
+    kind: Literal['once'] = 'once'
+    at: AwareDatetime
+
+
+ScheduleTrigger = Annotated[CronTrigger | IntervalTrigger | OnceTrigger, Field(discriminator='kind')]
+"""A cron, interval, or one-shot schedule trigger."""
+
+
+def _duration(count: int, unit: str) -> timedelta:
+    if unit.lower() == 'm':
+        return timedelta(minutes=count)
+    if unit.lower() == 'h':
+        return timedelta(hours=count)
+    return timedelta(days=count)
+
+
+def parse_schedule(text: str, *, timezone: str = 'UTC', now: datetime | None = None) -> ScheduleTrigger:
+    """Parse one of the supported compact schedule forms.
+
+    Accepted forms are `every <N><m|h|d>`, `in <N><m|h|d>`, an ISO 8601
+    datetime, or a five-field cron expression. A naive ISO datetime is
+    interpreted in `timezone`.
+
+    Args:
+        text: Schedule text to parse.
+        timezone: IANA timezone for naive datetimes and cron schedules.
+        now: Current time override used by relative one-shot schedules.
+
+    Returns:
+        The parsed trigger.
+
+    Raises:
+        ValueError: If the timezone or schedule text is invalid.
+        ImportError: If a cron expression is used without the scheduling extra.
+    """
+    timezone = _validate_timezone(timezone)
+    value = text.strip()
+    match = _DURATION_RE.fullmatch(value)
+    if match is not None:
+        duration = _duration(int(match.group('count')), match.group('unit'))
+        if match.group('form').lower() == 'every':
+            return IntervalTrigger(every=duration)
+        reference = now or datetime.now(tz=ZoneInfo(timezone))
+        if reference.tzinfo is None:
+            reference = reference.replace(tzinfo=ZoneInfo(timezone))
+        return OnceTrigger(at=reference + duration)
+
+    # Only a leading date marks an ISO datetime: a bare `T` also appears in cron day and
+    # month names such as `TUE` or `OCT`.
+    if _DATE_PREFIX_RE.match(value) is not None:
+        try:
+            at = datetime.fromisoformat(value.replace('Z', '+00:00'))
+        except ValueError as exc:
+            raise ValueError(_PARSE_ERROR) from exc
+        if at.tzinfo is None:
+            at = at.replace(tzinfo=ZoneInfo(timezone))
+        return OnceTrigger(at=at)
+
+    if len(value.split()) == 5:
+        return CronTrigger(expr=' '.join(value.split()))
+    raise ValueError(_PARSE_ERROR)
+
+
+def next_run_time(trigger: ScheduleTrigger, *, after: datetime, timezone: str) -> datetime | None:
+    """Return the first occurrence after `after`, or `None` for an expired one-shot."""
+    zone = ZoneInfo(_validate_timezone(timezone))
+    if isinstance(trigger, CronTrigger):
+        return next(_cron_sim(trigger.expr, after.astimezone(zone)))
+    if isinstance(trigger, IntervalTrigger):
+        return after + trigger.every
+    return trigger.at if trigger.at > after else None
+
+
+class Schedule(BaseModel):
+    """A persisted scheduled agent run."""
+
+    id: str = Field(default_factory=lambda: uuid4().hex[:12])
+    name: str
+    prompt: str
+    trigger: ScheduleTrigger
+    timezone: str = 'UTC'
+    deliver_to: str | None = None
+    enabled: bool = True
+    max_runs: int | None = Field(default=None, ge=1)
+    usage_limits: UsageLimits | None = None
+    created_at: AwareDatetime = Field(default_factory=lambda: datetime.now(datetime_timezone.utc))
+    next_run_at: AwareDatetime | None = None
+    runs_completed: int = 0
+    last_run_at: AwareDatetime | None = None
+    last_status: Literal['success', 'error', 'missed'] | None = None
+    last_error: str | None = None
+    last_delivery_error: str | None = None
+    last_output: str | None = None
+
+    @field_validator('timezone')
+    @classmethod
+    def validate_timezone(cls, value: str) -> str:
+        """Require a resolvable IANA timezone name."""
+        return _validate_timezone(value)
+
+    @property
+    def status(self) -> Literal['paused', 'completed', 'scheduled']:
+        """Return the schedule's user-facing lifecycle status."""
+        if not self.enabled:
+            return 'paused'
+        if self.next_run_at is None:
+            return 'completed'
+        return 'scheduled'
+
+
+@dataclass(frozen=True)
+class ScheduleResult:
+    """The outcome of one scheduled occurrence."""
+
+    schedule: Schedule
+    status: Literal['success', 'error', 'missed']
+    output: str | None
+    error: str | None
+    started_at: datetime
+    finished_at: datetime
+    usage: RunUsage | None
+
+
+ScheduleResultCallback = Callable[[ScheduleResult], Awaitable[None] | None]
+"""A synchronous or asynchronous scheduled-result callback."""

--- a/pydantic_ai_harness/scheduling/_types.py
+++ b/pydantic_ai_harness/scheduling/_types.py
@@ -142,10 +142,15 @@ def next_run_time(trigger: ScheduleTrigger, *, after: datetime, timezone: str) -
     return trigger.at if trigger.at > after else None
 
 
+def new_schedule_id() -> str:
+    """Return a short random schedule id; creators retry on the rare collision."""
+    return uuid4().hex[:12]
+
+
 class Schedule(BaseModel):
     """A persisted scheduled agent run."""
 
-    id: str = Field(default_factory=lambda: uuid4().hex[:12])
+    id: str = Field(default_factory=new_schedule_id)
     version: int = 0
     """Store-managed revision used for optimistic concurrency control."""
     name: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,9 @@ skills = [
 stackone = [
     "pydantic-ai-slim[mcp]>=2.18.0",
 ]
+scheduling = [
+    "cronsim>=2.6",
+]
 
 [project.urls]
 Homepage = 'https://github.com/pydantic/pydantic-ai-harness'

--- a/tests/scheduling/conftest.py
+++ b/tests/scheduling/conftest.py
@@ -1,0 +1,7 @@
+"""Collection rules and public-surface helpers for scheduling tests."""
+
+from __future__ import annotations
+
+import importlib.util
+
+collect_ignore = ['test_cron.py'] if importlib.util.find_spec('cronsim') is None else []

--- a/tests/scheduling/test_capability.py
+++ b/tests/scheduling/test_capability.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 from pydantic_ai import Agent
+from pydantic_ai.capabilities import PrefixTools
 from pydantic_ai.messages import InstructionPart
 from pydantic_ai.models.test import TestModel
 
@@ -32,6 +33,20 @@ class TestSchedulingCapability:
 
     def test_each_default_store_is_fresh(self) -> None:
         assert Scheduling[None]().resolved_store is not Scheduling[None]().resolved_store
+
+    def test_explicit_falsey_store_wins(self) -> None:
+        store = _FalseyScheduleStore()
+        assert not store
+        ScheduleRunner(Agent(TestModel()), deps=None, store=store)
+
+    def test_runner_resolves_wrapped_scheduling_store(self) -> None:
+        capability = Scheduling[None]()
+        agent: Agent[None, str] = Agent(
+            TestModel(),
+            deps_type=type(None),
+            capabilities=[PrefixTools(wrapped=capability, prefix='sched')],
+        )
+        ScheduleRunner(agent, deps=None)
 
     def test_invalid_timezone_rejected(self) -> None:
         with pytest.raises(ValueError, match='Unknown IANA timezone'):
@@ -87,3 +102,8 @@ class TestSchedulingCapability:
                 assert instructions is not None
                 assert expected in instructions
             assert result.output == 'success (no tool calls)'
+
+
+class _FalseyScheduleStore(InMemoryScheduleStore):
+    def __bool__(self) -> bool:
+        return False

--- a/tests/scheduling/test_capability.py
+++ b/tests/scheduling/test_capability.py
@@ -1,0 +1,89 @@
+"""Tests for the public `Scheduling` capability surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import InstructionPart
+from pydantic_ai.models.test import TestModel
+
+from pydantic_ai_harness.scheduling import (
+    InMemoryScheduleStore,
+    ScheduleRunner,
+    Scheduling,
+    SqliteScheduleStore,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run agent integration tests on the backend used by Pydantic AI's graph."""
+    return 'asyncio'
+
+
+class TestSchedulingCapability:
+    def test_default_store_is_owned_and_shared_with_runner(self) -> None:
+        capability = Scheduling[None]()
+        assert isinstance(capability.resolved_store, InMemoryScheduleStore)
+        agent: Agent[None, str] = Agent(TestModel(), deps_type=type(None), capabilities=[capability])
+        ScheduleRunner(agent, deps=None)
+
+    def test_each_default_store_is_fresh(self) -> None:
+        assert Scheduling[None]().resolved_store is not Scheduling[None]().resolved_store
+
+    def test_invalid_timezone_rejected(self) -> None:
+        with pytest.raises(ValueError, match='Unknown IANA timezone'):
+            Scheduling(timezone='not/a-zone')
+
+    def test_runner_store_resolution_errors_are_actionable(self) -> None:
+        with pytest.raises(ValueError, match='pass `store=` explicitly'):
+            ScheduleRunner(Agent(TestModel()), deps=None)
+        agent: Agent[None, str] = Agent(
+            TestModel(), deps_type=type(None), capabilities=[Scheduling[None](), Scheduling[None]()]
+        )
+        with pytest.raises(ValueError, match='multiple Scheduling'):
+            ScheduleRunner(agent, deps=None)
+
+    def test_from_spec_all_branches(self, tmp_path: Path) -> None:
+        assert isinstance(Scheduling.from_spec().resolved_store, InMemoryScheduleStore)
+        sqlite = Scheduling.from_spec(backend='sqlite', database=str(tmp_path / 'schedules.db'))
+        assert isinstance(sqlite.resolved_store, SqliteScheduleStore)
+        with pytest.raises(ValueError, match='database is only valid'):
+            Scheduling.from_spec(database='custom.db')
+        with pytest.raises(ValueError, match='Unknown scheduling backend'):
+            Scheduling.from_spec(backend='cloud')  # type: ignore[arg-type]
+
+    def test_serialization_name(self) -> None:
+        assert Scheduling.get_serialization_name() == 'Scheduling'
+
+    def test_agent_spec_roundtrip(self) -> None:
+        agent = Agent.from_spec(
+            {
+                'model': 'test',
+                'capabilities': [{'Scheduling': {'backend': 'memory', 'timezone': 'Asia/Kolkata'}}],
+            },
+            custom_capability_types=[Scheduling],
+        )
+        loaded = [cap for cap in agent.root_capability.capabilities if isinstance(cap, Scheduling)]
+        assert len(loaded) == 1
+        assert loaded[0].timezone == 'Asia/Kolkata'
+
+    async def test_guidance_states(self) -> None:
+        for guidance, expected in ((None, 'create_schedule'), ('custom guidance', 'custom guidance'), ('', None)):
+            model = TestModel(call_tools=[])
+            agent: Agent[None, str] = Agent(
+                model, deps_type=type(None), capabilities=[Scheduling[None](guidance=guidance)]
+            )
+            result = await agent.run('hello')
+            parameters = model.last_model_request_parameters
+            assert parameters is not None
+            parts = parameters.instruction_parts or []
+            instructions = InstructionPart.join(parts) if parts else None
+            if expected is None:
+                assert instructions is None
+            else:
+                assert instructions is not None
+                assert expected in instructions
+            assert result.output == 'success (no tool calls)'

--- a/tests/scheduling/test_cron.py
+++ b/tests/scheduling/test_cron.py
@@ -1,0 +1,81 @@
+"""Cron-only scheduling tests, skipped in the slim dependency matrix."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+from pydantic import ValidationError
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import RunContext
+from pydantic_ai.usage import RunUsage
+
+from pydantic_ai_harness.scheduling import (
+    CronTrigger,
+    InMemoryScheduleStore,
+    Schedule,
+    ScheduleRunner,
+    Scheduling,
+    parse_schedule,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run agent integration tests on the backend used by Pydantic AI's graph."""
+    return 'asyncio'
+
+
+class TestCronSchedules:
+    def test_parse_and_reject(self) -> None:
+        assert parse_schedule('0 9 * * *') == CronTrigger(expr='0 9 * * *')
+        with pytest.raises(ValidationError):
+            CronTrigger(expr='99 99 * * *')
+
+    def test_parse_day_and_month_names_despite_containing_t(self) -> None:
+        assert parse_schedule('0 9 * * TUE') == CronTrigger(expr='0 9 * * TUE')
+        assert parse_schedule('0 9 * OCT SAT') == CronTrigger(expr='0 9 * OCT SAT')
+
+    async def test_next_run_keeps_wall_clock_hour_across_spring_forward(self) -> None:
+        zone = ZoneInfo('America/New_York')
+        now = datetime(2026, 3, 7, 10, tzinfo=zone)
+        schedule = Schedule(
+            id='dst',
+            name='DST',
+            prompt='work',
+            trigger=CronTrigger(expr='0 9 * * *'),
+            timezone='America/New_York',
+            next_run_at=now.astimezone(timezone.utc),
+        )
+        store = InMemoryScheduleStore()
+        await store.add(schedule)
+        result = (await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(now.astimezone(timezone.utc)))[
+            0
+        ]
+        assert result.schedule.next_run_at is not None
+        local_next = result.schedule.next_run_at.astimezone(zone)
+        assert local_next == datetime(2026, 3, 8, 9, tzinfo=zone)
+        assert local_next.hour == 9
+
+    async def test_tool_listing_renders_cron_expression(self) -> None:
+        capability = Scheduling[None]()
+        await capability.resolved_store.add(
+            Schedule(
+                id='cron',
+                name='Cron',
+                prompt='work',
+                trigger=CronTrigger(expr='0 9 * * *'),
+                next_run_at=datetime(2030, 1, 1, 9, tzinfo=timezone.utc),
+            )
+        )
+        toolset = capability.get_toolset()
+        ctx = RunContext(deps=None, model=TestModel(), usage=RunUsage())
+        tools = await toolset.get_tools(ctx)
+        output = await toolset.call_tool('list_schedules', {}, ctx, tools['list_schedules'])
+        assert output == (
+            'id: cron\nname: Cron\nstatus: scheduled\nschedule: 0 9 * * *\nnext run (UTC): 2030-01-01T09:00:00+00:00'
+        )

--- a/tests/scheduling/test_runner.py
+++ b/tests/scheduling/test_runner.py
@@ -10,6 +10,7 @@ from pydantic_ai import Agent
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.usage import UsageLimits
 
 from pydantic_ai_harness.scheduling import (
     InMemoryScheduleStore,
@@ -92,6 +93,11 @@ class TestScheduleRunnerExecution:
         assert result.schedule.next_run_at is None
         assert result.schedule.status == 'completed'
 
+    async def test_future_schedule_is_not_claimed(self) -> None:
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('future', due_at=NOW + timedelta(hours=1)))
+        assert await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(NOW) == []
+
     async def test_error_records_and_recurring_schedule_continues(self) -> None:
         async def fail(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             del messages, info
@@ -104,6 +110,19 @@ class TestScheduleRunnerExecution:
         assert result.error == 'RuntimeError: model broke'
         assert result.schedule.next_run_at == NOW + timedelta(hours=1)
         assert result.schedule.last_output is None
+
+    async def test_schedule_usage_limits_cap_the_run(self) -> None:
+        store = InMemoryScheduleStore()
+        schedule = _schedule('budget')
+        schedule.usage_limits = UsageLimits(request_limit=0)
+        await store.add(schedule)
+        result = (await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(NOW))[0]
+        assert result.status == 'error'
+        assert result.error is not None
+        assert result.error.startswith('UsageLimitExceeded:')
+        stored = await store.get('budget')
+        assert stored is not None
+        assert stored.next_run_at == NOW + timedelta(hours=1)
 
     async def test_timeout_is_recorded_without_retry(self) -> None:
         async def slow(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
@@ -130,15 +149,35 @@ class TestScheduleRunnerExecution:
         with pytest.raises(ValueError, match='run_timeout'):
             ScheduleRunner(agent, deps=None, store=store, run_timeout=0)
 
-    async def test_failed_claim_save_releases_overlap_guard(self) -> None:
-        store = _FailOnceScheduleStore()
-        await store.add(_schedule('claim-failure'))
+    async def test_partial_claim_failure_releases_every_overlap_guard(self) -> None:
+        store = _FailSecondScheduleStore()
+        await store.add(_schedule('first'))
+        await store.add(_schedule('second'))
         runner = ScheduleRunner(Agent(TestModel()), deps=None, store=store)
         with pytest.raises(RuntimeError, match='save failed'):
             await runner.tick(NOW)
-        results = await runner.tick(NOW)
-        assert len(results) == 1
-        assert results[0].status == 'success'
+        results = await runner.tick(NOW + timedelta(hours=1))
+        assert {result.schedule.id for result in results} == {'first', 'second'}
+        assert all(result.status == 'success' for result in results)
+
+    async def test_queued_exhausted_schedule_completes_without_agent_call(self) -> None:
+        calls = 0
+
+        def model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: no cover
+            nonlocal calls
+            del messages, info
+            calls += 1
+            return ModelResponse(parts=[TextPart('unexpected')])
+
+        store = InMemoryScheduleStore()
+        schedule = _schedule('exhausted', max_runs=2)
+        schedule.runs_completed = 2
+        await store.add(schedule)
+        assert await ScheduleRunner(Agent(FunctionModel(model)), deps=None, store=store).tick(NOW) == []
+        assert calls == 0
+        stored = await store.get('exhausted')
+        assert stored is not None
+        assert stored.next_run_at is None
 
 
 class TestMisfires:
@@ -238,14 +277,14 @@ def _async_callback(seen: list[str]) -> ScheduleResultCallback:
     return callback
 
 
-class _FailOnceScheduleStore(InMemoryScheduleStore):
+class _FailSecondScheduleStore(InMemoryScheduleStore):
     def __init__(self) -> None:
         super().__init__()
-        self._fail = True
+        self._failed = False
 
     async def save(self, schedule: Schedule) -> None:
-        if self._fail:
-            self._fail = False
+        if schedule.id == 'second' and not self._failed:
+            self._failed = True
             raise RuntimeError('save failed')
         await super().save(schedule)
 
@@ -277,8 +316,84 @@ class TestConcurrencyAndLoop:
             running.next_run_at = NOW
             await store.save(running)
             assert await runner.tick(NOW) == []
+            skipped = await store.get('overlap')
+            assert skipped is not None
+            assert skipped.next_run_at == NOW + timedelta(hours=1)
             release.set()
         assert len(first_results) == 1
+        stored = await store.get('overlap')
+        assert stored is not None
+        assert stored.next_run_at == NOW + timedelta(hours=1)
+        assert stored.last_status == 'success'
+
+    async def test_concurrent_pause_survives_run_outcome(self) -> None:
+        started = anyio.Event()
+        release = anyio.Event()
+
+        async def slow(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            del messages, info
+            started.set()
+            await release.wait()
+            return ModelResponse(parts=[TextPart('done')])
+
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('paused-during-run'))
+        results: list[ScheduleResult] = []
+        runner = ScheduleRunner(Agent(FunctionModel(slow)), deps=None, store=store)
+
+        async def run_tick() -> None:
+            results.extend(await runner.tick(NOW))
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(run_tick)
+            await started.wait()
+            running = await store.get('paused-during-run')
+            assert running is not None
+            running.enabled = False
+            await store.save(running)
+            release.set()
+
+        assert results[0].status == 'success'
+        stored = await store.get('paused-during-run')
+        assert stored is not None
+        assert stored.enabled is False
+        assert stored.last_run_at == NOW
+        assert stored.last_status == 'success'
+        assert stored.last_output == 'done'
+
+    async def test_deletion_during_run_stays_deleted_and_delivers_result(self) -> None:
+        started = anyio.Event()
+        release = anyio.Event()
+        delivered: list[str] = []
+
+        async def slow(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            del messages, info
+            started.set()
+            await release.wait()
+            return ModelResponse(parts=[TextPart('done')])
+
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('deleted-during-run'))
+        results: list[ScheduleResult] = []
+        runner = ScheduleRunner(
+            Agent(FunctionModel(slow)),
+            deps=None,
+            store=store,
+            on_result=lambda result: delivered.append(result.status),
+        )
+
+        async def run_tick() -> None:
+            results.extend(await runner.tick(NOW))
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(run_tick)
+            await started.wait()
+            assert await store.remove('deleted-during-run') is True
+            release.set()
+
+        assert results[0].status == 'success'
+        assert delivered == ['success']
+        assert await store.list() == []
 
     async def test_run_until_stopped_can_stop_from_callback(self) -> None:
         store = InMemoryScheduleStore()

--- a/tests/scheduling/test_runner.py
+++ b/tests/scheduling/test_runner.py
@@ -17,6 +17,7 @@ from pydantic_ai_harness.scheduling import (
     IntervalTrigger,
     OnceTrigger,
     Schedule,
+    ScheduleConflictError,
     ScheduleResult,
     ScheduleResultCallback,
     ScheduleRunner,
@@ -154,16 +155,24 @@ class TestScheduleRunnerExecution:
         with pytest.raises(ValueError, match='run_timeout'):
             ScheduleRunner(agent, deps=None, store=store, run_timeout=0)
 
-    async def test_partial_claim_failure_releases_every_overlap_guard(self) -> None:
+    async def test_partial_claim_failure_drains_started_occurrences_before_raising(self) -> None:
         store = _FailSecondScheduleStore()
         await store.add(_schedule('first'))
         await store.add(_schedule('second'))
         runner = ScheduleRunner(Agent(TestModel()), deps=None, store=store)
         with pytest.raises(RuntimeError, match='save failed'):
             await runner.tick(NOW)
-        results = await runner.tick(NOW + timedelta(hours=1))
-        assert {result.schedule.id for result in results} == {'first', 'second'}
-        assert all(result.status == 'success' for result in results)
+        first = await store.get('first')
+        second = await store.get('second')
+        assert first is not None
+        assert second is not None
+        assert first.runs_completed == 1
+        assert first.last_status == 'success'
+        assert second.runs_completed == 0
+
+        results = await runner.tick(NOW)
+        assert [result.schedule.id for result in results] == ['second']
+        assert results[0].status == 'success'
 
     async def test_queued_exhausted_schedule_completes_without_agent_call(self) -> None:
         calls = 0
@@ -294,7 +303,108 @@ class _FailSecondScheduleStore(InMemoryScheduleStore):
         await super().save(schedule)
 
 
+class _PauseOnClaimStore(InMemoryScheduleStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self._injected = False
+
+    async def save(self, schedule: Schedule) -> None:
+        if schedule.runs_completed == 1 and not self._injected:  # pragma: no branch
+            self._injected = True
+            current = await super().get(schedule.id)
+            assert current is not None
+            current.enabled = False
+            await super().save(current)
+        await super().save(schedule)
+
+
+class _DeleteOnClaimConflictStore(InMemoryScheduleStore):
+    async def save(self, schedule: Schedule) -> None:
+        if schedule.runs_completed == 1:  # pragma: no branch
+            await self.remove(schedule.id)
+            raise ScheduleConflictError('deleted during claim')
+        await super().save(schedule)  # pragma: no cover - only claim saves use this test store
+
+
+class _AlwaysConflictOnClaimStore(InMemoryScheduleStore):
+    async def save(self, schedule: Schedule) -> None:
+        del schedule
+        raise ScheduleConflictError('forced claim conflict')
+
+
+class _EditOnOutcomeStore(InMemoryScheduleStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self._injected = False
+
+    async def save(self, schedule: Schedule) -> None:
+        if schedule.last_status == 'success' and not self._injected:
+            self._injected = True
+            current = await super().get(schedule.id)
+            assert current is not None
+            current.name = 'concurrent edit'
+            await super().save(current)
+        await super().save(schedule)
+
+
+class _AlwaysConflictOnOutcomeStore(InMemoryScheduleStore):
+    async def save(self, schedule: Schedule) -> None:
+        if schedule.last_status is not None:
+            raise ScheduleConflictError('forced outcome conflict')
+        await super().save(schedule)
+
+
 class TestConcurrencyAndLoop:
+    async def test_claim_conflict_rechecks_current_state(self) -> None:
+        store = _PauseOnClaimStore()
+        await store.add(_schedule('paused-before-claim'))
+
+        results = await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(NOW)
+
+        assert results == []
+        stored = await store.get('paused-before-claim')
+        assert stored is not None
+        assert stored.enabled is False
+        assert stored.runs_completed == 0
+        assert stored.next_run_at == NOW
+
+    async def test_claim_conflict_skips_a_deleted_schedule(self) -> None:
+        store = _DeleteOnClaimConflictStore()
+        await store.add(_schedule('deleted-before-retry'))
+
+        assert await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(NOW) == []
+        assert await store.get('deleted-before-retry') is None
+
+    async def test_claim_conflict_exhaustion_propagates(self) -> None:
+        store = _AlwaysConflictOnClaimStore()
+        await store.add(_schedule('contended-claim'))
+
+        with pytest.raises(ScheduleConflictError, match='forced claim conflict'):
+            await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(NOW)
+
+    async def test_outcome_conflict_preserves_concurrent_edit(self) -> None:
+        store = _EditOnOutcomeStore()
+        await store.add(_schedule('edited-during-outcome'))
+
+        result = (await ScheduleRunner(Agent(TestModel(custom_output_text='done')), deps=None, store=store).tick(NOW))[
+            0
+        ]
+
+        assert result.status == 'success'
+        assert result.schedule.name == 'concurrent edit'
+        stored = await store.get('edited-during-outcome')
+        assert stored is not None
+        assert stored.name == 'concurrent edit'
+        assert stored.last_status == 'success'
+        assert stored.last_output == 'done'
+
+    async def test_outcome_conflict_exhaustion_propagates(self) -> None:
+        store = _AlwaysConflictOnOutcomeStore()
+        await store.add(_schedule('contended-outcome'))
+
+        with pytest.RaisesGroup(pytest.RaisesExc(ScheduleConflictError, match='forced outcome conflict')):
+            await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(NOW)
+
     async def test_overlap_guard_skips_same_schedule(self) -> None:
         started = anyio.Event()
         release = anyio.Event()
@@ -425,6 +535,33 @@ class TestConcurrencyAndLoop:
         )
         with anyio.fail_after(1):
             await runner.run_until_stopped()
+
+    async def test_run_until_stopped_drains_started_occurrences_before_raising(self) -> None:
+        store = _FailSecondScheduleStore()
+        await store.add(_schedule('first'))
+        await store.add(_schedule('second'))
+        delivered: list[str] = []
+        runner = ScheduleRunner(
+            Agent(TestModel()),
+            deps=None,
+            store=store,
+            on_result=lambda result: delivered.append(result.schedule.id),
+            tick_interval=0.01,
+        )
+
+        with pytest.raises(RuntimeError, match='save failed'):
+            await runner.run_until_stopped()
+        assert delivered == ['first']
+
+    async def test_run_until_stopped_skips_future_schedules(self) -> None:
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('future', due_at=datetime.now(timezone.utc) + timedelta(hours=1)))
+        runner = ScheduleRunner(Agent(TestModel()), deps=None, store=store, tick_interval=0.01)
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(runner.run_until_stopped)
+            await anyio.sleep(0.02)
+            runner.stop()
 
 
 class TestScheduledRunRecursionGuard:

--- a/tests/scheduling/test_runner.py
+++ b/tests/scheduling/test_runner.py
@@ -98,6 +98,11 @@ class TestScheduleRunnerExecution:
         await store.add(_schedule('future', due_at=NOW + timedelta(hours=1)))
         assert await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(NOW) == []
 
+    async def test_tick_rejects_naive_now(self) -> None:
+        runner = ScheduleRunner(Agent(TestModel()), deps=None, store=InMemoryScheduleStore())
+        with pytest.raises(ValueError, match='now must be timezone-aware'):
+            await runner.tick(datetime(2026, 5, 1, 12))
+
     async def test_error_records_and_recurring_schedule_continues(self) -> None:
         async def fail(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             del messages, info

--- a/tests/scheduling/test_runner.py
+++ b/tests/scheduling/test_runner.py
@@ -1,0 +1,340 @@
+"""Tests for scheduled execution semantics."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import anyio
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+
+from pydantic_ai_harness.scheduling import (
+    InMemoryScheduleStore,
+    IntervalTrigger,
+    OnceTrigger,
+    Schedule,
+    ScheduleResult,
+    ScheduleResultCallback,
+    ScheduleRunner,
+    Scheduling,
+)
+
+pytestmark = pytest.mark.anyio
+
+NOW = datetime(2026, 5, 1, 12, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run agent integration tests on the backend used by Pydantic AI's graph."""
+    return 'asyncio'
+
+
+def _schedule(
+    schedule_id: str,
+    *,
+    trigger: IntervalTrigger | OnceTrigger | None = None,
+    due_at: datetime = NOW,
+    max_runs: int | None = None,
+) -> Schedule:
+    return Schedule(
+        id=schedule_id,
+        name=schedule_id,
+        prompt=f'run {schedule_id}',
+        trigger=trigger or IntervalTrigger(every=timedelta(hours=1)),
+        next_run_at=due_at,
+        max_runs=max_runs,
+    )
+
+
+class TestScheduleRunnerExecution:
+    async def test_success_advances_before_run_and_records_usage(self) -> None:
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('success'))
+        results = await ScheduleRunner(
+            Agent(TestModel(custom_output_text='done')),
+            deps=None,
+            store=store,
+        ).tick(NOW)
+        assert len(results) == 1
+        assert results[0].status == 'success'
+        assert results[0].output == 'done'
+        assert results[0].usage is not None
+        stored = await store.get('success')
+        assert stored is not None
+        assert stored.runs_completed == 1
+        assert stored.next_run_at == NOW + timedelta(hours=1)
+        assert stored.last_run_at == NOW
+        assert stored.last_status == 'success'
+        assert stored.last_output == 'done'
+        assert stored.last_error is None
+
+    async def test_empty_output_is_success(self) -> None:
+        def empty_output() -> str:
+            return ''
+
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('empty'))
+        result = (await ScheduleRunner(Agent(TestModel(), output_type=empty_output), deps=None, store=store).tick(NOW))[
+            0
+        ]
+        assert result.status == 'success'
+        assert result.output == ''
+
+    async def test_max_runs_exhaustion_completes(self) -> None:
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('limited', max_runs=1))
+        result = (await ScheduleRunner(Agent(TestModel()), deps=None, store=store).tick(NOW))[0]
+        assert result.schedule.runs_completed == 1
+        assert result.schedule.next_run_at is None
+        assert result.schedule.status == 'completed'
+
+    async def test_error_records_and_recurring_schedule_continues(self) -> None:
+        async def fail(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            del messages, info
+            raise RuntimeError('model broke')
+
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('failure'))
+        result = (await ScheduleRunner(Agent(FunctionModel(fail)), deps=None, store=store).tick(NOW))[0]
+        assert result.status == 'error'
+        assert result.error == 'RuntimeError: model broke'
+        assert result.schedule.next_run_at == NOW + timedelta(hours=1)
+        assert result.schedule.last_output is None
+
+    async def test_timeout_is_recorded_without_retry(self) -> None:
+        async def slow(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            del messages, info
+            await anyio.sleep(1)
+            return ModelResponse(parts=[TextPart('late')])  # pragma: no cover - cancelled by run_timeout first
+
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('timeout'))
+        result = (await ScheduleRunner(Agent(FunctionModel(slow)), deps=None, store=store, run_timeout=0.01).tick(NOW))[
+            0
+        ]
+        assert result.status == 'error'
+        assert result.error is not None
+        assert result.error.startswith('TimeoutError:')
+
+    async def test_invalid_runner_configuration(self) -> None:
+        agent = Agent(TestModel())
+        store = InMemoryScheduleStore()
+        with pytest.raises(ValueError, match='tick_interval'):
+            ScheduleRunner(agent, deps=None, store=store, tick_interval=0)
+        with pytest.raises(ValueError, match='misfire_grace'):
+            ScheduleRunner(agent, deps=None, store=store, misfire_grace=timedelta(seconds=-1))
+        with pytest.raises(ValueError, match='run_timeout'):
+            ScheduleRunner(agent, deps=None, store=store, run_timeout=0)
+
+    async def test_failed_claim_save_releases_overlap_guard(self) -> None:
+        store = _FailOnceScheduleStore()
+        await store.add(_schedule('claim-failure'))
+        runner = ScheduleRunner(Agent(TestModel()), deps=None, store=store)
+        with pytest.raises(RuntimeError, match='save failed'):
+            await runner.tick(NOW)
+        results = await runner.tick(NOW)
+        assert len(results) == 1
+        assert results[0].status == 'success'
+
+
+class TestMisfires:
+    async def test_recurring_misfire_runs_once_and_fast_forwards(self) -> None:
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('catch-up', due_at=NOW - timedelta(days=3)))
+        result = (
+            await ScheduleRunner(
+                Agent(TestModel()),
+                deps=None,
+                store=store,
+                misfire_grace=timedelta(minutes=10),
+            ).tick(NOW)
+        )[0]
+        assert result.status == 'success'
+        assert result.schedule.runs_completed == 1
+        assert result.schedule.next_run_at == NOW + timedelta(hours=1)
+
+    async def test_once_misfire_is_missed_without_agent_call(self) -> None:
+        calls = 0
+
+        def model(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:  # pragma: no cover
+            # Never reached when the missed path is correct; `calls` catches a regression.
+            nonlocal calls
+            del messages, info
+            calls += 1
+            return ModelResponse(parts=[TextPart('unexpected')])
+
+        store = InMemoryScheduleStore()
+        due = NOW - timedelta(hours=1)
+        await store.add(_schedule('missed', trigger=OnceTrigger(at=due), due_at=due))
+        result = (
+            await ScheduleRunner(
+                Agent(FunctionModel(model)),
+                deps=None,
+                store=store,
+                misfire_grace=timedelta(minutes=5),
+            ).tick(NOW)
+        )[0]
+        assert calls == 0
+        assert result.status == 'missed'
+        assert result.schedule.next_run_at is None
+        assert result.schedule.runs_completed == 0
+        assert result.error is not None
+        assert 'runner was not running' in result.error
+
+
+class TestCallbacks:
+    async def test_sync_and_async_callbacks(self) -> None:
+        sync_seen: list[str] = []
+        async_seen: list[str] = []
+
+        def sync_callback(result: ScheduleResult) -> None:
+            sync_seen.append(result.status)
+
+        sync_store = InMemoryScheduleStore()
+        await sync_store.add(_schedule('callback-sync'))
+        await ScheduleRunner(Agent(TestModel()), deps=None, store=sync_store, on_result=sync_callback).tick(NOW)
+        assert sync_seen == ['success']
+
+        async_store = InMemoryScheduleStore()
+        await async_store.add(_schedule('callback-async'))
+        await ScheduleRunner(
+            Agent(TestModel()), deps=None, store=async_store, on_result=_async_callback(async_seen)
+        ).tick(NOW)
+        assert async_seen == ['success']
+
+    async def test_callback_failure_is_delivery_error_not_run_error(self) -> None:
+        def fail(result: ScheduleResult) -> None:
+            del result
+            raise RuntimeError('delivery broke')
+
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('delivery'))
+        result = (await ScheduleRunner(Agent(TestModel()), deps=None, store=store, on_result=fail).tick(NOW))[0]
+        assert result.status == 'success'
+        assert result.schedule.last_delivery_error == 'RuntimeError: delivery broke'
+        stored = await store.get('delivery')
+        assert stored is not None
+        assert stored.last_status == 'success'
+
+    async def test_successful_delivery_clears_previous_error(self) -> None:
+        store = InMemoryScheduleStore()
+        schedule = _schedule('clear-delivery')
+        schedule.last_delivery_error = 'old error'
+        await store.add(schedule)
+        result = (
+            await ScheduleRunner(Agent(TestModel()), deps=None, store=store, on_result=lambda result: None).tick(NOW)
+        )[0]
+        assert result.schedule.last_delivery_error is None
+
+
+def _async_callback(seen: list[str]) -> ScheduleResultCallback:
+    async def callback(result: ScheduleResult) -> None:
+        seen.append(result.status)
+
+    return callback
+
+
+class _FailOnceScheduleStore(InMemoryScheduleStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self._fail = True
+
+    async def save(self, schedule: Schedule) -> None:
+        if self._fail:
+            self._fail = False
+            raise RuntimeError('save failed')
+        await super().save(schedule)
+
+
+class TestConcurrencyAndLoop:
+    async def test_overlap_guard_skips_same_schedule(self) -> None:
+        started = anyio.Event()
+        release = anyio.Event()
+
+        async def slow(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            del messages, info
+            started.set()
+            await release.wait()
+            return ModelResponse(parts=[TextPart('done')])
+
+        store = InMemoryScheduleStore()
+        await store.add(_schedule('overlap'))
+        first_results: list[ScheduleResult] = []
+
+        async def first_tick() -> None:
+            first_results.extend(await runner.tick(NOW))
+
+        runner = ScheduleRunner(Agent(FunctionModel(slow)), deps=None, store=store)
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(first_tick)
+            await started.wait()
+            running = await store.get('overlap')
+            assert running is not None
+            running.next_run_at = NOW
+            await store.save(running)
+            assert await runner.tick(NOW) == []
+            release.set()
+        assert len(first_results) == 1
+
+    async def test_run_until_stopped_can_stop_from_callback(self) -> None:
+        store = InMemoryScheduleStore()
+        await store.add(
+            _schedule(
+                'loop',
+                trigger=OnceTrigger(at=datetime.now(timezone.utc) + timedelta(seconds=1)),
+                due_at=datetime.now(timezone.utc),
+            )
+        )
+        runner: ScheduleRunner[None]
+
+        def stop(result: ScheduleResult) -> None:
+            assert result.status == 'success'
+            runner.stop()
+            runner.stop()
+
+        runner = ScheduleRunner(
+            Agent(TestModel()),
+            deps=None,
+            store=store,
+            on_result=stop,
+            tick_interval=0.01,
+        )
+        with anyio.fail_after(1):
+            await runner.run_until_stopped()
+
+
+class TestScheduledRunRecursionGuard:
+    async def test_scheduled_run_has_no_scheduling_tools_or_instructions(self) -> None:
+        captured: list[tuple[list[str], str | None]] = []
+
+        def inspect_request(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            del messages
+            captured.append(([tool.name for tool in info.function_tools], info.instructions))
+            return ModelResponse(parts=[TextPart('done')])
+
+        capability = Scheduling[None]()
+        await capability.resolved_store.add(_schedule('guard'))
+        agent: Agent[None, str] = Agent(FunctionModel(inspect_request), deps_type=type(None), capabilities=[capability])
+        results = await ScheduleRunner(agent, deps=None).tick(NOW)
+        assert results[0].status == 'success'
+        assert captured == [([], None)]
+
+    async def test_ordinary_run_keeps_scheduling_tools_and_instructions(self) -> None:
+        captured: list[tuple[list[str], str | None]] = []
+
+        def inspect_request(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            del messages
+            captured.append(([tool.name for tool in info.function_tools], info.instructions))
+            return ModelResponse(parts=[TextPart('done')])
+
+        agent: Agent[None, str] = Agent(
+            FunctionModel(inspect_request), deps_type=type(None), capabilities=[Scheduling[None]()]
+        )
+        await agent.run('hello')
+        assert 'create_schedule' in captured[0][0]
+        assert captured[0][1] is not None
+        assert 'ScheduleRunner' in captured[0][1]

--- a/tests/scheduling/test_store.py
+++ b/tests/scheduling/test_store.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from pydantic_ai.usage import UsageLimits
 
 from pydantic_ai_harness.scheduling import (
     InMemoryScheduleStore,
@@ -90,6 +91,7 @@ class TestSqliteScheduleStore:
     async def test_roundtrip_across_instances(self, tmp_path: Path) -> None:
         database = str(tmp_path / 'persistent.db')
         expected = _schedule('kept')
+        expected.usage_limits = UsageLimits(request_limit=3, total_tokens_limit=10_000)
         await SqliteScheduleStore(database).add(expected)
         loaded = await SqliteScheduleStore(database).get('kept')
         assert loaded is not None

--- a/tests/scheduling/test_store.py
+++ b/tests/scheduling/test_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -104,6 +105,13 @@ class TestSqliteScheduleStore:
         loaded = await SqliteScheduleStore(database).get('kept')
         assert loaded is not None
         assert loaded.model_dump() == expected.model_dump()
+
+    async def test_schema_failure_closes_the_connection(self, tmp_path: Path) -> None:
+        database = tmp_path / 'corrupt.db'
+        database.write_bytes(b'not a sqlite database')
+        store = SqliteScheduleStore(str(database))
+        with pytest.raises(sqlite3.DatabaseError):
+            await store.add(_schedule('any'))
 
     async def test_reserved_word_table_name(self, tmp_path: Path) -> None:
         store = SqliteScheduleStore(str(tmp_path / 'reserved.db'), table='select')

--- a/tests/scheduling/test_store.py
+++ b/tests/scheduling/test_store.py
@@ -13,6 +13,7 @@ from pydantic_ai_harness.scheduling import (
     InMemoryScheduleStore,
     IntervalTrigger,
     Schedule,
+    ScheduleConflictError,
     ScheduleStore,
     SqliteScheduleStore,
 )
@@ -57,7 +58,13 @@ class TestScheduleStoreCrud:
         first.name = 'Changed'
         assert (await store.get('first')).name == 'First'  # type: ignore[union-attr]
         await store.save(first)
-        assert (await store.get('first')).name == 'Changed'  # type: ignore[union-attr]
+        persisted = await store.get('first')
+        assert persisted is not None
+        assert persisted.name == 'Changed'
+        assert persisted.version == 1
+        assert (await store.list())[0].version == 1
+        with pytest.raises(ScheduleConflictError, match='changed since it was read'):
+            await store.save(first)
         assert await store.remove('first') is True
         assert await store.get('first') is None
 
@@ -97,3 +104,14 @@ class TestSqliteScheduleStore:
         loaded = await SqliteScheduleStore(database).get('kept')
         assert loaded is not None
         assert loaded.model_dump() == expected.model_dump()
+
+    async def test_reserved_word_table_name(self, tmp_path: Path) -> None:
+        store = SqliteScheduleStore(str(tmp_path / 'reserved.db'), table='select')
+        added = await store.add(_schedule('quoted'))
+        added.name = 'updated'
+        await store.save(added)
+        loaded = await store.get('quoted')
+        assert loaded is not None
+        assert loaded.name == 'updated'
+        assert [schedule.id for schedule in await store.list()] == ['quoted']
+        assert await store.remove('quoted') is True

--- a/tests/scheduling/test_store.py
+++ b/tests/scheduling/test_store.py
@@ -1,0 +1,96 @@
+"""Tests for public schedule-store backends."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from pydantic_ai_harness.scheduling import (
+    InMemoryScheduleStore,
+    IntervalTrigger,
+    Schedule,
+    ScheduleStore,
+    SqliteScheduleStore,
+)
+
+pytestmark = pytest.mark.anyio
+
+StoreFactory = Callable[[], ScheduleStore]
+
+
+@pytest.fixture(params=['memory', 'sqlite'])
+def store_factory(request: pytest.FixtureRequest, tmp_path: Path) -> StoreFactory:
+    """Build each store backend behind the public protocol."""
+    if request.param == 'memory':
+        return InMemoryScheduleStore
+    return lambda: SqliteScheduleStore(str(tmp_path / 'schedules.db'))
+
+
+def _schedule(schedule_id: str, name: str = 'job') -> Schedule:
+    return Schedule(
+        id=schedule_id,
+        name=name,
+        prompt=f'prompt:{name}',
+        trigger=IntervalTrigger(every=timedelta(hours=1)),
+        next_run_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+class TestScheduleStoreCrud:
+    async def test_empty_and_unknown(self, store_factory: StoreFactory) -> None:
+        store = store_factory()
+        assert await store.list() == []
+        assert await store.get('missing') is None
+        assert await store.remove('missing') is False
+        with pytest.raises(ValueError, match='Unknown schedule id'):
+            await store.save(_schedule('missing'))
+
+    async def test_add_get_save_remove_and_order(self, store_factory: StoreFactory) -> None:
+        store = store_factory()
+        first = await store.add(_schedule('first', 'First'))
+        await store.add(_schedule('second', 'Second'))
+        assert [item.id for item in await store.list()] == ['first', 'second']
+        first.name = 'Changed'
+        assert (await store.get('first')).name == 'First'  # type: ignore[union-attr]
+        await store.save(first)
+        assert (await store.get('first')).name == 'Changed'  # type: ignore[union-attr]
+        assert await store.remove('first') is True
+        assert await store.get('first') is None
+
+    async def test_duplicate_id_rejected(self, store_factory: StoreFactory) -> None:
+        store = store_factory()
+        await store.add(_schedule('same'))
+        with pytest.raises(ValueError, match='already exists'):
+            await store.add(_schedule('same'))
+
+
+class TestInMemoryScheduleStoreCopies:
+    async def test_list_and_save_do_not_leak_aliases(self) -> None:
+        store = InMemoryScheduleStore()
+        original = _schedule('copy')
+        await store.add(original)
+        original.prompt = 'mutated outside'
+        listed = await store.list()
+        listed[0].prompt = 'mutated listing'
+        stored = await store.get('copy')
+        assert stored is not None
+        assert stored.prompt == 'prompt:job'
+
+
+class TestSqliteScheduleStore:
+    def test_rejects_memory_and_bad_table(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="does not support ':memory:'"):
+            SqliteScheduleStore(':memory:')
+        with pytest.raises(ValueError, match='invalid table name'):
+            SqliteScheduleStore(str(tmp_path / 'db.sqlite'), table='bad name; drop')
+
+    async def test_roundtrip_across_instances(self, tmp_path: Path) -> None:
+        database = str(tmp_path / 'persistent.db')
+        expected = _schedule('kept')
+        await SqliteScheduleStore(database).add(expected)
+        loaded = await SqliteScheduleStore(database).get('kept')
+        assert loaded is not None
+        assert loaded.model_dump() == expected.model_dump()

--- a/tests/scheduling/test_store.py
+++ b/tests/scheduling/test_store.py
@@ -83,8 +83,9 @@ class TestInMemoryScheduleStoreCopies:
 
 class TestSqliteScheduleStore:
     def test_rejects_memory_and_bad_table(self, tmp_path: Path) -> None:
-        with pytest.raises(ValueError, match="does not support ':memory:'"):
-            SqliteScheduleStore(':memory:')
+        for database in ('', ':memory:'):
+            with pytest.raises(ValueError, match='does not support'):
+                SqliteScheduleStore(database)
         with pytest.raises(ValueError, match='invalid table name'):
             SqliteScheduleStore(str(tmp_path / 'db.sqlite'), table='bad name; drop')
 

--- a/tests/scheduling/test_store.py
+++ b/tests/scheduling/test_store.py
@@ -106,6 +106,27 @@ class TestSqliteScheduleStore:
         assert loaded is not None
         assert loaded.model_dump() == expected.model_dump()
 
+    async def test_version_check_holds_across_store_instances(self, tmp_path: Path) -> None:
+        database = str(tmp_path / 'shared.db')
+        store_a = SqliteScheduleStore(database)
+        store_b = SqliteScheduleStore(database)
+        await store_a.add(_schedule('shared'))
+
+        from_a = await store_a.get('shared')
+        from_b = await store_b.get('shared')
+        assert from_a is not None
+        assert from_b is not None
+        from_a.name = 'from a'
+        from_b.name = 'from b'
+        await store_a.save(from_a)
+
+        with pytest.raises(ScheduleConflictError, match='changed since it was read'):
+            await store_b.save(from_b)
+        stored = await store_b.get('shared')
+        assert stored is not None
+        assert stored.name == 'from a'
+        assert stored.version == 1
+
     async def test_schema_failure_closes_the_connection(self, tmp_path: Path) -> None:
         database = tmp_path / 'corrupt.db'
         database.write_bytes(b'not a sqlite database')

--- a/tests/scheduling/test_toolset.py
+++ b/tests/scheduling/test_toolset.py
@@ -10,7 +10,14 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 
-from pydantic_ai_harness.scheduling import InMemoryScheduleStore, IntervalTrigger, OnceTrigger, Schedule, Scheduling
+from pydantic_ai_harness.scheduling import (
+    InMemoryScheduleStore,
+    IntervalTrigger,
+    OnceTrigger,
+    Schedule,
+    ScheduleConflictError,
+    Scheduling,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -48,6 +55,7 @@ class TestSchedulingTools:
         assert 'Review changes' not in listing
         details = await _call(capability, 'get_schedule', {'schedule_id': schedule_id})
         assert 'prompt: Review changes' in details
+        assert 'version:' not in details
         updated = await _call(
             capability,
             'update_schedule',
@@ -100,11 +108,7 @@ class TestSchedulingTools:
             )
         await _add(capability, _recurring('invalid-update'))
         with pytest.raises(ModelRetry, match='Invalid schedule update'):
-            await _call(
-                capability,
-                'update_schedule',
-                {'schedule_id': 'invalid-update', 'max_runs': 0},
-            )
+            await _call(capability, 'update_schedule', {'schedule_id': 'invalid-update', 'max_runs': -1})
 
     async def test_not_found_lists_known_ids(self) -> None:
         capability = Scheduling[None]()
@@ -190,17 +194,86 @@ class TestSchedulingTools:
         assert stored is not None
         assert stored.runs_completed == 3
 
-    async def test_update_to_once_rejects_existing_max_runs(self) -> None:
+    async def test_update_clears_fields_and_drops_inherited_limit_for_once(self) -> None:
         capability = Scheduling[None]()
         schedule = _recurring('limited')
         schedule.max_runs = 3
+        schedule.deliver_to = 'alerts'
         await _add(capability, schedule)
+
+        await _call(
+            capability,
+            'update_schedule',
+            {'schedule_id': 'limited', 'deliver_to': '', 'max_runs': 0},
+        )
+        cleared = await capability.resolved_store.get('limited')
+        assert cleared is not None
+        assert cleared.deliver_to is None
+        assert cleared.max_runs is None
+
+        cleared.max_runs = 3
+        await capability.resolved_store.save(cleared)
+        await _call(capability, 'update_schedule', {'schedule_id': 'limited', 'schedule': 'in 1h'})
+        converted = await capability.resolved_store.get('limited')
+        assert converted is not None
+        assert isinstance(converted.trigger, OnceTrigger)
+        assert converted.max_runs is None
+
+    async def test_update_to_once_rejects_explicit_max_runs(self) -> None:
+        capability = Scheduling[None]()
+        await _add(capability, _recurring('limited'))
         with pytest.raises(ModelRetry, match='only valid for recurring'):
             await _call(
                 capability,
                 'update_schedule',
-                {'schedule_id': 'limited', 'schedule': 'in 1h'},
+                {'schedule_id': 'limited', 'schedule': 'in 1h', 'max_runs': 2},
             )
+
+    async def test_pause_retries_on_a_concurrent_claim(self) -> None:
+        store = _ClaimAfterReadStore()
+        capability = Scheduling[None](store=store)
+        original = _recurring('racing')
+        original.next_run_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        await _add(capability, original)
+
+        await _call(capability, 'pause_schedule', {'schedule_id': 'racing'})
+
+        stored = await store.get('racing')
+        assert stored is not None
+        assert stored.enabled is False
+        assert stored.runs_completed == 1
+        assert stored.next_run_at == datetime(2026, 1, 1, 1, tzinfo=timezone.utc)
+
+    async def test_conflict_retry_exhaustion_is_a_model_retry(self) -> None:
+        store = _AlwaysConflictStore()
+        capability = Scheduling[None](store=store)
+        await _add(capability, _recurring('contended'))
+
+        with pytest.raises(ModelRetry, match='changed while this update was being applied'):
+            await _call(capability, 'pause_schedule', {'schedule_id': 'contended'})
+        assert store.save_attempts == 3
+
+    @pytest.mark.parametrize(
+        ('tool_name', 'arguments', 'paused'),
+        [
+            ('update_schedule', {'name': 'updated'}, False),
+            ('resume_schedule', {}, True),
+            ('run_schedule_now', {}, False),
+        ],
+    )
+    async def test_mutating_tools_retry_a_conflict(
+        self, tool_name: str, arguments: dict[str, object], paused: bool
+    ) -> None:
+        store = _ConflictOnceStore()
+        capability = Scheduling[None](store=store)
+        schedule = _recurring(tool_name)
+        schedule.enabled = not paused
+        await _add(capability, schedule)
+        arguments['schedule_id'] = tool_name
+
+        await _call(capability, tool_name, arguments)
+
+        assert store.save_attempts == 2
 
     async def test_pause_resume_recomputes_and_run_now_queues(self) -> None:
         capability = Scheduling[None]()
@@ -274,6 +347,46 @@ def _recurring(schedule_id: str) -> Schedule:
         trigger=IntervalTrigger(every=timedelta(hours=1)),
         next_run_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
     )
+
+
+class _ClaimAfterReadStore(InMemoryScheduleStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self._injected = False
+
+    async def get(self, schedule_id: str) -> Schedule | None:
+        read = await super().get(schedule_id)
+        if read is not None and not self._injected:
+            self._injected = True
+            claimed = await super().get(schedule_id)
+            assert claimed is not None
+            claimed.runs_completed += 1
+            claimed.next_run_at = claimed.next_run_at + timedelta(hours=1) if claimed.next_run_at is not None else None
+            await super().save(claimed)
+        return read
+
+
+class _AlwaysConflictStore(InMemoryScheduleStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.save_attempts = 0
+
+    async def save(self, schedule: Schedule) -> None:
+        del schedule
+        self.save_attempts += 1
+        raise ScheduleConflictError('forced conflict')
+
+
+class _ConflictOnceStore(InMemoryScheduleStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.save_attempts = 0
+
+    async def save(self, schedule: Schedule) -> None:
+        self.save_attempts += 1
+        if self.save_attempts == 1:
+            raise ScheduleConflictError('forced conflict')
+        await super().save(schedule)
 
 
 class TestToolsetIdentity:

--- a/tests/scheduling/test_toolset.py
+++ b/tests/scheduling/test_toolset.py
@@ -215,6 +215,39 @@ class TestSchedulingTools:
         assert queued.next_run_at is not None
         assert queued.next_run_at <= datetime.now(timezone.utc)
 
+    async def test_completed_schedules_are_terminal(self) -> None:
+        capability = Scheduling[None]()
+        completed = _recurring('completed')
+        completed.next_run_at = None
+        paused_completed = _recurring('paused-completed')
+        paused_completed.enabled = False
+        paused_completed.next_run_at = None
+        await _add(capability, completed)
+        await _add(capability, paused_completed)
+
+        with pytest.raises(ModelRetry, match='completed.*Create a new schedule'):
+            await _call(capability, 'run_schedule_now', {'schedule_id': 'completed'})
+        with pytest.raises(ModelRetry, match='not paused'):
+            await _call(capability, 'resume_schedule', {'schedule_id': 'completed'})
+
+        await _call(capability, 'resume_schedule', {'schedule_id': 'paused-completed'})
+        resumed = await capability.resolved_store.get('paused-completed')
+        assert resumed is not None
+        assert resumed.enabled is True
+        assert resumed.next_run_at is None
+
+    async def test_lowering_max_runs_below_attempt_count_completes_schedule(self) -> None:
+        capability = Scheduling[None]()
+        schedule = _recurring('lower-limit')
+        schedule.runs_completed = 3
+        await _add(capability, schedule)
+
+        await _call(capability, 'update_schedule', {'schedule_id': 'lower-limit', 'max_runs': 2})
+        updated = await capability.resolved_store.get('lower-limit')
+        assert updated is not None
+        assert updated.max_runs == 2
+        assert updated.next_run_at is None
+
 
 def _recurring(schedule_id: str) -> Schedule:
     return Schedule(

--- a/tests/scheduling/test_toolset.py
+++ b/tests/scheduling/test_toolset.py
@@ -1,0 +1,243 @@
+"""Tests for scheduling CRUD tools through the public capability surface."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import RunContext
+from pydantic_ai.usage import RunUsage
+
+from pydantic_ai_harness.scheduling import InMemoryScheduleStore, IntervalTrigger, OnceTrigger, Schedule, Scheduling
+
+pytestmark = pytest.mark.anyio
+
+
+def _ctx() -> RunContext[None]:
+    return RunContext(deps=None, model=TestModel(), usage=RunUsage())
+
+
+async def _call(capability: Scheduling[None], name: str, arguments: dict[str, object]) -> str:
+    toolset = capability.get_toolset()
+    ctx = _ctx()
+    tools = await toolset.get_tools(ctx)
+    result = await toolset.call_tool(name, arguments, ctx, tools[name])
+    assert isinstance(result, str)
+    return result
+
+
+async def _add(capability: Scheduling[None], schedule: Schedule) -> None:
+    await capability.resolved_store.add(schedule)
+
+
+class TestSchedulingTools:
+    async def test_create_list_get_update_delete(self) -> None:
+        capability = Scheduling[None]()
+        assert await _call(capability, 'list_schedules', {}) == 'No schedules.'
+        created = await _call(
+            capability,
+            'create_schedule',
+            {'name': 'Review', 'prompt': 'Review changes', 'schedule': 'every 2h', 'deliver_to': 'ops'},
+        )
+        schedule_id = (await capability.resolved_store.list())[0].id
+        assert schedule_id in created
+        listing = await _call(capability, 'list_schedules', {})
+        assert 'Review' in listing
+        assert 'Review changes' not in listing
+        details = await _call(capability, 'get_schedule', {'schedule_id': schedule_id})
+        assert 'prompt: Review changes' in details
+        updated = await _call(
+            capability,
+            'update_schedule',
+            {'schedule_id': schedule_id, 'name': 'Review PR', 'prompt': 'Review it', 'max_runs': 2},
+        )
+        assert 'Review PR' in updated
+        stored = await capability.resolved_store.get(schedule_id)
+        assert stored is not None
+        assert stored.prompt == 'Review it'
+        assert stored.max_runs == 2
+        deleted = await _call(capability, 'delete_schedule', {'schedule_id': schedule_id})
+        assert 'deleted' in deleted
+        assert await capability.resolved_store.list() == []
+
+    async def test_past_once_and_once_max_runs_are_retries(self) -> None:
+        capability = Scheduling[None]()
+        with pytest.raises(ModelRetry, match='time is in the past'):
+            await _call(
+                capability,
+                'create_schedule',
+                {'name': 'Past', 'prompt': 'work', 'schedule': '2020-01-01T00:00:00Z'},
+            )
+        with pytest.raises(ModelRetry, match='only valid for recurring'):
+            await _call(
+                capability,
+                'create_schedule',
+                {'name': 'Once', 'prompt': 'work', 'schedule': 'in 1h', 'max_runs': 2},
+            )
+        assert await capability.resolved_store.list() == []
+
+    async def test_parse_and_model_validation_are_retries(self) -> None:
+        capability = Scheduling[None]()
+        with pytest.raises(ModelRetry, match='Invalid schedule'):
+            await _call(
+                capability,
+                'create_schedule',
+                {'name': 'Bad', 'prompt': 'work', 'schedule': 'whenever', 'max_runs': 0},
+            )
+        with pytest.raises(ModelRetry, match='Invalid schedule'):
+            await _call(
+                capability,
+                'create_schedule',
+                {'name': 'Bad limit', 'prompt': 'work', 'schedule': 'every 1h', 'max_runs': 0},
+            )
+        await _add(capability, _recurring('invalid-update'))
+        with pytest.raises(ModelRetry, match='Invalid schedule update'):
+            await _call(
+                capability,
+                'update_schedule',
+                {'schedule_id': 'invalid-update', 'max_runs': 0},
+            )
+
+    async def test_not_found_lists_known_ids(self) -> None:
+        capability = Scheduling[None]()
+        await _add(capability, _recurring('known'))
+        with pytest.raises(ModelRetry, match='Known ids: known'):
+            await _call(capability, 'get_schedule', {'schedule_id': 'missing'})
+
+    async def test_trigger_update_recomputes_and_resets_runs(self) -> None:
+        capability = Scheduling[None]()
+        schedule = _recurring('change')
+        schedule.runs_completed = 4
+        await _add(capability, schedule)
+        await _call(
+            capability,
+            'update_schedule',
+            {'schedule_id': 'change', 'schedule': 'every 2h'},
+        )
+        stored = await capability.resolved_store.get('change')
+        assert stored is not None
+        assert stored.runs_completed == 0
+        assert stored.trigger == IntervalTrigger(every=timedelta(hours=2))
+        assert stored.next_run_at is not None
+        assert stored.next_run_at > datetime.now(timezone.utc)
+
+    async def test_render_variants_and_optional_update_fields(self) -> None:
+        capability = Scheduling[None]()
+        day = _recurring('day')
+        day.trigger = IntervalTrigger(every=timedelta(days=1))
+        day.last_status = 'error'
+        day.last_error = 'RuntimeError: old failure'
+        day.last_delivery_error = 'RuntimeError: delivery failure'
+        minute = _recurring('minute')
+        minute.trigger = IntervalTrigger(every=timedelta(minutes=30))
+        once = Schedule(
+            id='once',
+            name='once',
+            prompt='one shot',
+            trigger=OnceTrigger(at=datetime(2030, 1, 1, tzinfo=timezone.utc)),
+            next_run_at=datetime(2030, 1, 1, tzinfo=timezone.utc),
+            last_output='previous output',
+        )
+        for item in (day, minute, once):
+            await _add(capability, item)
+        listing = await _call(capability, 'list_schedules', {})
+        assert 'schedule: every 1d' in listing
+        assert 'schedule: every 30m' in listing
+        assert 'schedule: 2030-01-01T00:00:00+00:00' in listing
+        assert 'last status: error' in listing
+        assert 'last error: RuntimeError: old failure' in listing
+        assert 'last delivery error: RuntimeError: delivery failure' in listing
+        details = await _call(capability, 'get_schedule', {'schedule_id': 'once'})
+        assert 'last output: previous output' in details
+        await _call(
+            capability,
+            'update_schedule',
+            {'schedule_id': 'minute', 'deliver_to': 'alerts'},
+        )
+        updated = await capability.resolved_store.get('minute')
+        assert updated is not None
+        assert updated.deliver_to == 'alerts'
+
+    async def test_update_rejects_a_past_once(self) -> None:
+        capability = Scheduling[None]()
+        await _add(capability, _recurring('past-update'))
+        with pytest.raises(ModelRetry, match='time is in the past'):
+            await _call(
+                capability,
+                'update_schedule',
+                {'schedule_id': 'past-update', 'schedule': '2020-01-01T00:00:00Z'},
+            )
+
+    async def test_same_trigger_does_not_reset_runs(self) -> None:
+        capability = Scheduling[None]()
+        schedule = _recurring('same-trigger')
+        schedule.runs_completed = 3
+        await _add(capability, schedule)
+        await _call(
+            capability,
+            'update_schedule',
+            {'schedule_id': 'same-trigger', 'schedule': 'every 1h'},
+        )
+        stored = await capability.resolved_store.get('same-trigger')
+        assert stored is not None
+        assert stored.runs_completed == 3
+
+    async def test_update_to_once_rejects_existing_max_runs(self) -> None:
+        capability = Scheduling[None]()
+        schedule = _recurring('limited')
+        schedule.max_runs = 3
+        await _add(capability, schedule)
+        with pytest.raises(ModelRetry, match='only valid for recurring'):
+            await _call(
+                capability,
+                'update_schedule',
+                {'schedule_id': 'limited', 'schedule': 'in 1h'},
+            )
+
+    async def test_pause_resume_recomputes_and_run_now_queues(self) -> None:
+        capability = Scheduling[None]()
+        schedule = _recurring('queue')
+        schedule.next_run_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        await _add(capability, schedule)
+        assert 'paused' in await _call(capability, 'pause_schedule', {'schedule_id': 'queue'})
+        with pytest.raises(ModelRetry, match='Resume it'):
+            await _call(capability, 'run_schedule_now', {'schedule_id': 'queue'})
+        assert 'resumed' in await _call(capability, 'resume_schedule', {'schedule_id': 'queue'})
+        resumed = await capability.resolved_store.get('queue')
+        assert resumed is not None
+        assert resumed.next_run_at is not None
+        assert resumed.next_run_at > datetime.now(timezone.utc)
+        assert 'next runner tick' in await _call(capability, 'run_schedule_now', {'schedule_id': 'queue'})
+        queued = await capability.resolved_store.get('queue')
+        assert queued is not None
+        assert queued.next_run_at is not None
+        assert queued.next_run_at <= datetime.now(timezone.utc)
+
+
+def _recurring(schedule_id: str) -> Schedule:
+    return Schedule(
+        id=schedule_id,
+        name=schedule_id,
+        prompt='work',
+        trigger=IntervalTrigger(every=timedelta(hours=1)),
+        next_run_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+class TestToolsetIdentity:
+    async def test_id_and_registered_tools(self) -> None:
+        capability = Scheduling[None](store=InMemoryScheduleStore())
+        toolset = capability.get_toolset()
+        assert toolset.id == 'scheduling'
+        assert set(await toolset.get_tools(_ctx())) == {
+            'create_schedule',
+            'list_schedules',
+            'get_schedule',
+            'update_schedule',
+            'pause_schedule',
+            'resume_schedule',
+            'delete_schedule',
+            'run_schedule_now',
+        }

--- a/tests/scheduling/test_toolset.py
+++ b/tests/scheduling/test_toolset.py
@@ -92,6 +92,12 @@ class TestSchedulingTools:
                 'create_schedule',
                 {'name': 'Bad limit', 'prompt': 'work', 'schedule': 'every 1h', 'max_runs': 0},
             )
+        with pytest.raises(ModelRetry, match='Invalid schedule: Duration is too large'):
+            await _call(
+                capability,
+                'create_schedule',
+                {'name': 'Huge interval', 'prompt': 'work', 'schedule': 'every 1000000000d'},
+            )
         await _add(capability, _recurring('invalid-update'))
         with pytest.raises(ModelRetry, match='Invalid schedule update'):
             await _call(
@@ -227,6 +233,17 @@ class TestSchedulingTools:
 
         with pytest.raises(ModelRetry, match='completed.*Create a new schedule'):
             await _call(capability, 'run_schedule_now', {'schedule_id': 'completed'})
+        with pytest.raises(ModelRetry, match='completed.*Create a new schedule'):
+            await _call(
+                capability,
+                'update_schedule',
+                {'schedule_id': 'completed', 'schedule': 'every 2h'},
+            )
+        await _call(capability, 'update_schedule', {'schedule_id': 'completed', 'name': 'renamed'})
+        renamed = await capability.resolved_store.get('completed')
+        assert renamed is not None
+        assert renamed.name == 'renamed'
+        assert renamed.next_run_at is None
         with pytest.raises(ModelRetry, match='not paused'):
             await _call(capability, 'resume_schedule', {'schedule_id': 'completed'})
 

--- a/tests/scheduling/test_toolset.py
+++ b/tests/scheduling/test_toolset.py
@@ -338,6 +338,45 @@ class TestSchedulingTools:
         assert updated.max_runs == 2
         assert updated.next_run_at is None
 
+    async def test_resume_of_an_expired_once_is_a_retry(self) -> None:
+        capability = Scheduling[None]()
+        past = datetime.now(timezone.utc) - timedelta(hours=1)
+        expired = Schedule(
+            id='expired-once',
+            name='expired-once',
+            prompt='work',
+            trigger=OnceTrigger(at=past),
+            enabled=False,
+            next_run_at=past,
+        )
+        await _add(capability, expired)
+
+        with pytest.raises(ModelRetry, match='expired while paused'):
+            await _call(capability, 'resume_schedule', {'schedule_id': 'expired-once'})
+
+        stored = await capability.resolved_store.get('expired-once')
+        assert stored is not None
+        assert stored.enabled is False
+        assert stored.next_run_at == past
+
+    async def test_create_retries_a_colliding_generated_id(self) -> None:
+        store = _DuplicateIdOnceStore()
+        capability = Scheduling[None](store=store)
+
+        created = await _call(capability, 'create_schedule', {'name': 'n', 'prompt': 'p', 'schedule': 'every 2h'})
+
+        assert created.startswith('Schedule created.')
+        assert len(store.attempted_ids) == 2
+        assert store.attempted_ids[0] != store.attempted_ids[1]
+
+    async def test_create_id_collision_exhaustion_is_a_model_retry(self) -> None:
+        store = _AlwaysDuplicateIdStore()
+        capability = Scheduling[None](store=store)
+
+        with pytest.raises(ModelRetry, match='fresh id'):
+            await _call(capability, 'create_schedule', {'name': 'n', 'prompt': 'p', 'schedule': 'every 2h'})
+        assert len(store.attempted_ids) == 3
+
 
 def _recurring(schedule_id: str) -> Schedule:
     return Schedule(
@@ -347,6 +386,28 @@ def _recurring(schedule_id: str) -> Schedule:
         trigger=IntervalTrigger(every=timedelta(hours=1)),
         next_run_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
     )
+
+
+class _DuplicateIdOnceStore(InMemoryScheduleStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attempted_ids: list[str] = []
+
+    async def add(self, schedule: Schedule) -> Schedule:
+        self.attempted_ids.append(schedule.id)
+        if len(self.attempted_ids) == 1:
+            raise ValueError(f'A schedule with id {schedule.id!r} already exists.')
+        return await super().add(schedule)
+
+
+class _AlwaysDuplicateIdStore(InMemoryScheduleStore):
+    def __init__(self) -> None:
+        super().__init__()
+        self.attempted_ids: list[str] = []
+
+    async def add(self, schedule: Schedule) -> Schedule:
+        self.attempted_ids.append(schedule.id)
+        raise ValueError(f'A schedule with id {schedule.id!r} already exists.')
 
 
 class _ClaimAfterReadStore(InMemoryScheduleStore):

--- a/tests/scheduling/test_types.py
+++ b/tests/scheduling/test_types.py
@@ -57,6 +57,15 @@ class TestScheduleParsing:
         with pytest.raises(ValidationError, match='at least every 1 minute'):
             parse_schedule('every 0m')
 
+    def test_interval_ceiling(self) -> None:
+        with pytest.raises(ValidationError, match='cron expression for longer cadences'):
+            IntervalTrigger(every=timedelta(days=366))
+
+    @pytest.mark.parametrize('value', ['every 1000000000d', 'in 999999999d'])
+    def test_duration_overflow(self, value: str) -> None:
+        with pytest.raises(ValueError, match='Duration is too large'):
+            parse_schedule(value, now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
     def test_missing_cronsim_has_install_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setitem(sys.modules, 'cronsim', None)
         with pytest.raises(ImportError, match=r'pip install pydantic-ai-harness\[scheduling\]'):

--- a/tests/scheduling/test_types.py
+++ b/tests/scheduling/test_types.py
@@ -1,0 +1,92 @@
+"""Tests for public scheduling types and schedule parsing."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+from pydantic import ValidationError
+
+from pydantic_ai_harness.scheduling import (
+    CronTrigger,
+    IntervalTrigger,
+    OnceTrigger,
+    Schedule,
+    parse_schedule,
+)
+
+
+class TestScheduleParsing:
+    def test_interval_forms_are_case_insensitive(self) -> None:
+        assert parse_schedule('every 30m') == IntervalTrigger(every=timedelta(minutes=30))
+        assert parse_schedule('EVERY 2H') == IntervalTrigger(every=timedelta(hours=2))
+        assert parse_schedule('every 1d') == IntervalTrigger(every=timedelta(days=1))
+
+    def test_relative_once_uses_explicit_now(self) -> None:
+        now = datetime(2026, 1, 2, 3, tzinfo=timezone.utc)
+        assert parse_schedule('in 2h', now=now) == OnceTrigger(at=now + timedelta(hours=2))
+
+    def test_relative_once_interprets_naive_now_in_timezone(self) -> None:
+        now = datetime(2026, 1, 2, 3)
+        trigger = parse_schedule('in 1d', timezone='Asia/Kolkata', now=now)
+        assert isinstance(trigger, OnceTrigger)
+        assert trigger.at == datetime(2026, 1, 3, 3, tzinfo=ZoneInfo('Asia/Kolkata'))
+
+    def test_iso_forms_and_naive_timezone(self) -> None:
+        assert parse_schedule('2026-01-02T03:04:05Z') == OnceTrigger(
+            at=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+        )
+        trigger = parse_schedule('2026-01-02 03:04:05', timezone='America/New_York')
+        assert isinstance(trigger, OnceTrigger)
+        assert trigger.at == datetime(2026, 1, 2, 3, 4, 5, tzinfo=ZoneInfo('America/New_York'))
+
+    def test_rejects_unsupported_text_and_bad_iso(self) -> None:
+        for value in ('tomorrow morning', '2026-99-99T10:00:00'):
+            with pytest.raises(ValueError, match='every <N>'):
+                parse_schedule(value)
+
+    def test_rejects_unknown_timezone(self) -> None:
+        with pytest.raises(ValueError, match='Unknown IANA timezone'):
+            parse_schedule('in 1h', timezone='Mars/Olympus')
+
+    def test_interval_floor(self) -> None:
+        with pytest.raises(ValidationError, match='at least every 1 minute'):
+            IntervalTrigger(every=timedelta(seconds=59))
+        with pytest.raises(ValidationError, match='at least every 1 minute'):
+            parse_schedule('every 0m')
+
+    def test_missing_cronsim_has_install_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, 'cronsim', None)
+        with pytest.raises(ImportError, match=r'pip install pydantic-ai-harness\[scheduling\]'):
+            parse_schedule('0 9 * * *')
+
+
+class TestScheduleModel:
+    def test_status(self) -> None:
+        schedule = Schedule(name='daily', prompt='work', trigger=IntervalTrigger(every=timedelta(days=1)))
+        assert schedule.status == 'completed'
+        schedule.next_run_at = datetime(2026, 1, 2, tzinfo=timezone.utc)
+        assert schedule.status == 'scheduled'
+        schedule.enabled = False
+        assert schedule.status == 'paused'
+
+    def test_defaults_and_validation(self) -> None:
+        schedule = Schedule(name='daily', prompt='work', trigger=IntervalTrigger(every=timedelta(days=1)))
+        assert len(schedule.id) == 12
+        assert schedule.created_at.tzinfo is not None
+        assert schedule.runs_completed == 0
+        with pytest.raises(ValidationError, match='greater than or equal to 1'):
+            Schedule(name='bad', prompt='work', trigger=schedule.trigger, max_runs=0)
+        with pytest.raises(ValidationError, match='Unknown IANA timezone'):
+            Schedule(name='bad', prompt='work', trigger=schedule.trigger, timezone='bad/timezone')
+
+    def test_once_requires_an_aware_datetime(self) -> None:
+        with pytest.raises(ValidationError):
+            OnceTrigger(at=datetime(2026, 1, 1))
+
+
+class TestCronTriggerImport:
+    def test_public_type_is_available(self) -> None:
+        assert CronTrigger.__name__ == 'CronTrigger'

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -134,6 +134,7 @@ _CAPABILITY_PAGE_META = {
     'subagents.md': ('subagents', 'Subagents'),
     'dynamic-workflow.md': ('dynamic_workflow', 'Dynamic Workflow'),
     'planning.md': ('planning', 'Planning'),
+    'scheduling.md': ('scheduling', 'Scheduling'),
     'system-reminders.md': ('system_reminders', 'System Reminders'),
     'capability-creation.md': ('capability_creation', 'Runtime Capability Creation'),
     'guardrails.md': ('guardrails', 'Input, Output & Tool Guardrails'),

--- a/uv.lock
+++ b/uv.lock
@@ -36,7 +36,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version < '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -53,7 +53,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -780,6 +780,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
     { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
     { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+]
+
+[[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -2363,6 +2371,9 @@ modal = [
 mongodb = [
     { name = "pymongo" },
 ]
+scheduling = [
+    { name = "cronsim" },
+]
 skills = [
     { name = "pyyaml" },
 ]
@@ -2396,6 +2407,7 @@ lint = [
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.11,<0.12" },
+    { name = "cronsim", marker = "extra == 'scheduling'", specifier = ">=2.6" },
     { name = "exa-py", marker = "extra == 'exa'", specifier = ">=2.16.0" },
     { name = "genai-prices", specifier = ">=0.0.71" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -2412,7 +2424,7 @@ requires-dist = [
     { name = "pymongo", marker = "extra == 'mongodb'", specifier = ">=4.17.0" },
     { name = "pyyaml", marker = "extra == 'skills'", specifier = ">=6.0.2" },
 ]
-provides-extras = ["acp", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "skills", "stackone", "temporal"]
+provides-extras = ["acp", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "scheduling", "skills", "stackone", "temporal"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #111

Adds a `scheduling` capability package: model-managed schedules (cron, intervals, one-shots) executed by an in-process runner, with results delivered to a callback the application owns.

## What ships

- `Scheduling` -- an `AbstractCapability` exposing CRUD tools (`create_schedule`, `list_schedules`, `get_schedule`, `update_schedule`, `pause_schedule`, `resume_schedule`, `delete_schedule`, `run_schedule_now`) over a pluggable `ScheduleStore`, plus guidance instructions. Spec-serializable: `- Scheduling: {backend: sqlite, database: schedules.db, timezone: Europe/Berlin}`.
- `ScheduleRunner` -- an embedder-owned loop (`run_until_stopped()` / `stop()`) that claims due schedules and runs each as a fresh, isolated agent run. `tick()` is public so an external scheduler (system cron, a workflow engine, serverless) can drive the same store without the loop.
- `ScheduleStore` protocol with `InMemoryScheduleStore` and `SqliteScheduleStore`. Saves are versioned: `save` replaces only a matching `Schedule.version` and raises `ScheduleConflictError` for a stale one, so the toolset and the runner can write concurrently without reverting each other's updates.
- Schedule text forms: `every <N><m|h|d>`, `in <N><m|h|d>`, ISO 8601 datetime, five-field cron. Cron parsing/DST handling comes from `cronsim` behind a new `scheduling` extra; interval and one-shot schedules work without the extra.

## Design decisions

- **At-most-once.** `next_run_at` advances and persists before the agent runs; a crash mid-run skips an occurrence rather than double-firing on restart.
- **Optimistic concurrency.** The system has two writers by construction (the tools and the runner), so the store contract is versioned saves rather than last-write-wins: every writer re-reads and retries on `ScheduleConflictError`. A pause can no longer revert a concurrent claim's run count, and a claim cannot double-fire under concurrent ticks.
- **A counted occurrence is a started occurrence.** The runner starts each schedule as soon as its claim is persisted instead of batching claims and then executing. A store failure later in the sweep drains already-started runs before surfacing, so `runs_completed` never advances for an occurrence that was silently discarded.
- **No automatic retry.** A failed run records `last_error` and waits; for recurring schedules the next occurrence is the retry. Callback failures are recorded separately (`last_delivery_error`) and never fail the run. Empty output is success.
- **No backlog replay.** Recurring schedules overdue beyond `misfire_grace` run once and fast-forward; overdue one-shots are recorded as `missed` instead of running hours late. Resume recomputes from now. Past one-shots are rejected at creation.
- **No self-scheduling through this capability.** Inside a scheduled run the scheduling tools and instructions are absent (contextvar-guarded), so a scheduled prompt cannot manage schedules through the `Scheduling` tools. Tools the application exposes separately are outside this guard.
- **Completed is terminal.** A one-shot that ran or a schedule that reached `max_runs` cannot be revived through `resume_schedule`, `run_schedule_now`, or a `max_runs` edit; the bound is enforced again at the claim seam. Run outcomes retry from a fresh read on version conflict, so a pause, edit, or deletion made during a long run always wins over the runner's pre-run snapshot.
- **Spend control per schedule.** `Schedule.usage_limits` (falling back to a runner-wide default) caps each unattended run with core `UsageLimits`. The model-facing tools deliberately cannot set model or provider.
- **Delivery is a seam, not a system.** `on_result` (sync or async) plus an opaque `deliver_to` hint. Transports are #110 / #63; they can build on this callback without this package growing platform code.
- **Single-runner assumption.** The store protocol documents one runner per store; versioned saves coordinate writers within that design, and multi-process claim semantics can arrive later as a store backend without changing the runner.

## Out of scope, deliberately

Messaging/webhook transports (#110, #63), natural-language schedule phrases beyond the `every`/`in` forms, per-schedule model overrides, automatic retry, and multi-process runner coordination.

## Notes for review

- New optional dependency: `scheduling = ["cronsim>=2.6"]` (lazy import; clear install hint without it). Touches `pyproject.toml`/`uv.lock`, so the PR needs the `dependencies:approved` label.
- Tests mirror the package; the cron-only file is collection-skipped in the slim matrix. Full suite passes with 100% branch coverage; pyright strict and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
