### PR TITLE
Restore `CodeMode` discovery announcements after compaction or history loss

### DIFF
--- a/pydantic_ai_harness/code_mode/_capability.py
+++ b/pydantic_ai_harness/code_mode/_capability.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass, field, replace
 from typing import TYPE_CHECKING, Any
@@ -10,7 +11,13 @@ from pydantic import TypeAdapter, ValidationError
 from pydantic_ai import AbstractToolset
 from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
 from pydantic_ai.capabilities._tool_search import ToolSearch as _ToolSearch
-from pydantic_ai.messages import ModelResponse, NativeToolSearchReturnPart, SystemPromptPart
+from pydantic_ai.messages import (
+    CompactionPart,
+    ModelMessage,
+    ModelResponse,
+    NativeToolSearchReturnPart,
+    SystemPromptPart,
+)
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition, ToolSelector
 from typing_extensions import TypedDict
 
@@ -26,6 +33,11 @@ _DISCOVERY_ANNOUNCEMENT_PREFIX = (
     'New functions are now available inside `run_code`. Their signatures have been '
     'added to the available-functions catalog in the system prompt'
 )
+_DISCOVERY_ANNOUNCEMENT_RE = re.compile(
+    rf'{re.escape(_DISCOVERY_ANNOUNCEMENT_PREFIX)}: '
+    r'(?P<names>`[^`]+`(?:, `[^`]+`)*)\.'
+)
+_BACKTICKED_NAME_RE = re.compile(r'`([^`]+)`')
 
 
 @dataclass
@@ -123,17 +135,26 @@ class CodeMode(AbstractCapability[AgentDepsT]):
     keeps the system prompt shorter and is the better choice.
     """
 
-    _announced_tools: set[str] = field(default_factory=set[str], init=False, repr=False)
+    _in_flight_announcements: set[str] = field(default_factory=set[str], init=False, repr=False)
 
     def get_ordering(self) -> CapabilityOrdering:
         """CodeMode wraps around ToolSearch so that search_tools stays native."""
         return CapabilityOrdering(position='outermost', wraps=[_ToolSearch])
 
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> CodeMode[AgentDepsT]:
-        """Return a fresh instance so concurrent runs don't share `_announced_tools`."""
+        """Return a fresh instance so concurrent runs don't share in-flight announcements."""
         if not self.dynamic_catalog:
             return self
         return replace(self)
+
+    async def before_model_request(
+        self,
+        ctx: RunContext[AgentDepsT],
+        request_context: ModelRequestContext,
+    ) -> ModelRequestContext:
+        """Clear announcements that the next model step has incorporated or discarded."""
+        self._in_flight_announcements.clear()
+        return request_context
 
     def get_wrapper_toolset(self, toolset: AbstractToolset[AgentDepsT]) -> AbstractToolset[AgentDepsT] | None:
         """Wrap the agent's assembled toolset, splitting it into native + sandboxed subsets if needed."""
@@ -184,16 +205,31 @@ class CodeMode(AbstractCapability[AgentDepsT]):
         return response
 
     def _announce_newly_discovered(self, ctx: RunContext[AgentDepsT], names: Sequence[str]) -> None:
-        """Enqueue a system-prompt announcement for any names we haven't already announced."""
-        fresh = [n for n in names if n not in self._announced_tools]
+        """Enqueue names absent from visible history and the current step's pending queue."""
+        announced = _visible_announced_tools(ctx.messages)
+        fresh = list(dict.fromkeys(n for n in names if n not in announced and n not in self._in_flight_announcements))
         if not fresh:
             return
-        self._announced_tools.update(fresh)
+        self._in_flight_announcements.update(fresh)
         listing = ', '.join(f'`{name}`' for name in fresh)
         # Enqueue a `SystemPromptPart` so the announcement is framed as system-level context.
         # Mid-conversation `SystemPromptPart`s are rendered inline (not hoisted to the top-level
         # system prompt) on all providers since pydantic/pydantic-ai#5509, so this is cache-safe.
         ctx.enqueue(SystemPromptPart(content=f'{_DISCOVERY_ANNOUNCEMENT_PREFIX}: {listing}.'))
+
+
+def _visible_announced_tools(messages: Sequence[ModelMessage]) -> set[str]:
+    """Read authored discovery announcements after the latest compaction boundary."""
+    announced: set[str] = set()
+    for message in reversed(messages):
+        for part in reversed(message.parts):
+            if isinstance(part, CompactionPart):
+                return announced
+            if isinstance(part, SystemPromptPart):
+                match = _DISCOVERY_ANNOUNCEMENT_RE.fullmatch(part.content)
+                if match:
+                    announced.update(_BACKTICKED_NAME_RE.findall(match.group('names')))
+    return announced
 
 
 class _DiscoveredCatalog(TypedDict):

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -12,7 +12,7 @@ import asyncio
 import functools
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar, runtime_checkable
 from unittest.mock import MagicMock
 
 import pytest
@@ -58,6 +58,11 @@ async def _close_direct_toolsets(anyio_backend: str) -> AsyncIterator[None]:
 pytestmark = pytest.mark.anyio
 
 T = TypeVar('T')
+
+
+@runtime_checkable
+class _ToolVisibilityAccessor(Protocol):
+    def visibility_of(self, tool_name: str) -> object: ...
 
 
 @pytest.fixture
@@ -1255,9 +1260,13 @@ class TestCodeMode:
         assert 'load_capability' in by_name
         assert 'run_code' in by_name
 
-        # The deferred member tool stays hidden until loaded: not folded into `run_code`
-        # and not surfaced as a plain native tool.
-        assert 'demo_tool' not in by_name
+        # The upcoming declared/visibility split retains hidden declarations in
+        # `function_tools`; use its visibility accessor when available.
+        request_parameters = model.last_model_request_parameters
+        if isinstance(request_parameters, _ToolVisibilityAccessor):
+            assert request_parameters.visibility_of('demo_tool') != 'visible'
+        else:
+            assert 'demo_tool' not in by_name
         run_code_desc = by_name['run_code'].description or ''
         assert 'demo_tool' not in run_code_desc
         assert 'load_capability' not in run_code_desc
@@ -2482,10 +2491,10 @@ class TestDynamicCatalog:
 
     async def test_for_run_returns_fresh_state_when_enabled(self) -> None:
         cap = CodeMode[object](dynamic_catalog=True)
-        cap._announced_tools.add('foo')  # pyright: ignore[reportPrivateUsage]
+        cap._in_flight_announcements.add('foo')  # pyright: ignore[reportPrivateUsage]
         fresh = await cap.for_run(build_run_context(None))
         assert fresh is not cap
-        assert fresh._announced_tools == set()  # pyright: ignore[reportPrivateUsage]
+        assert fresh._in_flight_announcements == set()  # pyright: ignore[reportPrivateUsage]
 
     async def test_for_run_returns_self_when_disabled(self) -> None:
         cap = CodeMode[object]()
@@ -2576,6 +2585,93 @@ class TestDynamicCatalog:
             )
         # Only the first discovery of `weather` announces.
         assert ctx.pending_messages is not None
+        assert len(ctx.pending_messages) == 1
+
+    async def test_announcement_in_visible_history_deduplicates_across_steps(self) -> None:
+        from pydantic_ai.messages import ModelRequest, ToolCallPart
+
+        cap = CodeMode[object](dynamic_catalog=True)
+        ctx = build_run_context(None)
+        result = {'discovered_tools': [{'name': 'weather'}]}
+        await cap.after_tool_execute(
+            ctx,
+            call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c1'),
+            tool_def=_search_tool_def(),
+            args={},
+            result=result,
+        )
+        assert ctx.pending_messages is not None
+        [announcement] = ctx.pending_messages[0].messages
+        assert isinstance(announcement, ModelRequest)
+        ctx.messages.append(announcement)
+        ctx.pending_messages.clear()
+
+        await cap.before_model_request(ctx, request_context=None)  # pyright: ignore[reportArgumentType]
+        await cap.after_tool_execute(
+            ctx,
+            call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c2'),
+            tool_def=_search_tool_def(),
+            args={},
+            result=result,
+        )
+
+        assert ctx.pending_messages == []
+
+    async def test_compaction_boundary_allows_announcement_again(self) -> None:
+        from pydantic_ai.messages import CompactionPart, ModelRequest, ModelResponse, ToolCallPart
+
+        cap = CodeMode[object](dynamic_catalog=True)
+        ctx = build_run_context(None)
+        result = {'discovered_tools': [{'name': 'weather'}]}
+        await cap.after_tool_execute(
+            ctx,
+            call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c1'),
+            tool_def=_search_tool_def(),
+            args={},
+            result=result,
+        )
+        assert ctx.pending_messages is not None
+        [announcement] = ctx.pending_messages[0].messages
+        assert isinstance(announcement, ModelRequest)
+        ctx.messages.extend([announcement, ModelResponse(parts=[CompactionPart()])])
+        ctx.pending_messages.clear()
+
+        await cap.before_model_request(ctx, request_context=None)  # pyright: ignore[reportArgumentType]
+        await cap.after_tool_execute(
+            ctx,
+            call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c2'),
+            tool_def=_search_tool_def(),
+            args={},
+            result=result,
+        )
+
+        assert len(ctx.pending_messages) == 1
+
+    async def test_dropped_announcement_is_enqueued_again(self) -> None:
+        from pydantic_ai.messages import ToolCallPart
+
+        cap = CodeMode[object](dynamic_catalog=True)
+        ctx = build_run_context(None)
+        result = {'discovered_tools': [{'name': 'weather'}]}
+        await cap.after_tool_execute(
+            ctx,
+            call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c1'),
+            tool_def=_search_tool_def(),
+            args={},
+            result=result,
+        )
+        assert ctx.pending_messages is not None
+        ctx.pending_messages.clear()  # A history processor omitted the authored announcement.
+
+        await cap.before_model_request(ctx, request_context=None)  # pyright: ignore[reportArgumentType]
+        await cap.after_tool_execute(
+            ctx,
+            call=ToolCallPart(tool_name='search_tools', args={}, tool_call_id='c2'),
+            tool_def=_search_tool_def(),
+            args={},
+            result=result,
+        )
+
         assert len(ctx.pending_messages) == 1
 
     # -- discovery announcement: native search path -----------------------


### PR DESCRIPTION
With `dynamic_catalog=True`, `_announced_tools` was a run-lifetime in-memory set: after a `CompactionPart` (or a history processor dropping the announcement `SystemPromptPart`s), the model lost the announcement but the set still remembered it — so a rediscovered tool's catalog entry was never re-announced. Found while verifying CodeMode against pydantic-ai's tool-reveal endgame (pydantic/pydantic-ai#7104) and compaction follow-up (pydantic/pydantic-ai#7225), but the history-processor variant reproduces against pinned main today.

Announced-state is now derived from visible history — announcements parsed from our own authored format, scanning in reverse and stopping at the latest `CompactionPart`, mirroring core's `parse_discovered_tools` — plus a small in-flight set (cleared each step) for same-step dedup before the enqueued part lands. Re-announcing when compaction or a processor removed the original is deliberate and tested; same-run dedup without compaction is unchanged.

Also makes the deferred-capability assertion in `test_code_mode.py` compatible with the upcoming pydantic-ai declared/visibility split (pydantic/pydantic-ai#7104), where a hidden tool stays in `function_tools` with non-`'visible'` visibility instead of being absent.

Full suite: 4507 passed. The boundary behavior is mutation-verified (ignoring the compaction boundary in the scan fails the re-announce test).