### PR TITLE
fix(spend): count every billed response, and correct the guarantees the docs claim

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
     outputs:
       localstack: ${{ steps.detect.outputs.localstack }}
       mongodb: ${{ steps.detect-mongodb.outputs.mongodb }}
+      redis: ${{ steps.detect-redis.outputs.redis }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -90,6 +91,32 @@ jobs:
               exit "$status"
             fi
             echo 'mongodb=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      # A third step for the same reason the MongoDB one is separate: the three
+      # capabilities need independent answers, and this one's paths are the spend
+      # store rather than the Mongo-backed capabilities.
+      - id: detect-redis
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            pydantic_ai_harness/spend \
+            tests/spend \
+            integration_tests/redis \
+            Makefile \
+            pyproject.toml \
+            uv.lock \
+            .github/workflows/main.yml
+          then
+            echo 'redis=false' >> "$GITHUB_OUTPUT"
+          else
+            status=$?
+            if [ "$status" -ne 1 ]; then
+              exit "$status"
+            fi
+            echo 'redis=true' >> "$GITHUB_OUTPUT"
           fi
 
   lint:
@@ -375,6 +402,51 @@ jobs:
 
       - run: make integration-mongodb
 
+  redis-integration:
+    needs: [changes]
+    # Same shape as `mongodb-integration`: no fork clause, because the redis service
+    # container reads no secret and an external contributor's pull request must get
+    # the same signal a maintainer branch does.
+    if: >-
+      ${{ always()
+          && (github.ref_type == 'tag' || needs.changes.outputs.redis == 'true') }}
+    runs-on: ubuntu-latest
+    name: Redis integration tests
+    # A service container the runner owns, so nothing here starts it; without a
+    # timeout an unreachable container would sit on the six-hour default.
+    timeout-minutes: 15
+    services:
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # Without this an unreachable server is a skip, which is what a developer
+      # without a local Redis wants and exactly what must not happen here: a
+      # service container that never came up would report green having tested
+      # nothing.
+      REDIS_REQUIRE_LIVE: '1'
+      REDIS_TEST_URL: redis://127.0.0.1:6379
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          python-version: '3.14'
+          enable-cache: true # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
+          cache-suffix: redis
+
+      - run: uv sync --locked --group dev
+
+      - run: make integration-redis
+
   coverage:
     needs: [test]
     runs-on: ubuntu-latest
@@ -400,7 +472,7 @@ jobs:
 
   check:
     if: always()
-    needs: [changes, lint, test, test-floor, test-latest, base-import, coverage, localstack-integration, mongodb-integration]
+    needs: [changes, lint, test, test-floor, test-latest, base-import, coverage, localstack-integration, mongodb-integration, redis-integration]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
@@ -408,10 +480,10 @@ jobs:
           # localstack-integration is skipped when a pull request or branch push
           # doesn't touch LocalStack, when the pull request comes from a fork
           # (no secrets there), and `changes` is skipped on tag events.
-          # mongodb-integration is skipped only on the path filter -- it needs no
-          # secret, so it runs on fork pull requests too.
-          # All three still vote (block the merge) when they actually run and fail.
-          allowed-skips: changes, localstack-integration, mongodb-integration
+          # mongodb-integration and redis-integration are skipped only on the path
+          # filter -- neither needs a secret, so both run on fork pull requests too.
+          # All four still vote (block the merge) when they actually run and fail.
+          allowed-skips: changes, localstack-integration, mongodb-integration, redis-integration
           jobs: ${{ toJSON(needs) }}
 
   release:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := all
 
-.PHONY: .uv .prek install format lint typecheck test testcov integration-localstack integration-mongodb all
+.PHONY: .uv .prek install format lint typecheck test testcov integration-localstack integration-mongodb integration-redis all
 
 .uv:
 	@uv --version || echo 'Please install uv: https://docs.astral.sh/uv/getting-started/installation/'
@@ -37,5 +37,10 @@ integration-localstack:
 # the tests skip. Set MONGODB_TEST_URL to point at a server elsewhere.
 integration-mongodb:
 	uv run pytest integration_tests/mongodb/test_live_mongodb.py
+
+# Needs a reachable Redis (`docker run -d -p 6379:6379 redis:8`); without one the
+# tests skip. Set REDIS_TEST_URL to point at a server elsewhere.
+integration-redis:
+	uv run pytest integration_tests/redis/test_live_redis.py
 
 all: format lint typecheck testcov

--- a/docs/spend.md
+++ b/docs/spend.md
@@ -56,7 +56,7 @@ SpendLimits(
 |---|---|
 | `usd` / `tokens` | ceilings; set either, both, or neither |
 | `window` | `run`, `conversation`, `day`, `month`, `total` |
-| `scope` | derives a partition key from the run, so tenants count separately |
+| `scope` | derives a partition key from the run, so tenants count separately; typed against the agent's `deps` |
 | `warn_at` | fraction past which `BudgetStatus.warning` is set; never blocks |
 | `name` | distinguishes budgets sharing a window and scope |
 | `retain` | how long the counter is kept after its last write; `'window default'`, `'forever'`, or a `timedelta` |
@@ -64,6 +64,8 @@ SpendLimits(
 A window rolls over by producing a different store key rather than by resetting a counter, so a new day is simply a new key and nothing has to run at midnight. A `total` counter never expires. `run` and `conversation` buckets never roll over either, so expiry there hands back the ceiling rather than starting a new period -- but each mints a key per run or per conversation, so they carry a long horizon (24 hours and 30 days) instead, past which the counter is dropped rather than kept forever. That default is a compromise, and it is visible: a conversation resumed past its horizon starts from zero again, so set `retain='forever'` where a conversation ceiling has to hold for as long as the conversation does, and clean the keys up some other way.
 
 Budgets that share a `name`, `window`, and `scope` share one counter, which is how a single window carries both a USD and a token ceiling. The response is added to that counter once, not once per budget. Two budgets that share a `name` and `window` but declare *different* `scope` callables are refused at construction: they are different dimensions -- per tenant and per user, say -- and nothing stops the two returning the same string, which would merge them into one counter. Give them different names, or pass the same callable to both. Budgets that do share a counter must also agree on `retain`: one counter has one expiry, and the accrual writes whichever of them is listed first, so disagreeing would let declaration order decide when a `'forever'` ceiling rolls over.
+
+`Budget` is generic in the agent's dependency type, so a `scope` is checked against it: pass the capability to an `Agent` with a `deps_type` and a scope reaching for a field those deps do not have is a type error rather than an `AttributeError` on the first request.
 
 **A budget with no ceiling is a counter.** It accumulates and reports and never refuses anything, which is how per-tenant accounting with no cap is expressed:
 
@@ -127,11 +129,15 @@ limits = SpendLimits(budgets=[Budget(usd=Decimal('100'), window='day')], store=s
 
 It adds no dependency: `RedisClient` is a protocol of the two coroutines used, so any compatible client satisfies it. Amounts are stored as integer billionths of a dollar rather than through `INCRBYFLOAT`, which accumulates rounding error over the tens of thousands of requests a busy day produces. Billionths rather than millionths because the residue does not average out: an agent repeats requests of near-identical shape, so the same fraction rounds the same way every time.
 
-A response is applied as one Lua script, in one round trip, and every way it can refuse -- the ceiling below, a client or network failure -- lands before it writes anything. Split across separate commands, a failure between them leaves a window holding part of a response, which reads as a smaller number than was really spent and so releases the brake later than it should. The cost of doing it server-side is a ceiling -- the counters pass through Lua, whose numbers stop being exact integers above `2**53` billionths, about **$9,007,199** against a single key. Past that the store raises rather than rounding silently. Settling a protocol without that ceiling is [#532](https://github.com/pydantic/pydantic-ai-harness/issues/532).
+Each window is applied as one Lua script, in one round trip, so no other client sees a window holding part of a response and the exact-integer ceiling is checked before anything is written. That guarantee is per window, not across them: a response counting against a day budget and a month budget is two scripts, so a failure between the two leaves the day counted and the month not. Widening it needs a store operation that takes every window at once, tracked in [#536](https://github.com/pydantic/pydantic-ai-harness/issues/536).
+
+A failure *after* the server has run a script does not say whether it committed -- the connection can drop once `EVAL` has landed -- so an `add` that errors leaves the outcome unknown rather than untried. Nothing retries it: counting a billed response twice is a direction the brake survives, and counting it zero times is not.
+
+The cost of doing it server-side is a ceiling -- the counters pass through Lua, whose numbers stop being exact integers above `2**53` billionths, about **$9,007,199** against a single key. Past that the store raises rather than rounding silently. Settling a protocol without that ceiling is [#532](https://github.com/pydantic/pydantic-ai-harness/issues/532).
 
 The default store is built per capability, so two `SpendLimits` instances do not quietly share one counter. Pass the same store object to both when you want them to.
 
-A store that fails does not fail quietly. An error reading the counter refuses the request, which is the safe direction. An error writing it propagates out of the run after the model has already answered and been charged, and the response goes uncounted rather than half counted, since nothing is written until the script commits to writing all of it. That is deliberate: a swallowed write would drift the counter down and weaken the gate, which is worse than a visible failure. If your deployment would rather keep the answer than the count, wrap the store and decide there.
+A store that fails does not fail quietly. An error reading the counter refuses the request, which is the safe direction. An error writing it propagates out of the run after the model has already answered and been charged. That is deliberate: a swallowed write would drift the counter down and weaken the gate, which is worse than a visible failure. If your deployment would rather keep the answer than the count, wrap the store and decide there.
 
 Any object with `get` and `add` works, so a Postgres or DynamoDB counter is a small class rather than a fork.
 
@@ -159,9 +165,13 @@ State lives across runs deliberately, so `for_run` is not overridden: a daily bu
 
 `defer_loading=True` is refused. A deferred capability's hooks do not run until the model loads it, so an exhausted budget would not stop a request and the requests made meanwhile would go uncounted -- a brake the thing being braked decides when to apply.
 
-The capability declares itself innermost, so `after_model_request` reaches it before any capability that does not. Without that, a capability listed after this one -- which is how anyone would write it -- could raise `ModelRetry` on a response that was already generated and billed, and the counter would never see it.
+The accrual happens in `wrap_model_request`, immediately around the provider call, and the capability declares itself innermost so that wrapper is the innermost one. Every other capability's wrapper, and every capability's `after_model_request`, therefore runs outside it and cannot reject a response the counter has not already seen.
 
-That covers the ordinary case, not every case. Pydantic AI orders innermost capabilities against non-innermost ones only, and among themselves the one listed *later* runs `after_model_request` *first*. `TemporalDurability` and `InputGuardrail` also declare themselves innermost, so either of them listed after `SpendLimits` sees a response before the counter does and can still reject a billed one. List `SpendLimits` last among your innermost capabilities when that matters. Enforcing that needs a way to order innermost capabilities against each other, or the public composition-validation hook being decided in [pydantic-ai#5477](https://github.com/pydantic/pydantic-ai/issues/5477); tracked in [#534](https://github.com/pydantic/pydantic-ai-harness/issues/534).
+`after_model_request` is the wrong hook for this. It runs once the whole wrap chain has returned, so a capability whose own `wrap_model_request` awaits the response and then raises `ModelRetry` sends the run straight to a fresh request and the rejected one -- generated, billed, kept in history -- is never counted. Ordering cannot reach that case: the rejecting capability need not be innermost, and one listed *before* `SpendLimits` still wraps outside it.
+
+Wrapping also means a request the provider never saw is not charged for. `SkipModelRequest` from an earlier capability's `before_model_request` reaches `after_model_request` with a response the run never paid for, but never reaches the wrapped handler.
+
+What is left is siblings. Pydantic AI orders innermost capabilities against non-innermost ones only, and among themselves the one listed *later* nests further in. `TemporalDurability` and `InputGuardrail` also declare themselves innermost, so either of them listed after `SpendLimits` wraps inside it and can still reject a billed response before it is counted. List `SpendLimits` last among your innermost capabilities when that matters. Closing it outright needs a way to order innermost capabilities against each other, or the public composition-validation hook being decided in [pydantic-ai#5477](https://github.com/pydantic/pydantic-ai/issues/5477); tracked in [#534](https://github.com/pydantic/pydantic-ai-harness/issues/534).
 
 **Durable execution.** `SpendLimits` is not supported inside a Temporal workflow.
 
@@ -169,7 +179,7 @@ The capability hooks run in workflow code; only the model request itself is the 
 
 The sandbox refusing that clock is what surfaces this first, and `SpendLimits` translates the error into what it means rather than into the setting that silences it. Passing the package through the sandbox removes the message, not the replay.
 
-Enforce the budget **before** starting the workflow instead. That is why `exhausted()` works without a `RunContext`:
+Refuse the workflow **admission** before starting it instead. That is why `exhausted()` works without a `RunContext`:
 
 ```python
 async def start_if_funded(limits: SpendLimits[None], tenant_id: str) -> None:
@@ -212,6 +222,8 @@ A refusal emits a `spend budget exhausted` span with `spend.budget` and `spend.w
 ```
 
 `store`, `price`, `on_spend`, `clock`, and a budget's `scope` take callables or live objects. A spec naming them is rejected rather than silently ignored, because a spec that promises per-tenant scoping and does not deliver it is worse than one that refuses to load.
+
+The fields above are what `SpendLimits.from_spec` names in its signature, which is also what Pydantic AI reads to generate the spec's JSON schema -- so an editor following the `$schema` line completes and validates them. `BudgetSpec` is the entry shape, exported for anyone building a spec in code.
 
 Source: [`pydantic_ai_harness/spend/`](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/spend/).
 

--- a/integration_tests/redis/test_live_redis.py
+++ b/integration_tests/redis/test_live_redis.py
@@ -98,10 +98,14 @@ async def store() -> AsyncGenerator[RedisSpendStore, None]:
     try:
         yield RedisSpendStore(client, prefix=prefix)
     finally:
-        keys = [key async for key in client.scan_iter(match=f'{prefix}:*')]
-        if keys:
-            await client.delete(*keys)
-        await client.aclose()
+        # Closing sits in its own `finally` so a server that went away mid-test takes the
+        # key cleanup down without also leaking the connection into the rest of the suite.
+        try:
+            keys = [key async for key in client.scan_iter(match=f'{prefix}:*')]
+            if keys:
+                await client.delete(*keys)
+        finally:
+            await client.aclose()
 
 
 async def _ttl(store: RedisSpendStore, key: str) -> int:

--- a/integration_tests/redis/test_live_redis.py
+++ b/integration_tests/redis/test_live_redis.py
@@ -38,6 +38,7 @@ from collections.abc import AsyncGenerator
 from datetime import timedelta
 from decimal import Decimal
 from typing import NoReturn
+from urllib.parse import urlsplit
 
 import pytest
 from redis.asyncio import Redis
@@ -62,6 +63,21 @@ def _redis_url() -> str:
     return os.environ.get('REDIS_TEST_URL', 'redis://127.0.0.1:6379')
 
 
+def _redis_target() -> str:
+    """Host and port, without the credentials a Redis URL may carry.
+
+    `REDIS_TEST_URL` accepts `redis://user:password@host:6379`, and the only place
+    this string is used is a skip or failure message -- which CI keeps. Naming the
+    variable rather than echoing an unparsable value keeps that true for a URL
+    `urlsplit` cannot make sense of.
+    """
+    host = urlsplit(_redis_url()).hostname
+    if host is None:
+        return 'the server named by REDIS_TEST_URL'
+    port = urlsplit(_redis_url()).port
+    return host if port is None else f'{host}:{port}'
+
+
 def _unavailable(message: str) -> NoReturn:
     if _requires_live():
         pytest.fail(message)
@@ -76,7 +92,7 @@ async def store() -> AsyncGenerator[RedisSpendStore, None]:
         await client.ping()
     except (RedisError, OSError) as error:
         await client.aclose()
-        _unavailable(f'no reachable Redis at {_redis_url()}: {error}')
+        _unavailable(f'no reachable Redis at {_redis_target()}: {error}')
 
     prefix = f'harness-test:{uuid.uuid4().hex}'
     try:

--- a/integration_tests/redis/test_live_redis.py
+++ b/integration_tests/redis/test_live_redis.py
@@ -1,0 +1,147 @@
+"""Live Redis conformance tests for `RedisSpendStore`.
+
+The unit suite in `tests/spend` drives the store through a fake that reproduces the
+result `_ADD_SCRIPT` is meant to produce. It never runs the Lua, so three things it
+cannot answer decide whether the store is correct:
+
+- that the script is valid Lua the server accepts at all;
+- that a zero `ttl` clears an expiry an earlier finite `retain` set, which is
+  `PERSIST` doing work `HINCRBY` would not do on its own;
+- that the exact-integer guard refuses the write before any field is incremented,
+  rather than after some of them.
+
+This file covers exactly those. It is not a second copy of the unit suite --
+API-shape coverage belongs there, where it runs on every matrix leg.
+
+Run against a local server with `make integration-redis` after starting one, e.g.
+`docker run -d -p 6379:6379 redis:8`. Without a reachable server the tests skip,
+unless `REDIS_REQUIRE_LIVE` is set (CI does), where an unreachable server fails
+instead -- a service container that never came up must not pass as a silent skip.
+
+External assumptions, verified 2026-08-04 against Redis 8 (`redis:8`):
+
+- `HINCRBY` does not alter a key's TTL. Source:
+  <https://redis.io/docs/latest/commands/hincrby/>.
+- `PERSIST` removes an expiry and returns 0 when the key has none, so calling it
+  unconditionally on the keep-forever path is safe. Source:
+  <https://redis.io/docs/latest/commands/persist/>.
+- `EVAL` runs the script to completion without interleaving another client's
+  command, but does not roll back on a mid-script error. Source:
+  <https://redis.io/docs/latest/develop/programmability/eval-intro/>.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import timedelta
+from decimal import Decimal
+from typing import NoReturn
+
+import pytest
+from redis.asyncio import Redis
+from redis.exceptions import RedisError, ResponseError
+
+from pydantic_ai_harness.spend import RedisSpendStore, Spent
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run live server tests once under asyncio."""
+    return 'asyncio'
+
+
+def _requires_live() -> bool:
+    return os.environ.get('REDIS_REQUIRE_LIVE', '').lower() in {'1', 'true', 'yes'}
+
+
+def _redis_url() -> str:
+    return os.environ.get('REDIS_TEST_URL', 'redis://127.0.0.1:6379')
+
+
+def _unavailable(message: str) -> NoReturn:
+    if _requires_live():
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+@pytest.fixture
+async def store() -> AsyncGenerator[RedisSpendStore, None]:
+    """A store on a reachable server, namespaced per test so runs cannot collide."""
+    client = Redis.from_url(_redis_url(), decode_responses=True)
+    try:
+        await client.ping()
+    except (RedisError, OSError) as error:
+        await client.aclose()
+        _unavailable(f'no reachable Redis at {_redis_url()}: {error}')
+
+    prefix = f'harness-test:{uuid.uuid4().hex}'
+    try:
+        yield RedisSpendStore(client, prefix=prefix)
+    finally:
+        keys = [key async for key in client.scan_iter(match=f'{prefix}:*')]
+        if keys:
+            await client.delete(*keys)
+        await client.aclose()
+
+
+async def _ttl(store: RedisSpendStore, key: str) -> int:
+    """Seconds left on a budget key. -1 means no expiry, -2 means the key is gone."""
+    return await store.client.ttl(f'{store.prefix}:{key}')  # pyright: ignore[reportAttributeAccessIssue]
+
+
+class TestLiveScript:
+    """What the fake reproduces rather than executes."""
+
+    async def test_the_script_runs_and_returns_the_four_totals(self, store: RedisSpendStore):
+        """The whole point of the Lua: valid on the server, and no second read to get the result."""
+        first = await store.add('k', usd=Decimal('0.000123456'), tokens=7, requests=1, unpriced=1, ttl=None)
+        assert first == Spent(usd=Decimal('0.000123456'), tokens=7, requests=1, unpriced_requests=1)
+
+        second = await store.add('k', usd=Decimal('0.000000675'), tokens=3, requests=1, unpriced=0, ttl=None)
+        assert second == Spent(usd=Decimal('0.000124131'), tokens=10, requests=2, unpriced_requests=1)
+        assert await store.get('k') == second
+
+    async def test_a_finite_horizon_sets_an_expiry(self, store: RedisSpendStore):
+        """The baseline the `'forever'` case below is measured against."""
+        await store.add('k', usd=Decimal('1'), tokens=1, requests=1, unpriced=0, ttl=timedelta(hours=1))
+
+        assert 0 < await _ttl(store, 'k') <= 3600
+
+    async def test_moving_a_budget_to_forever_clears_the_old_horizon(self, store: RedisSpendStore):
+        """`HINCRBY` leaves an expiry alone, so skipping `EXPIRE` is not the same as no expiry.
+
+        Reconfiguring a counter from a finite `retain` to `'forever'` left it expiring on
+        a horizon the configuration no longer mentions, handing the ceiling back on a
+        schedule. This is the assertion the fake cannot make on its own.
+        """
+        await store.add('k', usd=Decimal('1'), tokens=1, requests=1, unpriced=0, ttl=timedelta(hours=1))
+        assert await _ttl(store, 'k') > 0
+
+        await store.add('k', usd=Decimal('1'), tokens=1, requests=1, unpriced=0, ttl=None)
+
+        assert await _ttl(store, 'k') == -1
+
+    async def test_a_sub_second_horizon_still_expires(self, store: RedisSpendStore):
+        """`EXPIRE` takes whole seconds, and rounding down would leave the key forever."""
+        await store.add('k', usd=Decimal('1'), tokens=1, requests=1, unpriced=0, ttl=timedelta(milliseconds=500))
+
+        assert await _ttl(store, 'k') == 1
+
+    async def test_the_exact_integer_guard_refuses_before_writing_anything(self, store: RedisSpendStore):
+        """Checked against the running total inside the script, ahead of the first `HINCRBY`.
+
+        Past `2**53` billionths a Lua number stops being an exact integer, so the totals
+        the script returns would start rounding. The refusal has to leave the counter
+        untouched, or the window would hold part of the response it just rejected.
+        """
+        half = Decimal('4600000')
+        before = await store.add('k', usd=half, tokens=1, requests=1, unpriced=0, ttl=None)
+
+        with pytest.raises(ResponseError, match='exact-integer range'):
+            await store.add('k', usd=half, tokens=1, requests=1, unpriced=0, ttl=None)
+
+        assert await store.get('k') == before

--- a/pydantic_ai_harness/spend/README.md
+++ b/pydantic_ai_harness/spend/README.md
@@ -54,7 +54,7 @@ SpendLimits(
 |---|---|
 | `usd` / `tokens` | ceilings; set either, both, or neither |
 | `window` | `run`, `conversation`, `day`, `month`, `total` |
-| `scope` | derives a partition key from the run, so tenants count separately |
+| `scope` | derives a partition key from the run, so tenants count separately; typed against the agent's `deps` |
 | `warn_at` | fraction past which `BudgetStatus.warning` is set; never blocks |
 | `name` | distinguishes budgets sharing a window and scope |
 | `retain` | how long the counter is kept after its last write; `'window default'`, `'forever'`, or a `timedelta` |
@@ -62,6 +62,8 @@ SpendLimits(
 A window rolls over by producing a different store key rather than by resetting a counter, so a new day is simply a new key and nothing has to run at midnight. A `total` counter never expires. `run` and `conversation` buckets never roll over either, so expiry there hands back the ceiling rather than starting a new period -- but each mints a key per run or per conversation, so they carry a long horizon (24 hours and 30 days) instead, past which the counter is dropped rather than kept forever. That default is a compromise, and it is visible: a conversation resumed past its horizon starts from zero again, so set `retain='forever'` where a conversation ceiling has to hold for as long as the conversation does, and clean the keys up some other way.
 
 Budgets that share a `name`, `window`, and `scope` share one counter, which is how a single window carries both a USD and a token ceiling. The response is added to that counter once, not once per budget. Two budgets that share a `name` and `window` but declare *different* `scope` callables are refused at construction: they are different dimensions -- per tenant and per user, say -- and nothing stops the two returning the same string, which would merge them into one counter. Give them different names, or pass the same callable to both. Budgets that do share a counter must also agree on `retain`: one counter has one expiry, and the accrual writes whichever of them is listed first, so disagreeing would let declaration order decide when a `'forever'` ceiling rolls over.
+
+`Budget` is generic in the agent's dependency type, so a `scope` is checked against it: pass the capability to an `Agent` with a `deps_type` and a scope reaching for a field those deps do not have is a type error rather than an `AttributeError` on the first request.
 
 **A budget with no ceiling is a counter.** It accumulates and reports and never refuses anything, which is how per-tenant accounting with no cap is expressed:
 
@@ -125,11 +127,15 @@ limits = SpendLimits(budgets=[Budget(usd=Decimal('100'), window='day')], store=s
 
 It adds no dependency: `RedisClient` is a protocol of the two coroutines used, so any compatible client satisfies it. Amounts are stored as integer billionths of a dollar rather than through `INCRBYFLOAT`, which accumulates rounding error over the tens of thousands of requests a busy day produces. Billionths rather than millionths because the residue does not average out: an agent repeats requests of near-identical shape, so the same fraction rounds the same way every time.
 
-A response is applied as one Lua script, in one round trip, and every way it can refuse -- the ceiling below, a client or network failure -- lands before it writes anything. Split across separate commands, a failure between them leaves a window holding part of a response, which reads as a smaller number than was really spent and so releases the brake later than it should. The cost of doing it server-side is a ceiling -- the counters pass through Lua, whose numbers stop being exact integers above `2**53` billionths, about **$9,007,199** against a single key. Past that the store raises rather than rounding silently. Settling a protocol without that ceiling is [#532](https://github.com/pydantic/pydantic-ai-harness/issues/532).
+Each window is applied as one Lua script, in one round trip, so no other client sees a window holding part of a response and the exact-integer ceiling is checked before anything is written. That guarantee is per window, not across them: a response counting against a day budget and a month budget is two scripts, so a failure between the two leaves the day counted and the month not. Widening it needs a store operation that takes every window at once, tracked in [#536](https://github.com/pydantic/pydantic-ai-harness/issues/536).
+
+A failure *after* the server has run a script does not say whether it committed -- the connection can drop once `EVAL` has landed -- so an `add` that errors leaves the outcome unknown rather than untried. Nothing retries it: counting a billed response twice is a direction the brake survives, and counting it zero times is not.
+
+The cost of doing it server-side is a ceiling -- the counters pass through Lua, whose numbers stop being exact integers above `2**53` billionths, about **$9,007,199** against a single key. Past that the store raises rather than rounding silently. Settling a protocol without that ceiling is [#532](https://github.com/pydantic/pydantic-ai-harness/issues/532).
 
 The default store is built per capability, so two `SpendLimits` instances do not quietly share one counter. Pass the same store object to both when you want them to.
 
-A store that fails does not fail quietly. An error reading the counter refuses the request, which is the safe direction. An error writing it propagates out of the run after the model has already answered and been charged, and the response goes uncounted rather than half counted, since nothing is written until the script commits to writing all of it. That is deliberate: a swallowed write would drift the counter down and weaken the gate, which is worse than a visible failure. If your deployment would rather keep the answer than the count, wrap the store and decide there.
+A store that fails does not fail quietly. An error reading the counter refuses the request, which is the safe direction. An error writing it propagates out of the run after the model has already answered and been charged. That is deliberate: a swallowed write would drift the counter down and weaken the gate, which is worse than a visible failure. If your deployment would rather keep the answer than the count, wrap the store and decide there.
 
 Any object with `get` and `add` works, so a Postgres or DynamoDB counter is a small class rather than a fork.
 
@@ -157,9 +163,13 @@ State lives across runs deliberately, so `for_run` is not overridden: a daily bu
 
 `defer_loading=True` is refused. A deferred capability's hooks do not run until the model loads it, so an exhausted budget would not stop a request and the requests made meanwhile would go uncounted -- a brake the thing being braked decides when to apply.
 
-The capability declares itself innermost, so `after_model_request` reaches it before any capability that does not. Without that, a capability listed after this one -- which is how anyone would write it -- could raise `ModelRetry` on a response that was already generated and billed, and the counter would never see it.
+The accrual happens in `wrap_model_request`, immediately around the provider call, and the capability declares itself innermost so that wrapper is the innermost one. Every other capability's wrapper, and every capability's `after_model_request`, therefore runs outside it and cannot reject a response the counter has not already seen.
 
-That covers the ordinary case, not every case. Pydantic AI orders innermost capabilities against non-innermost ones only, and among themselves the one listed *later* runs `after_model_request` *first*. `TemporalDurability` and `InputGuardrail` also declare themselves innermost, so either of them listed after `SpendLimits` sees a response before the counter does and can still reject a billed one. List `SpendLimits` last among your innermost capabilities when that matters. Enforcing that needs a way to order innermost capabilities against each other, or the public composition-validation hook being decided in [pydantic-ai#5477](https://github.com/pydantic/pydantic-ai/issues/5477); tracked in [#534](https://github.com/pydantic/pydantic-ai-harness/issues/534).
+`after_model_request` is the wrong hook for this. It runs once the whole wrap chain has returned, so a capability whose own `wrap_model_request` awaits the response and then raises `ModelRetry` sends the run straight to a fresh request and the rejected one -- generated, billed, kept in history -- is never counted. Ordering cannot reach that case: the rejecting capability need not be innermost, and one listed *before* `SpendLimits` still wraps outside it.
+
+Wrapping also means a request the provider never saw is not charged for. `SkipModelRequest` from an earlier capability's `before_model_request` reaches `after_model_request` with a response the run never paid for, but never reaches the wrapped handler.
+
+What is left is siblings. Pydantic AI orders innermost capabilities against non-innermost ones only, and among themselves the one listed *later* nests further in. `TemporalDurability` and `InputGuardrail` also declare themselves innermost, so either of them listed after `SpendLimits` wraps inside it and can still reject a billed response before it is counted. List `SpendLimits` last among your innermost capabilities when that matters. Closing it outright needs a way to order innermost capabilities against each other, or the public composition-validation hook being decided in [pydantic-ai#5477](https://github.com/pydantic/pydantic-ai/issues/5477); tracked in [#534](https://github.com/pydantic/pydantic-ai-harness/issues/534).
 
 **Durable execution.** `SpendLimits` is not supported inside a Temporal workflow.
 
@@ -167,7 +177,7 @@ The capability hooks run in workflow code; only the model request itself is the 
 
 The sandbox refusing that clock is what surfaces this first, and `SpendLimits` translates the error into what it means rather than into the setting that silences it. Passing the package through the sandbox removes the message, not the replay.
 
-Enforce the budget **before** starting the workflow instead. That is why `exhausted()` works without a `RunContext`:
+Refuse the workflow **admission** before starting it instead. That is why `exhausted()` works without a `RunContext`:
 
 ```python
 async def start_if_funded(limits: SpendLimits[None], tenant_id: str) -> None:
@@ -210,6 +220,8 @@ A refusal emits a `spend budget exhausted` span with `spend.budget` and `spend.w
 ```
 
 `store`, `price`, `on_spend`, `clock`, and a budget's `scope` take callables or live objects. A spec naming them is rejected rather than silently ignored, because a spec that promises per-tenant scoping and does not deliver it is worse than one that refuses to load.
+
+The fields above are what `SpendLimits.from_spec` names in its signature, which is also what Pydantic AI reads to generate the spec's JSON schema -- so an editor following the `$schema` line completes and validates them. `BudgetSpec` is the entry shape, exported for anyone building a spec in code.
 
 ## API
 

--- a/pydantic_ai_harness/spend/__init__.py
+++ b/pydantic_ai_harness/spend/__init__.py
@@ -1,6 +1,6 @@
 """Spend tracking and budget enforcement for Pydantic AI agents."""
 
-from pydantic_ai_harness.spend._budget import Budget, Window
+from pydantic_ai_harness.spend._budget import Budget, BudgetSpec, Window
 from pydantic_ai_harness.spend._capability import PriceFunc, SpendCallback, SpendLimits
 from pydantic_ai_harness.spend._exceptions import SpendLimitExceeded, UnpricedModelError, UnpricedModelWarning
 from pydantic_ai_harness.spend._redis import RedisClient, RedisSpendStore
@@ -9,6 +9,7 @@ from pydantic_ai_harness.spend._store import InMemorySpendStore, SpendStore
 
 __all__ = [
     'Budget',
+    'BudgetSpec',
     'BudgetStatus',
     'InMemorySpendStore',
     'PriceFunc',

--- a/pydantic_ai_harness/spend/_budget.py
+++ b/pydantic_ai_harness/spend/_budget.py
@@ -11,11 +11,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Generic, Literal, TypedDict
+from typing import Any, Generic, Literal
 
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT, RunContext
-from typing_extensions import assert_never
+from typing_extensions import TypedDict, assert_never
 
 Window = Literal['run', 'conversation', 'day', 'month', 'total']
 """The period a budget counts over."""

--- a/pydantic_ai_harness/spend/_budget.py
+++ b/pydantic_ai_harness/spend/_budget.py
@@ -11,10 +11,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal
-from typing import Any, Literal
+from typing import Any, Generic, Literal, TypedDict
 
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.tools import RunContext
+from pydantic_ai.tools import AgentDepsT, RunContext
 from typing_extensions import assert_never
 
 Window = Literal['run', 'conversation', 'day', 'month', 'total']
@@ -51,12 +51,17 @@ _TTLS: dict[Window, timedelta | None] = {
 
 
 @dataclass(frozen=True, kw_only=True)
-class Budget:
+class Budget(Generic[AgentDepsT]):
     """One spend window: what it limits, over what period, for whom.
 
     A budget with neither `usd` nor `tokens` is a pure counter: it accumulates
     and reports, and never stops a run. That is how per-tenant accounting with
     no cap is expressed.
+
+    Generic in the agent's dependency type so `scope` is checked against it: the
+    parameter comes from the `Agent` the capability is passed to, so a scope
+    reaching for a field the deps do not have is a type error rather than an
+    `AttributeError` on the first request.
 
     ```python
     from decimal import Decimal
@@ -78,7 +83,7 @@ class Budget:
     window: Window = 'day'
     """The period the ceiling applies to."""
 
-    scope: Callable[[RunContext[Any]], str] | None = None
+    scope: Callable[[RunContext[AgentDepsT]], str] | None = None
     """Partitions the counter -- per tenant, per user, per agent. `None` counts globally."""
 
     warn_at: float | None = None
@@ -160,6 +165,27 @@ class Budget:
         return self.retain
 
 
+class BudgetSpec(TypedDict, total=False):
+    """The part of a `Budget` an agent spec can express.
+
+    Declared as a `TypedDict` rather than reusing `Budget` because `scope` is a
+    callable, which has no JSON schema: core's schema builder strips a callable from
+    the top level of a union but not from a dataclass field nested inside a
+    `Sequence`, and generation fails on it outright.
+
+    `usd` accepts a string so a price does not round through a YAML float. `retain`
+    takes only the two policies -- a `timedelta` has no spec form, and
+    `Budget.__post_init__` already refuses anything else.
+    """
+
+    usd: str | int | float
+    tokens: int
+    window: Window
+    warn_at: float
+    name: str
+    retain: Literal['window default', 'forever']
+
+
 def bucket(window: Window, ctx: RunContext[Any] | None, now: datetime) -> str | None:
     """The period identifier for `window`, or `None` when it needs a run and none was given.
 
@@ -191,7 +217,7 @@ def _run_identity(identity: str | None, window: Window) -> str:
     return identity
 
 
-def scope_key(budget: Budget, ctx: RunContext[Any] | None, explicit: str | None) -> str:
+def scope_key(budget: Budget[Any], ctx: RunContext[Any] | None, explicit: str | None) -> str:
     """The scope segment of a budget's store key.
 
     `explicit` is what `SpendLimits.status` was given, for use outside a run. It
@@ -222,7 +248,7 @@ def scope_key(budget: Budget, ctx: RunContext[Any] | None, explicit: str | None)
     return resolved
 
 
-def store_key(budget: Budget, bucket_id: str, scope: str) -> str:
+def store_key(budget: Budget[Any], bucket_id: str, scope: str) -> str:
     """Join the parts of a budget's store key.
 
     The window is part of the key because bucket values are not drawn from

--- a/pydantic_ai_harness/spend/_capability.py
+++ b/pydantic_ai_harness/spend/_capability.py
@@ -28,12 +28,13 @@ from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import ModelResponse
 from pydantic_ai.tools import AgentDepsT, RunContext
 
-from pydantic_ai_harness.spend._budget import Budget, bucket, scope_key, store_key
+from pydantic_ai_harness.spend._budget import Budget, BudgetSpec, bucket, scope_key, store_key
 from pydantic_ai_harness.spend._exceptions import SpendLimitExceeded, UnpricedModelError, UnpricedModelWarning
 from pydantic_ai_harness.spend._snapshot import BudgetStatus, SpendSnapshot, Spent
 from pydantic_ai_harness.spend._store import InMemorySpendStore, SpendStore, utc_now
 
 if TYPE_CHECKING:
+    from pydantic_ai.capabilities import WrapModelRequestHandler
     from pydantic_ai.models import ModelRequestContext
     from pydantic_ai.toolsets import AgentToolset
 
@@ -79,13 +80,14 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
 
     Durable execution: not supported inside a Temporal workflow. The hooks run in
     workflow code while only the model request is the activity, so Temporal replays
-    the accrual and a window counts the same response more than once. Enforce the
-    budget before starting the workflow instead, with `exhausted()`, which is why
-    that method works without a `RunContext`. Tracked in
-    <https://github.com/pydantic/pydantic-ai-harness/issues/531>.
+    the accrual and a window counts the same response more than once. `exhausted()`
+    works without a `RunContext` so a workflow can at least be refused admission on
+    what is already recorded -- but a workflow admitted that way records nothing of
+    its own, so it is a gate on the door, not a budget on what happens inside.
+    Tracked in <https://github.com/pydantic/pydantic-ai-harness/issues/531>.
     """
 
-    budgets: Sequence[Budget] = ()
+    budgets: Sequence[Budget[AgentDepsT]] = ()
     """Windows to accumulate against, and which of them can refuse a request."""
 
     store: SpendStore = field(default_factory=InMemorySpendStore)
@@ -164,7 +166,7 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
         # callable returns. Nothing stops those returning the same string, and the counter
         # that results mixes the two, because every update writes every metric. Sharing one
         # callable is how a USD and a token ceiling deliberately share a counter.
-        scoped: dict[tuple[str, str], Budget] = {}
+        scoped: dict[tuple[str, str], Budget[AgentDepsT]] = {}
         for budget in self.budgets:
             if budget.scope is None:
                 continue
@@ -183,7 +185,7 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
         # when a `'forever'` ceiling quietly rolls over. Rejected rather than reconciled -- taking
         # the longest would silently extend the shorter budget's horizon, which is the same class
         # of surprise pointing the other way.
-        retention: dict[tuple[str, str, bool], Budget] = {}
+        retention: dict[tuple[str, str, bool], Budget[AgentDepsT]] = {}
         for budget in self.budgets:
             counter = (budget.name, budget.window, budget.scope is None)
             prior = retention.get(counter)
@@ -220,17 +222,19 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
         return 'SpendLimits'
 
     def get_ordering(self) -> CapabilityOrdering:
-        """Sit innermost, so a capability listed after this one cannot reject a billed response.
+        """Sit innermost, so the accrual is the first thing to happen to a billed response.
 
-        `after_model_request` reaches innermost capabilities first. Anywhere else in the
-        chain, a capability listed after this one -- which is how anyone would write it --
-        can raise `ModelRetry` on a response that was already generated and billed, and the
-        counter never sees it.
+        Innermost puts this capability's `wrap_model_request` closest to the provider call,
+        so every other capability's wrapper -- and every capability's
+        `after_model_request` -- runs outside the accrual and cannot reject a response the
+        counter has not already seen.
 
         This orders against non-innermost capabilities only. Innermost members are not
-        ordered among themselves, and the one listed later runs `after_model_request`
-        first, so another innermost capability (`TemporalDurability`, `InputGuardrail`)
-        placed after this one can still reject a response before it is counted.
+        ordered among themselves, and the one listed later nests further in, so another
+        innermost capability (`TemporalDurability`, `InputGuardrail`) placed after this one
+        still wraps inside it and can reject a billed response before it is counted. List
+        `SpendLimits` last among innermost capabilities where that matters; closing it
+        outright is <https://github.com/pydantic/pydantic-ai-harness/issues/534>.
         """
         return CapabilityOrdering(position='innermost')
 
@@ -257,14 +261,29 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
             self._check(budget, read[key], ctx)
         return request_context
 
-    async def after_model_request(
+    async def wrap_model_request(
         self,
         ctx: RunContext[AgentDepsT],
         *,
         request_context: ModelRequestContext,
-        response: ModelResponse,
+        handler: WrapModelRequestHandler,
     ) -> ModelResponse:
-        """Price the response, add it to every window, and report the result."""
+        """Price what the provider returned and add it to every window, before anything can reject it.
+
+        The accrual belongs here rather than in `after_model_request` because
+        `after_model_request` runs outside this chain, once the whole chain has returned.
+        A capability whose own `wrap_model_request` awaits the response and then raises
+        `ModelRetry` sends the run straight to a fresh request, and the response it
+        rejected -- generated, billed, and kept in history -- is never counted. Ordering
+        cannot close that: the rejecting wrapper does not have to be innermost, and one
+        listed *before* this capability still nests outside it.
+
+        Wrapping is also why a request the provider never saw is not charged for.
+        `SkipModelRequest` from an earlier `before_model_request` reaches
+        `after_model_request` with a response the run never paid for; it does not reach
+        `handler`, so nothing accrues here.
+        """
+        response = await handler(request_context)
         usd, priced, price_error = self._price_of(response)
         accrued: dict[str, Spent] = {}
         statuses: list[BudgetStatus] = []
@@ -298,7 +317,9 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
         if price_error is not None:
             # Raised after the store and `on_spend` have seen the response, for the reason
             # `_price_of` gives. Ahead of the `on_unpriced` handling below, which would
-            # otherwise report a broken pricing function as an unknown model.
+            # otherwise report a broken pricing function as an unknown model. Raising from
+            # a wrapper rather than from `after_model_request` does not change that: the
+            # accrual is already committed above.
             raise UserError(f'`SpendLimits.price` {price_error} for a response.')
 
         if not priced and self.on_unpriced == 'zero' and any(budget.usd is not None for budget in self.budgets):
@@ -386,11 +407,17 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
     ) -> bool:
         """Whether any budget this call can read is exhausted, refusing to guess about the rest.
 
-        The pre-flight check a durable workflow makes before starting: its hooks cannot reach
-        a shared store mid-run, so the decision has to be made up front. `status()` omits what
-        it cannot resolve, and `any(...)` over the remainder is a brake that silently checks
-        nothing when every budget is scoped -- so this raises instead, naming the budgets that
-        need a `scope` or a `ctx`.
+        An admission check, and only that. It reads the counters; it reserves nothing and
+        records nothing, so work started on the strength of it goes unmeasured unless
+        something else accrues it. Under Temporal that is the whole of what is available --
+        the hooks cannot reach a shared store mid-run -- so a workflow admitted here spends
+        against a counter that never moves, and the next workflow is admitted on the same
+        stale reading. Sound as a floor on runaway spend already recorded, not as a ceiling
+        on what the workflow goes on to spend.
+
+        `status()` omits what it cannot resolve, and `any(...)` over the remainder is a brake
+        that silently checks nothing when every budget is scoped -- so this raises instead,
+        naming the budgets that need a `scope` or a `ctx`.
         """
         statuses, unresolved = await self._resolve(ctx, scope)
         if unresolved:
@@ -401,23 +428,48 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
         return any(status.exhausted for status in statuses)
 
     @classmethod
-    def from_spec(cls, *args: Any, **kwargs: Any) -> SpendLimits[Any]:
+    def from_spec(
+        cls,
+        *,
+        budgets: Sequence[BudgetSpec] = (),
+        on_unpriced: Literal['zero', 'raise'] = 'zero',
+        expose_tools: bool = False,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
+        **unsupported: Any,
+    ) -> SpendLimits[Any]:
         """Build from an agent spec, covering the fields a spec can express.
+
+        Every parameter is named because that signature is what core reads to generate
+        the spec's JSON schema: `build_schema_types` drops `*args`/`**kwargs`, so a
+        catch-all signature publishes the bare string `'SpendLimits'` and an editor
+        marks every documented `budgets:` block as invalid even though it loads.
 
         `budgets` arrive as mappings and become `Budget` instances, with `usd`
         accepted as a string so YAML cannot round a price through a float. The
         callables and the store have no spec representation and are rejected
         rather than dropped: a spec that promises per-tenant scoping and does
-        not deliver it is worse than a spec that refuses to load.
+        not deliver it is worse than a spec that refuses to load. `**unsupported`
+        stays so that rejection keeps naming the field; core drops it from the schema,
+        so it costs nothing there.
         """
-        unsupported = sorted({'store', 'price', 'on_spend', 'clock'} & kwargs.keys())
-        if unsupported:
+        callables = sorted({'store', 'price', 'on_spend', 'clock'} & unsupported.keys())
+        if callables:
             raise UserError(
-                f'SpendLimits cannot be built from a spec with {unsupported}: these take callables or a live '
+                f'SpendLimits cannot be built from a spec with {callables}: these take callables or a live '
                 'store. Construct the capability in code to use them.'
             )
-        budgets = [_budget_from_spec(entry) for entry in kwargs.pop('budgets', [])]
-        return cls(*args, budgets=budgets, **kwargs)
+        if unsupported:
+            raise UserError(f'SpendLimits has no spec field(s) {sorted(unsupported)}.')
+        return cls(
+            budgets=[_budget_from_spec(entry) for entry in budgets],
+            on_unpriced=on_unpriced,
+            expose_tools=expose_tools,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
+        )
 
     def _now(self) -> datetime:
         """The current time, naming the real problem when Temporal's sandbox refuses the clock.
@@ -441,13 +493,15 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
                 'SpendLimits is not safe to run inside a Temporal workflow. Its hooks run in '
                 'workflow code rather than in the model activity, so Temporal replays them and a '
                 'window counts the same response more than once; the clock they read is why the '
-                'sandbox stopped this. Enforce the budget before starting the workflow instead, '
-                'with `exhausted()`. See https://github.com/pydantic/pydantic-ai-harness/issues/531'
+                'sandbox stopped this. Refuse the workflow admission before starting it instead, '
+                'with `exhausted()` -- which reads the counters and does not move them, so it '
+                'bounds what has already been recorded rather than what the workflow will spend. '
+                'See https://github.com/pydantic/pydantic-ai-harness/issues/531'
             ) from error
 
     def _key(
         self,
-        budget: Budget,
+        budget: Budget[AgentDepsT],
         ctx: RunContext[AgentDepsT] | None,
         now: datetime,
         scope: str | None,
@@ -458,14 +512,14 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
             raise UserError(f"Budget {budget.name!r} uses window='{budget.window}', which needs a run.")
         return store_key(budget, bucket_id, scope_key(budget, ctx, scope))
 
-    def _check(self, budget: Budget, spent: Spent, ctx: RunContext[AgentDepsT]) -> None:
+    def _check(self, budget: Budget[AgentDepsT], spent: Spent, ctx: RunContext[AgentDepsT]) -> None:
         """Raise if `spent` has reached either of the budget's ceilings."""
         if budget.usd is not None and spent.usd >= budget.usd:
             self._refuse(budget, ctx, f'spent ${spent.usd} of ${budget.usd}')
         if budget.tokens is not None and spent.tokens >= budget.tokens:
             self._refuse(budget, ctx, f'used {spent.tokens} of {budget.tokens} tokens')
 
-    def _refuse(self, budget: Budget, ctx: RunContext[AgentDepsT], detail: str) -> None:
+    def _refuse(self, budget: Budget[AgentDepsT], ctx: RunContext[AgentDepsT], detail: str) -> None:
         """Record the refusal as a span and raise."""
         attributes: dict[str, str] = {'spend.budget': budget.name, 'spend.window': budget.window}
         if ctx.trace_include_content and budget.scope is not None:
@@ -475,7 +529,7 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
         ctx.tracer.start_span('spend budget exhausted', attributes=attributes).end()
         raise SpendLimitExceeded(f'Budget {budget.name!r} exhausted for this {budget.window}: {detail}')
 
-    def _keyed(self, ctx: RunContext[AgentDepsT]) -> list[tuple[Budget, str]]:
+    def _keyed(self, ctx: RunContext[AgentDepsT]) -> list[tuple[Budget[AgentDepsT], str]]:
         """Each budget paired with the store key it accumulates under right now.
 
         No collision check here. Every part of a key is fixed at construction -- `name`,
@@ -519,7 +573,7 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
         return Decimal(0), False, None
 
 
-def _status(budget: Budget, key: str, spent: Spent) -> BudgetStatus:
+def _status(budget: Budget[Any], key: str, spent: Spent) -> BudgetStatus:
     """Pair a budget with what its window has accumulated."""
     remaining_usd = None if budget.usd is None else budget.usd - spent.usd
     remaining_tokens = None if budget.tokens is None else budget.tokens - spent.tokens
@@ -535,7 +589,7 @@ def _status(budget: Budget, key: str, spent: Spent) -> BudgetStatus:
     )
 
 
-def _warning(budget: Budget, spent: Spent) -> bool:
+def _warning(budget: Budget[Any], spent: Spent) -> bool:
     """Whether spend has crossed the budget's warning fraction."""
     if budget.warn_at is None:
         return False
@@ -554,7 +608,7 @@ def _is_spec_mapping(entry: object) -> TypeGuard[Mapping[str, Any]]:
     return isinstance(entry, Mapping)
 
 
-def _budget_from_spec(entry: Any) -> Budget:
+def _budget_from_spec(entry: Any) -> Budget[Any]:
     """Build one `Budget` from its spec mapping."""
     if not _is_spec_mapping(entry):
         raise UserError(f'Each SpendLimits budget in a spec must be a mapping; got {entry!r}.')

--- a/pydantic_ai_harness/spend/_redis.py
+++ b/pydantic_ai_harness/spend/_redis.py
@@ -8,7 +8,7 @@ nothing extra.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
 from decimal import ROUND_HALF_UP, Decimal, localcontext
@@ -36,29 +36,38 @@ local unpriced = redis.call('HINCRBY', KEYS[1], '{_UNPRICED_FIELD}', ARGV[4])
 local ttl = tonumber(ARGV[5])
 if ttl > 0 then
   redis.call('EXPIRE', KEYS[1], ttl)
+else
+  redis.call('PERSIST', KEYS[1])
 end
 return {{usd, tokens, requests, unpriced}}
 """
 """Applies one response to a window and returns the four totals.
 
-Redis runs a script to completion without interleaving another command, and every
-way this one can refuse -- the ceiling below, a client or network failure before
-it starts -- happens before the first write. Issued as separate commands instead,
-a failure between them leaves a window counting some of a response and not the
-rest, which reads as a smaller number than was really spent and so releases the
+Redis runs a script to completion without interleaving another command, so no other
+client observes the four counters part-applied, and the ceiling below is checked
+against the running total before anything is written. Issued as separate commands
+instead, a failure between them leaves a window counting some of a response and not
+the rest, which reads as a smaller number than was really spent and so releases the
 brake later than it should.
 
-Not a transaction, though: Redis does not roll back a script that fails partway,
-so a command erroring after an earlier one succeeded would leave the hash
-half-applied. What could error there is a counter passing the 64-bit signed range
--- around 9.2 quintillion tokens or requests against one key -- which is not a
-number any deployment produces. Guarding it would mean reading three more fields
-on the hot path of every model request to prevent something unreachable.
+The ceiling is checked against the running total rather than the increment. Checking
+the increment alone in Python would not hold: increments that each pass can still
+carry the counter past the range where a Lua number is an exact integer, and past
+that the totals this returns are rounded.
 
-The ceiling is checked here, against the running total, and before anything is
-written. Checking the increment alone in Python would not hold: increments that
-each pass can still carry the counter past the range where a Lua number is an
-exact integer, and past that the totals this returns are rounded.
+Not a transaction, though: Redis does not roll back a script that fails partway, so
+a command erroring after an earlier one succeeded would leave the hash half-applied.
+What could error there is a counter passing the 64-bit signed range -- around 9.2
+quintillion tokens or requests against one key -- which is not a number any
+deployment produces. Guarding it would mean reading three more fields on the hot
+path of every model request to prevent something unreachable.
+
+A zero `ttl` means "keep this key", and says so with `PERSIST` rather than by doing
+nothing. `HINCRBY` leaves an existing expiry in place, so a budget moved from a
+finite `retain` to `'forever'` would otherwise keep expiring on the old horizon --
+handing back the ceiling on a schedule nothing in the configuration mentions any
+more, and diverging from `InMemorySpendStore`, which drops the expiry on the next
+write.
 """
 
 _LUA_EXACT_INTEGER = 2**53
@@ -75,15 +84,20 @@ than letting the rounding happen unannounced.
 class RedisClient(Protocol):
     """The part of a Redis client `RedisSpendStore` uses.
 
-    `redis.asyncio.Redis` satisfies this. So does any wrapper or fake exposing
-    the same two coroutines.
+    `redis.asyncio.Redis` satisfies this. So does any wrapper or fake exposing the
+    same two methods, `async def` included.
+
+    Declared as returning an `Awaitable` rather than as `async def`, which would
+    narrow the requirement to a `Coroutine` and is what an implementation actually
+    has to hand back. `redis.asyncio.Redis` types these as `Awaitable`, so an
+    `async def` protocol refused the one client this exists to accept.
     """
 
-    async def hgetall(self, name: str) -> Mapping[str | bytes, str | bytes]:
+    def hgetall(self, name: str) -> Awaitable[Mapping[str | bytes, str | bytes]]:
         """Every field of a hash. An absent hash reads as empty."""
         ...  # pragma: no cover
 
-    async def eval(self, script: str, numkeys: int, *keys_and_args: str | int) -> Sequence[int]:
+    def eval(self, script: str, numkeys: int, *keys_and_args: str | int) -> Awaitable[Sequence[int]]:
         """Run a Lua script server-side and return what it returns."""
         ...  # pragma: no cover
 
@@ -117,14 +131,19 @@ def _from_nanos(nanos: int) -> Decimal:
 
 
 def _expiry_seconds(ttl: timedelta) -> int:
-    """A positive `timedelta` as whole seconds, never rounding down to none.
+    """A positive `timedelta` as whole seconds, rounded up.
 
-    `EXPIRE` takes seconds, and the script reads zero as "keep this key". Truncating
+    `EXPIRE` takes seconds, and the script reads zero as "keep this key". Rounding down
     would turn any horizon under a second -- which `Budget.retain` accepts -- into no
     expiry at all, the opposite of what was asked for and a silent divergence from
-    `InMemorySpendStore`, which honours it exactly.
+    `InMemorySpendStore`, which honours the horizon exactly.
+
+    Ceiling division on the `timedelta` itself rather than on `total_seconds()`, which is
+    a float: `timedelta` divides in whole microseconds, so a horizon with a sub-millisecond
+    remainder rounds up like any other instead of being truncated away before the ceiling
+    is taken.
     """
-    return max(1, -(-int(ttl.total_seconds() * 1000) // 1000))
+    return max(1, -(-ttl // timedelta(seconds=1)))
 
 
 def _field(fields: Mapping[str | bytes, str | bytes], name: str) -> int:
@@ -185,12 +204,22 @@ class RedisSpendStore:
     ) -> Spent:
         """Add to `key` and return the result.
 
-        One round trip. Every failure this can actually hit -- the exact-integer
-        ceiling, a client or network error -- lands before the script writes
-        anything, so a window does not end up holding part of a response; see
-        `_ADD_SCRIPT` for the one case that is not true of and why it is not
-        guarded. The script returns each new total, so the result needs no second
-        read.
+        One round trip, and one window. The script returns each new total, so the
+        result needs no second read.
+
+        A failure before the server runs the script -- the client cannot connect, the
+        request never lands -- writes nothing. A failure after it does not say which:
+        the connection can drop once `EVAL` has already committed, so an error here
+        means the outcome is unknown rather than that nothing happened. Retrying an
+        `add` therefore risks counting the response twice, which is why
+        `SpendLimits.wrap_model_request` does not retry and lets the error end the run
+        instead. Over-counting a response the provider did bill is the direction a
+        brake can survive; under-counting is not.
+
+        One window, because the key is one window. A response counting against a day and
+        a month budget is two calls, so a failure between them leaves the day counted and
+        the month not; see `SpendLimits.wrap_model_request` and
+        <https://github.com/pydantic/pydantic-ai-harness/issues/536>.
         """
         nanos, total_tokens, total_requests, total_unpriced = await self.client.eval(
             _ADD_SCRIPT,

--- a/pydantic_ai_harness/spend/_snapshot.py
+++ b/pydantic_ai_harness/spend/_snapshot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pydantic_ai.usage import RequestUsage
@@ -33,8 +33,12 @@ class Spent:
 class BudgetStatus:
     """A budget and how much of it is left."""
 
-    budget: Budget
-    """The budget this describes."""
+    budget: Budget[Any]
+    """The budget this describes.
+
+    Unparameterised because this is a reading: the dependency type only types
+    `Budget.scope`, and nothing calls a scope through a status.
+    """
 
     key: str
     """The store key it accumulates under. Useful for debugging a scope or window."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev = [
     "pytest-examples>=0.0.18",
     "pytest-recording>=0.13.4",
     "mongomock-motor>=0.0.36",
+    "redis>=6.0.0",
 ]
 lint = [
     'ruff>=0.14',
@@ -149,6 +150,11 @@ exclude = ['template', '.venv', 'mutants', '.agents', '.claude']
 # helpers are registered via decorators and never referenced by name (matches pydantic-ai).
 executionEnvironments = [
     { root = 'tests', reportPrivateUsage = false, reportUnusedFunction = false },
+    # `redis.asyncio.Redis` ships `py.typed` but leaves most of its command surface
+    # partially unknown (`from_url`, `ping`, `scan_iter`, `ttl`). Only the live-Redis
+    # tests touch the client directly -- `RedisSpendStore` itself goes through the
+    # `RedisClient` protocol and stays fully checked.
+    { root = 'integration_tests/redis', reportUnknownMemberType = false, reportUnknownVariableType = false, reportUnknownArgumentType = false },
 ]
 
 [tool.pytest.ini_options]

--- a/tests/spend/test_spend.py
+++ b/tests/spend/test_spend.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any
 
-import jsonschema
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -1390,23 +1389,57 @@ class TestSpec:
         for runtime_only in ('"store"', '"price"', '"on_spend"', '"clock"', '"scope"'):
             assert runtime_only not in schema, runtime_only
 
-    def test_the_documented_yaml_validates_against_the_published_schema(self):
-        """The README's example, checked against the schema an editor reads from `$schema`."""
-        spec = {
-            'model': 'openai:gpt-5.4',
-            'capabilities': [
-                {
-                    'SpendLimits': {
-                        'budgets': [
-                            {'usd': '100', 'window': 'day'},
-                            {'usd': '2000', 'window': 'month', 'warn_at': 0.8},
-                        ],
-                        'on_unpriced': 'raise',
-                    }
-                }
-            ],
+    def test_the_schema_describes_a_budget_rather_than_an_open_object(self):
+        """A `Sequence[Budget]` cannot generate -- `scope` is a callable -- so entries take `BudgetSpec`."""
+        definitions = AgentSpec.model_json_schema_with_capabilities([SpendLimits])['$defs']
+
+        assert definitions['spec_params_SpendLimits']['properties']['budgets']['items'] == {
+            '$ref': '#/$defs/BudgetSpec'
         }
-        jsonschema.validate(spec, AgentSpec.model_json_schema_with_capabilities([SpendLimits]))
+        entry = definitions['BudgetSpec']
+        assert set(entry['properties']) == {'usd', 'tokens', 'window', 'warn_at', 'name', 'retain'}
+        # A price given as a string so YAML cannot round it through a float.
+        assert {'type': 'string'} in entry['properties']['usd']['anyOf']
+        assert entry['additionalProperties'] is False
+
+    async def test_the_documented_yaml_loads_and_the_budget_it_names_holds(self):
+        """The README's example, through the real loader rather than through `from_spec` directly."""
+        agent = Agent.from_spec(
+            {
+                'model': 'test',
+                'capabilities': [
+                    {
+                        'SpendLimits': {
+                            'budgets': [
+                                {'usd': '100', 'window': 'day'},
+                                {'usd': '2000', 'window': 'month', 'warn_at': 0.8},
+                            ],
+                            'on_unpriced': 'raise',
+                        }
+                    }
+                ],
+            },
+            custom_capability_types=[SpendLimits],
+        )
+
+        # `on_unpriced: raise` reached the capability: `TestModel` names no model, so
+        # nothing can price its response.
+        with pytest.raises(UnpricedModelError):
+            await agent.run('hi')
+
+    async def test_a_spec_budget_refuses_a_request_once_it_is_spent(self):
+        """A ceiling small enough to trip, so the loaded budget is shown to be wired to the gate."""
+        agent = Agent.from_spec(
+            {
+                'model': 'test',
+                'capabilities': [{'SpendLimits': {'budgets': [{'tokens': 1, 'window': 'total'}]}}],
+            },
+            custom_capability_types=[SpendLimits],
+        )
+        await agent.run('hi')
+
+        with pytest.raises(SpendLimitExceeded, match='tokens'):
+            await agent.run('hi')
 
 
 class TestDurableClock:

--- a/tests/spend/test_spend.py
+++ b/tests/spend/test_spend.py
@@ -2,20 +2,23 @@
 
 from __future__ import annotations
 
+import json
 import warnings
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any
 
+import jsonschema
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NoOpTracer, Tracer
 from pydantic_ai import Agent
-from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
-from pydantic_ai.exceptions import ModelRetry, UsageLimitExceeded, UserError
+from pydantic_ai.agent.spec import AgentSpec
+from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering, WrapModelRequestHandler
+from pydantic_ai.exceptions import ModelRetry, SkipModelRequest, UsageLimitExceeded, UserError
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
 from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -102,13 +105,33 @@ def _response(
     )
 
 
-async def _record(guard: SpendLimits[Any], *, ctx: RunContext[Any] | None = None, **kwargs: Any) -> ModelResponse:
-    response = _response(**kwargs)
-    return await guard.after_model_request(
+async def _record(
+    guard: SpendLimits[Any],
+    *,
+    ctx: RunContext[Any] | None = None,
+    response: ModelResponse | None = None,
+    **kwargs: Any,
+) -> ModelResponse:
+    """Drive one accrual by standing in for the provider call the capability wraps."""
+    recorded = response if response is not None else _response(**kwargs)
+
+    async def handler(request_context: ModelRequestContext) -> ModelResponse:
+        return recorded
+
+    return await guard.wrap_model_request(
         ctx if ctx is not None else _run_ctx(),
         request_context=_request_context(),
-        response=response,
+        handler=handler,
     )
+
+
+def _spec_budgets(*entries: Any) -> list[Any]:
+    """Budget entries as a spec really delivers them: parsed YAML, unvalidated.
+
+    `BudgetSpec` types the schema `from_spec` publishes to an editor; nothing enforces
+    it at the boundary, which is the whole of what these tests cover.
+    """
+    return list(entries)
 
 
 async def _gate(guard: SpendLimits[Any], *, ctx: RunContext[Any] | None = None) -> None:
@@ -447,7 +470,7 @@ class TestEnforcement:
             async def get(self, key: str) -> Spent:  # pragma: no cover - must never be reached
                 raise AssertionError('the gate read the store with no budgets configured')
 
-        guard = SpendLimits(store=Exploding())
+        guard = SpendLimits[None](store=Exploding())
         await _gate(guard)
 
     async def test_budgets_survive_across_runs(self):
@@ -463,7 +486,7 @@ class TestOrdering:
     """Nothing may reject a response before it is counted."""
 
     async def test_a_response_rejected_by_a_later_capability_is_still_counted(self):
-        """`after_model_request` runs innermost first, so anywhere else the counter loses a paid response."""
+        """The accrual runs inside the wrap chain, so every `after_model_request` is outside it."""
 
         class RejectFirst(AbstractCapability[None]):
             seen: int = 0
@@ -482,6 +505,56 @@ class TestOrdering:
 
         assert result.usage.requests == 2
         assert (await guard.status())[0].spent.requests == 2
+
+    async def test_a_response_a_wrapper_retries_on_is_still_counted(self):
+        """A wrapper that rejects a response it awaited retries before `after_model_request` ever runs.
+
+        Ordering cannot reach this one: the rejecting capability is not innermost and is
+        listed *before* `SpendLimits`, so it wraps outside the accrual either way. Accruing
+        in `after_model_request` left the provider billing two requests and the counter
+        seeing one.
+        """
+
+        class RetryOnce(AbstractCapability[None]):
+            seen: int = 0
+
+            async def wrap_model_request(
+                self,
+                ctx: RunContext[None],
+                *,
+                request_context: ModelRequestContext,
+                handler: WrapModelRequestHandler,
+            ) -> ModelResponse:
+                response = await handler(request_context)
+                self.seen += 1
+                if self.seen == 1:
+                    raise ModelRetry('try again')
+                return response
+
+        guard = SpendLimits(budgets=[Budget(window='total')], price=lambda r: Decimal('1'))
+        agent = Agent(_scripted_usage(), deps_type=type(None), capabilities=[RetryOnce(), guard])
+        result = await agent.run('hi')
+
+        assert result.usage.requests == 2
+        spent = (await guard.status())[0].spent
+        assert spent.requests == 2
+        assert spent.usd == Decimal('2')
+
+    async def test_a_request_the_provider_never_saw_is_not_counted(self):
+        """`SkipModelRequest` reaches `after_model_request` but never reaches the wrapped handler."""
+
+        class ServeFromCache(AbstractCapability[None]):
+            async def before_model_request(
+                self, ctx: RunContext[None], request_context: ModelRequestContext
+            ) -> ModelRequestContext:
+                raise SkipModelRequest(ModelResponse(parts=[TextPart(content='cached')]))
+
+        guard = SpendLimits(budgets=[Budget(window='total')], price=lambda r: Decimal('1'))
+        agent = Agent(_scripted_usage(), deps_type=type(None), capabilities=[ServeFromCache(), guard])
+        result = await agent.run('hi')
+
+        assert result.output == 'cached'
+        assert (await guard.status())[0].spent == Spent()
 
     def test_it_declares_innermost(self):
         assert SpendLimits[None]().get_ordering() == CapabilityOrdering(position='innermost')
@@ -532,7 +605,7 @@ class TestPricing:
             model_name='gpt-4.1',
             provider_name='openai',
         )
-        await guard.after_model_request(_run_ctx(), request_context=_request_context(), response=response)
+        await _record(guard, response=response)
 
         spent = (await guard.status())[0].spent
         assert spent.unpriced_requests == 1
@@ -675,7 +748,7 @@ class TestConfigurationFromData:
     def test_an_unknown_window_is_refused(self, window: str):
         """A `Literal` is not enforced at runtime, so a spec typo would reach `assert_never`."""
         with pytest.raises(UserError, match='window must be one of'):
-            SpendLimits[None].from_spec(budgets=[{'window': window}])
+            SpendLimits[None].from_spec(budgets=_spec_budgets({'window': window}))
 
     @pytest.mark.parametrize('policy', ['raises', 'Zero', ''])
     def test_an_unknown_unpriced_policy_is_refused(self, policy: str):
@@ -703,7 +776,7 @@ class TestObservability:
         async def record(snapshot: SpendSnapshot) -> None:
             seen.append(snapshot.usd)
 
-        guard = SpendLimits(price=lambda r: Decimal('3'), on_spend=record)
+        guard = SpendLimits[None](price=lambda r: Decimal('3'), on_spend=record)
         await _record(guard)
 
         assert seen == [Decimal('3')]
@@ -897,7 +970,14 @@ class FakeRedis:
     """The two coroutines `RedisSpendStore` uses, over a dict.
 
     `eval` stands in for the server running the script: the same four increments
-    and the same expiry, applied as one step, which is what Redis guarantees.
+    and the same expiry, applied as one step, which is what Redis guarantees. It
+    reproduces the *result* the script is meant to produce and does not run the Lua,
+    so what it pins is the store's contract rather than the script's correctness --
+    `integration_tests/redis/` is where the script itself is executed.
+
+    `HINCRBY` leaves an existing expiry alone, which is why a zero `ttl` has to clear
+    one rather than skip the call: modelled here so a `retain='forever'` budget that
+    kept a stale horizon shows up as a failure.
     """
 
     def __init__(self, *, bytes_keys: bool = False) -> None:
@@ -928,6 +1008,8 @@ class FakeRedis:
             fields[field] = fields.get(field, 0) + amount
         if ttl > 0:
             self.expiries[name] = ttl
+        else:
+            self.expiries.pop(name, None)
         return [fields['usd_nanos'], fields['tokens'], fields['requests'], fields['unpriced']]
 
 
@@ -982,14 +1064,40 @@ class TestRedisStore:
 
     @pytest.mark.parametrize(
         ('retain', 'expected'),
-        [(timedelta(milliseconds=500), 1), (timedelta(seconds=1), 1), (timedelta(seconds=90), 90)],
+        [
+            (timedelta(milliseconds=500), 1),
+            (timedelta(seconds=1), 1),
+            (timedelta(seconds=90), 90),
+            # Rounding on `total_seconds()` truncated the remainder to milliseconds before
+            # taking the ceiling, so a horizon with a finer tail expired early.
+            (timedelta(seconds=1, microseconds=1), 2),
+            (timedelta(seconds=2, microseconds=999), 3),
+        ],
     )
-    async def test_a_sub_second_horizon_still_expires(self, retain: timedelta, expected: int):
-        """`EXPIRE` takes seconds and the script reads zero as "keep"; truncating would never expire."""
+    async def test_a_horizon_is_rounded_up_never_down(self, retain: timedelta, expected: int):
+        """`EXPIRE` takes seconds and the script reads zero as "keep"; rounding down would never expire."""
         client = FakeRedis()
         await RedisSpendStore(client).add('k', usd=Decimal('1'), tokens=1, requests=1, unpriced=0, ttl=retain)
 
         assert client.expiries == {'pydantic-ai-harness:spend:k': expected}
+
+    async def test_moving_a_budget_to_forever_clears_the_old_horizon(self):
+        """`HINCRBY` leaves an expiry in place, so skipping `EXPIRE` is not the same as no expiry.
+
+        A counter written under a finite `retain` and then reconfigured to `'forever'` kept
+        expiring on the horizon nothing in the configuration mentions any more, handing the
+        ceiling back on a schedule. `InMemorySpendStore` drops the expiry on the next write;
+        this is the same behavior.
+        """
+        client = FakeRedis()
+        store = RedisSpendStore(client)
+        await store.add('k', usd=Decimal('1'), tokens=1, requests=1, unpriced=0, ttl=timedelta(hours=1))
+        assert client.expiries == {'pydantic-ai-harness:spend:k': 3600}
+
+        await store.add('k', usd=Decimal('1'), tokens=1, requests=1, unpriced=0, ttl=None)
+
+        assert client.expiries == {}
+        assert 'PERSIST' in client.calls[-1]
 
     async def test_it_drives_the_gate(self):
         guard = SpendLimits(
@@ -1250,21 +1358,55 @@ class TestSpec:
 
     def test_a_budget_must_be_a_mapping(self):
         with pytest.raises(UserError, match='must be a mapping'):
-            SpendLimits[None].from_spec(budgets=['100'])
+            SpendLimits[None].from_spec(budgets=_spec_budgets('100'))
 
     def test_every_number_a_spec_carries_is_coerced(self):
         """Only `usd` was converted, so the others reached `__post_init__` and compared str to int."""
-        guard = SpendLimits[None].from_spec(budgets=[{'usd': '1', 'tokens': '5000', 'warn_at': '0.8'}])
+        guard = SpendLimits[None].from_spec(budgets=_spec_budgets({'usd': '1', 'tokens': '5000', 'warn_at': '0.8'}))
 
         assert guard.budgets[0] == Budget(usd=Decimal('1'), tokens=5000, warn_at=0.8)
 
     def test_a_number_that_is_not_a_number_is_named(self):
         with pytest.raises(UserError, match="budget 'tokens' is not a number"):
-            SpendLimits[None].from_spec(budgets=[{'tokens': 'lots'}])
+            SpendLimits[None].from_spec(budgets=_spec_budgets({'tokens': 'lots'}))
 
     def test_a_budget_scope_is_refused(self):
         with pytest.raises(UserError, match='cannot be expressed in a spec'):
-            SpendLimits[None].from_spec(budgets=[{'scope': 'tenant'}])
+            SpendLimits[None].from_spec(budgets=_spec_budgets({'scope': 'tenant'}))
+
+    def test_an_unknown_spec_field_is_named(self):
+        """`**unsupported` keeps the callable message specific, so it must not swallow the rest."""
+        with pytest.raises(UserError, match=r"no spec field\(s\) \['budget'\]"):
+            SpendLimits[None].from_spec(budget=[])
+
+    def test_the_schema_carries_the_configuration_the_docs_document(self):
+        """A `*args/**kwargs` signature published the bare name, marking every documented block invalid."""
+        schema = json.dumps(AgentSpec.model_json_schema_with_capabilities([SpendLimits]), sort_keys=True)
+
+        assert '"budgets"' in schema
+        assert '"on_unpriced"' in schema
+        assert '"expose_tools"' in schema
+        # The four runtime-only fields take callables or a live store and have no spec form.
+        for runtime_only in ('"store"', '"price"', '"on_spend"', '"clock"', '"scope"'):
+            assert runtime_only not in schema, runtime_only
+
+    def test_the_documented_yaml_validates_against_the_published_schema(self):
+        """The README's example, checked against the schema an editor reads from `$schema`."""
+        spec = {
+            'model': 'openai:gpt-5.4',
+            'capabilities': [
+                {
+                    'SpendLimits': {
+                        'budgets': [
+                            {'usd': '100', 'window': 'day'},
+                            {'usd': '2000', 'window': 'month', 'warn_at': 0.8},
+                        ],
+                        'on_unpriced': 'raise',
+                    }
+                }
+            ],
+        }
+        jsonschema.validate(spec, AgentSpec.model_json_schema_with_capabilities([SpendLimits]))
 
 
 class TestDurableClock:

--- a/uv.lock
+++ b/uv.lock
@@ -2387,6 +2387,7 @@ dev = [
     { name = "pytest-anyio" },
     { name = "pytest-examples" },
     { name = "pytest-recording" },
+    { name = "redis" },
 ]
 lint = [
     { name = "pyright" },
@@ -2428,6 +2429,7 @@ dev = [
     { name = "pytest-anyio" },
     { name = "pytest-examples", specifier = ">=0.0.18" },
     { name = "pytest-recording", specifier = ">=0.13.4" },
+    { name = "redis", specifier = ">=6.0.0" },
 ]
 lint = [
     { name = "pyright", specifier = ">=1.1.408" },
@@ -3109,6 +3111,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Post-merge review of #474 (Codex, on the merged commit). Seven findings; all seven validated against
core source and reproduced, five fixed in code, two corrected in docs plus a tracking issue. One
additional defect surfaced while building the tests.

## Fixed

**1. A wrapper's `ModelRetry` bypassed accounting.** `after_model_request` runs once the whole
wrap chain has returned (`_agent_graph.py` `ModelRequestNode._make_request` calls
`_finish_handling` after it). A capability that awaited a response in its own
`wrap_model_request` and then raised `ModelRetry` went straight to `_build_retry_node`, skipping
`_finish_handling` entirely -- so a second provider call happened and the first, billed response
was never counted. Reproduced at the reviewer's exact numbers: 2 provider requests, 1 recorded, $1
instead of $2.

Ordering could not fix it. The rejecting capability need not be innermost, and one listed *before*
`SpendLimits` still wraps outside it. The accrual moved into `wrap_model_request`, which is a
strictly stronger position than `position='innermost'` bought before: every other wrapper and every
`after_model_request` now runs outside it.

Free with the move: `SkipModelRequest` reaches `after_model_request` with a response the run never
paid for, but never reaches the wrapped handler -- so a cache hit is no longer charged for.

**2. Redis `retain='forever'` kept an old expiry.** `ttl=None` became `0`, and the script skipped
`EXPIRE` without calling `PERSIST`. `HINCRBY` leaves an expiry in place, so a budget moved from a
finite `retain` to `'forever'` kept expiring on a horizon the configuration no longer mentioned,
handing back the ceiling on a schedule. Diverged from `InMemorySpendStore`, which drops the expiry
on the next write.

**4. `SpendLimits` published no fields to the AgentSpec schema.** `from_spec(*args, **kwargs)` --
core's `build_schema_types` drops `VAR_POSITIONAL`/`VAR_KEYWORD`, leaving no type hints, so the
schema was `{"const": "SpendLimits"}` and nothing else. Every documented `budgets:` block validated
as invalid in an editor following the `$schema` line, while loading fine at runtime. Now an explicit
keyword-only signature with a `BudgetSpec` `TypedDict` (needed because `Budget.scope` is a callable
and core only strips callables at the top level of a union). `**unsupported` stays -- core drops it
from the schema, and it is what keeps the specific `UserError` for `store`/`price`/`on_spend`/
`clock`.

**7a. TTL rounding.** `_expiry_seconds` truncated to milliseconds before taking the ceiling, so
`1s + 1µs` became 1 second. Now ceiling-divides the `timedelta` itself, which is exact in
microseconds.

**7b. `Budget.scope` used `RunContext[Any]`.** The sole outlier -- every other capability types
user-supplied callables against `AgentDepsT`. `Budget` is now generic, so through
`Agent(deps_type=Deps, capabilities=[...])` a scope reaching for a field the deps do not have is a
pyright error instead of an `AttributeError` on the first request. Free to do now: `SpendLimits` is
not in `v0.16.0`, so this is not yet a breaking change.

**Bonus, found while writing the live tests: `redis.asyncio.Redis` did not satisfy `RedisClient`.**
The protocol declared `async def`, which narrows the requirement to a `Coroutine`; redis-py types
these as `Awaitable`. Under pyright strict the one client the protocol exists to accept was
rejected, contradicting its own docstring. Now declared `def ... -> Awaitable[...]`, which
`async def` implementations still satisfy. Nothing the unit fake could have caught.

## Corrected rather than coded

**5. `exhausted()` was described as enforcement.** It is an admission check: it reads the counters,
reserves nothing, records nothing. A workflow admitted on it records no spend of its own, so the
counter never moves and the next workflow is admitted on the same stale reading. Narrowed in the
class docstring, `exhausted()`, the sandbox-error translation, README and docs page; #531 corrected.

**6. Redis failure guarantees were too strong.** "Every failure lands before the script writes
anything" is false for a connection that drops after `EVAL` committed -- the outcome is *unknown*,
not untried, which is why nothing retries an `add`. The old `_ADD_SCRIPT` docstring also
contradicted itself on this. #532 corrected.

**3. Atomicity is per window, not per response.** Confirmed by reproduction: with day and month
budgets and a store failing on its second write, the day key holds the response and the month key is
absent. The docs now say so. A real fix needs a batch store operation, and two things have to be
settled first (`SpendStore` is a public Protocol; Redis Cluster needs same-slot keys for a multi-key
script) -- filed as #536 rather than rushed here.

## Live-Redis integration suite

`integration_tests/redis/`, mirroring `integration_tests/mongodb/`: a `redis:8` service container,
a `detect-redis` path filter, `make integration-redis`, and `REDIS_REQUIRE_LIVE` so a container
that never came up fails instead of silently skipping.

This is why finding 6 asked for it. The unit fake reproduces the *result* `_ADD_SCRIPT` is meant to
produce without running the Lua, which is exactly how the `PERSIST` bug survived. Verified the new
test catches it: reverting `PERSIST` fails with `assert 3600 == -1`.

## Deliberate scope decisions

- **`StepPersistence.from_spec` has the identical schema defect** -- also `*args/**kwargs`, also
  publishing a bare literal. Filed as #537 rather than fixed here: a different capability with its
  own field surface to get right, and mixing two capabilities in one diff.
- **`SpendStore` keeps `async def`** while `RedisClient` moves to `Awaitable`. The change was made
  for a concrete failure against a third-party client; `SpendStore` is implemented by users, who
  will write `async def`, and no failure exists to justify churning it.
- **`BudgetStatus.budget` is `Budget[Any]`, not generic.** It is a reading -- the deps type only
  types `scope`, and nothing calls a scope through a status. Making it generic would ripple through
  `SpendSnapshot` and `on_spend` for no checkable benefit.
- **No real-Redis test for the exact-integer ceiling beyond the guard itself.** Verified that the
  refusal leaves the counter untouched; not testing an actual $9M counter.

## Verification

`make lint`, `make typecheck`, full suite, and 100% branch coverage all pass. The live-Redis suite
passes against `redis:8` locally.

**Needs the `dependencies:approved` label** -- `redis` added to the dev group for the integration
tests. The lock diff is that one package.
