### PR TITLE
Fix `Planning` cache-point order

### DIFF
--- a/docs/planning.md
+++ b/docs/planning.md
@@ -30,10 +30,10 @@ Long agentic runs drift: the model loses track of what it set out to do and what
 
 ## The solution
 
-The model owns the plan through the `planning` toolset. The current plan is surfaced back as an ephemeral reminder appended to the tail of each request, behind a cache breakpoint:
+The model owns the plan through the `planning` toolset. The current plan is surfaced back as an ephemeral reminder appended to the tail of each request, with a cache breakpoint after its stable opening tag:
 
 - The reminder is added after the durable history is persisted, so it reaches the model but is never written to `message_history`. No reminders accumulate across turns.
-- A `CachePoint` is placed immediately before the reminder, so the cached prefix (tools + system + real conversation) stays byte-identical turn over turn. Only the reminder falls outside the cache.
+- A `CachePoint` follows the stable `<plan-reminder>` opening tag, so the cached prefix (tools + system + real conversation + that tag) stays byte-identical turn over turn. Only the mutable reminder content falls outside the cache.
 
 ## Usage
 
@@ -157,7 +157,7 @@ Addressing steps by mutable integer index (insert/remove/reorder) is error-prone
 
 ## Caching guarantee
 
-The plan is never injected into the system prompt or instructions. Static usage guidance goes there (cache-stable); only the mutable plan rides the ephemeral tail reminder, which lives solely in the per-request copy and is never persisted. Set `inject=False` to disable it. `CachePoint` is supported on Anthropic and Amazon Bedrock; on providers without prompt caching it is simply ignored.
+The plan is never injected into the system prompt or instructions. Static usage guidance goes there (cache-stable); only the mutable plan rides the ephemeral tail reminder, which lives solely in the per-request copy and is never persisted. Set `inject=False` to disable it. Pydantic AI maps `CachePoint` for models whose profiles support prompt caching; on other models it is ignored.
 
 ## Configuration
 
@@ -166,7 +166,7 @@ from pydantic_ai_harness.planning import Planning
 
 Planning(
     guidance=None,           # static system-prompt guidance; None = default, '' = omit
-    cache_ttl='5m',          # TTL for the cache breakpoint before the reminder ('5m' | '1h')
+    cache_ttl='5m',          # TTL for the cache breakpoint after the stable opening tag ('5m' | '1h')
     store=None,              # None = fresh in-memory plan per run; or a PlanStore to persist
     enable_subtasks=False,   # add subtask/dependency tools and the 'blocked' status
     inject=True,             # surface the current plan as a cache-safe tail reminder

--- a/pydantic_ai_harness/planning/README.md
+++ b/pydantic_ai_harness/planning/README.md
@@ -22,10 +22,10 @@ Long agentic runs drift: the model loses track of what it set out to do and what
 
 ## The solution
 
-`Planning` gives the model a small toolset that owns the plan. The current plan is surfaced back to the model as an *ephemeral* reminder appended to the tail of each request, behind a cache breakpoint:
+`Planning` gives the model a small toolset that owns the plan. The current plan is surfaced back to the model as an *ephemeral* reminder appended to the tail of each request, with a cache breakpoint after its stable opening tag:
 
 - The reminder is added after the durable history is persisted, so it reaches the model but is never written to `message_history`. No reminders accumulate across turns.
-- A `CachePoint` is placed immediately *before* the reminder, so the cached prefix (tools + system + real conversation) stays byte-identical turn over turn. Only the reminder falls outside the cache.
+- A `CachePoint` follows the stable `<plan-reminder>` opening tag, so the cached prefix (tools + system + real conversation + that tag) stays byte-identical turn over turn. Only the mutable reminder content falls outside the cache.
 
 So the plan stays current in the model's view while the cached prefix is never invalidated; the only added cost is re-reading the reminder each turn.
 
@@ -146,7 +146,7 @@ Addressing steps by mutable integer index (insert/remove/reorder) is error-prone
 
 ## Caching guarantee
 
-The plan is never injected into the system prompt or instructions. Static usage guidance goes there (cache-stable); only the mutable plan rides the ephemeral tail reminder. Set `inject=False` to disable the reminder entirely. `CachePoint` is supported on Anthropic and Amazon Bedrock; on providers without prompt caching it's simply ignored.
+The plan is never injected into the system prompt or instructions. Static usage guidance goes there (cache-stable); only the mutable plan rides the ephemeral tail reminder. Set `inject=False` to disable the reminder entirely. Pydantic AI maps `CachePoint` for models whose profiles support prompt caching; on other models it is ignored.
 
 ## Configuration
 
@@ -155,7 +155,7 @@ from pydantic_ai_harness.planning import Planning
 
 Planning(
     guidance=None,           # static system-prompt guidance; None = default, '' = omit
-    cache_ttl='5m',          # TTL for the cache breakpoint before the reminder ('5m' | '1h')
+    cache_ttl='5m',          # TTL for the cache breakpoint after the stable opening tag ('5m' | '1h')
     store=None,              # None = fresh in-memory plan per run; or a PlanStore to persist
     enable_subtasks=False,   # add subtask/dependency tools and the 'blocked' status
     inject=True,             # surface the current plan as a cache-safe tail reminder

--- a/pydantic_ai_harness/planning/_capability.py
+++ b/pydantic_ai_harness/planning/_capability.py
@@ -51,10 +51,10 @@ class Planning(AbstractCapability[AgentDepsT]):
     `add_task`, `update_task_status`, `update_task_statuses`, `remove_task`, and
     -- when `enable_subtasks` is set -- `add_subtask`, `set_dependency`,
     `get_available_tasks`); `tools` narrows that surface to an allowlist. The
-    current plan is surfaced back as an *ephemeral*
-    reminder appended to the tail of each request behind a `CachePoint`, so the
-    cached prefix stays byte-identical across turns; only the reminder is
-    re-read each turn.
+    current plan is surfaced back as an *ephemeral* reminder appended to the
+    tail of each request. Its cache-stable opening tag precedes a `CachePoint`,
+    so the cached prefix stays byte-identical across turns; only the mutable
+    plan content is re-read each turn.
 
     By default the plan lives in memory for the duration of a single run (a
     fresh, isolated plan per run). Pass a `store` (or `store_resolver`) to
@@ -85,7 +85,7 @@ class Planning(AbstractCapability[AgentDepsT]):
     """
 
     cache_ttl: Literal['5m', '1h'] = '5m'
-    """TTL for the cache breakpoint placed before the plan reminder."""
+    """TTL for the cache breakpoint placed after the stable plan-reminder opening tag."""
 
     store: PlanStore | None = None
     """Storage backend. `None` keeps a fresh in-memory plan per run (the original
@@ -168,7 +168,7 @@ class Planning(AbstractCapability[AgentDepsT]):
         request_context: ModelRequestContext,
         handler: WrapModelRequestHandler,
     ) -> ModelResponse:
-        """Append the current plan as an ephemeral tail reminder behind a cache breakpoint."""
+        """Append the current plan as an ephemeral tail reminder with a cache breakpoint."""
         if not self.inject:
             return await handler(request_context)
         items = await self.resolve_store(ctx).get_items()
@@ -177,7 +177,9 @@ class Planning(AbstractCapability[AgentDepsT]):
         messages = request_context.messages
         last = messages[-1]
         if isinstance(last, ModelRequest):
-            reminder = UserPromptPart(content=[CachePoint(ttl=self.cache_ttl), _reminder_text(render_plan(items))])
+            reminder = UserPromptPart(
+                content=['<plan-reminder>\n', CachePoint(ttl=self.cache_ttl), _reminder_text(render_plan(items))]
+            )
             messages[-1] = replace(last, parts=[*last.parts, reminder])
         return await handler(request_context)
 
@@ -224,4 +226,4 @@ class Planning(AbstractCapability[AgentDepsT]):
 
 
 def _reminder_text(plan: str) -> str:
-    return f'<plan-reminder>\nYour current plan (keep it updated with the planning tools):\n\n{plan}\n</plan-reminder>'
+    return f'Your current plan (keep it updated with the planning tools):\n\n{plan}\n</plan-reminder>'

--- a/tests/planning/test_planning.py
+++ b/tests/planning/test_planning.py
@@ -926,10 +926,10 @@ class TestReminder:
         reminder = cast(UserPromptPart, seen[-1].parts[-1])
         content = reminder.content
         assert isinstance(content, list)
-        assert isinstance(content[0], CachePoint)
-        assert content[0].ttl == '1h'
-        assert '<plan-reminder>' in cast(str, content[1])
-        assert 'Do X' in cast(str, content[1])
+        assert content[0] == '<plan-reminder>\n'
+        assert isinstance(content[1], CachePoint)
+        assert content[1].ttl == '1h'
+        assert 'Do X' in cast(str, content[2])
 
     async def test_last_not_model_request_passthrough(self) -> None:
         store = InMemoryPlanStore()
@@ -982,6 +982,17 @@ class TestEndToEnd:
         )
         assert '<plan-reminder>' in sent
         assert 'Step A' in sent
+        reminder = next(
+            part
+            for message in captured['messages']
+            for part in message.parts
+            if isinstance(part, UserPromptPart)
+            and isinstance(part.content, list)
+            and '<plan-reminder>\n' in part.content
+        )
+        assert reminder.content[0] == '<plan-reminder>\n'
+        assert isinstance(reminder.content[1], CachePoint)
+        assert 'Step A' in cast(str, reminder.content[2])
         # ephemeral: never written to durable history
         durable = '\n'.join(
             part.content


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

## Summary

- Put a stable `<plan-reminder>` opening tag before `Planning`'s `CachePoint`, so provider mappers never receive a breakpoint as the first item in an injected user prompt.
- Preserve the cache boundary: only the mutable plan body follows the breakpoint.
- Add the regression assertion to the public Agent planning flow and align the Planning docs.

## Boundary notes

Pydantic AI maps each `UserPromptPart` independently for OpenAI-compatible and Bedrock providers, so a cache breakpoint needs earlier content in the same part. A no-network OpenAI Responses run with a fake client now makes both model calls and maps the second plan reminder with the breakpoint on its stable opening tag.

## Linked Issue

Fixes #438

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)