### PR TITLE
Require a label on new PRs and pin the PR-title convention

### DIFF
--- a/.agents/skills/pushing-commits-to-the-repo/SKILL.md
+++ b/.agents/skills/pushing-commits-to-the-repo/SKILL.md
@@ -1,14 +1,25 @@
 ---
 name: pushing-commits-to-the-repo
-description: What to do after you push — watch CI to green, triage every review comment to a reply
-  and a reaction, and escalate genuine design trade-offs to maintainers. Use whenever you push a
-  commit to a PR.
+description: What to do when you open a PR and every time you push -- label the PR, watch CI to
+  green, triage every review comment to a reply and a reaction, and escalate genuine design
+  trade-offs to maintainers. Use whenever you open a PR or push a commit to one.
 ---
 
 # pushing-commits-to-the-repo
 
 Pushing starts a loop; it does not end the task. **Work stops only when CI is green AND no comment
 is left unresolved.**
+
+## When you open the PR
+
+Apply a label -- the repo triages and filters by them. Fetch the real list first with
+`gh label list --limit 100`, because the set changes and a guessed label silently fails to apply.
+Pick the one naming what the PR *is* (`bug`, `enhancement`, `documentation`) and add a topic label
+where one fits (`capability`, `primitive`, `agent-feature`, `core-change`, `code-mode`, `media`,
+`externalization`, ...): `gh pr edit <number> --add-label <label>`.
+
+Labelling needs triage permission on the repo. If it fails, quote the actual error rather than
+concluding you lack permission.
 
 ## Before you push
 - Attempt the push. If it fails, read the real error — do not preemptively decide you lack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,11 @@ need.
 - Always link sources for any claims made during research
 - Run `make lint && make typecheck && make test` before every commit
 - Commit messages should summarize the "why", not the "what"
+- PR titles feed the release notes verbatim -- GitHub builds "What's Changed" from them. Write an
+  imperative sentence naming the change, and wrap every code identifier (class names, keyword
+  arguments, module paths, CLI flags, env vars, file paths) in backticks. No `feat:` / `fix:` /
+  `docs:` prefix -- that belongs on the commit subject, not the title. Merged titles predating this
+  rule carry prefixes; follow the rule, not the back catalogue.
 
 ## Pushing changes
 


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David reviewed the plan before implementation.

Two conventions that existed nowhere in this repo, ported from pydantic-ai [#7134](https://github.com/pydantic/pydantic-ai/pull/7134).

### PR titles (`AGENTS.md`)

Harness release notes are generated verbatim from PR titles -- GitHub's "What's Changed" on `v0.16.0` lists them as written. So the title is user-facing copy, not a commit subject. New bullet under `## Contributing rules for AICAs`, next to the existing commit-message bullet, which is where the title-vs-subject distinction actually bites: imperative sentence, code identifiers in backticks, no `feat:` / `fix:` / `docs:` prefix.

One deliberate divergence from pyai #7134: it tells the agent to check the convention against `gh pr list --state merged`. Here that instruction backfires -- roughly half of recent merged titles carry prefixes (`feat(guardrails):`, `fix(ci):`, `docs(agent_docs):`), so an agent following it would copy the style the rule bans. Replaced with an explicit "follow the rule, not the back catalogue".

### Labelling (`pushing-commits-to-the-repo` skill)

The skill covered only what happens *after* a push. New `## When you open the PR` section: fetch the real label set with `gh label list --limit 100` first (a guessed label silently fails to apply), pick a type label, add a topic label where one fits. The frontmatter `description:` now names the open-PR case so the skill loads then too.

Adapted from pyai in two places:
- type labels are harness's real ones (`bug` / `enhancement` / `documentation`); pyai's `feature` / `docs` / `chore` / `refactor` don't exist here.
- dropped pyai's "size labels are applied automatically -- don't set them". Harness has no size labels, and the sentence would prime for a mechanism that isn't there.

Every label named in the new section was checked against `gh label list` on this repo.

### Notes

- Context-file-only change, in its own PR per the standing scope rule. No dependency files touched.
- `make lint && make typecheck && make test` pass. `tests/test_skill_examples.py` and the docs-parity tests read these files.
- `SKILL.md` frontmatter re-parsed with `yaml.safe_load` after editing -- a malformed `description:` stops the skill loading silently.
