### PR TITLE
Read deferred-tool hiddenness from visibility, not absence

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,17 @@ filterwarnings = [
     "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning",
     # Experimental capabilities warn on import by design; assert it explicitly where it matters.
     'ignore::pydantic_ai_harness.experimental.HarnessExperimentalWarning',
+    # pydantic-settings 2.15 started warning about models whose annotations hold unresolved
+    # forward references, and `mcp`'s `FastMCP` settings model has one on `lifespan` (it refers
+    # to `FastMCP`, defined later in that module). Neither model is ours, and the field is not a
+    # settings source we read. Transitive, so it reaches the floor job first — `lowest-direct`
+    # pins our direct deps but still resolves pydantic-settings to latest.
+    #
+    # Matched on message rather than `ignore::pydantic_settings.exceptions.IncompleteFieldDefinitionWarning`:
+    # the class doesn't exist before 2.15, and a category filter naming a class pytest can't
+    # import fails collection outright — which would break every job resolving an older
+    # pydantic-settings, including the locked one.
+    "ignore:Field '.*' has an incomplete definition",
 ]
 anyio_mode = 'auto'
 

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -1267,7 +1267,7 @@ class TestCodeMode:
         request_parameters = model.last_model_request_parameters
         if isinstance(request_parameters, _ToolVisibilityAccessor):
             assert request_parameters.visibility_of('demo_tool') != 'visible'
-        else:
+        else:  # pragma: no cover - only the `lowest-versions` floor lacks the accessor
             assert 'demo_tool' not in by_name
         run_code_desc = by_name['run_code'].description or ''
         assert 'demo_tool' not in run_code_desc

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -12,7 +12,7 @@ import asyncio
 import functools
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, TypeVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -58,11 +58,6 @@ async def _close_direct_toolsets(anyio_backend: str) -> AsyncIterator[None]:
 pytestmark = pytest.mark.anyio
 
 T = TypeVar('T')
-
-
-@runtime_checkable
-class _ToolVisibilityAccessor(Protocol):
-    def visibility_of(self, tool_name: str) -> object: ...
 
 
 @pytest.fixture
@@ -1261,14 +1256,12 @@ class TestCodeMode:
         assert 'run_code' in by_name
 
         # The deferred member tool stays hidden until loaded: not folded into `run_code`
-        # and not surfaced as a plain native tool. Since the declared/visibility split,
-        # `function_tools` retains hidden declarations, so hiddenness is read from the
-        # visibility accessor rather than from the name being absent.
-        request_parameters = model.last_model_request_parameters
-        if isinstance(request_parameters, _ToolVisibilityAccessor):
-            assert request_parameters.visibility_of('demo_tool') != 'visible'
-        else:  # pragma: no cover - only the `lowest-versions` floor lacks the accessor
-            assert 'demo_tool' not in by_name
+        # and not surfaced as a plain native tool. Assert on reveal state rather than on the
+        # name being absent from `function_tools` -- once pydantic-ai splits declaration from
+        # visibility, `function_tools` keeps the hidden declaration and only the reveal set
+        # distinguishes the two. `revealed_tool_names` means the same thing on both sides of
+        # that change, so this holds without version-sniffing.
+        assert 'demo_tool' not in model.last_model_request_parameters.revealed_tool_names
         run_code_desc = by_name['run_code'].description or ''
         assert 'demo_tool' not in run_code_desc
         assert 'load_capability' not in run_code_desc

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -12,7 +12,7 @@ import asyncio
 import functools
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar, runtime_checkable
 from unittest.mock import MagicMock
 
 import pytest
@@ -58,6 +58,11 @@ async def _close_direct_toolsets(anyio_backend: str) -> AsyncIterator[None]:
 pytestmark = pytest.mark.anyio
 
 T = TypeVar('T')
+
+
+@runtime_checkable
+class _ToolVisibilityAccessor(Protocol):
+    def visibility_of(self, tool_name: str) -> object: ...
 
 
 @pytest.fixture
@@ -1256,8 +1261,14 @@ class TestCodeMode:
         assert 'run_code' in by_name
 
         # The deferred member tool stays hidden until loaded: not folded into `run_code`
-        # and not surfaced as a plain native tool.
-        assert 'demo_tool' not in by_name
+        # and not surfaced as a plain native tool. Since the declared/visibility split,
+        # `function_tools` retains hidden declarations, so hiddenness is read from the
+        # visibility accessor rather than from the name being absent.
+        request_parameters = model.last_model_request_parameters
+        if isinstance(request_parameters, _ToolVisibilityAccessor):
+            assert request_parameters.visibility_of('demo_tool') != 'visible'
+        else:
+            assert 'demo_tool' not in by_name
         run_code_desc = by_name['run_code'].description or ''
         assert 'demo_tool' not in run_code_desc
         assert 'load_capability' not in run_code_desc


### PR DESCRIPTION
Closes #572.

`test on latest pydantic-ai` fails `TestCodeMode::test_deferred_capability_loader_stays_native_with_tools_all` against current Pydantic AI. This is a stale assertion, not a core regression.

Measured directly against Pydantic AI main (`f9cd74f8e`), with a deferred capability and `CodeMode(tools='all')`:

```
function_tools: ['demo_tool', 'load_capability', 'run_code']
visibility_of('demo_tool'): withheld
```

The tool is still withheld from the wire — the behaviour #276 protects is intact. What changed is that since the declared/visibility split, `function_tools` **retains** hidden declarations and hiddenness is expressed through `visibility_of` rather than by the name being absent. So the assertion that `demo_tool` is not in `function_tools` no longer describes "hidden".

This reads hiddenness from the visibility accessor, guarded behind a runtime-checkable protocol so the test still passes against a Pydantic AI that predates it. Same accommodation already written in #562; lifting it to `main` on its own so every open branch stops failing this job while that PR is in flight.

Verified: `tests/code_mode/` is 130 passed against both the locked Pydantic AI and Pydantic AI main.
