### PR TITLE
fix(step-persistence): expose explicit AgentSpec fields

### DIFF
--- a/pydantic_ai_harness/step_persistence/_capability.py
+++ b/pydantic_ai_harness/step_persistence/_capability.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Literal
 from uuid import uuid4
 
@@ -133,8 +134,8 @@ class StepPersistence(AbstractCapability[AgentDepsT]):
         cls,
         *,
         backend: Literal['memory', 'file', 'sqlite'] = 'memory',
-        directory: str = '.step-persistence',
-        database: str = '.step-persistence.db',
+        directory: str | Path | None = None,
+        database: str | Path | None = None,
         max_snapshots_per_run: int | None = None,
         agent_name: str | None = None,
         run_id: str | None = None,
@@ -145,37 +146,53 @@ class StepPersistence(AbstractCapability[AgentDepsT]):
         defer_loading: bool = False,
         **unsupported: Any,
     ) -> StepPersistence[Any]:
-        """Construct from a serialised spec.
+        """Construct a spec-serializable capability.
 
-        Supports `backend='memory'` (default), `backend='file'` (with
-        `directory`), or `backend='sqlite'` (with `database`). Raises
-        `ValueError` for any other `backend` value -- silently falling
-        back to in-memory storage would turn a typo into accidental
-        non-durability.
+        The explicit keyword-only signature is intentional: Pydantic AI uses
+        it to publish the capability fields in `AgentSpec` JSON schema. The
+        three backend-construction knobs are `backend`, `directory`,
+        `database`, and `max_snapshots_per_run`; the remaining arguments are
+        `StepPersistence`'s serializable base fields.
 
-        `max_snapshots_per_run` (default `None`, unbounded) is forwarded to
-        the constructed store to bound per-run snapshot growth.
+        `store` and other runtime-only values are not accepted here because a
+        live store cannot be represented in YAML or JSON. Construct the
+        capability directly in Python when a custom store is needed.
         """
+        if 'store' in unsupported:
+            raise UserError(
+                '`store` is runtime-only and cannot be loaded from an AgentSpec. '
+                'Construct StepPersistence(store=...) in Python instead.'
+            )
         if unsupported:
             raise UserError(f'StepPersistence has no spec field(s) {sorted(unsupported)}.')
+        if backend != 'file' and directory is not None:
+            raise ValueError('directory is only valid with backend="file"')
+        if backend != 'sqlite' and database is not None:
+            raise ValueError('database is only valid with backend="sqlite"')
         if backend == 'memory':
             store: StepStore = InMemoryStepStore(max_snapshots_per_run=max_snapshots_per_run)
         elif backend == 'file':
             from pydantic_ai_harness.step_persistence._store import FileStepStore
 
-            store = FileStepStore(directory, max_snapshots_per_run=max_snapshots_per_run)
+            store = FileStepStore(
+                directory or '.step-persistence',
+                max_snapshots_per_run=max_snapshots_per_run,
+            )
         elif backend == 'sqlite':
             from pydantic_ai_harness.step_persistence._store import SqliteStepStore
 
-            store = SqliteStepStore(database=database, max_snapshots_per_run=max_snapshots_per_run)
-        else:  # pragma: no cover - Literal validation rejects this through the schema
+            store = SqliteStepStore(
+                database=database or '.step-persistence.db',
+                max_snapshots_per_run=max_snapshots_per_run,
+            )
+        else:
             raise ValueError(f'unknown backend {backend!r}; expected `memory`, `file`, or `sqlite`')
         return cls(
             store=store,
             agent_name=agent_name,
             run_id=run_id,
             parent_run_id=parent_run_id,
-            metadata=metadata or {},
+            metadata=metadata if metadata is not None else {},
             id=id,
             description=description,
             defer_loading=defer_loading,

--- a/pydantic_ai_harness/step_persistence/_capability.py
+++ b/pydantic_ai_harness/step_persistence/_capability.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from pydantic_ai import CallToolsNode, ModelRequestNode
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.capabilities.abstract import AgentNode, NodeResult, WrapRunHandler
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
 from pydantic_ai.models import ModelRequestContext
 from pydantic_ai.run import AgentRunResult
@@ -128,7 +129,22 @@ class StepPersistence(AbstractCapability[AgentDepsT]):
     """Free-form metadata stored on the `RunRecord` and on each event."""
 
     @classmethod
-    def from_spec(cls, *args: Any, **kwargs: Any) -> StepPersistence[Any]:
+    def from_spec(
+        cls,
+        *,
+        backend: Literal['memory', 'file', 'sqlite'] = 'memory',
+        directory: str = '.step-persistence',
+        database: str = '.step-persistence.db',
+        max_snapshots_per_run: int | None = None,
+        agent_name: str | None = None,
+        run_id: str | None = None,
+        parent_run_id: str | None = None,
+        metadata: dict[str, str] | None = None,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
+        **unsupported: Any,
+    ) -> StepPersistence[Any]:
         """Construct from a serialised spec.
 
         Supports `backend='memory'` (default), `backend='file'` (with
@@ -140,21 +156,30 @@ class StepPersistence(AbstractCapability[AgentDepsT]):
         `max_snapshots_per_run` (default `None`, unbounded) is forwarded to
         the constructed store to bound per-run snapshot growth.
         """
-        backend = kwargs.pop('backend', 'memory')
-        max_snapshots_per_run = kwargs.pop('max_snapshots_per_run', None)
+        if unsupported:
+            raise UserError(f'StepPersistence has no spec field(s) {sorted(unsupported)}.')
         if backend == 'memory':
-            return cls(store=InMemoryStepStore(max_snapshots_per_run=max_snapshots_per_run), **kwargs)
-        if backend == 'file':
+            store: StepStore = InMemoryStepStore(max_snapshots_per_run=max_snapshots_per_run)
+        elif backend == 'file':
             from pydantic_ai_harness.step_persistence._store import FileStepStore
 
-            directory = kwargs.pop('directory', '.step-persistence')
-            return cls(store=FileStepStore(directory, max_snapshots_per_run=max_snapshots_per_run), **kwargs)
-        if backend == 'sqlite':
+            store = FileStepStore(directory, max_snapshots_per_run=max_snapshots_per_run)
+        elif backend == 'sqlite':
             from pydantic_ai_harness.step_persistence._store import SqliteStepStore
 
-            database = kwargs.pop('database', '.step-persistence.db')
-            return cls(store=SqliteStepStore(database=database, max_snapshots_per_run=max_snapshots_per_run), **kwargs)
-        raise ValueError(f'unknown backend {backend!r}; expected `memory`, `file`, or `sqlite`')
+            store = SqliteStepStore(database=database, max_snapshots_per_run=max_snapshots_per_run)
+        else:  # pragma: no cover - Literal validation rejects this through the schema
+            raise ValueError(f'unknown backend {backend!r}; expected `memory`, `file`, or `sqlite`')
+        return cls(
+            store=store,
+            agent_name=agent_name,
+            run_id=run_id,
+            parent_run_id=parent_run_id,
+            metadata=metadata or {},
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
+        )
 
     def compaction_transcript_handle(self) -> str | None:
         """Retrieval handle to this run's transcript, for compaction receipts.

--- a/tests/step_persistence/test_snapshot_retention.py
+++ b/tests/step_persistence/test_snapshot_retention.py
@@ -393,7 +393,7 @@ class TestFromSpecForwarding:
         assert cap.store._max_snapshots_per_run == 3
 
     async def test_file_backend_forwards_bound(self, tmp_path: Path) -> None:
-        cap = StepPersistence.from_spec(backend='file', directory=tmp_path, max_snapshots_per_run=4)
+        cap = StepPersistence.from_spec(backend='file', directory=str(tmp_path), max_snapshots_per_run=4)
         assert isinstance(cap.store, FileStepStore)
         assert cap.store._max_snapshots_per_run == 4
 

--- a/tests/step_persistence/test_step_persistence.py
+++ b/tests/step_persistence/test_step_persistence.py
@@ -11,12 +11,15 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pydantic_ai import Agent, CallToolsNode, ModelRequestNode, ModelRetry, RunContext
 from pydantic_ai._agent_graph import GraphAgentState  # pyright: ignore[reportPrivateUsage]
+from pydantic_ai.agent.spec import AgentSpec
 from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.capabilities.combined import CombinedCapability
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -1016,8 +1019,50 @@ class TestStepPersistenceCapability:
         assert cap.agent_name == 'a'
 
     async def test_from_spec_file_backend(self, tmp_path: Path) -> None:
-        cap = StepPersistence.from_spec(backend='file', directory=tmp_path)
+        cap = StepPersistence.from_spec(backend='file', directory=str(tmp_path))
         assert isinstance(cap.store, FileStepStore)
+
+    def test_agent_spec_schema_exposes_step_persistence_fields(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([StepPersistence])
+        params = schema['$defs']['spec_params_StepPersistence']
+        properties = params['properties']
+
+        assert params['additionalProperties'] is False
+        assert {
+            'backend',
+            'directory',
+            'database',
+            'max_snapshots_per_run',
+            'agent_name',
+            'run_id',
+            'parent_run_id',
+            'metadata',
+            'id',
+            'description',
+            'defer_loading',
+        } <= properties.keys()
+        assert properties['backend']['enum'] == ['memory', 'file', 'sqlite']
+
+    def test_agent_spec_loads_step_persistence(self, tmp_path: Path) -> None:
+        spec = {
+            'capabilities': [
+                {
+                    'StepPersistence': {
+                        'backend': 'file',
+                        'directory': str(tmp_path),
+                        'agent_name': 'worker',
+                        'metadata': {'team': 'infra'},
+                    }
+                }
+            ]
+        }
+
+        agent = Agent.from_spec(spec, custom_capability_types=[StepPersistence], model=TestModel())
+        assert isinstance(agent.root_capability, CombinedCapability)
+        capability = next(cap for cap in agent.root_capability.capabilities if isinstance(cap, StepPersistence))
+        assert isinstance(capability.store, FileStepStore)
+        assert capability.agent_name == 'worker'
+        assert capability.metadata == {'team': 'infra'}
 
     async def test_from_spec_file_backend_default_directory(self) -> None:
         cap = StepPersistence.from_spec(backend='file')
@@ -1572,7 +1617,11 @@ class TestFromSpecBackendValidation:
     def test_unknown_backend_raises(self) -> None:
         """A typo like `backend='disk'` raises instead of silently using memory."""
         with pytest.raises(ValueError, match='unknown backend'):
-            StepPersistence.from_spec(backend='disk')
+            StepPersistence.from_spec(backend=cast(Any, 'disk'))
+
+    def test_unknown_spec_field_raises(self) -> None:
+        with pytest.raises(UserError, match='no spec field'):
+            StepPersistence.from_spec(runtime_only='value')
 
     def test_memory_backend_still_works(self) -> None:
         cap: StepPersistence[Any] = StepPersistence.from_spec(backend='memory')

--- a/tests/step_persistence/test_step_persistence.py
+++ b/tests/step_persistence/test_step_persistence.py
@@ -11,14 +11,13 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import pytest
 from pydantic_ai import Agent, CallToolsNode, ModelRequestNode, ModelRetry, RunContext
 from pydantic_ai._agent_graph import GraphAgentState  # pyright: ignore[reportPrivateUsage]
 from pydantic_ai.agent.spec import AgentSpec
-from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.capabilities.combined import CombinedCapability
+from pydantic_ai.capabilities import AbstractCapability, CombinedCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     ModelMessage,
@@ -1022,48 +1021,6 @@ class TestStepPersistenceCapability:
         cap = StepPersistence.from_spec(backend='file', directory=str(tmp_path))
         assert isinstance(cap.store, FileStepStore)
 
-    def test_agent_spec_schema_exposes_step_persistence_fields(self) -> None:
-        schema = AgentSpec.model_json_schema_with_capabilities([StepPersistence])
-        params = schema['$defs']['spec_params_StepPersistence']
-        properties = params['properties']
-
-        assert params['additionalProperties'] is False
-        assert {
-            'backend',
-            'directory',
-            'database',
-            'max_snapshots_per_run',
-            'agent_name',
-            'run_id',
-            'parent_run_id',
-            'metadata',
-            'id',
-            'description',
-            'defer_loading',
-        } <= properties.keys()
-        assert properties['backend']['enum'] == ['memory', 'file', 'sqlite']
-
-    def test_agent_spec_loads_step_persistence(self, tmp_path: Path) -> None:
-        spec = {
-            'capabilities': [
-                {
-                    'StepPersistence': {
-                        'backend': 'file',
-                        'directory': str(tmp_path),
-                        'agent_name': 'worker',
-                        'metadata': {'team': 'infra'},
-                    }
-                }
-            ]
-        }
-
-        agent = Agent.from_spec(spec, custom_capability_types=[StepPersistence], model=TestModel())
-        assert isinstance(agent.root_capability, CombinedCapability)
-        capability = next(cap for cap in agent.root_capability.capabilities if isinstance(cap, StepPersistence))
-        assert isinstance(capability.store, FileStepStore)
-        assert capability.agent_name == 'worker'
-        assert capability.metadata == {'team': 'infra'}
-
     async def test_from_spec_file_backend_default_directory(self) -> None:
         cap = StepPersistence.from_spec(backend='file')
         assert isinstance(cap.store, FileStepStore)
@@ -1617,7 +1574,11 @@ class TestFromSpecBackendValidation:
     def test_unknown_backend_raises(self) -> None:
         """A typo like `backend='disk'` raises instead of silently using memory."""
         with pytest.raises(ValueError, match='unknown backend'):
-            StepPersistence.from_spec(backend=cast(Any, 'disk'))
+            Agent.from_spec(
+                {'capabilities': [{'StepPersistence': {'backend': 'disk'}}]},
+                custom_capability_types=[StepPersistence],
+                model=TestModel(),
+            )
 
     def test_unknown_spec_field_raises(self) -> None:
         with pytest.raises(UserError, match='no spec field'):
@@ -1630,6 +1591,58 @@ class TestFromSpecBackendValidation:
     def test_sqlite_backend(self, tmp_path: Path) -> None:
         cap: StepPersistence[Any] = StepPersistence.from_spec(backend='sqlite', database=str(tmp_path / 'runs.db'))
         assert isinstance(cap.store, SqliteStepStore)
+
+    def test_mismatched_backend_options_raise(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match='directory is only valid'):
+            StepPersistence.from_spec(backend='memory', directory=tmp_path)
+        with pytest.raises(ValueError, match='database is only valid'):
+            StepPersistence.from_spec(backend='file', database=tmp_path / 'runs.db')
+
+    def test_runtime_store_is_rejected(self) -> None:
+        with pytest.raises(UserError, match='runtime-only'):
+            StepPersistence.from_spec(store=InMemoryStepStore())
+
+    def test_agent_spec_schema_exposes_step_persistence_fields(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([StepPersistence])
+        params = schema['$defs']['spec_params_StepPersistence']
+        properties = params['properties']
+
+        assert params['additionalProperties'] is False
+        assert {
+            'backend',
+            'directory',
+            'database',
+            'max_snapshots_per_run',
+            'agent_name',
+            'run_id',
+            'parent_run_id',
+            'metadata',
+            'id',
+            'description',
+            'defer_loading',
+        } <= properties.keys()
+        assert properties['backend']['enum'] == ['memory', 'file', 'sqlite']
+
+    def test_agent_spec_loads_step_persistence(self, tmp_path: Path) -> None:
+        spec = {
+            'capabilities': [
+                {
+                    'StepPersistence': {
+                        'backend': 'file',
+                        'directory': str(tmp_path),
+                        'agent_name': 'worker',
+                        'metadata': {'team': 'infra'},
+                    }
+                }
+            ]
+        }
+
+        agent = Agent.from_spec(spec, custom_capability_types=[StepPersistence], model=TestModel())
+        assert isinstance(agent.root_capability, CombinedCapability)
+        capability = next(cap for cap in agent.root_capability.capabilities if isinstance(cap, StepPersistence))
+        assert isinstance(capability.store, FileStepStore)
+        assert capability.agent_name == 'worker'
+        assert capability.metadata == {'team': 'infra'}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`StepPersistence.from_spec` previously accepted only `*args, **kwargs`. Pydantic AI drops variadic parameters when building an `AgentSpec` schema, so configured `StepPersistence` capabilities appeared as a bare string with no configurable fields in YAML/JSON schema validation.

## Changes

- Expose the spec-supported fields with an explicit keyword-only signature.
- Preserve the `AbstractCapability` fields (`id`, `description`, `defer_loading`).
- Keep a runtime-only `**unsupported` catch-all with a clear `UserError`.
- Preserve the memory, file, and sqlite backend behavior.
- Add schema-generation, AgentSpec loading, unknown-field, and backend regression coverage.

## Verification

- `make lint`
- `make typecheck`
- `make test` — 4480 passed, 47 skipped
- `make testcov` — 100% coverage

Fixes #537
