### PR TITLE
Add a compile-tested gh-aw engine definition for a `pydantic-ai` behavior-defined engine

### DIFF
--- a/.github/workflows/shared/pydantic-ai-engine.md
+++ b/.github/workflows/shared/pydantic-ai-engine.md
@@ -1,0 +1,51 @@
+---
+runtimes:
+  uv: {}
+pre-agent-steps:
+  - name: Install Pydantic AI Harness CLI
+    run: |
+      uv tool install --quiet "pydantic-ai-harness==0.1.0"
+      pydantic-harness --version
+engine:
+  id: pydantic-ai
+  display-name: Pydantic AI
+  description: Pydantic AI Harness coding agent CLI running in non-interactive mode
+  experimental: true
+  mcp: false
+  provider:
+    name: github
+  behaviors:
+    secret-strategy: universal-llm-consumer
+    capabilities:
+      tools-allowlist: false
+      max-turns: true
+      web-search: false
+    network:
+      defaults:
+        - host.docker.internal
+        - github.com
+        - raw.githubusercontent.com
+        - api.github.com
+        - objects.githubusercontent.com
+        - pypi.org
+        - files.pythonhosted.org
+      provider-domains:
+        copilot: api.githubcopilot.com
+        anthropic: api.anthropic.com
+        openai: api.openai.com
+    execution:
+      command-name: pydantic-harness
+      args:
+        - --no-color
+      step-name: Execute Pydantic AI Harness CLI
+      model-env-var: PYDANTIC_AI_MODEL
+      provider-env-mode: universal-llm-consumer
+      write-timestamp: true
+---
+
+<!--
+# Pydantic AI Harness CLI
+
+Shared engine definition for the Pydantic AI Harness coding agent.
+Import this file and set `engine: id: pydantic-ai` to use it.
+-->

--- a/.github/workflows/smoke-pydantic-ai.md
+++ b/.github/workflows/smoke-pydantic-ai.md
@@ -1,0 +1,22 @@
+---
+name: Smoke Pydantic AI
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+model: copilot/claude-sonnet-4-5
+engine:
+  id: pydantic-ai
+imports:
+  - shared/pydantic-ai-engine.md
+network:
+  allowed: []
+tools:
+  bash:
+    - "*"
+timeout-minutes: 10
+---
+
+# Smoke Test: Pydantic AI Engine
+
+Run `git log --oneline -1` and report the resulting commit line. Keep the output to one line.


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

(David directed this work and lightly reviewed it.)

## What this is

The seed of the gh-aw (GitHub Agentic Workflows) integration: an owner-maintained
behavior-defined engine definition for a `pydantic-ai` engine, plus a minimal smoke
workflow that imports it. This is the shape gh-aw maintainers asked for when a Go-level
pydantic engine was proposed and closed ([github/gh-aw#45493](https://github.com/github/gh-aw/pull/45493):
"as a shared agentic workflow, not in the go compiler/code") -- third-party engines are
markdown definition files published in the engine owner's repo and imported pinned to a tag
([engines reference](https://github.github.io/gh-aw/reference/engines/)).

## What is verified

Both files compile clean with `gh aw compile --strict` on gh-aw **v0.85.4** (latest stable).
Bisected against release binaries: imported new engine ids are rejected up to v0.84.3 and work
from v0.84.4 (the fix landed via [github/gh-aw#50145](https://github.com/github/gh-aw/pull/50145)).
Cross-repo pinned imports (`owner/repo/path.md@tag`) were separately verified to resolve and
vendor correctly. The files are committed byte-identical to what was tested.

## What is placeholder (why this is a draft)

- `pydantic-harness`, the headless coding-agent CLI the definition invokes, **does not exist
  yet** -- the harness currently ships no console entry point. The CLI design is being worked
  out; this PR pins the compile-level contract it must satisfy.
- The `pydantic-ai-harness==0.1.0` version pin in the install step is a placeholder.
- `mcp: false` matches what was tested; the design intent is `mcp: true` (Pydantic AI has a
  real MCP client, so MCP servers and gh-aw safe outputs can flow through the MCP gateway
  instead of CLI-proxy shims).
- No `.lock.yml` is committed, so the smoke workflow cannot run on Actions yet.

Constraints research, empirical findings, and the design discussion live with the branch;
the public announcement issue on github/gh-aw links here.
