### PR TITLE
Check every capability's `AgentSpec` schema entry, and fix `ToolOutputLimits` schema generation

### DIFF
--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -252,7 +252,8 @@ built-in prompt entirely. The `summary_prompt` template on the capability must c
 backend. A spec naming any of them is rejected rather than silently ignored, because a spec
 that promises a summarize band and quietly gets the default spill band is worse than one that
 refuses to load. A spec that names none of them gets the default `Spill(then=Truncate())`
-band.
+band. Giving `bands` a spec form is tracked in
+[#555](https://github.com/pydantic/pydantic-ai-harness/issues/555).
 
 The fields above are what `ToolOutputLimits.from_spec` names in its signature, which is also
 what Pydantic AI reads to generate the spec's JSON schema -- so an editor following the

--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -236,6 +236,28 @@ built-in prompt entirely. The `summary_prompt` template on the capability must c
   retries get distinct handles too (keyed per `retry`), so a retried call never clobbers the
   earlier attempt's spill.
 
+## Specs
+
+`Agent.from_spec` supports the part of the configuration a spec can express:
+
+```yaml
+- ToolOutputLimits:
+    over_tokens: true
+    strip_ansi: true
+    tool_filter: [read_file, run_tests]
+```
+
+`bands` and `per_tool` hold `Action` objects with a recursive `then` fallback and, on
+`Summarize`, a model or a callable; `tokenizer` and `store` take a callable and a live
+backend. A spec naming any of them is rejected rather than silently ignored, because a spec
+that promises a summarize band and quietly gets the default spill band is worse than one that
+refuses to load. A spec that names none of them gets the default `Spill(then=Truncate())`
+band.
+
+The fields above are what `ToolOutputLimits.from_spec` names in its signature, which is also
+what Pydantic AI reads to generate the spec's JSON schema -- so an editor following the
+`$schema` line completes and validates them.
+
 ## Relationship to other capabilities
 
 - Distinct from [compaction](compaction.md), which compresses or drops context already inside

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -212,6 +212,28 @@ built-in prompt entirely. The `summary_prompt` template on the capability must c
   retries get distinct handles too (keyed per `retry`), so a retried call never clobbers the
   earlier attempt's spill.
 
+## Specs
+
+`Agent.from_spec` supports the part of the configuration a spec can express:
+
+```yaml
+- ToolOutputLimits:
+    over_tokens: true
+    strip_ansi: true
+    tool_filter: [read_file, run_tests]
+```
+
+`bands` and `per_tool` hold `Action` objects with a recursive `then` fallback and, on
+`Summarize`, a model or a callable; `tokenizer` and `store` take a callable and a live
+backend. A spec naming any of them is rejected rather than silently ignored, because a spec
+that promises a summarize band and quietly gets the default spill band is worse than one that
+refuses to load. A spec that names none of them gets the default `Spill(then=Truncate())`
+band.
+
+The fields above are what `ToolOutputLimits.from_spec` names in its signature, which is also
+what Pydantic AI reads to generate the spec's JSON schema -- so an editor following the
+`$schema` line completes and validates them.
+
 ## Relationship to other capabilities
 
 - Supersedes the spill scope of PR #185 `ToolOutputManagement` (one-way truncate / spill with

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -228,7 +228,8 @@ built-in prompt entirely. The `summary_prompt` template on the capability must c
 backend. A spec naming any of them is rejected rather than silently ignored, because a spec
 that promises a summarize band and quietly gets the default spill band is worse than one that
 refuses to load. A spec that names none of them gets the default `Spill(then=Truncate())`
-band.
+band. Giving `bands` a spec form is tracked in
+[#555](https://github.com/pydantic/pydantic-ai-harness/issues/555).
 
 The fields above are what `ToolOutputLimits.from_spec` names in its signature, which is also
 what Pydantic AI reads to generate the spec's JSON schema -- so an editor following the

--- a/pydantic_ai_harness/tool_output_limits/_bands.py
+++ b/pydantic_ai_harness/tool_output_limits/_bands.py
@@ -19,6 +19,11 @@ from typing import TYPE_CHECKING
 from pydantic_ai_harness.tool_output_limits._payload import TruncationStrategy
 
 if TYPE_CHECKING:
+    # Keep this deferred. Importing `Model` at runtime makes `Summarize.model` resolve, and
+    # pydantic then drops the whole `spec_ToolOutputLimits` entry from the AgentSpec schema
+    # instead of raising -- trading a loud failure for a silent one that erases every other
+    # field. `ToolOutputLimits.from_spec` publishes the schema and never reaches this
+    # annotation, so nothing is gained by resolving it.
     from pydantic_ai.models import Model
 
 _DEFAULT_TRUNCATE_CHARS = 4_000

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -9,7 +9,7 @@ from typing import Any, TypeGuard
 
 from pydantic_ai import FunctionToolset
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.messages import ToolCallPart, ToolReturn, ToolReturnContent, UserContent
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition, ToolSelector, matches_tool_selector
 from pydantic_ai.toolsets import AgentToolset
@@ -151,6 +151,55 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         self._store = self.store if self.store is not None else LocalFileStore()
         self._bands = self._prepare_bands(self.bands)
         self._per_tool = {name: self._prepare_bands(bands) for name, bands in self.per_tool.items()}
+
+    @classmethod
+    def from_spec(
+        cls,
+        *,
+        tool_filter: ToolSelector[Any] = 'all',
+        over_tokens: bool = False,
+        strip_ansi: bool = False,
+        summary_prompt: str = _DEFAULT_SUMMARY_PROMPT,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
+        **unsupported: Any,
+    ) -> ToolOutputLimits[Any]:
+        """Build from an agent spec, covering the fields a spec can express.
+
+        Every parameter is named because that signature is what core reads to generate the
+        spec's JSON schema. Without it core reads `__init__` instead, and `bands` reaches
+        `Summarize.model`, whose `Model` annotation is only imported under `TYPE_CHECKING`
+        in `_bands.py`; pydantic then raises `PydanticUserError` while building the schema,
+        so a spec that mentions this capability at all cannot produce a schema for any
+        capability.
+
+        `bands` and `per_tool` carry `Action` dataclasses with a recursive `then` fallback
+        and a model or callable on `Summarize`; `tokenizer` and `store` are a callable and a
+        live backend. None of them has a spec representation, so they are rejected rather
+        than dropped -- a spec that promises a summarize band and silently gets the default
+        spill band is worse than a spec that refuses to load. `**unsupported` stays so that
+        rejection keeps naming the field; core drops it from the schema, so it costs nothing
+        there.
+        """
+        runtime_only = sorted({'bands', 'per_tool', 'tokenizer', 'store'} & unsupported.keys())
+        if runtime_only:
+            raise UserError(
+                f'ToolOutputLimits cannot be built from a spec with {runtime_only}: bands take `Action` '
+                'objects, and the tokenizer and store take a callable or a live backend. Construct the '
+                'capability in code to use them.'
+            )
+        if unsupported:
+            raise UserError(f'ToolOutputLimits has no spec field(s) {sorted(unsupported)}.')
+        return cls(
+            tool_filter=tool_filter,
+            over_tokens=over_tokens,
+            strip_ansi=strip_ansi,
+            summary_prompt=summary_prompt,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
+        )
 
     @staticmethod
     def _prepare_bands(bands: Sequence[Band]) -> list[Band]:

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -174,13 +174,20 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         so a spec that mentions this capability at all cannot produce a schema for any
         capability.
 
+        Moving that `Model` import out of `TYPE_CHECKING` looks like the smaller fix and is
+        the worse one: it makes the name resolve, and pydantic then drops the whole
+        `spec_ToolOutputLimits` entry from the capabilities union instead of raising. The
+        loud failure becomes a silent one, and every field here disappears from the schema
+        while the spec keeps loading. Verified, not assumed. Keep the import deferred.
+
         `bands` and `per_tool` carry `Action` dataclasses with a recursive `then` fallback
         and a model or callable on `Summarize`; `tokenizer` and `store` are a callable and a
         live backend. None of them has a spec representation, so they are rejected rather
         than dropped -- a spec that promises a summarize band and silently gets the default
         spill band is worse than a spec that refuses to load. `**unsupported` stays so that
         rejection keeps naming the field; core drops it from the schema, so it costs nothing
-        there.
+        there. Making `bands` spec-expressible through a `BandSpec` is tracked in
+        <https://github.com/pydantic/pydantic-ai-harness/issues/555>.
         """
         runtime_only = sorted({'bands', 'per_tool', 'tokenizer', 'store'} & unsupported.keys())
         if runtime_only:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,48 @@ if TYPE_CHECKING:
 else:
     from dirty_equals import IsDatetime, IsNow, IsPartialDict, IsStr
 
-__all__ = ('IsDatetime', 'IsNow', 'IsPartialDict', 'IsStr')
+__all__ = ('EXTRA_MODULES', 'IsDatetime', 'IsNow', 'IsPartialDict', 'IsStr', 'is_missing_optional_extra')
+
+# Top-level modules that this repo's own optional extras provide, from
+# `[project.optional-dependencies]` in `pyproject.toml`. A capability package fails to
+# import in the `slim` and `lowest-versions` CI jobs only because one of these is absent.
+EXTRA_MODULES = frozenset(
+    {
+        'acp',  # agent-client-protocol -- acp
+        'browser_use',  # browser-use -- browser-use
+        'exa_py',  # exa-py -- exa
+        'fastmcp',  # fastmcp -- stackone
+        'logfire',  # logfire -- logfire
+        'mcp',  # pydantic-ai-slim[mcp] -- stackone
+        'modal',  # modal -- modal
+        'pydantic_monty',  # pydantic-monty -- code-mode, dynamic-workflow
+        'pymongo',  # pymongo -- mongodb
+        'yaml',  # pyyaml -- skills
+    }
+)
+
+
+def is_missing_optional_extra(error: ImportError) -> bool:
+    """True when an import failed only because one of this repo's optional extras is absent.
+
+    Deliberately not "the import failed". A capability whose annotations name something
+    only the type checker has, or that imports a third party nothing declares, has to stay
+    visible -- tolerating any `ImportError` would let both disappear from
+    `tests/test_capability_specs.py`'s sweep and from the doc-snippet check.
+
+    Two things have to hold. The failure must bottom out in a `ModuleNotFoundError`, which
+    a capability's import gate hides: `browser_use`, `exa` and `stackone` catch it and
+    re-raise their own `ImportError` carrying an install hint, so the module name lives on
+    the `__cause__` chain rather than on the exception raised (`stackone` nests two deep).
+    And the module it names must be one an extra declared in `pyproject.toml` provides.
+    """
+    cause: BaseException | None = error
+    while cause is not None:
+        if isinstance(cause, ModuleNotFoundError) and cause.name is not None:
+            return cause.name.split('.')[0] in EXTRA_MODULES
+        cause = cause.__cause__
+    return False
+
 
 # Prevent accidental real model requests during tests.
 pydantic_ai.models.ALLOW_MODEL_REQUESTS = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
@@ -54,16 +55,25 @@ def is_missing_optional_extra(error: ImportError) -> bool:
     visible -- tolerating any `ImportError` would let both disappear from
     `tests/test_capability_specs.py`'s sweep and from the doc-snippet check.
 
-    Two things have to hold. The failure must bottom out in a `ModuleNotFoundError`, which
+    Three things have to hold. The failure must bottom out in a `ModuleNotFoundError`, which
     a capability's import gate hides: `browser_use`, `exa` and `stackone` catch it and
     re-raise their own `ImportError` carrying an install hint, so the module name lives on
     the `__cause__` chain rather than on the exception raised (`stackone` nests two deep).
-    And the module it names must be one an extra declared in `pyproject.toml` provides.
+    The module it names must be one an extra declared in `pyproject.toml` provides. And that
+    module has to be genuinely absent.
+
+    The last check is what separates "the extra is not installed" from "something inside an
+    installed extra is missing". `browser_use.browser` going missing while `browser_use`
+    imports is a version skew or a broken install -- a real failure, and one that hits
+    exactly the capabilities this tolerance covers, so it has to be reported rather than
+    skipped. Matching on the top-level name alone cannot tell the two apart; asking whether
+    that top-level module resolves can.
     """
     cause: BaseException | None = error
     while cause is not None:
         if isinstance(cause, ModuleNotFoundError) and cause.name is not None:
-            return cause.name.split('.')[0] in EXTRA_MODULES
+            top, _, _ = cause.name.partition('.')
+            return top in EXTRA_MODULES and importlib.util.find_spec(top) is None
         cause = cause.__cause__
     return False
 

--- a/tests/test_capability_specs.py
+++ b/tests/test_capability_specs.py
@@ -37,8 +37,9 @@ from __future__ import annotations
 import functools
 import importlib
 import pkgutil
+import types
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -129,8 +130,13 @@ def _capability_modules() -> list[str]:
 
 
 def _is_capability_type(obj: object) -> TypeGuard[type[AbstractCapability[Any]]]:
-    """`vars(module)` is untyped, so narrow before reaching for a capability's classmethods."""
-    return isinstance(obj, type) and issubclass(obj, AbstractCapability)
+    """`vars(module)` is untyped, so narrow before reaching for a capability's classmethods.
+
+    A subscripted generic (`Callable[[str], int]`, exported by `media`, `spend`, `subagents`
+    and others) satisfies `isinstance(obj, type)` on Python 3.10 but is not a class, so
+    `issubclass` raises `TypeError` on it there while returning False everywhere else.
+    """
+    return isinstance(obj, type) and not isinstance(obj, types.GenericAlias) and issubclass(obj, AbstractCapability)
 
 
 def _discover() -> tuple[list[type[AbstractCapability[Any]]], dict[str, ImportError]]:
@@ -238,6 +244,12 @@ def test_capability_package_imports(module: str) -> None:
         'it; otherwise this is a defect, and tolerating it here would drop the capability out of '
         'the schema sweep below without anything saying so.'
     )
+
+
+def test_a_subscripted_generic_is_not_mistaken_for_a_capability() -> None:
+    """`isinstance(Callable[...], type)` is True on Python 3.10, where `issubclass` then raises."""
+    assert _is_capability_type(Callable[[str], int]) is False
+    assert _is_capability_type(_Unschematizable) is True
 
 
 def test_only_an_absent_declared_extra_is_tolerated() -> None:

--- a/tests/test_capability_specs.py
+++ b/tests/test_capability_specs.py
@@ -43,11 +43,13 @@ from __future__ import annotations
 
 import functools
 import importlib
+import importlib.util
 import pkgutil
 import types
 import warnings
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, TypeGuard
@@ -262,8 +264,18 @@ def test_a_subscripted_generic_is_not_mistaken_for_a_capability() -> None:
     assert _is_capability_type(_Unschematizable) is True
 
 
-def test_only_an_absent_declared_extra_is_tolerated() -> None:
-    """`is_missing_optional_extra` decides what may vanish from the sweep, so pin its edges."""
+def _nothing_resolves(name: str) -> ModuleSpec | None:
+    """Stand-in for `importlib.util.find_spec` in an environment where nothing is installed."""
+    return None
+
+
+def test_an_absent_declared_extra_is_tolerated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The predicate reads two things: the exception, and whether the module resolves.
+
+    Every extra is installed in some environment that runs these tests and absent in
+    another, so the second input is pinned here rather than left to the environment.
+    """
+    monkeypatch.setattr(importlib.util, 'find_spec', _nothing_resolves)
     assert is_missing_optional_extra(ModuleNotFoundError('no modal', name='modal')) is True
     # `browser_use`, `exa` and `stackone` re-raise a bare `ImportError` naming their extra.
     re_raised = ImportError('browser-use is required for BrowserUse')
@@ -273,6 +285,24 @@ def test_only_an_absent_declared_extra_is_tolerated() -> None:
     nested = ImportError('stackone needs fastmcp')
     nested.__cause__ = re_raised
     assert is_missing_optional_extra(nested) is True
+
+
+def test_a_missing_submodule_inside_an_installed_extra_is_reported() -> None:
+    """A version skew or a broken install is a real failure, not an absent extra.
+
+    `logfire` is in the `dev` group, so it is present in every environment that runs these
+    tests. Reducing `logfire.variables` to its top-level name would tolerate this, and the
+    capability would drop out of the sweep exactly when its dependency is broken.
+    """
+    assert importlib.util.find_spec('logfire') is not None
+    assert is_missing_optional_extra(ModuleNotFoundError('gone', name='logfire.variables')) is False
+    gated = ImportError('logfire is required for ManagedPrompt')
+    gated.__cause__ = ModuleNotFoundError('gone', name='logfire.variables')
+    assert is_missing_optional_extra(gated) is False
+
+
+def test_anything_other_than_a_declared_extra_is_reported() -> None:
+    """`is_missing_optional_extra` decides what may vanish from the sweep, so pin its edges."""
     # A harness module that no longer exists, and a third party nothing declares, are defects.
     assert is_missing_optional_extra(ModuleNotFoundError('gone', name='pydantic_ai_harness.exa')) is False
     assert is_missing_optional_extra(ModuleNotFoundError('gone', name='requests')) is False

--- a/tests/test_capability_specs.py
+++ b/tests/test_capability_specs.py
@@ -60,7 +60,7 @@ _BASE_FIELDS = frozenset({'id', 'description', 'defer_loading'})
 
 _REPO = 'https://github.com/pydantic/pydantic-ai-harness'
 # The sweep that catalogued the causes below, until each has its own issue.
-_SWEEP = f'{_REPO}/pull/PENDING'
+_SWEEP = f'{_REPO}/pull/546'
 
 # Tracking issue per root cause -- one line to change when an issue is opened or closed.
 _TRACKERS = {

--- a/tests/test_capability_specs.py
+++ b/tests/test_capability_specs.py
@@ -1,0 +1,300 @@
+"""Keep every capability's configurable fields visible in the `AgentSpec` JSON schema.
+
+A spec file carries a `# yaml-language-server: $schema=` line, so each `capabilities:` block
+is validated against the generated schema. A capability whose fields never reach that schema
+still loads at runtime -- it only marks every configured block invalid in an editor and fails
+any CI that validates specs. Nothing in a normal test run notices, which is why this defect
+has now shipped from three separate authors (#537, #538, and the entries below).
+
+Core builds a capability's schema entry from exactly one signature: `from_spec` when the
+capability overrides it, `__init__` otherwise (`pydantic_ai/agent/spec.py`
+`_get_schema_target`, then `pydantic_ai/_spec.py` `build_schema_types`). Four ways that
+signature yields nothing usable, all of them silent:
+
+1. `from_spec(*args, **kwargs)` -- `build_schema_types` drops variadic parameters, leaving
+   no hints at all.
+2. A name in the read signature's annotations is not resolvable at runtime (a
+   `TYPE_CHECKING`-only import, or a core alias like `ModelSelection`, which is the string
+   `'Model | KnownModelName | str'` and is resolved against the *harness* module's globals).
+   `_get_schema_target` catches the `NameError` and falls back to `AbstractCapability`'s
+   variadic `from_spec`, i.e. straight to case 1.
+3. A field type with no JSON schema. `filter_serializable_type` only strips `TypeVar` and
+   `Callable`, so an arbitrary class survives into a TypedDict built with
+   `arbitrary_types_allowed=True`. A bare `X` or a nullable `X | None` then fails schema
+   generation and pydantic drops the whole `spec_<Name>` member from the capabilities union,
+   erasing every other field on that capability. (`X | <representable>` is the benign case:
+   only `X` is dropped.)
+4. Schema generation raises outright, so no capability in the spec gets a schema.
+
+The opt-out is in the code, not in a list here: `get_capability_registry` keys on
+`get_serialization_name()`, so returning `None` removes a capability from the spec system
+entirely and the sweep below skips it by construction. `SubAgents`, the guardrails and
+`DynamicWorkflow` do exactly that.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import pkgutil
+import warnings
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, TypeGuard
+
+import pytest
+from pydantic_ai.agent.spec import AgentSpec
+from pydantic_ai.capabilities import AbstractCapability
+
+_ROOT = Path(__file__).parent.parent
+_PACKAGE = _ROOT / 'pydantic_ai_harness'
+_HARNESS = 'pydantic_ai_harness'
+
+# `AbstractCapability`'s own fields. All three are plain JSON types, so any capability that
+# publishes an entry at all can publish these -- which is what lets this check run with no
+# allowlist. A `from_spec` override that forgets them silently removes the ability to set
+# `id` or `defer_loading` on that capability from a spec.
+_BASE_FIELDS = frozenset({'id', 'description', 'defer_loading'})
+
+_REPO = 'https://github.com/pydantic/pydantic-ai-harness'
+# The sweep that catalogued the causes below, until each has its own issue.
+_SWEEP = f'{_REPO}/pull/PENDING'
+
+# Tracking issue per root cause -- one line to change when an issue is opened or closed.
+_TRACKERS = {
+    'variadic-from-spec': f'{_REPO}/issues/537',
+    'unresolvable-annotation': _SWEEP,
+    'unrepresentable-field': _SWEEP,
+    'missing-base-fields': _SWEEP,
+}
+
+# Capabilities that publish no schema entry at all, by root cause. An entry leaves this map
+# when its capability starts publishing one; the map is expected to shrink to nothing.
+_NO_SCHEMA_ENTRY = {
+    # `from_spec(*args, **kwargs)`. PR #543 is in review for this one.
+    'StepPersistence': 'variadic-from-spec',
+    # `model: ModelSelection`, whose `'Model | ...'` alias resolves against this module.
+    'Advisor': 'unresolvable-annotation',
+    'SummarizingCompaction': 'unresolvable-annotation',
+    # `logfire_instance: Logfire | None`, imported under `TYPE_CHECKING`.
+    'ManagedPrompt': 'unresolvable-annotation',
+    # Inherits `local_docs_path: Path | None`, but `@dataclass` rebuilds `__init__` in
+    # `_deprecated.py`, which does not import `Path` at runtime.
+    'PyaiDocs': 'unresolvable-annotation',
+    # `os_access: AbstractOS | None`
+    'CodeMode': 'unrepresentable-field',
+    # `source: HistorySource`
+    'ConversationSearch': 'unrepresentable-field',
+    # `session: ModalSandboxSession | None`
+    'ModalSandbox': 'unrepresentable-field',
+}
+
+# Capabilities whose entry exists but cannot express the `AbstractCapability` base fields.
+_NO_BASE_FIELDS = {
+    'BrowserUse': 'missing-base-fields',
+    'ExaAgent': 'missing-base-fields',
+    'ExaSearch': 'missing-base-fields',
+    'Memory': 'missing-base-fields',
+    'Planning': 'missing-base-fields',
+    # Not a forgotten `from_spec`: `include`/`exclude` are `Collection[str] | None`, so the
+    # long form is dropped and only the one-parameter short form survives.
+    'Skills': 'unrepresentable-field',
+}
+
+
+def _is_missing_optional_extra(exc_name: str | None) -> bool:
+    """True when an import failed because an optional extra is absent, not because of a defect.
+
+    A missing extra always names a third-party distribution (`modal`, `exa_py`, `fastmcp`).
+    Anything under `pydantic_ai` -- harness itself or its one required dependency -- is
+    installed in every environment, so a failure naming one of those is a real break and
+    must not be tolerated here: the annotation defect above surfaces as an unresolvable
+    name, and tolerating "the import failed" would hide it.
+    """
+    return exc_name is not None and not exc_name.startswith('pydantic_ai')
+
+
+def _import_capability_module(module: str) -> ModuleType | None:
+    """Import a capability package, or `None` when its optional extra is not installed."""
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')  # deprecation shims and `experimental` warn on import
+            return importlib.import_module(module)
+    except ModuleNotFoundError as exc:  # pragma: no cover -- only reached without an extra installed
+        if _is_missing_optional_extra(exc.name):
+            return None
+        raise
+
+
+def _capability_modules() -> list[str]:
+    """Every capability package: the top level plus `experimental` (matches `test_docs_parity`)."""
+    modules: list[str] = []
+    for path, prefix in ((_PACKAGE, _HARNESS), (_PACKAGE / 'experimental', f'{_HARNESS}.experimental')):
+        modules.extend(info.name for info in pkgutil.iter_modules([str(path)], f'{prefix}.') if info.ispkg)
+    return sorted(modules)
+
+
+def _is_capability_type(obj: object) -> TypeGuard[type[AbstractCapability[Any]]]:
+    """`vars(module)` is untyped, so narrow before reaching for a capability's classmethods."""
+    return isinstance(obj, type) and issubclass(obj, AbstractCapability)
+
+
+def _discover_capabilities() -> list[type[AbstractCapability[Any]]]:
+    """Every spec-registerable capability class, keyed by serialization name to dedupe re-exports."""
+    found: dict[str, type[AbstractCapability[Any]]] = {}
+    for module_name in _capability_modules():
+        module = _import_capability_module(module_name)
+        if module is None:  # pragma: no cover -- only reached without an extra installed
+            continue
+        for obj in vars(module).values():
+            # `AbstractCapability` has no abstract methods, so `inspect.isabstract` does not
+            # exclude it; a package re-exporting it (or a core capability) would otherwise be
+            # swept as if harness owned its schema.
+            if not _is_capability_type(obj) or not obj.__module__.startswith(_HARNESS):
+                continue
+            name = obj.get_serialization_name()
+            if name is not None:
+                found[name] = obj
+    return [found[name] for name in sorted(found)]
+
+
+_CAPABILITIES = _discover_capabilities()
+
+if TYPE_CHECKING:
+
+    class _DeferredOnly:
+        """Never exists at runtime, standing in for `Model` in `tool_output_limits/_bands.py`."""
+
+
+@dataclass(frozen=True)
+class _Nested:
+    """A nested dataclass whose own annotation names something only the type checker has."""
+
+    value: _DeferredOnly | None = None
+
+
+@dataclass
+class _Unschematizable(AbstractCapability[Any]):
+    """`Sequence[_Nested]` resolves, so `__init__` is read and pydantic then fails on `_Nested`."""
+
+    nested: Sequence[_Nested] = ()
+
+
+def _name(capability: type[AbstractCapability[Any]]) -> str:
+    serialization_name = capability.get_serialization_name()
+    assert serialization_name is not None  # `_discover_capabilities` filters out the opt-outs
+    return serialization_name
+
+
+def _cases(known_gaps: dict[str, str]) -> list[Any]:
+    """One parameter per capability, xfailing the ones a tracked issue already covers.
+
+    The xfails are strict, so a capability that starts passing fails until its entry is
+    removed. That is what keeps the maps above shrinking rather than becoming a permanent
+    exemption list.
+    """
+    cases: list[Any] = []
+    for capability in _CAPABILITIES:
+        name = _name(capability)
+        cause = known_gaps.get(name)
+        marks = (
+            ()
+            if cause is None
+            else (pytest.mark.xfail(strict=True, reason=f'{name}: {cause}, tracked in {_TRACKERS[cause]}'),)
+        )
+        cases.append(pytest.param(capability, marks=marks, id=name))
+    return cases
+
+
+@functools.cache
+def _schema(capability: type[AbstractCapability[Any]]) -> dict[str, Any]:
+    return AgentSpec.model_json_schema_with_capabilities([capability])
+
+
+def _defs(capability: type[AbstractCapability[Any]]) -> dict[str, Any]:
+    defs: dict[str, Any] = _schema(capability).get('$defs', {})
+    return defs
+
+
+def test_capabilities_discovered() -> None:
+    # Guard against a moved package root making every check below vacuously pass. The slim
+    # CI job has no `modal`/`exa`/`browser-use`/`stackone` extras, so it finds five fewer.
+    assert len(_CAPABILITIES) >= 25
+
+
+def test_is_missing_optional_extra_only_tolerates_third_party() -> None:
+    assert _is_missing_optional_extra('modal') is True
+    assert _is_missing_optional_extra('pydantic_ai_harness.exa') is False
+    assert _is_missing_optional_extra('pydantic_ai.agent.spec') is False
+    assert _is_missing_optional_extra(None) is False
+
+
+def _generation_problem(capability: type[AbstractCapability[Any]]) -> str | None:
+    """Why this capability cannot be schematized at all, or `None` when it can."""
+    try:
+        _schema(capability)
+    except Exception as exc:
+        return (
+            f'Generating the AgentSpec schema for {_name(capability)} raises {type(exc).__name__}: {exc}\n'
+            'One capability that cannot be schematized breaks the schema for every capability in the '
+            'spec, not only its own entry. Give it a `from_spec` naming only the parameters a spec can '
+            'express (see `SpendLimits.from_spec` and `ToolOutputLimits.from_spec`), keeping a '
+            '`**unsupported: Any` catch-all so the runtime-only fields are rejected by name.'
+        )
+    return None
+
+
+@pytest.mark.parametrize('capability', _cases({}))
+def test_capability_spec_schema_generates(capability: type[AbstractCapability[Any]]) -> None:
+    problem = _generation_problem(capability)
+    assert problem is None, problem
+
+
+def test_the_generation_check_catches_a_capability_that_cannot_be_schematized() -> None:
+    """`_Unschematizable` reproduces the shape `ToolOutputLimits` had before its `from_spec`.
+
+    The nested dataclass resolves fine, so `_get_schema_target` reads `__init__` and hands
+    pydantic a type it cannot build a schema for. That raises rather than being dropped, which
+    is what made one capability able to break the schema for a whole spec.
+    """
+    problem = _generation_problem(_Unschematizable)
+
+    assert problem is not None
+    assert 'from_spec' in problem
+
+
+@pytest.mark.parametrize('capability', _cases(_NO_SCHEMA_ENTRY))
+def test_capability_publishes_a_spec_entry(capability: type[AbstractCapability[Any]]) -> None:
+    name = _name(capability)
+    defs = _defs(capability)
+    assert f'spec_{name}' in defs or f'short_spec_{name}' in defs, (
+        f'{name} publishes no fields to the AgentSpec schema, so every `{name}:` block a user writes '
+        'is invalid against the schema the spec file points at, while still loading at runtime.\n'
+        'Give it a `from_spec` naming every spec-expressible parameter as keyword-only, including '
+        '`id`, `description` and `defer_loading`, plus a `**unsupported: Any` catch-all. See '
+        "`SpendLimits.from_spec` for the reference shape, and this module's docstring for the four "
+        'ways a signature ends up publishing nothing.\n'
+        f'If the capability should not be configurable from a spec at all, override '
+        f'`get_serialization_name` to return `None` instead (as `SubAgents` does).'
+    )
+
+
+@pytest.mark.parametrize('capability', _cases(_NO_SCHEMA_ENTRY | _NO_BASE_FIELDS))
+def test_capability_spec_accepts_base_fields(capability: type[AbstractCapability[Any]]) -> None:
+    name = _name(capability)
+    params = _defs(capability).get(f'spec_params_{name}')
+    assert params is not None, (
+        f'{name} publishes only a one-parameter short form, so a spec cannot set '
+        f'{sorted(_BASE_FIELDS)} on it. Either the `from_spec` signature names a single parameter, '
+        "or a field type with no JSON schema caused the full form to be dropped (see this module's "
+        'docstring, cause 3).'
+    )
+    missing = sorted(_BASE_FIELDS - set(params['properties']))
+    assert not missing, (
+        f'{name} does not publish {missing} to the AgentSpec schema, so a spec cannot set those '
+        f'fields on it. `AbstractCapability` defines them for every capability; a `from_spec` '
+        'override has to name them and pass them through to the constructor, or they reach '
+        '`cls()` only by accident through `**kwargs` and never reach the schema.'
+    )

--- a/tests/test_capability_specs.py
+++ b/tests/test_capability_specs.py
@@ -26,6 +26,13 @@ signature yields nothing usable, all of them silent:
    only `X` is dropped.)
 4. Schema generation raises outright, so no capability in the spec gets a schema.
 
+Cases 2 and 3 are silent because core swallows them: `_get_schema_target` catches the
+`NameError` and falls back, and pydantic's union handling drops a member it cannot
+schematize instead of raising. Proposed upstream in
+<https://github.com/pydantic/pydantic-ai/issues/7180>. This file is the downstream half --
+if either path stops being silent, cases 2 and 3 arrive as a real error and layers 1 and 2
+change character.
+
 The opt-out is in the code, not in a list here: `get_capability_registry` keys on
 `get_serialization_name()`, so returning `None` removes a capability from the spec system
 entirely and the sweep below skips it by construction. `SubAgents`, the guardrails and
@@ -62,15 +69,16 @@ _HARNESS = 'pydantic_ai_harness'
 _BASE_FIELDS = frozenset({'id', 'description', 'defer_loading'})
 
 _REPO = 'https://github.com/pydantic/pydantic-ai-harness'
-# The sweep that catalogued the causes below, until each has its own issue.
-_SWEEP = f'{_REPO}/pull/546'
 
 # Tracking issue per root cause -- one line to change when an issue is opened or closed.
+# Every issue carries its own per-capability breakdown; the maps below only say which
+# capability belongs to which. Fixing a capability means deleting its entry here too, since
+# the xfails are strict and an unexpected pass fails the build.
 _TRACKERS = {
     'variadic-from-spec': f'{_REPO}/issues/537',
-    'unresolvable-annotation': _SWEEP,
-    'unrepresentable-field': _SWEEP,
-    'missing-base-fields': _SWEEP,
+    'unresolvable-annotation': f'{_REPO}/issues/552',
+    'unrepresentable-field': f'{_REPO}/issues/553',
+    'missing-base-fields': f'{_REPO}/issues/554',
 }
 
 # Capabilities that publish no schema entry at all, by root cause. An entry leaves this map
@@ -81,7 +89,8 @@ _NO_SCHEMA_ENTRY = {
     # `model: ModelSelection`, whose `'Model | ...'` alias resolves against this module.
     'Advisor': 'unresolvable-annotation',
     'SummarizingCompaction': 'unresolvable-annotation',
-    # `logfire_instance: Logfire | None`, imported under `TYPE_CHECKING`.
+    # `logfire_instance: Logfire | None`, imported under `TYPE_CHECKING`. Resolving the name
+    # is not enough here -- `Logfire | None` then lands in cause 3 (see #553).
     'ManagedPrompt': 'unresolvable-annotation',
     # Inherits `local_docs_path: Path | None`, but `@dataclass` rebuilds `__init__` in
     # `_deprecated.py`, which does not import `Path` at runtime.
@@ -101,8 +110,9 @@ _NO_BASE_FIELDS = {
     'ExaSearch': 'missing-base-fields',
     'Memory': 'missing-base-fields',
     'Planning': 'missing-base-fields',
-    # Not a forgotten `from_spec`: `include`/`exclude` are `Collection[str] | None`, so the
-    # long form is dropped and only the one-parameter short form survives.
+    # Tracked under #553, not #554: `include`/`exclude` are `Collection[str] | None`, so the
+    # long form is dropped and only the one-parameter short form survives. Naming the base
+    # fields in `from_spec` would not bring it back.
     'Skills': 'unrepresentable-field',
 }
 

--- a/tests/test_capability_specs.py
+++ b/tests/test_capability_specs.py
@@ -48,6 +48,8 @@ import pytest
 from pydantic_ai.agent.spec import AgentSpec
 from pydantic_ai.capabilities import AbstractCapability
 
+from tests.conftest import is_missing_optional_extra  # pyright: ignore[reportMissingTypeStubs]
+
 _ROOT = Path(__file__).parent.parent
 _PACKAGE = _ROOT / 'pydantic_ai_harness'
 _HARNESS = 'pydantic_ai_harness'
@@ -104,28 +106,18 @@ _NO_BASE_FIELDS = {
 }
 
 
-def _is_missing_optional_extra(exc_name: str | None) -> bool:
-    """True when an import failed because an optional extra is absent, not because of a defect.
+def _import_capability_module(module: str) -> ModuleType | ImportError:
+    """Import a capability package, returning the failure rather than raising it.
 
-    A missing extra always names a third-party distribution (`modal`, `exa_py`, `fastmcp`).
-    Anything under `pydantic_ai` -- harness itself or its one required dependency -- is
-    installed in every environment, so a failure naming one of those is a real break and
-    must not be tolerated here: the annotation defect above surfaces as an unresolvable
-    name, and tolerating "the import failed" would hide it.
+    Discovery runs at module import, so raising here is a collection error that takes every
+    check in this file down with it. Returned, an unimportable package is one named test.
     """
-    return exc_name is not None and not exc_name.startswith('pydantic_ai')
-
-
-def _import_capability_module(module: str) -> ModuleType | None:
-    """Import a capability package, or `None` when its optional extra is not installed."""
     try:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')  # deprecation shims and `experimental` warn on import
             return importlib.import_module(module)
-    except ModuleNotFoundError as exc:  # pragma: no cover -- only reached without an extra installed
-        if _is_missing_optional_extra(exc.name):
-            return None
-        raise
+    except ImportError as error:  # pragma: no cover -- only reached without an extra installed
+        return error
 
 
 def _capability_modules() -> list[str]:
@@ -141,12 +133,19 @@ def _is_capability_type(obj: object) -> TypeGuard[type[AbstractCapability[Any]]]
     return isinstance(obj, type) and issubclass(obj, AbstractCapability)
 
 
-def _discover_capabilities() -> list[type[AbstractCapability[Any]]]:
-    """Every spec-registerable capability class, keyed by serialization name to dedupe re-exports."""
+def _discover() -> tuple[list[type[AbstractCapability[Any]]], dict[str, ImportError]]:
+    """Every spec-registerable capability, plus the packages that would not import.
+
+    Capabilities are keyed by serialization name to dedupe re-exports. Only failures that
+    are not an absent extra are reported: those are the ones a test has to fail on.
+    """
     found: dict[str, type[AbstractCapability[Any]]] = {}
+    unimportable: dict[str, ImportError] = {}
     for module_name in _capability_modules():
         module = _import_capability_module(module_name)
-        if module is None:  # pragma: no cover -- only reached without an extra installed
+        if isinstance(module, ImportError):  # pragma: no cover -- only reached without an extra installed
+            if not is_missing_optional_extra(module):
+                unimportable[module_name] = module
             continue
         for obj in vars(module).values():
             # `AbstractCapability` has no abstract methods, so `inspect.isabstract` does not
@@ -157,10 +156,11 @@ def _discover_capabilities() -> list[type[AbstractCapability[Any]]]:
             name = obj.get_serialization_name()
             if name is not None:
                 found[name] = obj
-    return [found[name] for name in sorted(found)]
+    return [found[name] for name in sorted(found)], unimportable
 
 
-_CAPABILITIES = _discover_capabilities()
+_CAPABILITY_MODULES = _capability_modules()
+_CAPABILITIES, _UNIMPORTABLE = _discover()
 
 if TYPE_CHECKING:
 
@@ -219,16 +219,46 @@ def _defs(capability: type[AbstractCapability[Any]]) -> dict[str, Any]:
 
 
 def test_capabilities_discovered() -> None:
-    # Guard against a moved package root making every check below vacuously pass. The slim
-    # CI job has no `modal`/`exa`/`browser-use`/`stackone` extras, so it finds five fewer.
+    # Half of the anti-vacuity guard: a moved package root, or an environment where most
+    # capabilities skipped, cannot make the parametrized checks below pass on nothing. The
+    # `slim` CI job lacks the `browser-use`, `exa` and `stackone` extras and still finds 27.
+    # The other half is `test_capability_package_imports`, which keeps the only reason a
+    # capability may go missing to an extra this repo declares.
     assert len(_CAPABILITIES) >= 25
+    assert len(_CAPABILITY_MODULES) >= 25
 
 
-def test_is_missing_optional_extra_only_tolerates_third_party() -> None:
-    assert _is_missing_optional_extra('modal') is True
-    assert _is_missing_optional_extra('pydantic_ai_harness.exa') is False
-    assert _is_missing_optional_extra('pydantic_ai.agent.spec') is False
-    assert _is_missing_optional_extra(None) is False
+@pytest.mark.parametrize('module', _CAPABILITY_MODULES, ids=lambda m: m.removeprefix(f'{_HARNESS}.'))
+def test_capability_package_imports(module: str) -> None:
+    error = _UNIMPORTABLE.get(module)
+    assert error is None, (
+        f"{module} does not import, and the failure is not one of this repo's optional extras "
+        f'({type(error).__name__}: {error}).\n'
+        'Add the missing module to `EXTRA_MODULES` in `tests/conftest.py` if a new extra provides '
+        'it; otherwise this is a defect, and tolerating it here would drop the capability out of '
+        'the schema sweep below without anything saying so.'
+    )
+
+
+def test_only_an_absent_declared_extra_is_tolerated() -> None:
+    """`is_missing_optional_extra` decides what may vanish from the sweep, so pin its edges."""
+    assert is_missing_optional_extra(ModuleNotFoundError('no modal', name='modal')) is True
+    # `browser_use`, `exa` and `stackone` re-raise a bare `ImportError` naming their extra.
+    re_raised = ImportError('browser-use is required for BrowserUse')
+    re_raised.__cause__ = ModuleNotFoundError('no browser_use', name='browser_use')
+    assert is_missing_optional_extra(re_raised) is True
+    # `stackone` nests two `ImportError`s over the `ModuleNotFoundError`.
+    nested = ImportError('stackone needs fastmcp')
+    nested.__cause__ = re_raised
+    assert is_missing_optional_extra(nested) is True
+    # A harness module that no longer exists, and a third party nothing declares, are defects.
+    assert is_missing_optional_extra(ModuleNotFoundError('gone', name='pydantic_ai_harness.exa')) is False
+    assert is_missing_optional_extra(ModuleNotFoundError('gone', name='requests')) is False
+    # A name that vanished from a module never reaches a `ModuleNotFoundError` at all.
+    assert is_missing_optional_extra(ImportError('cannot import name X')) is False
+    nameless_cause = ImportError('wrapped')
+    nameless_cause.__cause__ = ModuleNotFoundError('no name on this one')
+    assert is_missing_optional_extra(nameless_cause) is False
 
 
 def _generation_problem(capability: type[AbstractCapability[Any]]) -> str | None:

--- a/tests/test_doc_snippets.py
+++ b/tests/test_doc_snippets.py
@@ -32,6 +32,8 @@ import pytest
 from _pytest.mark import ParameterSet
 from pytest_examples import CodeExample, find_examples
 
+from tests.conftest import is_missing_optional_extra  # pyright: ignore[reportMissingTypeStubs]
+
 _ROOT = Path(__file__).parent.parent
 _HARNESS = 'pydantic_ai_harness'
 
@@ -54,16 +56,6 @@ def _harness_import_targets(tree: ast.AST) -> Iterable[tuple[str, str | None]]:
                     yield alias.name, None
 
 
-def _is_missing_harness_module(exc_name: str | None) -> bool:
-    """True when an ImportError is a genuinely absent harness module, not a missing extra.
-
-    A missing optional dependency (e.g. `acp` in the `slim` CI job) raises
-    `ModuleNotFoundError` naming the third-party package, not the harness module --
-    the harness module exists, its extra just isn't installed.
-    """
-    return exc_name is not None and exc_name.startswith(_HARNESS)
-
-
 def _snippet_problem(source: str) -> str | None:
     """Return why a snippet is invalid, or `None` if it parses and its harness imports resolve."""
     try:
@@ -76,10 +68,10 @@ def _snippet_problem(source: str) -> str | None:
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')  # a deprecated shim path still resolves; existence is what we check
                 imported = importlib.import_module(module)
-        except ImportError as exc:
-            if _is_missing_harness_module(exc.name):
-                return f'imports `{module}`, which does not exist: {exc}'
-            continue  # missing optional extra in this environment; the harness module exists
+        except ImportError as error:
+            if is_missing_optional_extra(error):
+                continue  # the harness module exists; this environment lacks its declared extra
+            return f'imports `{module}`, which does not resolve: {error}'
         if name is not None and not hasattr(imported, name):
             return f'imports `{name}` from `{module}`, but that name does not exist'
     return None
@@ -118,14 +110,8 @@ def test_snippet_problem_detects_each_failure_mode() -> None:
     assert _snippet_problem('from os import path\nimport sys') is None
     # Invalid: syntax, a module that does not exist, and a name that does not exist.
     assert 'does not parse' in (_snippet_problem('def (:') or '')
-    assert 'does not exist' in (_snippet_problem('from pydantic_ai_harness.nope import X') or '')
+    assert 'does not resolve' in (_snippet_problem('from pydantic_ai_harness.nope import X') or '')
     assert 'does not exist' in (_snippet_problem('from pydantic_ai_harness import NoSuchCapability') or '')
-
-
-def test_missing_harness_module_classification() -> None:
-    assert _is_missing_harness_module('pydantic_ai_harness.experimental.nope') is True
-    assert _is_missing_harness_module('acp') is False  # a missing extra, not a harness module
-    assert _is_missing_harness_module(None) is False
 
 
 def test_missing_optional_extra_is_not_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -136,3 +122,13 @@ def test_missing_optional_extra_is_not_a_failure(monkeypatch: pytest.MonkeyPatch
 
     monkeypatch.setattr(importlib, 'import_module', _extra_missing)
     assert _snippet_problem('from pydantic_ai_harness.experimental.acp import run_acp_stdio') is None
+
+
+def test_a_third_party_nothing_declares_is_still_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An undeclared import is a defect, not an uninstalled extra -- see
+    # `is_missing_optional_extra`. Tolerating it would hide the module from every check.
+    def _undeclared_missing(module: str) -> object:
+        raise ModuleNotFoundError("No module named 'requests'", name='requests')
+
+    monkeypatch.setattr(importlib, 'import_module', _undeclared_missing)
+    assert 'does not resolve' in (_snippet_problem('from pydantic_ai_harness.shell import Shell') or '')

--- a/tests/test_doc_snippets.py
+++ b/tests/test_doc_snippets.py
@@ -23,9 +23,11 @@ from __future__ import annotations as _annotations
 
 import ast
 import importlib
+import importlib.util
 import os
 import warnings
 from collections.abc import Iterable
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 
 import pytest
@@ -117,10 +119,17 @@ def test_snippet_problem_detects_each_failure_mode() -> None:
 def test_missing_optional_extra_is_not_a_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     # Simulate the `slim` environment: the harness module exists, but importing it
     # fails because its third-party extra is absent. That is not a broken snippet.
+    # `acp` is installed here, so its absence has to be simulated too -- the tolerance
+    # asks whether the module resolves, not only what the exception names.
     def _extra_missing(module: str) -> object:
         raise ModuleNotFoundError("No module named 'acp'", name='acp')
 
     monkeypatch.setattr(importlib, 'import_module', _extra_missing)
+
+    def _nothing_resolves(name: str) -> ModuleSpec | None:
+        return None
+
+    monkeypatch.setattr(importlib.util, 'find_spec', _nothing_resolves)
     assert _snippet_problem('from pydantic_ai_harness.experimental.acp import run_acp_stdio') is None
 
 

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 import os
 import time
 from datetime import timedelta
@@ -11,7 +12,8 @@ from typing import Any
 
 import pytest
 from pydantic_ai import Agent
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.agent.spec import AgentSpec
+from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.messages import (
     BinaryContent,
     ModelMessage,
@@ -751,3 +753,72 @@ class TestAgentIntegration:
         returns = [p for m in result.all_messages() for p in m.parts if isinstance(p, ToolReturnPart)]
         small = [p for p in returns if p.tool_name == 'small_tool']
         assert small and small[0].content == 'tiny'
+
+
+# ---------------------------------------------------------------------------
+# Agent spec
+# ---------------------------------------------------------------------------
+
+
+class TestAgentSpec:
+    def test_the_schema_generates_at_all(self):
+        """Reading `__init__` reached `Summarize.model`, whose `Model` is `TYPE_CHECKING`-only.
+
+        Pydantic raised `PydanticUserError` there, so naming this capability in a spec broke
+        schema generation for every capability in it, not just this one.
+        """
+        definitions = AgentSpec.model_json_schema_with_capabilities([ToolOutputLimits])['$defs']
+
+        assert 'spec_params_ToolOutputLimits' in definitions
+
+    def test_the_schema_carries_the_options_a_spec_can_set(self):
+        schema = json.dumps(AgentSpec.model_json_schema_with_capabilities([ToolOutputLimits]), sort_keys=True)
+
+        for expressible in ('"tool_filter"', '"over_tokens"', '"strip_ansi"', '"summary_prompt"'):
+            assert expressible in schema, expressible
+        # `AbstractCapability`'s own fields reach `cls()` through `**kwargs` when `from_spec`
+        # forgets them, so they need naming to reach the schema.
+        for base_field in ('"id"', '"description"', '"defer_loading"'):
+            assert base_field in schema, base_field
+        # Bands hold `Action` objects; the tokenizer and store hold a callable and a backend.
+        for runtime_only in ('"bands"', '"per_tool"', '"tokenizer"', '"store"'):
+            assert runtime_only not in schema, runtime_only
+
+    def test_a_runtime_only_field_is_refused_by_name(self):
+        with pytest.raises(UserError, match=r"\['bands', 'store'\]"):
+            ToolOutputLimits[None].from_spec(bands=[Band(over=1, action=Truncate())], store=LocalFileStore())
+
+    def test_an_unknown_spec_field_is_named(self):
+        """`**unsupported` keeps the runtime-only message specific, so it must not swallow the rest."""
+        with pytest.raises(UserError, match=r"no spec field\(s\) \['band'\]"):
+            ToolOutputLimits[None].from_spec(band=[])
+
+    def test_the_defaults_survive_a_spec_that_sets_nothing(self):
+        capability = ToolOutputLimits[None].from_spec()
+
+        assert isinstance(capability._bands[0].action, Spill)
+        assert capability.summary_prompt == ToolOutputLimits[None]().summary_prompt
+
+    def test_a_spec_loads_and_the_options_it_names_hold(self):
+        agent = Agent.from_spec(
+            {
+                'model': 'test',
+                'capabilities': [
+                    {
+                        'ToolOutputLimits': {
+                            'over_tokens': True,
+                            'strip_ansi': True,
+                            'tool_filter': ['big_tool'],
+                            'id': 'limits',
+                        }
+                    }
+                ],
+            },
+            custom_capability_types=[ToolOutputLimits],
+        )
+
+        [capability] = [c for c in agent.root_capability.capabilities if isinstance(c, ToolOutputLimits)]
+        assert capability.over_tokens is True
+        assert capability.strip_ansi is True
+        assert capability.tool_filter == ['big_tool']
+        assert capability.id == 'limits'


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David directed the scope; the implementation and the sweep below are unreviewed by him.

#537 reported that `StepPersistence` publishes no fields to the `AgentSpec` JSON schema. #538 fixed the same thing in `SpendLimits`. A repo-wide sweep says it is **9 of 31 capabilities, from four distinct root causes** -- so the next report is a matter of time, and a per-capability fix does not stop it.

The asymmetry is why nobody notices: a capability whose fields never reach the schema still loads perfectly at runtime. Nothing fails until a user opens a spec file against the schema its `# yaml-language-server: $schema=` line points at, or a CI job validates one.

## What lands

**`tests/test_capability_specs.py`** -- discovers every capability under `pydantic_ai_harness/*/` (plus `experimental/`), imports it, and keeps the ones whose `get_serialization_name()` is not `None`. Three layers per capability:

1. `AgentSpec.model_json_schema_with_capabilities([C])` does not raise.
2. Its `$defs` carries `spec_<name>` or `short_spec_<name>`.
3. `$defs['spec_params_<name>'].properties` covers `id`, `description`, `defer_loading`.

Layers 1 and 2 need **no allowlist**, which is the property that keeps this from becoming a rubber stamp: `AbstractCapability` gives every capability three JSON-expressible fields, so no capability legitimately publishes nothing. The sanctioned opt-out already lives in code rather than in a list here -- `get_capability_registry` keys on `get_serialization_name()`, so returning `None` removes a capability from the spec system entirely and the sweep skips it by construction (`SubAgents`, the guardrails, `DynamicWorkflow` do exactly that).

Structural prior art is `tests/test_docs_parity.py`: filesystem discovery, an anti-vacuity assertion, `ids=` per capability, and messages that say what to do rather than what failed.

### Two things the `slim` and `lowest-versions` jobs caught

**The tolerance has to mean "this extra is absent", not "the import failed."** `browser_use`, `exa` and `stackone` catch the underlying `ModuleNotFoundError` and re-raise their own `ImportError` carrying an install hint (`stackone` nests two deep), so a check keyed on the exception type or on its `name` matched nothing and the sweep died on collection.

`is_missing_optional_extra` now requires **both**: the failure bottoms out in a `ModuleNotFoundError` somewhere on the `__cause__` chain, **and** the module it names is one that `[project.optional-dependencies]` provides (`EXTRA_MODULES` in `tests/conftest.py`, one line per extra). So it cannot swallow a genuine defect: a `NameError` from root cause 2 is not an `ImportError` at all, `ImportError: cannot import name X` never reaches a `ModuleNotFoundError`, a vanished harness module names itself, and an undeclared third-party import (`requests`) is not in the set. It lives in `conftest.py` because `test_doc_snippets.py` needs the same answer and its old spelling tolerated any import failure -- the same hole, one check over.

**Discovery must not raise.** It runs at module import, so an unimportable package was a collection error that took every check in the file down. `_import_capability_module` now returns the failure, and `test_capability_package_imports` is parametrized over all packages, so an unexplained failure is one named test and every other capability is still swept.

The two anti-vacuity properties are split so they cannot fight: `test_capabilities_discovered` holds the floor (>= 25 of 31; `slim` finds 27), which stops "discovery found nothing" and "almost everything skipped"; `test_capability_package_imports` pins *why* something may go missing to a declared extra, which stops the floor from being met by tolerating skips it should not.

**`ToolOutputLimits.from_spec`** -- the one live break, and the only capability fixed here.

## The four root causes

Core reads one signature to build the entry: `from_spec` when overridden, `__init__` otherwise (`pydantic_ai/agent/spec.py` `_get_schema_target`, then `pydantic_ai/_spec.py` `build_schema_types`).

**1. Variadic `from_spec`** (1) -- `build_schema_types` drops `VAR_POSITIONAL`/`VAR_KEYWORD`, leaving no hints.

| Capability | Field |
|---|---|
| `StepPersistence` | `from_spec(*args, **kwargs)` -- #537, PR #543 in review |

**2. A name in the read annotations does not resolve at runtime** (4) -- [#552](https://github.com/pydantic/pydantic-ai-harness/issues/552) -- `_get_schema_target` wraps `get_function_type_hints(cls.__init__)` in `except (NameError, TypeError, AttributeError)` and falls back to `cls.from_spec`, which is `AbstractCapability`'s variadic default. So the capability lands in exactly the #537 state, silently.

| Capability | Name | Fixable by importing it at runtime? |
|---|---|---|
| `Advisor` | `model: ModelSelection`, whose core definition is the *string* `'Model \| KnownModelName \| str'` and resolves against the harness module's globals | Yes for layer 2 (verified) -- still fails layer 3 |
| `SummarizingCompaction` | same alias; `Model` sits in the module's `TYPE_CHECKING` block | Yes, fully (verified) |
| `ManagedPrompt` | `logfire_instance: Logfire \| None` | **No** -- it then hits cause 3 (verified: short form only) |
| `PyaiDocs` | inherits `local_docs_path: Path \| None`, but `@dataclass` rebuilds `__init__` in `_deprecated.py`, which does not import `Path` | Yes, fully (verified) |

**3. A field type with no JSON schema deletes the whole entry** (3 at layer 2, 1 more at layer 3) -- [#553](https://github.com/pydantic/pydantic-ai-harness/issues/553) -- `filter_serializable_type` strips only `TypeVar` and `Callable`, so an arbitrary class survives into a TypedDict built with `arbitrary_types_allowed=True`. Pydantic then **drops the whole `spec_<Name>` member from the union rather than raising**. One unrepresentable field erases every other field on the capability.

Probed the exact rule, because it decides whether a fix is a one-liner: a bare `X` fails, `X | None` fails (pydantic's nullable path), and `X | <something representable>` is benign -- only `X` is dropped.

| Capability | Field |
|---|---|
| `CodeMode` | `os_access: AbstractOS \| None` |
| `ConversationSearch` | `source: HistorySource` (bare, so the short form dies too) |
| `ModalSandbox` | `session: ModalSandboxSession \| None` |
| `Skills` | `include` / `exclude`: `Collection[str] \| None`. Layer 2 passes on the surviving short form; layer 3 is where it shows |

**4. Schema generation raises outright** (1) -- fixed here.

`ToolOutputLimits.bands` is `Sequence[Band]`, and `Band` reaches `Summarize.model: str | Model | None` where `Model` is `TYPE_CHECKING`-only in `_bands.py`. Unlike a `PydanticInvalidForJsonSchema` (swallowed by the union), the resulting `PydanticUserError` propagates: any user whose spec names this capability could not generate a schema for **any** capability.

Harness-side, and fixed the `SpendLimits` way -- an explicit keyword-only `from_spec` naming `tool_filter`, `over_tokens`, `strip_ansi`, `summary_prompt` and the three base fields, with `**unsupported: Any` rejecting `bands`, `per_tool`, `tokenizer` and `store` by name. Moving the import out of `TYPE_CHECKING` was the other candidate and is worse: it converts the hard raise into cause 3, silently dropping the whole entry, verified rather than assumed. That is exactly the change a future contributor makes while tidying up, so the reason sits in a comment at the `TYPE_CHECKING` block in `_bands.py` as well as in `from_spec`'s docstring.

Rejecting `bands` takes nothing away. A spec naming it already failed -- `from_spec` passed raw dicts to `_prepare_bands`, which reads `band.over`.

## Everything else is xfailed, not fixed

Per the standing scope rule, the other 8 capabilities keep failing behind strict `xfail`s grouped by root cause, each pointing at a tracker. Strict is load-bearing: a capability that starts passing fails the build until its entry is deleted, so the map shrinks visibly rather than becoming a permanent exemption list.

`_TRACKERS` in that module holds one line per root cause: #537 (variadic), #552 (unresolvable annotation), #553 (unrepresentable field), #554 (missing base fields). Each issue carries its per-capability breakdown and a comment naming the constraint the reference imposes -- chiefly that fixing a capability means deleting its line here in the same PR, since a strict xfail that starts passing turns the build red.

## Layer 3: xfailed rather than landed green

Layer 3 fails for six capabilities whose `from_spec` overrides omit `id` / `description` / `defer_loading` -- a spec cannot set them today, which had gone unnoticed. `BrowserUse`, `ExaAgent`, `ExaSearch`, `Memory`, `Planning` (`Skills` fails it for the cause-3 reason above).

Tracked in [#554](https://github.com/pydantic/pydantic-ai-harness/issues/554), except `Skills`, which is [#553](https://github.com/pydantic/pydantic-ai-harness/issues/553): `spec_params_Skills` does not exist at all, so naming the base fields would not bring it back.

Landing them green was the alternative and I did not take it, for two reasons. `Skills` is not a one-liner -- its layer-3 failure is cause 3, so layer 3 could not land fully green regardless. And adding spec fields to five capabilities is a user-facing change to each, which the repo's own Docs rule then pulls README and docs-page edits into -- a different PR's worth of surface than "guard, and fix the crash".

## Deliberate scope decisions

- **`bands` is not made spec-expressible.** A `BandSpec` TypedDict (the `BudgetSpec` precedent from #538) would need a discriminated union over four `Action` dataclasses with a recursive `then`, plus `Summarize.model`. That is a new capability surface, not a fix to a break. Tracked in [#555](https://github.com/pydantic/pydantic-ai-harness/issues/555), linked from `from_spec`'s docstring, the README and the docs page.
- **`PyaiDocs` is swept even though it is a deprecation alias.** It carries a distinct serialization name that old specs still use, so it is a real (if low-value) entry.
- **Core is not changed.** Causes 2 and 3 are both core defects -- `_get_schema_target`'s silent fallback and pydantic's silent union drop are what make the failure invisible. Neither is reimplementable in harness, and per `core-boundary.md` a core proposal is the right vehicle: [pydantic-ai#7180](https://github.com/pydantic/pydantic-ai/issues/7180), cited from this module's docstring as the upstream half. If either path stops being silent, layers 1 and 2 change character.
- **`agent_docs/` additions are a separate PR.** `from_spec`, `AgentSpec` and `get_serialization_name` appear **zero** times in `agent_docs/` today, which is why this recurred across authors. Split out per the context-file scope rule into #551; the capability-scoped README and docs page ride here.

## Verification

`make lint`, `make typecheck`, `make test` and `make testcov` all pass; branch coverage holds at 100%.
