### PR TITLE
Resolve `FastMCP` settings before StackOne test fixtures

### DIFF
--- a/tests/stackone/conftest.py
+++ b/tests/stackone/conftest.py
@@ -45,8 +45,9 @@ def _fastmcp_server(name: str) -> FastMCP:
     """Create a test FastMCP server after resolving its settings forward references."""
     from mcp.server.fastmcp.server import FastMCP, Settings
 
-    # `pydantic-settings` 2.15 treats FastMCP's unresolved `lifespan` annotation as an error under this
-    # suite's warnings policy. Resolve it before the local test server reads its settings.
+    # The `mcp` SDK leaves the `lifespan` annotation on `Settings` as an unresolved forward reference,
+    # and `pydantic-settings` >= 2.15 warns about that at construction, which this suite's `error`
+    # warnings policy escalates. Drop the rebuild once `mcp` resolves the annotation itself.
     Settings.model_rebuild()
     return FastMCP(name)
 

--- a/tests/stackone/conftest.py
+++ b/tests/stackone/conftest.py
@@ -41,12 +41,20 @@ def run_context() -> RunContext[None]:
     )
 
 
+def _fastmcp_server(name: str) -> FastMCP:
+    """Create a test FastMCP server after resolving its settings forward references."""
+    from mcp.server.fastmcp.server import FastMCP, Settings
+
+    # `pydantic-settings` 2.15 treats FastMCP's unresolved `lifespan` annotation as an error under this
+    # suite's warnings policy. Resolve it before the local test server reads its settings.
+    Settings.model_rebuild()
+    return FastMCP(name)
+
+
 @pytest.fixture
 def stackone_server() -> FastMCP:
     """In-process stand-in for StackOne's MCP endpoint in `individual` tool mode."""
-    from mcp.server.fastmcp import FastMCP
-
-    server = FastMCP('stackone-fake')
+    server = _fastmcp_server('stackone-fake')
 
     @server.tool()
     def bamboohr_list_employees(limit: int = 10) -> list[dict[str, str]]:
@@ -69,9 +77,7 @@ def stackone_server() -> FastMCP:
 @pytest.fixture
 def search_execute_server() -> FastMCP:
     """In-process stand-in for StackOne's MCP endpoint in `search_execute` tool mode."""
-    from mcp.server.fastmcp import FastMCP
-
-    server = FastMCP('stackone-fake-search')
+    server = _fastmcp_server('stackone-fake-search')
 
     @server.tool()
     def bamboohr_search_actions(query: str, top_k: int = 10) -> list[dict[str, str]]:


### PR DESCRIPTION
## Summary

Resolve FastMCP's `Settings` model before shared StackOne fixtures construct local servers. With FastMCP 3.4.5 and pydantic-settings 2.15.0, the unresolved `lifespan` annotation becomes an error under the suite warnings policy.

This is test-fixture-only compatibility work. Runtime code, dependency constraints, and the lockfile are unchanged.

## Linked Issue

Fixes #571

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests updated for the compatibility behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] `make testcov` passes locally with 100% coverage
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)

## AI assistance

Prepared with AI assistance. The reproduction, diff, and validation reported above were verified in the checked-out repository.