### PR TITLE
Prevent silent guardrail configuration failures

### DIFF
--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -419,11 +419,12 @@ ToolGuardrail(
 
 `hidden` is not a blocklist with a nicer name. A hidden tool is dropped from the definitions sent to the model, so it costs no tokens and the model never attempts it; a blocked tool stays visible and the model learns it was refused. Hiding takes a static list of names -- for policy that depends on `deps` or on the arguments, use `guard`.
 
-Configured `tools` and `hidden` names are checked when a run completes successfully. A
-dynamic toolset may omit a tool on one step and offer it later, so a name that
-never appears is the only typo signal. That warning catches `tools=['send_monye']`,
-which otherwise leaves the intended tool unguarded, and a misspelled `hidden`
-name, which otherwise stays visible to the model.
+Configured `hidden` names are checked when a run completes successfully. Configured
+`tools` names are checked then only when `guard` or `result_guard` is set. A dynamic
+toolset may omit a tool on one step and offer it later, so a name that never appears
+is the only typo signal. That warning catches `tools=['send_monye']`, which otherwise
+leaves the intended tool unguarded, and a misspelled `hidden` name, which otherwise
+stays visible to the model.
 
 ### What a tool guard does not see
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -141,6 +141,23 @@ OutputGuardrail(guard=for_text(redact_secrets))  # raises on a non-string output
 OutputGuardrail(guard=for_text(redact_secrets, on_other='allow'))  # skips it deliberately
 ```
 
+A tool result guard receives `ToolResultInfo`, not just a value. Use
+`for_tool_result_text` to adapt a detector for a bare string result or a
+`ToolReturn.return_value` string:
+
+```python
+from pydantic_ai_harness.guardrails import ToolGuardrail
+from pydantic_ai_harness.guardrails.detectors import for_tool_result_text, redact_secrets
+
+ToolGuardrail(result_guard=for_tool_result_text(redact_secrets))
+```
+
+When it redacts a `ToolReturn`, the adapter replaces `return_value` and
+preserves its `content`, `metadata`, and `kind`. `ToolReturn.content` is sent
+as a separate user-prompt part, so the adapter does not inspect it. As with
+`for_text`, a non-text result raises by default; pass `on_other='allow'` to
+skip one deliberately.
+
 A detector on the input side needs a text prompt. A multimodal prompt reaches
 the guard rendered as text, so a detector that matches one returns `replace`,
 which `InputGuardrail` refuses rather than dropping the attached parts (see
@@ -401,6 +418,12 @@ ToolGuardrail(
 ```
 
 `hidden` is not a blocklist with a nicer name. A hidden tool is dropped from the definitions sent to the model, so it costs no tokens and the model never attempts it; a blocked tool stays visible and the model learns it was refused. Hiding takes a static list of names -- for policy that depends on `deps` or on the arguments, use `guard`.
+
+Configured `tools` and `hidden` names are checked when the run finishes. A
+dynamic toolset may omit a tool on one step and offer it later, so a name that
+never appears is the only typo signal. That warning catches `tools=['send_monye']`,
+which otherwise leaves the intended tool unguarded, and a misspelled `hidden`
+name, which otherwise stays visible to the model.
 
 ### What a tool guard does not see
 

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -419,7 +419,7 @@ ToolGuardrail(
 
 `hidden` is not a blocklist with a nicer name. A hidden tool is dropped from the definitions sent to the model, so it costs no tokens and the model never attempts it; a blocked tool stays visible and the model learns it was refused. Hiding takes a static list of names -- for policy that depends on `deps` or on the arguments, use `guard`.
 
-Configured `tools` and `hidden` names are checked when the run finishes. A
+Configured `tools` and `hidden` names are checked when a run completes successfully. A
 dynamic toolset may omit a tool on one step and offer it later, so a name that
 never appears is the only typo signal. That warning catches `tools=['send_monye']`,
 which otherwise leaves the intended tool unguarded, and a misspelled `hidden`

--- a/pydantic_ai_harness/guardrails/README.md
+++ b/pydantic_ai_harness/guardrails/README.md
@@ -379,7 +379,7 @@ ToolGuardrail(
 
 `hidden` is not a blocklist with a nicer name. A hidden tool is dropped from the definitions sent to the model, so it costs no tokens and the model never attempts it; a blocked tool stays visible and the model learns it was refused. Hiding takes a static list of names -- for policy that depends on `deps` or on the arguments, use `guard`.
 
-Configured `tools` and `hidden` names are checked when the run finishes. A
+Configured `tools` and `hidden` names are checked when a run completes successfully. A
 dynamic toolset may omit a tool on one step and offer it later, so a name that
 never appears is the only typo signal. That warning catches `tools=['send_monye']`,
 which otherwise leaves the intended tool unguarded, and a misspelled `hidden`

--- a/pydantic_ai_harness/guardrails/README.md
+++ b/pydantic_ai_harness/guardrails/README.md
@@ -143,6 +143,23 @@ OutputGuardrail(guard=for_text(redact_secrets))  # raises on a non-string output
 OutputGuardrail(guard=for_text(redact_secrets, on_other='allow'))  # skips it deliberately
 ```
 
+A tool result guard receives `ToolResultInfo`, not just a value. Use
+`for_tool_result_text` to adapt a detector for a bare string result or a
+`ToolReturn.return_value` string:
+
+```python
+from pydantic_ai_harness.guardrails import ToolGuardrail
+from pydantic_ai_harness.guardrails.detectors import for_tool_result_text, redact_secrets
+
+ToolGuardrail(result_guard=for_tool_result_text(redact_secrets))
+```
+
+When it redacts a `ToolReturn`, the adapter replaces `return_value` and
+preserves its `content`, `metadata`, and `kind`. `ToolReturn.content` is sent
+as a separate user-prompt part, so the adapter does not inspect it. As with
+`for_text`, a non-text result raises by default; pass `on_other='allow'` to
+skip one deliberately.
+
 A detector on the input side needs a text prompt. A multimodal prompt reaches
 the guard rendered as text, so a detector that matches one returns `replace`,
 which `InputGuardrail` refuses rather than dropping the attached parts (see
@@ -361,6 +378,12 @@ ToolGuardrail(
 ```
 
 `hidden` is not a blocklist with a nicer name. A hidden tool is dropped from the definitions sent to the model, so it costs no tokens and the model never attempts it; a blocked tool stays visible and the model learns it was refused. Hiding takes a static list of names -- for policy that depends on `deps` or on the arguments, use `guard`.
+
+Configured `tools` and `hidden` names are checked when the run finishes. A
+dynamic toolset may omit a tool on one step and offer it later, so a name that
+never appears is the only typo signal. That warning catches `tools=['send_monye']`,
+which otherwise leaves the intended tool unguarded, and a misspelled `hidden`
+name, which otherwise stays visible to the model.
 
 ### What a tool guard does not see
 

--- a/pydantic_ai_harness/guardrails/README.md
+++ b/pydantic_ai_harness/guardrails/README.md
@@ -379,11 +379,12 @@ ToolGuardrail(
 
 `hidden` is not a blocklist with a nicer name. A hidden tool is dropped from the definitions sent to the model, so it costs no tokens and the model never attempts it; a blocked tool stays visible and the model learns it was refused. Hiding takes a static list of names -- for policy that depends on `deps` or on the arguments, use `guard`.
 
-Configured `tools` and `hidden` names are checked when a run completes successfully. A
-dynamic toolset may omit a tool on one step and offer it later, so a name that
-never appears is the only typo signal. That warning catches `tools=['send_monye']`,
-which otherwise leaves the intended tool unguarded, and a misspelled `hidden`
-name, which otherwise stays visible to the model.
+Configured `hidden` names are checked when a run completes successfully. Configured
+`tools` names are checked then only when `guard` or `result_guard` is set. A dynamic
+toolset may omit a tool on one step and offer it later, so a name that never appears
+is the only typo signal. That warning catches `tools=['send_monye']`, which otherwise
+leaves the intended tool unguarded, and a misspelled `hidden` name, which otherwise
+stays visible to the model.
 
 ### What a tool guard does not see
 

--- a/pydantic_ai_harness/guardrails/_capability.py
+++ b/pydantic_ai_harness/guardrails/_capability.py
@@ -197,6 +197,11 @@ class InputGuardrail(AbstractCapability[AgentDepsT]):
     parallel: bool = False
     """Run the guard concurrently with the model request and cancel the model call on failure."""
 
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        """Exclude a callable policy from YAML and JSON agent specifications."""
+        return None
+
     def get_ordering(self) -> CapabilityOrdering:
         """Sit innermost so message-morphing capabilities run first and the guard sees the final prompt."""
         return CapabilityOrdering(position='innermost')
@@ -352,6 +357,11 @@ class OutputGuardrail(AbstractCapability[AgentDepsT]):
     In a chain the first `block` or `retry` ends it, and a `replace` substitutes
     the output the remaining guards see.
     """
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        """Exclude a callable policy from YAML and JSON agent specifications."""
+        return None
 
     def get_ordering(self) -> CapabilityOrdering:
         """Sit outermost (inside `Instrumentation`) so the guard sees the final processed output."""

--- a/pydantic_ai_harness/guardrails/_tool_guardrail.py
+++ b/pydantic_ai_harness/guardrails/_tool_guardrail.py
@@ -298,11 +298,10 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
         *,
         handler: WrapRunHandler,
     ) -> AgentRunResult[object]:
-        """Report selector names only after dynamic tool preparation has finished."""
-        try:
-            return await handler()
-        finally:
-            self._warn_unmatched_names()
+        """Report unmatched selector names after a successful, prepared run."""
+        result = await handler()
+        self._warn_unmatched_names()
+        return result
 
     def _warn_unmatched_names(self) -> None:
         """Warn when a configured selector never appeared in this run."""

--- a/pydantic_ai_harness/guardrails/_tool_guardrail.py
+++ b/pydantic_ai_harness/guardrails/_tool_guardrail.py
@@ -237,6 +237,9 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
     _seen_tools: set[str] = field(default_factory=set[str], init=False, repr=False, compare=False)
     """`tools` names that appeared during this run."""
 
+    _prepared_tools: bool = field(default=False, init=False, repr=False, compare=False)
+    """Whether this run reached function-tool preparation."""
+
     def __post_init__(self) -> None:
         """Reject a bare string where a collection of tool names is meant.
 
@@ -281,6 +284,7 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
         may legitimately offer a tool only on some steps, so first absence is not
         evidence of a typo.
         """
+        self._prepared_tools = True
         offered = {tool_def.name for tool_def in tool_defs}
         self._seen_tools.update(set(self.tools or ()).intersection(offered))
         self._seen_hidden.update(set(self.hidden).intersection(offered))
@@ -302,6 +306,8 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
 
     def _warn_unmatched_names(self) -> None:
         """Warn when a configured selector never appeared in this run."""
+        if not self._prepared_tools:
+            return
         if self.tools and (self.guard is not None or self.result_guard is not None):
             for name in sorted(set(self.tools) - self._seen_tools):
                 warnings.warn(

--- a/pydantic_ai_harness/guardrails/_tool_guardrail.py
+++ b/pydantic_ai_harness/guardrails/_tool_guardrail.py
@@ -212,9 +212,9 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
     An empty sequence guards nothing, which is the same as configuring no guard at all --
     write `None` when you mean every tool.
 
-    A configured name that no offered tool matches warns after the run. Toolsets
-    can vary between run steps, so absence from one step is not enough to diagnose
-    a typo.
+    A configured name that no offered tool matches warns after a successful run when
+    `guard` or `result_guard` is set. Toolsets can vary between run steps, so absence
+    from one step is not enough to diagnose a typo.
     """
 
     hidden: Sequence[str] = field(default_factory=tuple)

--- a/pydantic_ai_harness/guardrails/_tool_guardrail.py
+++ b/pydantic_ai_harness/guardrails/_tool_guardrail.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, TypeGuard, cast
 
-from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
+from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering, WrapRunHandler
 from pydantic_ai.exceptions import (
     ApprovalRequired,
     ModelRetry,
@@ -40,6 +40,7 @@ from pydantic_ai.exceptions import (
     ToolRetryError,
     UserError,
 )
+from pydantic_ai.run import AgentRunResult
 from pydantic_ai.tools import AgentDepsT, RunContext
 from typing_extensions import assert_never
 
@@ -101,7 +102,10 @@ class ToolResultInfo(ToolCallInfo):
     A tool may return a [`ToolReturn`][pydantic_ai.messages.ToolReturn] wrapper
     rather than a bare value, in which case that wrapper is what arrives here.
     Stringifying it yields a repr and replacing it with a string discards its
-    metadata, so read `result.return_value` when you mean the payload.
+    metadata. Use
+    [`for_tool_result_text`][pydantic_ai_harness.guardrails.detectors.for_tool_result_text]
+    when a text detector should inspect a string payload without losing the
+    wrapper's content or metadata.
 
     This is the object the tool produced, not a copy: read it, and return
     `GuardrailResult.replace` to change it. Mutating it in place changes what the
@@ -207,6 +211,10 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
 
     An empty sequence guards nothing, which is the same as configuring no guard at all --
     write `None` when you mean every tool.
+
+    A configured name that no offered tool matches warns after the run. Toolsets
+    can vary between run steps, so absence from one step is not enough to diagnose
+    a typo.
     """
 
     hidden: Sequence[str] = field(default_factory=tuple)
@@ -218,17 +226,16 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
     refused. Hiding is a static name list; for policy that depends on `deps` or
     the arguments, use `guard`.
 
-    A name here that no offered tool answers to raises a `UserWarning`. Unlike a
-    misspelled `tools` entry, which only widens what is inspected, a misspelled
-    `hidden` entry leaves the tool on the wire and reads, at the call site,
-    exactly like a tool that was hidden.
+    A name here that no offered tool answers to raises a `UserWarning` after the
+    run. A misspelled entry leaves the tool on the wire and reads, at the call
+    site, exactly like a tool that was hidden.
     """
 
     _seen_hidden: set[str] = field(default_factory=set[str], init=False, repr=False, compare=False)
-    """`hidden` names some offered tool has answered to, so a tool that appears late is not warned about."""
+    """`hidden` names that appeared during this run."""
 
-    _warned_hidden: set[str] = field(default_factory=set[str], init=False, repr=False, compare=False)
-    """`hidden` names already warned about, so a per-step hook does not warn once per step."""
+    _seen_tools: set[str] = field(default_factory=set[str], init=False, repr=False, compare=False)
+    """`tools` names that appeared during this run."""
 
     def __post_init__(self) -> None:
         """Reject a bare string where a collection of tool names is meant.
@@ -250,6 +257,15 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
         """Sit innermost: see the final arguments, and the tool result before other capabilities rewrite it."""
         return CapabilityOrdering(position='innermost')
 
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        """Exclude a callable policy from YAML and JSON agent specifications."""
+        return None
+
+    async def for_run(self, ctx: RunContext[AgentDepsT]) -> ToolGuardrail[AgentDepsT]:
+        """Start a fresh selector observation window for each run."""
+        return replace(self)
+
     def _guards(self, tool_name: str) -> bool:
         """Whether this guard applies to `tool_name`."""
         return self.tools is None or tool_name in self.tools
@@ -261,24 +277,46 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
     ) -> list[ToolDefinition]:
         """Drop the `hidden` tools from what the model is offered.
 
-        A name that matches nothing is warned about once. `hidden` is the one setting whose
-        failure mode is silent exposure: a typo leaves the tool on the wire and reads, at the
-        call site, exactly like a tool that was hidden. The warning is per name rather than
-        per step, since a toolset may legitimately offer a tool only some of the time.
+        Names are observed for a warning at the completed-run boundary. A toolset
+        may legitimately offer a tool only on some steps, so first absence is not
+        evidence of a typo.
         """
+        offered = {tool_def.name for tool_def in tool_defs}
+        self._seen_tools.update(set(self.tools or ()).intersection(offered))
+        self._seen_hidden.update(set(self.hidden).intersection(offered))
         if not self.hidden:
             return tool_defs
-        hidden = set(self.hidden)
-        self._seen_hidden.update(hidden.intersection(tool_def.name for tool_def in tool_defs))
-        for name in sorted(hidden - self._seen_hidden - self._warned_hidden):
-            self._warned_hidden.add(name)
+        return [tool_def for tool_def in tool_defs if tool_def.name not in self.hidden]
+
+    async def wrap_run(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        handler: WrapRunHandler,
+    ) -> AgentRunResult[object]:
+        """Report selector names only after dynamic tool preparation has finished."""
+        try:
+            return await handler()
+        finally:
+            self._warn_unmatched_names()
+
+    def _warn_unmatched_names(self) -> None:
+        """Warn when a configured selector never appeared in this run."""
+        if self.tools and (self.guard is not None or self.result_guard is not None):
+            for name in sorted(set(self.tools) - self._seen_tools):
+                warnings.warn(
+                    f'ToolGuardrail.tools names {name!r}, which no tool offered during this run is called. '
+                    'Neither guard was applied to it.',
+                    UserWarning,
+                    stacklevel=3,
+                )
+        for name in sorted(set(self.hidden) - self._seen_hidden):
             warnings.warn(
-                f'ToolGuardrail.hidden names {name!r}, which no tool offered so far is called. '
-                'A tool that is never named stays available to the model.',
+                f'ToolGuardrail.hidden names {name!r}, which no tool offered during this run is called. '
+                'The name stays available to the model.',
                 UserWarning,
-                stacklevel=2,
+                stacklevel=3,
             )
-        return [tool_def for tool_def in tool_defs if tool_def.name not in hidden]
 
     async def before_tool_execute(
         self,

--- a/pydantic_ai_harness/guardrails/detectors.py
+++ b/pydantic_ai_harness/guardrails/detectors.py
@@ -422,7 +422,12 @@ def for_tool_result_text(
     def guard(info: ToolResultInfo) -> GuardrailResult:
         result = info.result
         if isinstance(result, str):
-            return detector(result)
+            verdict = detector(result)
+            if verdict.action == 'replace' and not isinstance(verdict.replacement, str):
+                raise UserError(
+                    'A text detector used with for_tool_result_text() must replace a tool result with text.'
+                )
+            return verdict
         if _is_text_tool_return(result):
             assert isinstance(result.return_value, str)
             verdict = detector(result.return_value)

--- a/pydantic_ai_harness/guardrails/detectors.py
+++ b/pydantic_ai_harness/guardrails/detectors.py
@@ -45,14 +45,23 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Iterable, Mapping
-from typing import Literal
+from dataclasses import replace
+from typing import Literal, TypeGuard
 
 from pydantic_ai.exceptions import UserError
+from pydantic_ai.messages import ToolReturn
 
 from pydantic_ai_harness.guardrails._shared import GuardrailResult
+from pydantic_ai_harness.guardrails._tool_guardrail import ToolResultInfo
 
 TextDetector = Callable[[str], GuardrailResult]
-"""A check over text. Plug one into `InputGuardrail`, or into `OutputGuardrail` via `for_text`."""
+"""A check over text. Adapt one with `for_text` or `for_tool_result_text` at non-text guard boundaries."""
+
+
+def _is_text_tool_return(value: object) -> TypeGuard[ToolReturn[str]]:
+    """Whether `value` is a `ToolReturn` with a string payload."""
+    return isinstance(value, ToolReturn) and isinstance(value.return_value, str)
+
 
 _NEWLINE = r'(?:\r?\n|\\+n)'
 """A line break as it reaches a detector.
@@ -391,6 +400,45 @@ def for_text(
         raise UserError(
             f'A text detector received {type(value).__name__}, which it cannot rewrite without changing the '
             "output's type. Apply it to a field of the output, or pass on_other='allow' to skip non-text."
+        )
+
+    return guard
+
+
+def for_tool_result_text(
+    detector: TextDetector, *, on_other: Literal['raise', 'allow'] = 'raise'
+) -> Callable[[ToolResultInfo], GuardrailResult]:
+    """Adapt a text detector to the result object `ToolGuardrail` supplies.
+
+    Plain string results are passed to `detector`. A `ToolReturn` with a string
+    `return_value` is rebuilt when the detector redacts it, retaining its
+    `content`, `metadata`, and `kind`. `ToolReturn.content` is a separate
+    model-directed user-content channel and is not inspected here.
+
+    A non-text result has no safe text replacement. The default raises with the
+    adapter name; `on_other='allow'` deliberately skips it.
+    """
+
+    def guard(info: ToolResultInfo) -> GuardrailResult:
+        result = info.result
+        if isinstance(result, str):
+            return detector(result)
+        if _is_text_tool_return(result):
+            assert isinstance(result.return_value, str)
+            verdict = detector(result.return_value)
+            if verdict.action != 'replace':
+                return verdict
+            replacement = verdict.replacement
+            if not isinstance(replacement, str):
+                raise UserError(
+                    'A text detector used with for_tool_result_text() must replace a tool result with text.'
+                )
+            return GuardrailResult.replace(replace(result, return_value=replacement))
+        if on_other == 'allow':
+            return GuardrailResult.allow()
+        raise UserError(
+            f'for_tool_result_text() received {type(result).__name__}, which has no text payload to rewrite. '
+            "Pass on_other='allow' to skip non-text tool results."
         )
 
     return guard

--- a/pydantic_ai_harness/planning/_store.py
+++ b/pydantic_ai_harness/planning/_store.py
@@ -105,30 +105,45 @@ def apply_updates(
     if parent_id is not None:
         item.parent_id = parent_id
     if depends_on is not None:
-        item.depends_on = depends_on
+        item.depends_on = list(depends_on)
+
+
+def _snapshot(item: PlanItem) -> PlanItem:
+    """Return an item detached from the store and other public values."""
+    return item.model_copy(deep=True)
 
 
 async def emit_created(emitter: PlanEventEmitter | None, item: PlanItem) -> None:
     """Emit a `created` event when an emitter is attached."""
     if emitter is not None:
-        await emitter.emit(PlanEvent(event_type=PlanEventType.created, item=item))
+        await emitter.emit(PlanEvent(event_type=PlanEventType.created, item=_snapshot(item)))
 
 
 async def emit_deleted(emitter: PlanEventEmitter | None, item: PlanItem) -> None:
     """Emit a `deleted` event when an emitter is attached."""
     if emitter is not None:
-        await emitter.emit(PlanEvent(event_type=PlanEventType.deleted, item=item))
+        await emitter.emit(PlanEvent(event_type=PlanEventType.deleted, item=_snapshot(item)))
 
 
 async def emit_mutation(emitter: PlanEventEmitter | None, updated: PlanItem, previous: PlanItem | None) -> None:
     """Emit `updated`, then `status_changed`/`completed` if the status moved."""
     if emitter is None or previous is None:
         return
-    await emitter.emit(PlanEvent(event_type=PlanEventType.updated, item=updated, previous_state=previous))
+    await emitter.emit(
+        PlanEvent(event_type=PlanEventType.updated, item=_snapshot(updated), previous_state=_snapshot(previous))
+    )
     if updated.status != previous.status:
-        await emitter.emit(PlanEvent(event_type=PlanEventType.status_changed, item=updated, previous_state=previous))
+        await emitter.emit(
+            PlanEvent(
+                event_type=PlanEventType.status_changed, item=_snapshot(updated), previous_state=_snapshot(previous)
+            )
+        )
         if updated.status is TaskStatus.completed:
-            await emitter.emit(PlanEvent(event_type=PlanEventType.completed, item=updated, previous_state=previous))
+            await emitter.emit(
+                PlanEvent(
+                    event_type=PlanEventType.completed, item=_snapshot(updated), previous_state=_snapshot(previous)
+                )
+            )
 
 
 class InMemoryPlanStore:
@@ -140,23 +155,25 @@ class InMemoryPlanStore:
 
     async def get_items(self) -> list[PlanItem]:
         """Return every step in insertion order."""
-        return list(self._items)
+        return [_snapshot(item) for item in self._items]
 
     async def set_items(self, items: list[PlanItem]) -> None:
         """Replace the whole list with `items`."""
-        self._items = list(items)
+        self._items = [_snapshot(item) for item in items]
 
     async def get_item(self, item_id: str) -> PlanItem | None:
         """Return the step with `item_id`, or `None`."""
-        return next((item for item in self._items if item.id == item_id), None)
+        item = next((item for item in self._items if item.id == item_id), None)
+        return None if item is None else _snapshot(item)
 
     async def add_item(self, item: PlanItem) -> PlanItem:
         """Append `item` and return it."""
         if any(existing.id == item.id for existing in self._items):
             raise ValueError(f'A step with id {item.id!r} is already in this plan.')
-        self._items.append(item)
-        await emit_created(self._emitter, item)
-        return item
+        stored = _snapshot(item)
+        self._items.append(stored)
+        await emit_created(self._emitter, stored)
+        return _snapshot(stored)
 
     async def update_item(
         self,
@@ -169,10 +186,10 @@ class InMemoryPlanStore:
         depends_on: list[str] | None = None,
     ) -> PlanItem | None:
         """Apply the non-`None` fields to `item_id`; return the updated step or `None`."""
-        item = await self.get_item(item_id)
+        item = next((item for item in self._items if item.id == item_id), None)
         if item is None:
             return None
-        previous = item.model_copy() if self._emitter is not None else None
+        previous = _snapshot(item) if self._emitter is not None else None
         apply_updates(
             item,
             content=content,
@@ -182,7 +199,7 @@ class InMemoryPlanStore:
             depends_on=depends_on,
         )
         await emit_mutation(self._emitter, item, previous)
-        return item
+        return _snapshot(item)
 
     async def remove_item(self, item_id: str) -> bool:
         """Delete `item_id`; return whether it existed."""

--- a/tests/guardrails/test_detectors.py
+++ b/tests/guardrails/test_detectors.py
@@ -7,17 +7,27 @@ import time
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import UserError
-from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, UserPromptPart
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturn,
+    ToolReturnPart,
+    UserPromptPart,
+)
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness import GuardrailResult, InputGuardrail, OutputBlocked, OutputGuardrail
+from pydantic_ai_harness.guardrails import ToolGuardrail, ToolResultInfo
 from pydantic_ai_harness.guardrails.detectors import (
     DEFAULT_PII_PATTERNS,
     DEFAULT_SECRET_PATTERNS,
     TextDetector,
     blocked_keywords,
     for_text,
+    for_tool_result_text,
     personal_data,
     redact_personal_data,
     redact_secrets,
@@ -478,6 +488,87 @@ class TestForText:
 
     def test_a_non_string_can_be_skipped_deliberately(self):
         assert for_text(redact_secrets, on_other='allow')(42).action == 'allow'
+
+
+class TestForToolResultText:
+    """A text detector adapted to the value `ToolGuardrail` hands to its result guard."""
+
+    @staticmethod
+    def _info(result: object) -> ToolResultInfo:
+        return ToolResultInfo(name='lookup', args={}, tool_call_id='call-1', result=result)
+
+    def test_a_plain_string_reaches_the_detector(self):
+        verdict = for_tool_result_text(redact_secrets)(self._info(f'key: {_OPENAI_KEY}'))
+
+        assert verdict == GuardrailResult.replace('key: [redacted:openai_key]')
+
+    def test_an_unmodified_tool_return_is_allowed(self):
+        verdict = for_tool_result_text(redact_secrets)(self._info(ToolReturn('no secret')))
+
+        assert verdict == GuardrailResult.allow()
+
+    def test_a_text_detector_must_replace_with_text(self):
+        def invalid_detector(_: str) -> GuardrailResult:
+            return GuardrailResult.replace(42)
+
+        with pytest.raises(UserError, match='must replace a tool result with text'):
+            for_tool_result_text(invalid_detector)(self._info(ToolReturn('secret')))
+
+    async def test_a_real_tool_return_is_redacted_without_losing_its_metadata(self):
+        metadata = {'request_id': 'r1'}
+
+        def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+                return ModelResponse(parts=[TextPart(content='done')])
+            return ModelResponse(parts=[ToolCallPart(tool_name='lookup', args={}, tool_call_id='call-1')])
+
+        agent = Agent(
+            FunctionModel(respond),
+            deps_type=type(None),
+            capabilities=[ToolGuardrail(result_guard=for_tool_result_text(redact_secrets))],
+        )
+
+        @agent.tool_plain
+        def lookup() -> ToolReturn:
+            return ToolReturn(f'key: {_OPENAI_KEY}', content='keep this context', metadata=metadata)
+
+        result = await agent.run('hi')
+        returns = [
+            part for message in result.all_messages() for part in message.parts if isinstance(part, ToolReturnPart)
+        ]
+
+        assert [(part.content, part.metadata) for part in returns] == [
+            ('key: [redacted:openai_key]', metadata),
+        ]
+        assert 'keep this context' in str(result.all_messages())
+
+    async def test_a_non_text_tool_result_must_be_allowed_explicitly(self):
+        def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+                return ModelResponse(parts=[TextPart(content='done')])
+            return ModelResponse(parts=[ToolCallPart(tool_name='lookup', args={}, tool_call_id='call-1')])
+
+        blocked_agent = Agent(
+            FunctionModel(respond),
+            deps_type=type(None),
+            capabilities=[ToolGuardrail(result_guard=for_tool_result_text(redact_secrets))],
+        )
+        allowed_agent = Agent(
+            FunctionModel(respond),
+            deps_type=type(None),
+            capabilities=[ToolGuardrail(result_guard=for_tool_result_text(redact_secrets, on_other='allow'))],
+        )
+
+        @blocked_agent.tool_plain
+        @allowed_agent.tool_plain
+        def lookup() -> dict[str, str]:
+            return {'status': 'clean'}
+
+        with pytest.raises(UserError, match='for_tool_result_text'):
+            await blocked_agent.run('hi')
+        result = await allowed_agent.run('hi')
+
+        assert result.output == 'done'
 
 
 class TestGuardChain:

--- a/tests/guardrails/test_detectors.py
+++ b/tests/guardrails/test_detectors.py
@@ -507,12 +507,13 @@ class TestForToolResultText:
 
         assert verdict == GuardrailResult.allow()
 
-    def test_a_text_detector_must_replace_with_text(self):
+    @pytest.mark.parametrize('result', ['secret', ToolReturn('secret')])
+    def test_a_text_detector_must_replace_with_text(self, result: object):
         def invalid_detector(_: str) -> GuardrailResult:
             return GuardrailResult.replace(42)
 
         with pytest.raises(UserError, match='must replace a tool result with text'):
-            for_tool_result_text(invalid_detector)(self._info(ToolReturn('secret')))
+            for_tool_result_text(invalid_detector)(self._info(result))
 
     async def test_a_real_tool_return_is_redacted_without_losing_its_metadata(self):
         metadata = {'request_id': 'r1'}

--- a/tests/guardrails/test_tool_guardrail.py
+++ b/tests/guardrails/test_tool_guardrail.py
@@ -6,14 +6,14 @@ import asyncio
 import json
 import warnings
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NoReturn
 
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NoOpTracer, Tracer
-from pydantic_ai import Agent, AgentSpec, DeferredToolRequests, DeferredToolResults, ToolDenied
+from pydantic_ai import Agent, AgentRunResult, AgentSpec, DeferredToolRequests, DeferredToolResults, ToolDenied
 from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
 from pydantic_ai.exceptions import ApprovalRequired, ModelRetry, SkipToolExecution, ToolFailed, UserError
 from pydantic_ai.messages import (
@@ -653,6 +653,19 @@ class TestHiddenNameWarning:
 
         assert raised == []
 
+    async def test_an_unprepared_successful_run_does_not_warn_about_hidden_names(self):
+        guard = ToolGuardrail[object](hidden=['danger'])
+
+        async def succeed() -> AgentRunResult[object]:
+            return AgentRunResult(output='done')
+
+        with warnings.catch_warnings(record=True) as raised:
+            warnings.simplefilter('always')
+            result = await guard.wrap_run(_run_ctx(), handler=succeed)
+
+        assert result.output == 'done'
+        assert raised == []
+
     async def test_a_run_without_function_tools_warns_about_hidden_names(self):
         agent = Agent(
             _scripted(ModelResponse(parts=[TextPart(content='done')])),
@@ -670,7 +683,19 @@ class TestHiddenNameWarning:
             'The name stays available to the model.'
         ]
 
-    async def test_a_prepared_run_that_errors_still_warns_about_hidden_names(self):
+    async def test_a_warning_does_not_mask_a_prepared_run_error(self):
+        guard = ToolGuardrail[object](hidden=['danger'])
+        await guard.prepare_tools(_run_ctx(), [_tool_def('safe')])
+
+        async def fail() -> NoReturn:
+            raise RuntimeError('boom')
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            with pytest.raises(RuntimeError, match='boom'):
+                await guard.wrap_run(_run_ctx(), handler=fail)
+
+    async def test_a_prepared_run_error_does_not_warn_about_hidden_names(self):
         def fail(_: list[ModelMessage], __: AgentInfo) -> ModelResponse:
             raise RuntimeError('boom')
 
@@ -689,10 +714,7 @@ class TestHiddenNameWarning:
             with pytest.raises(RuntimeError, match='boom'):
                 await agent.run('hi')
 
-        assert [str(warning.message) for warning in raised] == [
-            "ToolGuardrail.hidden names 'danger', which no tool offered during this run is called. "
-            'The name stays available to the model.'
-        ]
+        assert raised == []
 
     async def test_a_name_no_tool_answers_to_is_warned_about(self):
         agent, _ = _agent_with(

--- a/tests/guardrails/test_tool_guardrail.py
+++ b/tests/guardrails/test_tool_guardrail.py
@@ -639,6 +639,20 @@ class TestHiddenTools:
 class TestHiddenNameWarning:
     """`hidden` is the one setting whose typo fails open."""
 
+    async def test_an_unstarted_agent_iteration_does_not_warn_about_hidden_names(self):
+        agent = Agent(
+            _scripted(ModelResponse(parts=[TextPart(content='done')])),
+            deps_type=type(None),
+            capabilities=[ToolGuardrail(hidden=['danger'])],
+        )
+
+        with warnings.catch_warnings(record=True) as raised:
+            warnings.simplefilter('always')
+            async with agent.iter('hi'):
+                pass
+
+        assert raised == []
+
     async def test_a_run_without_function_tools_warns_about_hidden_names(self):
         agent = Agent(
             _scripted(ModelResponse(parts=[TextPart(content='done')])),
@@ -651,6 +665,30 @@ class TestHiddenNameWarning:
             result = await agent.run('hi')
 
         assert result.output == 'done'
+        assert [str(warning.message) for warning in raised] == [
+            "ToolGuardrail.hidden names 'danger', which no tool offered during this run is called. "
+            'The name stays available to the model.'
+        ]
+
+    async def test_a_prepared_run_that_errors_still_warns_about_hidden_names(self):
+        def fail(_: list[ModelMessage], __: AgentInfo) -> ModelResponse:
+            raise RuntimeError('boom')
+
+        agent = Agent(
+            FunctionModel(fail),
+            deps_type=type(None),
+            capabilities=[ToolGuardrail(hidden=['danger'])],
+        )
+
+        @agent.tool_plain
+        def safe() -> str:  # pragma: no cover - the model fails before tool execution
+            return 'safe'
+
+        with warnings.catch_warnings(record=True) as raised:
+            warnings.simplefilter('always')
+            with pytest.raises(RuntimeError, match='boom'):
+                await agent.run('hi')
+
         assert [str(warning.message) for warning in raised] == [
             "ToolGuardrail.hidden names 'danger', which no tool offered during this run is called. "
             'The name stays available to the model.'

--- a/tests/guardrails/test_tool_guardrail.py
+++ b/tests/guardrails/test_tool_guardrail.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -12,7 +13,7 @@ from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NoOpTracer, Tracer
-from pydantic_ai import Agent, DeferredToolRequests, DeferredToolResults, ToolDenied
+from pydantic_ai import Agent, AgentSpec, DeferredToolRequests, DeferredToolResults, ToolDenied
 from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
 from pydantic_ai.exceptions import ApprovalRequired, ModelRetry, SkipToolExecution, ToolFailed, UserError
 from pydantic_ai.messages import (
@@ -26,11 +27,14 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext, ToolDefinition
+from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness.guardrails import (
     GuardrailError,
     GuardrailResult,
+    InputGuardrail,
+    OutputGuardrail,
     ToolBlocked,
     ToolCallInfo,
     ToolGuardrail,
@@ -372,6 +376,31 @@ class TestHumanInTheLoop:
         with pytest.raises(SkipToolExecution):
             await _guard_args(guard, {}, tool_name='dangerous')
 
+    async def test_a_misspelled_tools_name_warns_after_the_unmatched_call(self):
+        guarded: list[str] = []
+
+        def block(call: ToolCallInfo) -> GuardrailResult:  # pragma: no cover - this test verifies it cannot run
+            guarded.append(call.name)
+            return GuardrailResult.block('blocked')
+
+        agent, executed = _agent_with(
+            ToolGuardrail(guard=block, tools=['lookpu']),
+            _calls_lookup(query='weather'),
+            ModelResponse(parts=[TextPart(content='done')]),
+        )
+
+        with warnings.catch_warnings(record=True) as raised:
+            warnings.simplefilter('always')
+            result = await agent.run('hi')
+
+        assert result.output == 'done'
+        assert guarded == []
+        assert executed == [{'query': 'weather'}]
+        assert [str(warning.message) for warning in raised] == [
+            "ToolGuardrail.tools names 'lookpu', which no tool offered during this run is called. "
+            'Neither guard was applied to it.'
+        ]
+
 
 class TestResultGuard:
     """The `result_guard` callable, evaluated after the tool returns."""
@@ -531,7 +560,7 @@ class TestResultGuardOnAFailedTool:
             await agent.run('hi')
 
     async def test_a_tool_the_guard_does_not_cover_is_left_alone(self):
-        agent, seen = self._agent(lambda info: GuardrailResult.block('refused'), ToolFailed('boom'), tools=['other'])
+        agent, seen = self._agent(lambda info: GuardrailResult.block('refused'), ToolFailed('boom'), tools=[])
 
         result = await agent.run('hi')
 
@@ -610,22 +639,50 @@ class TestHiddenTools:
 class TestHiddenNameWarning:
     """`hidden` is the one setting whose typo fails open."""
 
+    async def test_a_run_without_function_tools_warns_about_hidden_names(self):
+        agent = Agent(
+            _scripted(ModelResponse(parts=[TextPart(content='done')])),
+            deps_type=type(None),
+            capabilities=[ToolGuardrail(hidden=['danger'])],
+        )
+
+        with warnings.catch_warnings(record=True) as raised:
+            warnings.simplefilter('always')
+            result = await agent.run('hi')
+
+        assert result.output == 'done'
+        assert [str(warning.message) for warning in raised] == [
+            "ToolGuardrail.hidden names 'danger', which no tool offered during this run is called. "
+            'The name stays available to the model.'
+        ]
+
     async def test_a_name_no_tool_answers_to_is_warned_about(self):
-        guard = ToolGuardrail[object](hidden=['dangre'])
+        agent, _ = _agent_with(
+            ToolGuardrail(hidden=['dangre']),
+            ModelResponse(parts=[TextPart(content='done')]),
+        )
 
         with pytest.warns(UserWarning, match="names 'dangre'"):
-            await guard.prepare_tools(_run_ctx(), [_tool_def('danger')])
+            result = await agent.run('hi')
 
-    async def test_the_warning_fires_once_not_once_per_step(self):
-        guard = ToolGuardrail[object](hidden=['dangre'])
+        assert result.output == 'done'
 
-        with pytest.warns(UserWarning):
-            await guard.prepare_tools(_run_ctx(), [_tool_def('danger')])
-        with warnings.catch_warnings(record=True) as later:
+    async def test_the_warning_fires_once_after_a_multi_step_run(self):
+        agent, _ = _agent_with(
+            ToolGuardrail(hidden=['dangre']),
+            _calls_lookup(query='weather'),
+            ModelResponse(parts=[TextPart(content='done')]),
+        )
+
+        with warnings.catch_warnings(record=True) as raised:
             warnings.simplefilter('always')
-            await guard.prepare_tools(_run_ctx(), [_tool_def('danger')])
+            result = await agent.run('hi')
 
-        assert later == []
+        assert result.output == 'done'
+        assert [str(warning.message) for warning in raised] == [
+            "ToolGuardrail.hidden names 'dangre', which no tool offered during this run is called. "
+            'The name stays available to the model.'
+        ]
 
     async def test_a_name_that_matches_is_not_warned_about(self):
         guard = ToolGuardrail[object](hidden=['danger'])
@@ -647,6 +704,67 @@ class TestHiddenNameWarning:
             await guard.prepare_tools(_run_ctx(), [_tool_def('safe')])
 
         assert raised == []
+
+    async def test_a_hidden_tool_that_appears_after_an_absent_step_is_not_warned_about(self):
+        ready = False
+        safe_tools = FunctionToolset[None]()
+        danger_tools = FunctionToolset[None]()
+        offered: list[list[str]] = []
+
+        @safe_tools.tool_plain
+        def safe() -> str:
+            nonlocal ready
+            ready = True
+            return 'ready'
+
+        @danger_tools.tool_plain
+        def danger() -> str:  # pragma: no cover - hidden from the model
+            return 'danger'
+
+        def toolset(_: RunContext[None]) -> FunctionToolset[None]:
+            return danger_tools if ready else safe_tools
+
+        def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            offered.append(sorted(tool.name for tool in info.function_tools))
+            if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+                return ModelResponse(parts=[TextPart(content='done')])
+            return ModelResponse(parts=[ToolCallPart(tool_name='safe', args={}, tool_call_id='call-1')])
+
+        agent = Agent(
+            FunctionModel(respond),
+            deps_type=type(None),
+            capabilities=[ToolGuardrail(hidden=['danger'])],
+            toolsets=[toolset],
+        )
+
+        with warnings.catch_warnings(record=True) as raised:
+            warnings.simplefilter('always')
+            result = await agent.run('hi')
+
+        assert result.output == 'done'
+        assert offered == [['safe'], []]
+        assert raised == []
+
+
+class TestAgentSpec:
+    def test_callable_guardrails_are_not_represented_in_agent_spec_schema(self):
+        schema = AgentSpec.model_json_schema()
+
+        schema_text = json.dumps(schema)
+        assert 'InputGuardrail' not in schema_text
+        assert 'OutputGuardrail' not in schema_text
+        assert 'ToolGuardrail' not in schema_text
+
+    @pytest.mark.parametrize('capability_type', [InputGuardrail, OutputGuardrail, ToolGuardrail])
+    def test_agent_spec_rejects_callable_guardrails(self, capability_type: type[AbstractCapability[None]]):
+        with pytest.raises(
+            ValueError, match=rf'Custom capability class {capability_type.__name__} has opted out of serialization'
+        ):
+            Agent.from_spec(
+                {'capabilities': [capability_type.__name__]},
+                custom_capability_types=[capability_type],
+                model=TestModel(),
+            )
 
 
 class TestHardFailure:

--- a/tests/planning/test_stores.py
+++ b/tests/planning/test_stores.py
@@ -97,6 +97,38 @@ class TestCrudAcrossBackends:
         assert await store.remove_item(second.id) is True
         assert [i.content for i in await store.get_items()] == ['first']
 
+    async def test_public_plan_items_do_not_alias_store_state(self, store_factory: StoreFactory) -> None:
+        store = store_factory(None)
+        supplied = _item('original', depends_on=['first'])
+        await store.set_items([supplied])
+        supplied.content = 'caller mutation'
+        supplied.depends_on.append('caller')
+
+        stored = await store.get_item(supplied.id)
+        assert stored is not None
+        assert (stored.content, stored.depends_on) == ('original', ['first'])
+        stored.content = 'get_item mutation'
+        stored.depends_on.append('get_item')
+
+        [listed] = await store.get_items()
+        assert (listed.content, listed.depends_on) == ('original', ['first'])
+        listed.content = 'get_items mutation'
+        listed.depends_on.append('get_items')
+
+        added = await store.add_item(_item('added', depends_on=['first']))
+        added.content = 'add_item mutation'
+        added.depends_on.append('add_item')
+        updated = await store.update_item(added.id, content='updated', depends_on=['second'])
+        assert updated is not None
+        updated.content = 'update_item mutation'
+        updated.depends_on.append('update_item')
+
+        items = await store.get_items()
+        assert [(item.content, item.depends_on) for item in items] == [
+            ('original', ['first']),
+            ('updated', ['second']),
+        ]
+
 
 class TestEvents:
     async def test_created_updated_status_completed_deleted(self, store_factory: StoreFactory) -> None:
@@ -136,6 +168,29 @@ class TestEvents:
         item = await store.add_item(_item('x'))
         # update path with previous=None (no emitter) still works
         assert (await store.update_item(item.id, status=TaskStatus.completed)) is not None
+
+    async def test_event_mutation_cannot_change_store_or_return_values(self, store_factory: StoreFactory) -> None:
+        emitter = PlanEventEmitter()
+
+        def mutate(event: PlanEvent) -> None:
+            event.item.content = 'listener mutation'
+            event.item.depends_on.append('listener')
+            if event.previous_state is not None:
+                event.previous_state.depends_on.append('previous listener')
+
+        emitter.on(PlanEventType.created, mutate)
+        emitter.on(PlanEventType.updated, mutate)
+        store = store_factory(emitter)
+
+        added = await store.add_item(_item('original', depends_on=['first']))
+        assert (added.content, added.depends_on) == ('original', ['first'])
+        updated = await store.update_item(added.id, content='updated', depends_on=['second'])
+        assert updated is not None
+        assert (updated.content, updated.depends_on) == ('updated', ['second'])
+
+        stored = await store.get_item(added.id)
+        assert stored is not None
+        assert (stored.content, stored.depends_on) == ('updated', ['second'])
 
 
 class TestSqliteSpecifics:


### PR DESCRIPTION
This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

## Summary
- Warn after a run when ToolGuardrail selectors never match, while preserving dynamic late-arriving hidden tools.
- Add ToolReturn-aware text-detector adaptation and exclude callable guardrails from AgentSpec serialization.
- Isolate in-memory planning items and plan-event payloads from caller and listener mutation.

## Verification
- make format
- make lint
- make typecheck
- make testcov (4,467 passed, 47 skipped; 100% coverage)

## Related issues
- [#403](https://github.com/pydantic/pydantic-ai-harness/issues/403) -- planning store remediation.
- [#469](https://github.com/pydantic/pydantic-ai-harness/issues/469) -- ToolGuardrail selector remediation.
- [#477](https://github.com/pydantic/pydantic-ai-harness/issues/477) -- detector adapter remediation.