### PR TITLE
fix(codemode): keep unserializable final expressions in the run

### DIFF
--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -26,6 +26,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.tool_manager import ParallelExecutionMode, ToolManager
 from pydantic_ai.tools import AgentDepsT, ToolDenied, ToolSelector, matches_tool_selector
 from pydantic_ai.toolsets.abstract import SchemaValidatorProt, ToolsetTool
+from pydantic_core import PydanticSerializationError, to_jsonable_python
 
 try:
     from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME  # pyright: ignore[reportPrivateUsage]
@@ -115,6 +116,23 @@ _RUN_CODE_ARGS_VALIDATOR: SchemaValidatorProt = _RUN_CODE_ADAPTER.validator  # p
 # Used to serialize tool return values before sending into Monty (dump_python)
 # and to reconstruct multimodal types (e.g. BinaryContent) from Monty results (validate_python).
 _TOOL_RETURN_CONTENT_TA: TypeAdapter[Any] = TypeAdapter(ToolReturnContent)
+
+
+def _ensure_serializable_result(result: Any) -> Any:
+    """Return a tool result that can be serialized into a `ToolReturnPart`.
+
+    Most results pass through unchanged so multimodal values stay native. If a model returns an
+    unsupported Python object as the final expression, normalize only that failure path and keep
+    the rest of the structure intact. This prevents an instrumentation/history serialization error
+    from aborting the agent run.
+    """
+    try:
+        _TOOL_RETURN_CONTENT_TA.dump_json(result)
+    except PydanticSerializationError:
+        result = to_jsonable_python(result, fallback=str, bytes_mode='base64')
+        return _TOOL_RETURN_CONTENT_TA.validate_python(result)
+    return result
+
 
 _RUN_CODE_DESCRIPTION_HEAD = """\
 Write and run Python code in a sandboxed environment.
@@ -694,6 +712,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
         # serialized dicts) so they flow through to the model natively.
         if result is not None:
             result = _TOOL_RETURN_CONTENT_TA.validate_python(result)
+            result = _ensure_serializable_result(result)
 
         # Build return value:
         # - No print → return result directly (multimodal content stays top-level

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -1214,6 +1214,39 @@ class TestCodeMode:
         # The agent's final output reflects the value flowing through the sandbox.
         assert result.output == 'sum is 10'
 
+    async def test_code_mode_stringifies_unserializable_final_expression(self) -> None:
+        """An unsupported final expression becomes a string instead of crashing serialization."""
+        from pydantic_ai.messages import (
+            ModelMessage,
+            ModelRequest,
+            ModelResponse,
+            TextPart,
+            ToolCallPart,
+            ToolReturnPart,
+        )
+        from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+        observed_returns: list[Any] = []
+
+        def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            if not any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+                return ModelResponse(parts=[ToolCallPart(tool_name='run_code', args={'code': 'dict'})])
+
+            last_request = messages[-1]
+            assert isinstance(last_request, ModelRequest)
+            run_code_return = next(
+                part for part in last_request.parts if isinstance(part, ToolReturnPart) and part.tool_name == 'run_code'
+            )
+            observed_returns.append(run_code_return.content)
+            return ModelResponse(parts=[TextPart(str(run_code_return.content))])
+
+        agent: Agent[object, str] = Agent(FunctionModel(model_fn), capabilities=[CodeMode[object]()])
+
+        result = await agent.run('return a class')
+
+        assert observed_returns == ["<class 'dict'>"]
+        assert result.output == "<class 'dict'>"
+
     async def test_deferred_capability_loader_stays_native_with_tools_all(self) -> None:
         """Regression for the deferred-capability bootstrap (issue #276).
 


### PR DESCRIPTION
## Summary

When CodeMode's final expression evaluates to a Python object that cannot be serialized by Pydantic AI, the resulting ToolReturnPart can crash the next model request. For example, returning the `dict` class raises `PydanticSerializationError` while Pydantic AI estimates request usage.

This change keeps the existing native path for serializable and multimodal values. Only when serialization fails does it normalize unsupported leaves with Pydantic Core's JSON fallback, converting them to strings before rebuilding the ToolReturnContent value.

## Linked Issue

Fixes #405

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint` passes locally
- [x] `make typecheck` passes locally
- [x] `make test` passes locally
- [x] `make testcov` passes locally with 100% coverage
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)