### PR TITLE
Add `use_cloud` and `progress` to the `BrowserUse` capability

### DIFF
--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -230,6 +230,15 @@ origin.
   Ending a call disconnects from an attached browser rather than terminating
   it -- browser-use only kills a browser process it launched itself -- so a
   browser you manage survives `'call'` scope.
+- **Cloud browsers.** `use_cloud=True` runs each session in a
+  [Browser Use Cloud](https://cloud.browser-use.com) browser instead of a local
+  Chromium: for sites that block automated traffic, or to keep the browser off
+  the machine running the agent and fan out many in parallel. It needs a
+  `BROWSER_USE_API_KEY`, and bills for as long as the browser is alive. The
+  browser is provisioned when a session starts and released when it stops, so it
+  follows `session_scope` like a local one, and the same teardown that kills a
+  local browser on a failed or cancelled run stops a billed cloud one. The local
+  `headless` default does not apply -- a cloud browser has no local window.
 - **Telemetry.** browser-use collects anonymized telemetry by default; set
   `ANONYMIZED_TELEMETRY=false` to disable it.
 
@@ -270,6 +279,24 @@ durable execution, use the default `'call'` scope so each tool invocation owns
 its browser, and validate that composition for the durability integration you
 use; the capability does not currently include durability integration tests.
 
+## Live progress
+
+A `browse_web` call runs the sub-agent's whole loop and can take minutes with
+nothing to show for it until it returns. Set `progress` to a string sink to
+watch it work:
+
+```python
+from pydantic_ai_harness.browser_use import BrowserUse
+
+browser = BrowserUse(llm='anthropic:claude-sonnet-4-6', progress=print)
+```
+
+It reports the task when the call starts, then each step's stated goal.
+The sink is called from the sub-agent's step loop, so keep it quick and
+non-blocking. A `browser_agent` factory can set `BrowserTask.on_step` to
+something other than the narrator for anything richer, including an async
+callback.
+
 ## Instructions
 
 The capability contributes short delegation guidance to the system prompt:
@@ -301,6 +328,8 @@ BrowserUse(
     session_scope='call',        # 'call' = fresh browser per call; 'agent' = one shared session
     cdp_url=None,                # attach to a remote Chromium over CDP; overrides the profile
     guidance=None,               # host-model instructions: None = default, '' = none, str = custom
+    use_cloud=None,              # True = a Browser Use Cloud browser (needs BROWSER_USE_API_KEY)
+    progress=None,               # string sink narrating the task and each step, e.g. progress=print
     browser_agent=None,          # BrowserAgentFactory; None builds a real browser_use.Agent
 )
 ```
@@ -384,10 +413,10 @@ from pydantic_ai_harness.browser_use import BrowserUse
 agent = Agent.from_file('agent.yaml', custom_capability_types=[BrowserUse])
 ```
 
-The `llm`, `browser_profile`, `output_schema`, `agent_settings`, and
-`browser_agent` fields are not spec-serializable; spec-loaded instances use
+The `llm`, `browser_profile`, `output_schema`, `agent_settings`, `progress`,
+and `browser_agent` fields are not spec-serializable; spec-loaded instances use
 browser-use's own default model selection and browser and agent configuration,
-prose output, and the default agent factory.
+prose output, no progress reporting, and the default agent factory.
 
 The API may change between releases while the capability settles; breaking
 changes ship deprecation warnings where practical.

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -223,6 +223,15 @@ origin.
   Ending a call disconnects from an attached browser rather than terminating
   it -- browser-use only kills a browser process it launched itself -- so a
   browser you manage survives `'call'` scope.
+- **Cloud browsers.** `use_cloud=True` runs each session in a
+  [Browser Use Cloud](https://cloud.browser-use.com) browser instead of a local
+  Chromium: for sites that block automated traffic, or to keep the browser off
+  the machine running the agent and fan out many in parallel. It needs a
+  `BROWSER_USE_API_KEY`, and bills for as long as the browser is alive. The
+  browser is provisioned when a session starts and released when it stops, so it
+  follows `session_scope` like a local one, and the same teardown that kills a
+  local browser on a failed or cancelled run stops a billed cloud one. The local
+  `headless` default does not apply -- a cloud browser has no local window.
 - **Telemetry.** browser-use collects anonymized telemetry by default; set
   `ANONYMIZED_TELEMETRY=false` to disable it.
 
@@ -263,6 +272,24 @@ durable execution, use the default `'call'` scope so each tool invocation owns
 its browser, and validate that composition for the durability integration you
 use; the capability does not currently include durability integration tests.
 
+## Live progress
+
+A `browse_web` call runs the sub-agent's whole loop and can take minutes with
+nothing to show for it until it returns. Set `progress` to a string sink to
+watch it work:
+
+```python
+from pydantic_ai_harness.browser_use import BrowserUse
+
+browser = BrowserUse(llm='anthropic:claude-sonnet-4-6', progress=print)
+```
+
+It reports the task when the call starts, then each step's stated goal.
+The sink is called from the sub-agent's step loop, so keep it quick and
+non-blocking. A `browser_agent` factory can set `BrowserTask.on_step` to
+something other than the narrator for anything richer, including an async
+callback.
+
 ## Instructions
 
 The capability contributes short delegation guidance to the system prompt:
@@ -294,6 +321,8 @@ BrowserUse(
     session_scope='call',        # 'call' = fresh browser per call; 'agent' = one shared session
     cdp_url=None,                # attach to a remote Chromium over CDP; overrides the profile
     guidance=None,               # host-model instructions: None = default, '' = none, str = custom
+    use_cloud=None,              # True = a Browser Use Cloud browser (needs BROWSER_USE_API_KEY)
+    progress=None,               # string sink narrating the task and each step, e.g. progress=print
     browser_agent=None,          # BrowserAgentFactory; None builds a real browser_use.Agent
 )
 ```
@@ -377,10 +406,10 @@ from pydantic_ai_harness.browser_use import BrowserUse
 agent = Agent.from_file('agent.yaml', custom_capability_types=[BrowserUse])
 ```
 
-The `llm`, `browser_profile`, `output_schema`, `agent_settings`, and
-`browser_agent` fields are not spec-serializable; spec-loaded instances use
+The `llm`, `browser_profile`, `output_schema`, `agent_settings`, `progress`,
+and `browser_agent` fields are not spec-serializable; spec-loaded instances use
 browser-use's own default model selection and browser and agent configuration,
-prose output, and the default agent factory.
+prose output, no progress reporting, and the default agent factory.
 
 The API may change between releases while the capability settles; breaking
 changes ship deprecation warnings where practical.

--- a/pydantic_ai_harness/browser_use/__init__.py
+++ b/pydantic_ai_harness/browser_use/__init__.py
@@ -9,6 +9,7 @@ from pydantic_ai_harness.browser_use._toolset import (
     BrowserAgentHistory,
     BrowserTask,
     BrowserUseToolset,
+    StepCallback,
     default_browser_agent,
 )
 
@@ -22,6 +23,7 @@ __all__ = [
     'BrowserUseToolset',
     'ChatModelInput',
     'PydanticAIChatModel',
+    'StepCallback',
     'default_browser_agent',
     'resolve_chat_model',
 ]

--- a/pydantic_ai_harness/browser_use/_capability.py
+++ b/pydantic_ai_harness/browser_use/_capability.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Literal
 from urllib.parse import urlsplit
@@ -260,6 +261,31 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
     tests.
     """
 
+    use_cloud: bool | None = None
+    """Run each session in a [Browser Use Cloud](https://cloud.browser-use.com) browser.
+
+    For sites that block automated traffic, or to keep the browser off the
+    machine running the agent and fan out many in parallel. Needs a
+    `BROWSER_USE_API_KEY`, and bills for as long as the browser is alive. The
+    browser is provisioned when a session starts and released when it stops, so
+    it follows `session_scope` like a local one. When set, it overrides the
+    `browser_profile`'s own `use_cloud`.
+
+    The local `headless` default does not apply to a cloud session, which has no
+    local window.
+    """
+
+    progress: Callable[[str], None] | None = None
+    """Report the task and each step's stated goal as the call runs, e.g. `progress=print`.
+
+    A `browse_web` call runs the sub-agent's whole loop and can take minutes with
+    nothing to show for it until it returns. `None` reports nothing.
+
+    The sink is called from the browser agent's step loop, so keep it quick and
+    non-blocking. For anything richer than narration, a `browser_agent` factory
+    can set its own `BrowserTask.on_step`.
+    """
+
     _toolset: BrowserUseToolset[AgentDepsT] | None = field(default=None, init=False, repr=False, compare=False)
     """The cached toolset, so `'agent'`-scoped session state has one owner."""
 
@@ -329,6 +355,8 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
                 settings=self.agent_settings if self.agent_settings is not None else BrowserAgentSettings(),
                 session_scope=self.session_scope,
                 cdp_url=self.cdp_url,
+                use_cloud=self.use_cloud,
+                progress=self.progress,
             )
         return self._toolset
 
@@ -372,14 +400,16 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
         extend_system_message: str | None = None,
         session_scope: Literal['call', 'agent'] = 'call',
         cdp_url: str | None = None,
+        use_cloud: bool | None = None,
         guidance: str | None = None,
     ) -> BrowserUse[AgentDepsT]:
         """Construct the capability from serializable spec options.
 
-        The `llm`, `browser_profile`, `output_schema`, `agent_settings`, and
-        `browser_agent` fields are not spec-serializable: spec-loaded instances
-        use browser-use's own default model selection, default browser and
-        agent configuration, prose output, and the default agent factory.
+        The `llm`, `browser_profile`, `output_schema`, `agent_settings`,
+        `progress`, and `browser_agent` fields are not spec-serializable:
+        spec-loaded instances use browser-use's own default model selection,
+        default browser and agent configuration, prose output, no progress
+        reporting, and the default agent factory.
         """
         return cls(
             allowed_domains=allowed_domains,
@@ -391,5 +421,6 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
             extend_system_message=extend_system_message,
             session_scope=session_scope,
             cdp_url=cdp_url,
+            use_cloud=use_cloud,
             guidance=guidance,
         )

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from fnmatch import fnmatch
-from typing import Literal, Protocol, overload
+from typing import Literal, Protocol, TypeAlias, overload
 from urllib.parse import urlsplit
 
 import anyio
@@ -22,7 +22,9 @@ from pydantic_ai_harness.browser_use._settings import BrowserAgentSettings
 try:
     from browser_use import Agent as _BrowserUseAgent
     from browser_use import Tools
+    from browser_use.agent.views import AgentOutput
     from browser_use.browser import BrowserProfile, BrowserSession
+    from browser_use.browser.views import BrowserStateSummary
     from browser_use.llm.base import BaseChatModel
 except ImportError as _import_error:  # pragma: no cover
     raise ImportError(
@@ -118,6 +120,28 @@ async def _kill(session: BrowserSession) -> bool:
     return succeeded
 
 
+StepCallback: TypeAlias = (
+    Callable[[BrowserStateSummary, AgentOutput, int], None]
+    | Callable[[BrowserStateSummary, AgentOutput, int], Awaitable[None]]
+)
+"""A per-step observer, in the shape browser-use's `register_new_step_callback` accepts.
+
+The union mirrors browser-use's own annotation, so either a sync or an async
+callback satisfies it.
+"""
+
+
+def _narrator(sink: Callable[[str], None]) -> StepCallback:
+    """Report each step's stated goal to `sink`, for `BrowserUse.progress`."""
+
+    def narrate(browser_state_summary: BrowserStateSummary, output: AgentOutput, step_number: int) -> None:
+        goal = (output.next_goal or output.evaluation_previous_goal or '').strip()
+        if goal:
+            sink(f'  - {goal}')
+
+    return narrate
+
+
 class BrowserAgentHistory(Protocol):
     """The subset of browser-use's `AgentHistoryList` that the `browse_web` tool reads.
 
@@ -203,6 +227,14 @@ class BrowserTask:
     can forward them verbatim.
     """
 
+    on_step: StepCallback | None = None
+    """The per-step observer to forward as browser-use's `register_new_step_callback`.
+
+    Set from `BrowserUse.progress`, which narrates each step's goal; `None` when
+    no progress sink is configured. A custom factory that wants its own
+    per-step behavior can pass a different callback instead of this one.
+    """
+
 
 class BrowserAgentFactory(Protocol):
     """Builds the browser agent that `browse_web` runs for one task.
@@ -261,6 +293,7 @@ def default_browser_agent(request: BrowserTask) -> BrowserAgent:
         sensitive_data=request.sensitive_data,
         extend_system_message=request.extend_system_message,
         enable_signal_handler=False,
+        register_new_step_callback=request.on_step,
         tools=_safe_tools(settings),
         override_system_message=settings.override_system_message,
         max_failures=settings.max_failures,
@@ -325,6 +358,8 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         settings: BrowserAgentSettings,
         session_scope: Literal['call', 'agent'],
         cdp_url: str | None,
+        use_cloud: bool | None = None,
+        progress: Callable[[str], None] | None = None,
     ) -> None:
         super().__init__()
         self._browser_agent = browser_agent
@@ -348,6 +383,9 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         )
         self._session_scope: Literal['call', 'agent'] = session_scope
         self._cdp_url = cdp_url
+        self._use_cloud = use_cloud
+        self._progress = progress
+        self._on_step = _narrator(progress) if progress is not None else None
         self._shared_session: BrowserSession | None = None
         self._pending_cleanup: list[BrowserSession] = []
         self._session_closed = False
@@ -364,9 +402,11 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         `BrowserSession` itself merges a provided `browser_profile` with directly
         passed fields, letting the non-`None` direct fields win, so the
         capability's `headless`, `allowed_domains`, and `cdp_url` override the
-        profile exactly like they would on a hand-built session. `headless`
-        defaults to on only when no profile is given; a profile keeps its own
-        setting.
+        profile exactly like they would on a hand-built session. `use_cloud`
+        overrides it too, but through the profile rather than alongside it.
+        `headless` defaults to on only when no profile is given and the session
+        is not a cloud one; a profile keeps its own setting, and a cloud browser
+        has no local window for the default to mean anything.
 
         In `'agent'` scope the session is created with `keep_alive=True`:
         without it, `browser_use.Agent` kills the session at the end of each
@@ -375,7 +415,7 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         the browser regardless.
         """
         headless = self._headless
-        if headless is None and self._browser_profile is None:
+        if headless is None and self._browser_profile is None and not self._use_cloud:
             headless = True
         browser_profile = self._browser_profile
         allowed_domains = self._allowed_domains
@@ -409,6 +449,14 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
                 )
         elif browser_profile is not None:
             browser_profile = browser_profile.model_copy(update={'block_ip_addresses': False})
+        if self._use_cloud is not None:
+            # Folded into the profile rather than passed alongside it: `BrowserSession`'s
+            # overloads split cloud and local keyword arguments, so `use_cloud` and
+            # `browser_profile` cannot be passed in the same call.
+            if browser_profile is None:
+                browser_profile = BrowserProfile(use_cloud=self._use_cloud)
+            else:
+                browser_profile = browser_profile.model_copy(update={'use_cloud': self._use_cloud})
         return BrowserSession(
             cdp_url=self._cdp_url,
             browser_profile=browser_profile,
@@ -429,6 +477,7 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
                 sensitive_data=self._sensitive_data,
                 extend_system_message=self._extend_system_message,
                 settings=self._settings,
+                on_step=self._on_step,
             )
         )
         return await agent.run(max_steps=self._max_steps)
@@ -475,6 +524,8 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
             The browser agent's final text result, or JSON conforming to the
             configured output schema when one is set.
         """
+        if self._progress is not None:
+            self._progress(f'* {task}')
         if self._session_scope == 'call':
             history = await self._run_in_fresh_session(task)
         else:

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -135,7 +135,10 @@ def _narrator(sink: Callable[[str], None]) -> StepCallback:
     """Report each step's stated goal to `sink`, for `BrowserUse.progress`."""
 
     def narrate(browser_state_summary: BrowserStateSummary, output: AgentOutput, step_number: int) -> None:
-        goal = (output.next_goal or output.evaluation_previous_goal or '').strip()
+        # Stripped before the fallback, not after: a whitespace-only `next_goal` is truthy, so
+        # choosing first and stripping second would let it beat a real `evaluation_previous_goal`
+        # and then narrate nothing.
+        goal = (output.next_goal or '').strip() or (output.evaluation_previous_goal or '').strip()
         if goal:
             sink(f'  - {goal}')
 

--- a/tests/browser_use/test_browser_use.py
+++ b/tests/browser_use/test_browser_use.py
@@ -1328,6 +1328,18 @@ class TestProgress:
 
         assert reported == ['* task', '  - Read the plan table']
 
+    async def test_a_blank_next_goal_does_not_beat_the_evaluation(self, kill_calls: list[BrowserSession]) -> None:
+        """A whitespace-only `next_goal` is truthy, so it must not swallow the fallback."""
+        reported: list[str] = []
+        factory = _success_factory()
+
+        await BrowserUse[None](progress=reported.append, browser_agent=factory).get_toolset().browse_web('task')
+        on_step = factory.requests[0].on_step
+        assert on_step is not None
+        on_step(*_step(next_goal='   ', evaluation_previous_goal='Read the plan table'))
+
+        assert reported == ['* task', '  - Read the plan table']
+
     async def test_a_step_that_states_no_goal_reports_nothing(self, kill_calls: list[BrowserSession]) -> None:
         reported: list[str] = []
         factory = _success_factory()

--- a/tests/browser_use/test_browser_use.py
+++ b/tests/browser_use/test_browser_use.py
@@ -18,7 +18,12 @@ import pytest
 # tests execution environment, while submodule imports resolve correctly.
 from browser_use.agent.service import Agent as BrowserUseAgent
 from browser_use.agent.service import Tools  # pyright: ignore[reportPrivateImportUsage]
+from browser_use.agent.views import AgentOutput
 from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.browser.views import (
+    BrowserStateSummary,
+    SerializedDOMState,  # pyright: ignore[reportPrivateImportUsage]
+)
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.views import ChatInvokeCompletion
 from pydantic import BaseModel, ValidationError
@@ -1237,6 +1242,144 @@ class TestBrowserUse:
         assert [part.content for part in parts] == ['The answer is 42.']
 
 
+class TestCloudBrowser:
+    """`use_cloud` reaches the session through the profile, and suspends the local headless default."""
+
+    async def test_cloud_session_skips_the_local_headless_default(self, kill_calls: list[BrowserSession]) -> None:
+        factory = _success_factory()
+
+        await BrowserUse[None](use_cloud=True, browser_agent=factory).get_toolset().browse_web('task')
+
+        session_profile = factory.requests[0].browser_session.browser_profile
+        assert session_profile.use_cloud is True
+        # A cloud browser has no local window, so the profile keeps browser-use's own default.
+        assert session_profile.headless is BrowserProfile().headless
+        assert session_profile.block_ip_addresses is True
+
+    async def test_cloud_session_without_a_derived_profile(self, kill_calls: list[BrowserSession]) -> None:
+        """`use_cloud` builds the profile itself when nothing else has already built one."""
+        factory = _success_factory()
+        capability = BrowserUse[None](use_cloud=True, block_ip_addresses=False, browser_agent=factory)
+
+        await capability.get_toolset().browse_web('task')
+
+        session_profile = factory.requests[0].browser_session.browser_profile
+        assert session_profile.use_cloud is True
+        assert session_profile.headless is BrowserProfile().headless
+
+    async def test_cloud_overrides_the_profiles_own_setting(self, kill_calls: list[BrowserSession]) -> None:
+        profile = BrowserProfile(use_cloud=False, user_agent='harness-test')
+        factory = _success_factory()
+        capability = BrowserUse[None](browser_profile=profile, use_cloud=True, browser_agent=factory)
+
+        await capability.get_toolset().browse_web('task')
+
+        session_profile = factory.requests[0].browser_session.browser_profile
+        assert session_profile.use_cloud is True
+        assert session_profile.user_agent == 'harness-test'
+        assert profile.use_cloud is False, 'the caller-owned profile must not be mutated'
+
+    async def test_unset_use_cloud_leaves_the_profile_alone(self, kill_calls: list[BrowserSession]) -> None:
+        factory = _success_factory()
+        capability = BrowserUse[None](browser_profile=BrowserProfile(use_cloud=True), browser_agent=factory)
+
+        await capability.get_toolset().browse_web('task')
+
+        assert factory.requests[0].browser_session.browser_profile.use_cloud is True
+
+
+def _step(
+    next_goal: str = '', evaluation_previous_goal: str = '', step_number: int = 1
+) -> tuple[BrowserStateSummary, AgentOutput, int]:
+    """The arguments a `StepCallback` receives, with only the narrated fields set."""
+    state = BrowserStateSummary(
+        dom_state=SerializedDOMState(_root=None, selector_map={}),
+        url='https://example.com',
+        title='Example',
+        tabs=[],
+    )
+    output = AgentOutput(action=[], next_goal=next_goal, evaluation_previous_goal=evaluation_previous_goal)
+    return state, output, step_number
+
+
+class TestProgress:
+    """`progress` narrates the task and each step's stated goal while a call runs."""
+
+    async def test_reports_the_task_then_each_step(self, kill_calls: list[BrowserSession]) -> None:
+        reported: list[str] = []
+        factory = _success_factory()
+        capability = BrowserUse[None](progress=reported.append, browser_agent=factory)
+
+        await capability.get_toolset().browse_web('find the price of the Pro plan')
+
+        on_step = factory.requests[0].on_step
+        assert on_step is not None
+        assert on_step(*_step(next_goal='Open the pricing page')) is None
+        assert reported == ['* find the price of the Pro plan', '  - Open the pricing page']
+
+    async def test_falls_back_to_the_previous_goal_evaluation(self, kill_calls: list[BrowserSession]) -> None:
+        reported: list[str] = []
+        factory = _success_factory()
+
+        await BrowserUse[None](progress=reported.append, browser_agent=factory).get_toolset().browse_web('task')
+        on_step = factory.requests[0].on_step
+        assert on_step is not None
+        on_step(*_step(evaluation_previous_goal='Read the plan table'))
+
+        assert reported == ['* task', '  - Read the plan table']
+
+    async def test_a_step_that_states_no_goal_reports_nothing(self, kill_calls: list[BrowserSession]) -> None:
+        reported: list[str] = []
+        factory = _success_factory()
+
+        await BrowserUse[None](progress=reported.append, browser_agent=factory).get_toolset().browse_web('task')
+        on_step = factory.requests[0].on_step
+        assert on_step is not None
+        on_step(*_step(next_goal='   '))
+
+        assert reported == ['* task']
+
+    async def test_no_sink_narrates_nothing(self, kill_calls: list[BrowserSession]) -> None:
+        factory = _success_factory()
+
+        await BrowserUse[None](browser_agent=factory).get_toolset().browse_web('task')
+
+        assert factory.requests[0].on_step is None
+
+    async def test_the_callback_reaches_the_browser_agent(
+        self, monkeypatch: pytest.MonkeyPatch, kill_calls: list[BrowserSession]
+    ) -> None:
+        """The default factory forwards `on_step` as browser-use's own step callback."""
+        reported: list[str] = []
+        recording_factory = _success_factory()
+        capability = BrowserUse[None](progress=reported.append, browser_agent=recording_factory)
+        await capability.get_toolset().browse_web('task')
+        on_step = recording_factory.requests[0].on_step
+        assert on_step is not None
+
+        seen: dict[str, object] = {}
+
+        def record_init(self: object, **kwargs: object) -> None:
+            seen.update(kwargs)
+
+        monkeypatch.setattr(BrowserUseAgent, '__init__', record_init)
+        default_browser_agent(
+            BrowserTask(
+                task='task',
+                llm=None,
+                browser_session=BrowserSession(),
+                use_vision=True,
+                output_schema=None,
+                sensitive_data=None,
+                extend_system_message=None,
+                settings=BrowserAgentSettings(),
+                on_step=on_step,
+            )
+        )
+
+        assert seen['register_new_step_callback'] is on_step
+
+
 class TestAgentSpec:
     def test_spec_schema_includes_browser_use(self) -> None:
         schema = AgentSpec.model_json_schema_with_capabilities([BrowserUse])
@@ -1253,6 +1396,7 @@ class TestAgentSpec:
             extend_system_message='Stay on the English site.',
             session_scope='agent',
             cdp_url='http://localhost:9222',
+            use_cloud=True,
             guidance='Delegate.',
         )
         assert capability.allowed_domains == ['example.com']
@@ -1264,11 +1408,13 @@ class TestAgentSpec:
         assert capability.extend_system_message == 'Stay on the English site.'
         assert capability.session_scope == 'agent'
         assert capability.cdp_url == 'http://localhost:9222'
+        assert capability.use_cloud is True
         assert capability.guidance == 'Delegate.'
         assert capability.llm is None
         assert capability.browser_profile is None
         assert capability.output_schema is None
         assert capability.agent_settings is None
+        assert capability.progress is None
         assert capability.browser_agent is None
 
     def test_agent_loads_from_spec_file(self, tmp_path: Path) -> None:


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

## Summary

#419 merged before it was signed off on, so this ports the two features that
[#513](https://github.com/pydantic/pydantic-ai-harness/pull/513) had and #419
did not. #513 branched off #419 (its head branch is `browser-use-419`) and has
not been updated since 2026-07-30, so it is now behind main and conflicting;
nothing else in it is unique.

- **`use_cloud`** -- run each session in a [Browser Use Cloud](https://cloud.browser-use.com)
  browser instead of a local Chromium: for sites that block automated traffic,
  or to keep the browser off the machine running the agent and fan out many in
  parallel. Needs `BROWSER_USE_API_KEY`, and bills while the browser is alive.
  The browser is provisioned when a session starts and released when it stops,
  so it follows `session_scope` like a local one, and the existing shielded,
  timeboxed teardown stops a billed cloud browser on a failed or cancelled run.
  Spec-serializable.
- **`progress`** -- a string sink (e.g. `progress=print`) that reports the task
  when a `browse_web` call starts and then each step's stated goal. A call runs
  the sub-agent's whole loop and can take minutes with nothing to show for it
  until it returns. Wired through a new `BrowserTask.on_step` field that the
  default factory forwards as browser-use's `register_new_step_callback`.

Both fields are appended after the existing ones and default to `None`, so no
existing positional binding or behavior changes -- `browser_use` shipped in
v0.18.0, so those bindings are public now.

### Not ported from #513

- **`available_file_paths`** -- #419 removed the field and added `_safe_tools()`
  (excluding `read_file`/`upload_file`) *after* #513 branched. Restoring it
  would undo that decision; `_settings.py`'s module docstring records the
  reason, that it needs an application-specific upload-approval policy.
- **The docstring/docs rework** -- it replaced the reasoning in the docstrings
  with one-liners and added `# ruff: noqa: D415` to suppress the fallout, which
  runs against `CLAUDE.md`'s "document the why, the constraints, and the
  non-obvious".

### Implementation note

`use_cloud` is folded into the `BrowserProfile` rather than passed alongside it,
because `BrowserSession.__init__`'s two overloads split cloud and local keyword
arguments -- `use_cloud` and `browser_profile` cannot appear in the same call.
`StepCallback` mirrors browser-use's own annotation as a union of the sync and
async callable shapes, so a custom factory can set an async `on_step`.

The local `headless=True` default is skipped for a cloud session, which has no
local window.

## Linked Issue

Follow-up to #418 / #419.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)
