### PR TITLE
fix: propagate usage limits to nested capability runs

### DIFF
--- a/pydantic_ai_harness/_usage.py
+++ b/pydantic_ai_harness/_usage.py
@@ -1,0 +1,19 @@
+"""Shared helpers for nested agent usage accounting."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from pydantic_ai.usage import UsageLimits
+
+
+def reserved_usage_limits(limits: UsageLimits | None) -> UsageLimits | None:
+    """Hold one request back for a nested model call made from a hook.
+
+    A hook can run after the parent request has passed its pre-request limit
+    check. Reserving one slot prevents the nested call from allowing that
+    already-approved parent request to exceed ``request_limit``.
+    """
+    if limits is None or limits.request_limit is None:
+        return limits
+    return replace(limits, request_limit=max(0, limits.request_limit - 1))

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -22,6 +22,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.tools import RunContext
 
+from pydantic_ai_harness._usage import reserved_usage_limits
 from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW
 from pydantic_ai_harness.compaction._pinning import is_pinned, reinject_pinned
 from pydantic_ai_harness.compaction._receipts import (
@@ -594,5 +595,5 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
             model,
             instructions='You are a context summarization assistant. Extract the most important information from conversations.',
         )
-        result = await agent.run(prompt, usage=ctx.usage)
+        result = await agent.run(prompt, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
         return result.output.strip()

--- a/pydantic_ai_harness/system_reminders/_capability.py
+++ b/pydantic_ai_harness/system_reminders/_capability.py
@@ -23,10 +23,11 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import KnownModelName, Model
 from pydantic_ai.tools import AgentDepsT, RunContext
 
+from pydantic_ai_harness._usage import reserved_usage_limits
+
 if TYPE_CHECKING:
     from pydantic_ai.capabilities.abstract import WrapModelRequestHandler
     from pydantic_ai.models import ModelRequestContext
-    from pydantic_ai.usage import UsageLimits
 
 
 @dataclass
@@ -292,24 +293,11 @@ class LLMReminder(Generic[AgentDepsT]):
                 agent = Agent(self.model, instructions=self.instructions, output_type=str)
                 self._agent = agent
             transcript = _build_compact_transcript(ctx.messages, self.max_context_messages)
-            result = await agent.run(transcript, usage=ctx.usage, usage_limits=_reserved_limits(ctx.usage_limits))
+            result = await agent.run(transcript, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
             text = result.output.strip()
             return text or None
         except Exception:
             return GoalReanchor[AgentDepsT]()(ctx)
-
-
-def _reserved_limits(limits: UsageLimits | None) -> UsageLimits | None:
-    """The parent run's limits with one request held back for the model call this reminder precedes.
-
-    `wrap_model_request` runs after the parent request already cleared `check_before_request`, so
-    a nested run spending the last slot would let that approved request push the run one past
-    `request_limit`. Holding the slot back makes the nested run raise `UsageLimitExceeded` first;
-    the caller falls back to `GoalReanchor`, which costs no request, and the budget holds.
-    """
-    if limits is None or limits.request_limit is None:
-        return limits
-    return replace(limits, request_limit=max(0, limits.request_limit - 1))
 
 
 def _should_fire(reminder: Reminder[AgentDepsT], count: int) -> bool:

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -14,6 +14,7 @@ from pydantic_ai.messages import ToolCallPart, ToolReturn, ToolReturnContent, Us
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition, ToolSelector, matches_tool_selector
 from pydantic_ai.toolsets import AgentToolset
 
+from pydantic_ai_harness._usage import reserved_usage_limits
 from pydantic_ai_harness.tool_output_limits._bands import (
     Action,
     Band,
@@ -414,7 +415,7 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         model = action.model if action.model is not None else ctx.model
         prompt = self.summary_prompt.format(tool_name=call.tool_name, output=text)
         agent: Agent[None, str] = Agent(model, instructions='You summarize oversized tool output.')
-        run = await agent.run(prompt, usage=ctx.usage)
+        run = await agent.run(prompt, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
         return run.output.strip()
 
 

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -30,7 +30,7 @@ from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameter
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RunUsage, UsageLimits
 
 from pydantic_ai_harness.compaction import (
     ClampOversizedMessages,
@@ -83,6 +83,7 @@ def _make_ctx(
     requests: int = 0,
     input_tokens: int = 0,
     output_tokens: int = 0,
+    usage_limits: UsageLimits | None = None,
 ) -> Any:
     """Build a minimal RunContext-like object for testing hooks."""
 
@@ -92,6 +93,7 @@ def _make_ctx(
     class _FakeCtx:
         usage: RunUsage
         model: Model = dataclasses.field(default_factory=TestModel)
+        usage_limits: UsageLimits | None = None
         deps: None = None
         tracer: Tracer = dataclasses.field(default_factory=NoOpTracer)
         # A declared field, like the real `RunContext`: a strategy reached from
@@ -101,7 +103,7 @@ def _make_ctx(
             default_factory=dict[str, AbstractCapability[None]]
         )
 
-    return _FakeCtx(usage=usage)
+    return _FakeCtx(usage=usage, usage_limits=usage_limits)
 
 
 def _make_request_context(messages: list[ModelMessage], model: Model | None = None) -> ModelRequestContext:
@@ -1886,6 +1888,24 @@ class TestSummarizingCompactionModel:
         assert MockAgent.call_args.args[0] is rc.model
         # Its usage is threaded into the parent run for honest accounting.
         assert mock_agent_instance.run.call_args.kwargs['usage'] is ctx.usage
+
+    @pytest.mark.anyio
+    async def test_nested_summary_reserves_parent_request_limit(self):
+        comp = SummarizingCompaction(max_messages=3, keep_messages=1, preserve_first_user_message=False)
+        messages: list[ModelMessage] = [_user('a'), _assistant('b'), _user('c'), _assistant('d')]
+        rc = _make_request_context(messages)
+        ctx = _make_ctx(usage_limits=UsageLimits(request_limit=5))
+
+        mock_result = AsyncMock()
+        mock_result.output = 'Bounded summary.'
+        with patch('pydantic_ai.Agent') as MockAgent:
+            mock_agent_instance = AsyncMock()
+            mock_agent_instance.run.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+            await comp.before_model_request(ctx, rc)
+
+        nested_limits = mock_agent_instance.run.call_args.kwargs['usage_limits']
+        assert nested_limits.request_limit == 4
 
     def test_default_prompt_has_structured_sections(self):
         from pydantic_ai_harness.compaction._summarizing_compaction import _DEFAULT_SUMMARY_PROMPT

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -22,7 +22,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RunUsage, UsageLimits
 
 from pydantic_ai_harness.compaction import (
     DEFAULT_CONTEXT_WINDOW,
@@ -65,6 +65,7 @@ def _ctx(model: Any = None) -> Any:
     @dataclasses.dataclass
     class _FakeCtx:
         usage: RunUsage = dataclasses.field(default_factory=RunUsage)
+        usage_limits: UsageLimits | None = None
         model: Model = dataclasses.field(default_factory=TestModel)
         deps: None = None
         tracer: Tracer = dataclasses.field(default_factory=NoOpTracer)

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -8,6 +8,7 @@ import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic_ai import Agent
@@ -24,7 +25,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RunUsage, UsageLimits
 
 from pydantic_ai_harness.tool_output_limits import (
     Band,
@@ -62,7 +63,13 @@ from pydantic_ai_harness.tool_output_limits._store import _safe_segment
 # ---------------------------------------------------------------------------
 
 
-def _make_ctx(*, run_id: str | None = 'run-1', retry: int = 0, model: Any = None) -> Any:
+def _make_ctx(
+    *,
+    run_id: str | None = 'run-1',
+    retry: int = 0,
+    model: Any = None,
+    usage_limits: UsageLimits | None = None,
+) -> Any:
     """Build a minimal RunContext-like object for testing the hook directly."""
 
     @dataclasses.dataclass
@@ -74,11 +81,12 @@ def _make_ctx(*, run_id: str | None = 'run-1', retry: int = 0, model: Any = None
         usage: RunUsage
         run_id: str | None
         retry: int
+        usage_limits: UsageLimits | None = None
         tool_call_id: str | None = 'call-1'
         model: Any = dataclasses.field(default_factory=_FakeModel)
         deps: None = None
 
-    ctx = _FakeCtx(usage=RunUsage(), run_id=run_id, retry=retry)
+    ctx = _FakeCtx(usage=RunUsage(), run_id=run_id, retry=retry, usage_limits=usage_limits)
     if model is not None:
         ctx.model = model
     return ctx
@@ -547,6 +555,21 @@ class TestSummarize:
         out = await _run(cap, 'x' * 100, ctx=ctx)
         assert out == 'THE SUMMARY'
         assert ctx.usage.requests == 1
+
+    async def test_inherited_model_reserves_parent_request_limit(self):
+        ctx = _make_ctx(model=_fixed_model('THE SUMMARY'), usage_limits=UsageLimits(request_limit=5))
+        cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=5, action=Summarize())])
+        mock_result = AsyncMock()
+        mock_result.output = 'THE SUMMARY'
+        mock_agent = AsyncMock()
+        mock_agent.run.return_value = mock_result
+
+        with patch('pydantic_ai.Agent', return_value=mock_agent):
+            out = await _run(cap, 'x' * 100, ctx=ctx)
+
+        assert out == 'THE SUMMARY'
+        nested_limits = mock_agent.run.call_args.kwargs['usage_limits']
+        assert nested_limits.request_limit == 4
 
     async def test_explicit_model_overrides_ctx(self):
         ctx = _make_ctx(model=_fixed_model('FROM CTX MODEL'))


### PR DESCRIPTION
## Summary

Nested model runs started by `SummarizingCompaction` and the `ToolOutputLimits` summarize action already share the parent `RunUsage`, but they did not receive the parent's `UsageLimits`. Pydantic AI therefore applied its default `request_limit=50` to the nested run.

This could stop a configured run early or allow the already-approved parent request to overshoot its request budget by one.

## Changes

- Share the one-request reservation logic used by `LLMReminder` in a small internal usage helper.
- Pass the reserved parent limits to compaction and tool-output summarization runs.
- Add regression coverage for a parent `request_limit=5` being forwarded as `4`.

## Verification

- `make lint`
- `make typecheck`
- `make test` -- 4282 passed, 47 skipped
- `make testcov` -- 100% branch coverage

Fixes #528
