### PR TITLE
Document `from_spec` as the published `AgentSpec` schema in `agent_docs`

### DIFF
--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -176,6 +176,12 @@ carry a `spec_<Name>` (or `short_spec_<Name>`) entry, and the properties of
 Every failure above is silent, so the generated schema is the only thing that
 answers the question.
 
+The two middle cases are silent because core swallows them: `_get_schema_target`
+catches the `NameError` and falls back, and pydantic's union handling drops a
+member it cannot schematize instead of raising. Proposed upstream in
+[pydantic-ai#7180](https://github.com/pydantic/pydantic-ai/issues/7180). Until
+that lands, generating the schema is the check.
+
 ### Policy Lives In The Pluggable Component
 
 When a capability takes a dependency behind a `Protocol` -- `PlanStore`,

--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -122,6 +122,57 @@ warnings where practical.
   editors, and stack traces (`modal_sandbox` is the reference; `filesystem` is
   0-based pending migration).
 
+### The Read Signature Is The Published Schema
+
+Core generates a capability's `AgentSpec` JSON schema from one signature:
+`from_spec` when the capability overrides it, `__init__` otherwise
+(`pydantic_ai/agent/spec.py` `_get_schema_target`, then `pydantic_ai/_spec.py`
+`build_schema_types`). A spec file points an editor at that schema with its
+`# yaml-language-server: $schema=` line, so a field missing from it is a red
+squiggle on a block that loads perfectly at runtime, and a failure in any CI
+that validates specs. Nothing fails until a user opens the file, which is why
+this has now shipped from three separate authors.
+
+Four ways a signature publishes nothing, all silent:
+
+- **Variadic parameters are dropped.** `from_spec(*args, **kwargs)` leaves no
+  type hints, so the capability publishes the bare string `"<Name>"` and no
+  fields at all.
+- **Every name in the annotations must resolve at runtime.** A
+  `TYPE_CHECKING`-only import, or a core alias whose definition is a string
+  (`ModelSelection` is `'Model | KnownModelName | str'`, resolved against *your*
+  module's globals) raises `NameError`. `_get_schema_target` catches it and
+  falls back to `AbstractCapability`'s variadic `from_spec` -- straight to the
+  previous case. Import the name at runtime, or name the parameter in
+  `from_spec` with a type a spec can express.
+- **One field type with no JSON schema deletes the whole entry.**
+  `filter_serializable_type` strips only `TypeVar` and `Callable`, so an
+  arbitrary class survives into a TypedDict built with
+  `arbitrary_types_allowed=True`. A bare `X` or a nullable `X | None` then fails
+  schema generation, and pydantic drops the entire `spec_<Name>` member from the
+  capabilities union rather than raising: every other field on that capability
+  disappears with it. (`X | <something representable>` is the benign case -- only
+  `X` is dropped.)
+- **The base fields have to be named again.** `id`, `description` and
+  `defer_loading` reach `cls()` through `**kwargs` when a `from_spec` override
+  omits them, so they keep working at runtime and never appear in the schema.
+  Name them and pass them through.
+
+`**unsupported: Any` is the sanctioned catch-all. Core drops it from the schema,
+so it costs nothing there, and it keeps a runtime-only field -- a callable, a
+live client, a store -- rejected *by name* rather than silently ignored: a spec
+that promises per-tenant scoping and does not deliver it is worse than one that
+refuses to load. `SpendLimits.from_spec` is the reference implementation;
+`ToolOutputLimits.from_spec` is the same shape for a capability whose main
+option has no spec form at all.
+
+A capability that should not be configurable from a spec overrides
+`get_serialization_name` to return `None` instead (`SubAgents`, the guardrails,
+`DynamicWorkflow`), which removes it from the registry entirely. That is the
+sanctioned opt-out; there is no allowlist.
+
+`tests/test_capability_specs.py` checks all of this for every capability.
+
 ### Policy Lives In The Pluggable Component
 
 When a capability takes a dependency behind a `Protocol` -- `PlanStore`,

--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -162,16 +162,19 @@ Four ways a signature publishes nothing, all silent:
 so it costs nothing there, and it keeps a runtime-only field -- a callable, a
 live client, a store -- rejected *by name* rather than silently ignored: a spec
 that promises per-tenant scoping and does not deliver it is worse than one that
-refuses to load. `SpendLimits.from_spec` is the reference implementation;
-`ToolOutputLimits.from_spec` is the same shape for a capability whose main
-option has no spec form at all.
+refuses to load. `SpendLimits.from_spec` is the reference implementation.
 
 A capability that should not be configurable from a spec overrides
 `get_serialization_name` to return `None` instead (`SubAgents`, the guardrails,
 `DynamicWorkflow`), which removes it from the registry entirely. That is the
 sanctioned opt-out; there is no allowlist.
 
-`tests/test_capability_specs.py` checks all of this for every capability.
+Confirm it by generating the schema rather than by reading the signature back.
+`AgentSpec.model_json_schema_with_capabilities([YourCapability])['$defs']` has to
+carry a `spec_<Name>` (or `short_spec_<Name>`) entry, and the properties of
+`spec_params_<Name>` have to include `id`, `description` and `defer_loading`.
+Every failure above is silent, so the generated schema is the only thing that
+answers the question.
 
 ### Policy Lives In The Pluggable Component
 

--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -133,7 +133,8 @@ squiggle on a block that loads perfectly at runtime, and a failure in any CI
 that validates specs. Nothing fails until a user opens the file, which is why
 this has now shipped from three separate authors.
 
-Four ways a signature publishes nothing, all silent:
+Four ways a signature silently publishes less than it should. The first three
+erase the whole entry; the fourth drops only the base fields:
 
 - **Variadic parameters are dropped.** `from_spec(*args, **kwargs)` leaves no
   type hints, so the capability publishes the bare string `"<Name>"` and no

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -100,6 +100,11 @@ README, or source code.
   explicit, tested incompatibility. Mocked lifecycle tests alone do not
   establish state continuity across activity, process, or replay boundaries.
 - Relevant protocol-shaped output is snapshotted.
+- A new or changed capability publishes its configurable fields -- including
+  `id`, `description` and `defer_loading` -- to the `AgentSpec` schema.
+  `tests/test_capability_specs.py` checks this repo-wide; see
+  `capability-authoring.md` "The Read Signature Is The Published Schema" for the
+  four ways a signature ends up publishing nothing.
 - `make lint`, `make typecheck`, and `make test` pass before handoff.
 
 ## Docs

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -103,10 +103,11 @@ README, or source code.
 - A new or changed capability publishes its configurable fields -- including
   `id`, `description` and `defer_loading` -- to the `AgentSpec` schema. Check by
   generating it:
-  `AgentSpec.model_json_schema_with_capabilities([C])['$defs']` carries
-  `spec_<Name>` with those properties. See `capability-authoring.md` "The Read
-  Signature Is The Published Schema" for the four ways a signature ends up
-  publishing nothing.
+  `AgentSpec.model_json_schema_with_capabilities([C])['$defs']` carries a
+  `spec_<Name>` entry, and `$defs['spec_params_<Name>']['properties']` covers
+  those three fields. See `capability-authoring.md` "The Read Signature Is The
+  Published Schema" for the four ways a signature ends up publishing less than
+  it should.
 - `make lint`, `make typecheck`, and `make test` pass before handoff.
 
 ## Docs

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -101,10 +101,12 @@ README, or source code.
   establish state continuity across activity, process, or replay boundaries.
 - Relevant protocol-shaped output is snapshotted.
 - A new or changed capability publishes its configurable fields -- including
-  `id`, `description` and `defer_loading` -- to the `AgentSpec` schema.
-  `tests/test_capability_specs.py` checks this repo-wide; see
-  `capability-authoring.md` "The Read Signature Is The Published Schema" for the
-  four ways a signature ends up publishing nothing.
+  `id`, `description` and `defer_loading` -- to the `AgentSpec` schema. Check by
+  generating it:
+  `AgentSpec.model_json_schema_with_capabilities([C])['$defs']` carries
+  `spec_<Name>` with those properties. See `capability-authoring.md` "The Read
+  Signature Is The Published Schema" for the four ways a signature ends up
+  publishing nothing.
 - `make lint`, `make typecheck`, and `make test` pass before handoff.
 
 ## Docs


### PR DESCRIPTION
This pull request was posted by Claude Code using claude-opus-5 on behalf of David. David directed the scope; the wording is unreviewed by him.

Documentation half of #546, split out per the standing rule that contributor-doc edits do not ride in a feature PR.

`from_spec` appears **zero** times in `agent_docs/` -- not in `capability-authoring.md`, not in `review-checklist.md`, not in `testing-capabilities.md`. `AgentSpec` and `get_serialization_name` appear nowhere either. That absence is why the same `AgentSpec`-schema defect has now shipped from three separate authors (#537, #538, and the 8 more that #546's sweep found). #546 adds the CI check; without this, the next author still meets the rule for the first time as a red build.

## `capability-authoring.md`

New subsection under `## API Design`, next to the other API rules an author reads before writing a signature:

- **The signature core reads *is* the published schema** -- `from_spec` when overridden, `__init__` otherwise, with the two core call sites named so the claim is checkable.
- **Why nothing catches it:** the schema is what an editor validates a spec block against via `# yaml-language-server: $schema=`. The block still loads at runtime, so no test and no run fails.
- **The four ways a signature publishes nothing**, each with what to do instead: variadics are dropped; every annotated name must resolve at runtime (including a core alias that is itself a string, which resolves against *your* module's globals); one field type with no JSON schema deletes the entire entry rather than raising; the base fields have to be named, or they reach `cls()` through `**kwargs` and never reach the schema.
- **`**unsupported: Any` is the sanctioned catch-all**, with `SpendLimits.from_spec` as the reference implementation.
- **The opt-out is `get_serialization_name() -> None`**, which is in code rather than in an allowlist.
- **How to confirm it**: generate the schema and look for `spec_<Name>` in `$defs` with the base fields among its properties. Every failure mode here is silent, so reading the signature back does not answer the question.
- **Why they are silent**: core swallows both middle cases -- `_get_schema_target` catches the `NameError` and falls back, and pydantic's union handling drops a member it cannot schematize instead of raising. Named as [pydantic-ai#7180](https://github.com/pydantic/pydantic-ai/issues/7180), so a reader knows generating the schema is a workaround for an upstream gap rather than a permanent ritual.

Every claim is stated as behavior of a named core symbol, not as a rule to obey, so a reader can verify it.

## `review-checklist.md`

One line under `## Tests`, carrying the same check and pointing at the section above.

## Notes

- Two markdown files. No dependency files, no code.
- `make lint`, `make typecheck` and `make test` pass. `tests/test_skill_examples.py` and the docs-parity tests read these files.
- The section title ("The Read Signature Is The Published Schema") is quoted from `review-checklist.md`, so renaming it means editing both.

## On Macroscope's finding

It was right: the first draft pointed at `tests/test_capability_specs.py`, which exists only in #546, and at `ToolOutputLimits.from_spec`, which is also only in #546.

Resolved by removing the forward references rather than by declaring a merge order. Both pages now say how to *confirm* the invariant -- generate the schema, check `$defs` for `spec_<Name>` and its base-field properties -- which is true today, stays true after #546 lands, and does not gate the guidance on a test file. It is also the stronger instruction: every failure mode in the section is silent, so the generated schema is the only thing that answers the question, and a reader who cannot run CI can still check.

The guidance itself is unchanged. This PR exists because `from_spec` appears zero times in `agent_docs`; nothing here is softened to satisfy the finding.
