### PR TITLE
Add `ToolErrorRecovery` capability

### DIFF
--- a/pydantic_ai_harness/tool_error_recovery/README.md
+++ b/pydantic_ai_harness/tool_error_recovery/README.md
@@ -1,0 +1,88 @@
+# Tool Error Recovery
+
+Recover from tool-call errors -- retry, report to the model, fall back, or propagate -- instead of crashing the agent run.
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/tool_error_recovery/)
+
+## Motivation
+
+Agentic tool calling can fail for many reasons, and adding error handling and retries to every tool is cumbersome. For third-party tools and MCPs, it's often impossible. `ToolErrorRecovery` is a standardized capability for AI agents to recover from errors during tool calls. Similar in spirit to [FastAPI's exception handlers](https://fastapi.tiangolo.com/tutorial/handling-errors/#install-custom-exception-handlers), but for agents.
+
+## Quick start
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.tool_error_recovery import ToolErrorRecovery
+
+agent = Agent('openai:gpt-5', capabilities=[ToolErrorRecovery()])
+```
+
+Out of the box, connection errors are retried, bugs are propagated, and everything else is reported to the model, preventing a crash of the agent run. Continue reading to learn how to customize the capability.
+
+## Features
+
+The `ToolErrorRecovery` capability supports four different recovery outcomes:
+
+| Outcome       | Effect                                                                       |
+| ------------- | ---------------------------------------------------------------------------- |
+| **retry**     | Re-attempt the tool call a number of times (invisible to the model)          |
+| **inform**    | Report a terminal failure to the model via `ToolFailed` (`outcome='failed'`) |
+| **fallback**  | Return a substitute value as the tool result                                 |
+| **propagate** | Re-raise the exception, will crash the run unless caught by another wrapper  |
+
+## Error Classification
+
+`ToolErrorRecovery` intercepts tool execution errors and applies a per-error reaction. A `classify` callable you supply inspects each failure and returns the intended recovery outcome:
+
+```python
+def classify(ctx: RunContext[Any], call: ToolCallPart, error: BaseException) -> RecoveryOutcome:
+    if isinstance(error, SomeException):
+        return RecoveryOutcome.inform(...)
+    # and so on
+```
+
+Notes:
+
+- You can classify on a tool's name and other properties of the tool call, on the exception type, or both.
+- The `ctx: RunContext` parameter is included for cases in which your classification logic additionally depends on the run context.
+- To not interfere with existing error handling, the following exceptions from the Pydantic AI control flow are never classified: `SkipToolExecution`, `CallDeferred`, `ApprovalRequired`, `ModelRetry`, `ToolRetryError`, `ToolFailed`, and `ToolFailedError`. Note that this list is hardcoded for now and would require updating if Pydantic AI changes their control flow exceptions.
+- Special care must be taken when classifying an exception which is a subclass, be careful about the order of `isinstance(...)` calls, or use `type(...) is` instead.
+
+## Default Behaviour
+
+As mentioned above, control flow exceptions are never classified. Our default classifier is:
+
+```python
+def classify(ctx: RunContext[Any], call: ToolCallPart, error: BaseException) -> RecoveryOutcome:
+    if isinstance(error, DEFAULT_BUG_TYPES):
+        return RecoveryOutcome.propagate()
+    if isinstance(error, HookTimeoutError):
+        return RecoveryOutcome.inform()
+    if isinstance(error, DEFAULT_TRANSIENT_TYPES):
+        return RecoveryOutcome.retry(3)
+    return RecoveryOutcome.inform()
+```
+
+The classification function is the key piece required to construct your own RecoveryPolicy via `RecoveryPolicy(classify=classify)`. A fully custom example could look like this:
+
+```python {test="skip"}
+from pydantic_ai import Agent
+from pydantic_ai_harness.tool_error_recovery import RecoveryPolicy, ToolErrorRecovery
+
+def classify(...):
+    # your classification logic
+
+agent = Agent('openai:gpt-5', capabilities=[
+    ToolErrorRecovery(
+        policy=RecoveryPolicy(
+            classify=classify,
+            format_error=my_formatter,
+            max_message_len=450,
+            include_traceback=False,
+            logger=my_logger,
+        ),
+        max_recoveries=10,
+        per_tool_recoveries={"my_tool_name": 5},
+    )
+])
+```

--- a/pydantic_ai_harness/tool_error_recovery/__init__.py
+++ b/pydantic_ai_harness/tool_error_recovery/__init__.py
@@ -1,0 +1,42 @@
+"""Tool-call error recovery for Pydantic AI agents.
+
+Turns failures into graceful degradation without hiding bugs.
+
+Governing principle: recovery splits the user surface (made quieter) from the
+operator surface (made louder). It is never *silence* -- a recovered failure always
+stays visible in the log. Genuine bugs are never disguised as success; only
+expected/operational failures are smoothed over.
+
+Public API:
+
+- `RecoveryOutcome` -- the verdict for a failed tool call (retry / inform / fallback / propagate).
+- `RecoveryPolicy` -- classify + render + log.
+- `make_default_classify` / `default_classify` -- a conservative built-in classifier.
+- `ToolErrorRecovery` -- recover from tool execution errors.
+"""
+
+from pydantic_ai_harness.tool_error_recovery._capability import ToolErrorRecovery
+from pydantic_ai_harness.tool_error_recovery._outcome import (
+    DEFAULT_BUG_TYPES,
+    DEFAULT_TRANSIENT_TYPES,
+    RecoveryOutcome,
+)
+from pydantic_ai_harness.tool_error_recovery._policy import (
+    ErrorFormatter,
+    RecoveryClassifier,
+    RecoveryPolicy,
+    default_classify,
+    make_default_classify,
+)
+
+__all__ = [
+    'DEFAULT_BUG_TYPES',
+    'DEFAULT_TRANSIENT_TYPES',
+    'ErrorFormatter',
+    'RecoveryClassifier',
+    'RecoveryOutcome',
+    'RecoveryPolicy',
+    'ToolErrorRecovery',
+    'default_classify',
+    'make_default_classify',
+]

--- a/pydantic_ai_harness/tool_error_recovery/_capability.py
+++ b/pydantic_ai_harness/tool_error_recovery/_capability.py
@@ -1,0 +1,202 @@
+"""The capability class: `ToolErrorRecovery`."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable, Generator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+import anyio
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.exceptions import (
+    ApprovalRequired,
+    CallDeferred,
+    ModelRetry,
+    SkipToolExecution,
+    ToolFailed,
+    ToolFailedError,
+    ToolRetryError,
+)
+from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.tools import AgentDepsT, ToolDefinition
+
+from pydantic_ai_harness.tool_error_recovery._outcome import RecoveryOutcome
+from pydantic_ai_harness.tool_error_recovery._policy import RecoveryPolicy
+
+# Control-flow signals that MUST always propagate untouched: recovery must never turn a
+# retry / approval / deferred / terminal-failure signal into something else. At the tool
+# boundary a tool-raised `ModelRetry` arrives as `ToolRetryError` and a tool-raised
+# `ToolFailed` (a terminal "report this failure to the model" signal, outcome='failed', no
+# retry) arrives as `ToolFailedError`; both raw and wrapped forms are listed.
+_CONTROL_FLOW: tuple[type[BaseException], ...] = (
+    SkipToolExecution,
+    CallDeferred,
+    ApprovalRequired,
+    ModelRetry,
+    ToolRetryError,
+    ToolFailed,
+    ToolFailedError,
+)
+
+
+@dataclass
+class ToolErrorRecovery(AbstractCapability[AgentDepsT]):
+    """Recover from tool execution errors: retry, inform, fallback, or propagate.
+
+    The `policy` decides the outcome from the error and the tool call, so a rule can key
+    on the error type, the tool name, or both. `max_recoveries` / `per_tool_recoveries`
+    bound how many failures are smoothed over per run before the error surfaces.
+
+    All logic lives in one hook (`wrap_tool_execute`), so counters have a single path and
+    control-flow signals are re-raised before any recovery.
+    """
+
+    policy: RecoveryPolicy = field(default_factory=RecoveryPolicy)
+    """How errors are classified, rendered, and logged."""
+
+    max_recoveries: int | None = None
+    """Per-run cap on smoothed-over failures across all tools; `None` = unlimited."""
+
+    per_tool_recoveries: Mapping[str, int] | None = None
+    """Per-tool caps by tool name, on top of `max_recoveries`."""
+
+    _used_total: int = field(default=0, init=False, repr=False)
+    _used_by_tool: dict[str, int] = field(default_factory=dict[str, int], init=False, repr=False)
+
+    @classmethod
+    def get_serialization_name(cls) -> str | None:
+        # Opting out of spec construction, though the budgets and the policy's data fields
+        # would serialize: `classify` is the decision this capability exists for, and a spec
+        # cannot express it. Half a policy in YAML reads like a configured one.
+        return None
+
+    async def for_run(self, ctx: RunContext[AgentDepsT]) -> ToolErrorRecovery[AgentDepsT]:
+        """Fresh per-run counters: `replace` copies all init fields and re-initializes the rest."""
+        return replace(self)
+
+    async def wrap_tool_execute(
+        self,
+        ctx: RunContext[AgentDepsT],
+        *,
+        call: ToolCallPart,
+        tool_def: ToolDefinition,
+        args: dict[str, Any],
+        handler: Callable[[dict[str, Any]], Awaitable[Any]],
+    ) -> Any:
+        attempt = 0
+        while True:
+            try:
+                return await handler(args)
+            except _CONTROL_FLOW:
+                raise  # never intercept control flow, whatever the classifier says
+            except Exception as exc:  # the recovery boundary
+                with self._chain_callable_bug('classify', call, exc):
+                    outcome = await self.policy.run_classify(ctx, call, exc)
+                if outcome is None or outcome.action == 'propagate':
+                    self._log(logging.ERROR, 'propagate', call, exc, None)
+                    raise
+                if outcome.action == 'retry' and attempt + 1 < outcome.max_attempts:
+                    self._log(logging.DEBUG, 'retry', call, exc, None)
+                    await self._sleep_backoff(outcome, attempt, call, exc)
+                    attempt += 1
+                    continue
+                terminal = (outcome.on_exhausted if outcome.action == 'retry' else outcome) or RecoveryOutcome.inform()
+                if terminal.action == 'propagate' or not self._spend(call):
+                    # budget checked BEFORE recovering; label the actual reason so operator
+                    # dashboards can tell a policy decision from an exhausted budget
+                    reason = 'propagate' if terminal.action == 'propagate' else 'budget-exhausted'
+                    self._log(logging.ERROR, reason, call, exc, None)
+                    raise
+                if terminal.action == 'fallback':
+                    self._log(logging.WARNING, 'fallback', call, exc, terminal.label)
+                    return terminal.value
+                # render before the WARNING, which would otherwise claim a recovery that never landed
+                with self._chain_callable_bug('format_error', call, exc):
+                    text = self.policy.render(call, exc, terminal.label, expose_message=terminal.expose_message)
+                self._log(logging.WARNING, 'inform', call, exc, terminal.label)
+                raise ToolFailed(text) from exc  # inform
+
+    # --- helpers for the single recovery path above ---
+
+    def _spend(self, call: ToolCallPart) -> bool:
+        """Spend one recovery from the budget. Returns False (do not recover) if exhausted.
+
+        Counts final recoveries, not retry attempts. No `await` between check and
+        increment -> atomic under cooperative asyncio, even with parallel tool calls.
+        """
+        if self.max_recoveries is not None and self._used_total >= self.max_recoveries:
+            return False
+        if self.per_tool_recoveries is not None:
+            limit = self.per_tool_recoveries.get(call.tool_name)
+            if limit is not None and self._used_by_tool.get(call.tool_name, 0) >= limit:
+                return False
+        self._used_total += 1
+        self._used_by_tool[call.tool_name] = self._used_by_tool.get(call.tool_name, 0) + 1
+        return True
+
+    async def _sleep_backoff(self, outcome: RecoveryOutcome, attempt: int, call: ToolCallPart, exc: Exception) -> None:
+        with self._chain_callable_bug('backoff', call, exc):
+            delay = outcome.backoff(attempt) if callable(outcome.backoff) else outcome.backoff * (2**attempt)
+        if delay > 0:
+            await anyio.sleep(delay)
+
+    @contextmanager
+    def _chain_callable_bug(self, which: str, call: ToolCallPart, exc: Exception) -> Generator[None, None, None]:
+        """Re-raise a bug from a user callable, chained to the failure it was handling.
+
+        Nothing `classify`/`backoff`/`format_error` raise is intended: a verdict is returned, not raised.
+        `__cause__` is explicit because the task group around tool calls overwrites `__context__`.
+        """
+        try:
+            yield
+        except Exception as bug:
+            self._log_callable_bug(which, call, exc, bug)
+            raise bug from exc
+
+    def _log_callable_bug(self, which: str, call: ToolCallPart, exc: Exception, bug: Exception) -> None:
+        """Log a callable's bug together with the failure it was handling.
+
+        `exc_info` carries the original, whose traceback would otherwise be lost; the bug's comes with the crash.
+        `recovery_error` stays the original: the incident is the tool failure, `recovery_bug` the broken callable.
+        """
+        self.policy.logger.log(
+            logging.ERROR,
+            'tool %r %s raised %s: %s -- while handling %s: %s',
+            call.tool_name,
+            which,
+            type(bug).__name__,
+            bug,
+            type(exc).__name__,
+            exc,
+            extra={
+                'recovery_scope': 'tool',
+                'recovery_tool': call.tool_name,
+                'recovery_action': f'{which}-failed',
+                'recovery_error': type(exc).__name__,
+                'recovery_bug': type(bug).__name__,
+                'recovery_label': None,
+            },
+            exc_info=exc,
+        )
+
+    def _log(self, level: int, action: str, call: ToolCallPart, exc: BaseException, label: str | None) -> None:
+        # The log is the only place a recovered failure stays visible to the operator.
+        self.policy.logger.log(
+            level,
+            'tool %r %s: %s: %s',
+            call.tool_name,
+            action,
+            type(exc).__name__,
+            exc,
+            extra={
+                'recovery_scope': 'tool',
+                'recovery_tool': call.tool_name,
+                'recovery_action': action,
+                'recovery_error': type(exc).__name__,
+                'recovery_label': label,
+            },
+            exc_info=exc if level >= logging.ERROR else None,
+        )

--- a/pydantic_ai_harness/tool_error_recovery/_outcome.py
+++ b/pydantic_ai_harness/tool_error_recovery/_outcome.py
@@ -1,0 +1,135 @@
+"""The recovery verdict (`RecoveryOutcome`) and the default error classifications."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import httpx
+from pydantic_ai.exceptions import UserError
+from typing_extensions import assert_never
+
+DEFAULT_BUG_TYPES: tuple[type[BaseException], ...] = (
+    TypeError,
+    AttributeError,
+    NameError,
+    KeyError,
+    IndexError,
+    AssertionError,
+    ImportError,
+)
+"""Programming errors: always propagate, never silently recovered."""
+
+DEFAULT_TRANSIENT_TYPES: tuple[type[BaseException], ...] = (
+    TimeoutError,
+    ConnectionError,
+    httpx.TimeoutException,
+    httpx.ConnectError,
+)
+"""Errors retried by default: only failures where the request never executed.
+
+Deliberately narrow -- no `OSError` (`FileNotFoundError`/`PermissionError` are not
+transient), no mid-flight `ReadError` (could double-execute a non-idempotent tool),
+no `HTTPStatusError` (retry semantics are a product decision). httpx ships with
+pydantic-ai-slim, so its types cost no dependency.
+"""
+
+
+@dataclass(frozen=True, kw_only=True)
+class RecoveryOutcome:
+    """What to do with a failed tool call.
+
+    Construct one with the classmethods -- `RecoveryOutcome.retry()`,
+    `RecoveryOutcome.inform()`, `RecoveryOutcome.fallback()`,
+    `RecoveryOutcome.propagate()` -- rather than the raw fields.
+
+    `inform` reports a terminal failure to the model (via `ToolFailed`, `outcome='failed'`);
+    `fallback` returns a substitute value as a normal (successful) tool result. Both let the
+    model continue; neither is a `ModelRetry` (no retry, no retry-budget cost).
+    """
+
+    action: Literal['retry', 'inform', 'fallback', 'propagate']
+    """How the capability should react to the failure."""
+
+    max_attempts: int = 1
+    """For `retry`, total attempts including the first."""
+
+    backoff: float | Callable[[int], float] = 0.0
+    """For `retry`, base delay in seconds (`base * 2 ** attempt`) or a callable of the 0-based attempt."""
+
+    on_exhausted: RecoveryOutcome | None = None
+    """For `retry`, the terminal outcome once attempts run out (default: `inform`)."""
+
+    label: str | None = None
+    """Curated short text: shown instead of the raw error, and the trace/metric dimension."""
+
+    value: Any = None
+    """For `fallback`, the substitute tool result (`None` is a valid substitute)."""
+
+    expose_message: bool = False
+    """For `inform`, append the capped `str(error)` to the model-facing text.
+
+    The explicit per-case opt-out of the leak-free default, for exceptions whose text
+    is meant for the model. `label` stays the low-cardinality metric dimension instead
+    of carrying the dynamic message.
+    """
+
+    def __post_init__(self) -> None:
+        """Reject field combinations the four-outcome contract does not allow."""
+        if self.expose_message and self.action != 'inform':
+            raise UserError("RecoveryOutcome.expose_message is only valid for action='inform'.")
+        match self.action:
+            case 'retry':
+                if self.max_attempts < 1:
+                    raise UserError(f'RecoveryOutcome.retry() requires max_attempts >= 1, got {self.max_attempts}.')
+                if self.on_exhausted is not None and self.on_exhausted.action == 'retry':
+                    raise UserError('RecoveryOutcome.retry() cannot use another retry as `on_exhausted`.')
+            case 'inform':
+                if self.value is not None:
+                    raise UserError("RecoveryOutcome(action='inform') must not set `value`.")
+            case 'propagate':
+                if self.label is not None or self.value is not None:
+                    raise UserError("RecoveryOutcome(action='propagate') must not set `label` or `value`.")
+            case 'fallback':
+                # Any `value` is valid -- `None` is a legitimate substitute result.
+                pass
+            case _:  # pragma: no cover - assert_never exhaustiveness guard
+                assert_never(self.action)
+
+    @classmethod
+    def retry(
+        cls,
+        max_attempts: int = 3,
+        *,
+        backoff: float | Callable[[int], float] = 0.0,
+        on_exhausted: RecoveryOutcome | None = None,
+    ) -> RecoveryOutcome:
+        """Retry the tool transparently up to `max_attempts` times (total, incl. the first).
+
+        `classify` decides again on every attempt, so a changed error can end the retrying
+        early; spent attempts fall through to `on_exhausted` (default: `inform`). `backoff`
+        is a base delay in seconds (`base * 2 ** attempt`) or a callable of the 0-based
+        attempt index.
+        """
+        return cls(action='retry', max_attempts=max_attempts, backoff=backoff, on_exhausted=on_exhausted)
+
+    @classmethod
+    def inform(cls, *, label: str | None = None, expose_message: bool = False) -> RecoveryOutcome:
+        """Report a terminal failure to the model (via `ToolFailed`, `outcome='failed'`) so it adapts.
+
+        No retry and no retry-budget cost. With `label`, the label is sent instead of the raw
+        exception (and is the trace/metric dimension). With `expose_message`, the capped
+        `str(error)` is appended.
+        """
+        return cls(action='inform', label=label, expose_message=expose_message)
+
+    @classmethod
+    def fallback(cls, value: Any = None, *, label: str | None = None) -> RecoveryOutcome:
+        """Return `value` as the tool result instead of the error."""
+        return cls(action='fallback', value=value, label=label)
+
+    @classmethod
+    def propagate(cls) -> RecoveryOutcome:
+        """Do not recover -- re-raise (the error stays loud for the operator)."""
+        return cls(action='propagate')

--- a/pydantic_ai_harness/tool_error_recovery/_policy.py
+++ b/pydantic_ai_harness/tool_error_recovery/_policy.py
@@ -1,0 +1,160 @@
+"""How tool failures are classified, rendered for the model, and logged."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import traceback
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import HookTimeoutError
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.messages import ToolCallPart
+
+from pydantic_ai_harness.tool_error_recovery._outcome import (
+    DEFAULT_BUG_TYPES,
+    DEFAULT_TRANSIENT_TYPES,
+    RecoveryOutcome,
+)
+
+_LOGGER = logging.getLogger('pydantic_ai_harness.tool_error_recovery')
+
+RecoveryClassifier = (
+    Callable[[ToolCallPart, BaseException], 'RecoveryOutcome | None | Awaitable[RecoveryOutcome | None]']
+    | Callable[
+        [RunContext[Any], ToolCallPart, BaseException],
+        'RecoveryOutcome | None | Awaitable[RecoveryOutcome | None]',
+    ]
+)
+"""Signature of the classifier passed to `RecoveryPolicy`.
+
+The callable receives the tool call and the exception and returns a
+`RecoveryOutcome` (`None` = propagate). It may optionally take a `RunContext`
+as a first argument -- for `deps`, message history, or other run state -- and may
+be sync or async, matching pydantic-ai's optional-`ctx` convention. It is
+re-invoked on every retry attempt, so keep it cheap and idempotent.
+"""
+
+ErrorFormatter = Callable[[ToolCallPart, BaseException, 'str | None'], str]
+"""Signature of a custom `(call, error, label) -> str` renderer for the model-facing error text.
+
+A custom renderer takes over entirely: neither the `max_message_len` cap nor an
+outcome's `expose_message` applies -- the callable sees the raw error and decides.
+"""
+
+
+def make_default_classify(
+    *,
+    transient: tuple[type[BaseException], ...] = DEFAULT_TRANSIENT_TYPES,
+    bugs: tuple[type[BaseException], ...] = DEFAULT_BUG_TYPES,
+) -> RecoveryClassifier:
+    """Build a conservative classifier: bugs propagate, transient errors retry, deadlines and the rest inform.
+
+    The default transient set covers builtin `TimeoutError`/`ConnectionError` plus httpx
+    timeouts and connect errors -- HTTP-based tools retry out of the box. Other client
+    libraries (qdrant, database drivers) define their own exception roots; pass them in:
+    `make_default_classify(transient=(*DEFAULT_TRANSIENT_TYPES, qdrant_client.QdrantException))`.
+    """
+
+    def classify(ctx: RunContext[Any], call: ToolCallPart, error: BaseException) -> RecoveryOutcome:
+        if isinstance(error, bugs):
+            return RecoveryOutcome.propagate()
+        if isinstance(error, HookTimeoutError):
+            # A deadline is wall-clock and may have fired after the call reached the
+            # server, breaking the "never executed" premise `transient` rests on.
+            return RecoveryOutcome.inform()
+        if isinstance(error, transient):
+            return RecoveryOutcome.retry(3)
+        return RecoveryOutcome.inform()
+
+    return classify
+
+
+default_classify: RecoveryClassifier = make_default_classify()
+
+
+def required_positionals(func: Callable[..., object]) -> int | None:
+    """How many positional parameters a call must fill, or `None` when the signature says nothing.
+
+    Counted rather than annotated, because the documented `lambda ctx, call, error` form carries none.
+    Only parameters the call fills count: an optional or keyword-only one would shift the payload by one.
+    `*args` absorbs any count, so it yields `None` rather than a misleading zero.
+    """
+    try:
+        parameters = list(inspect.signature(func).parameters.values())
+    except ValueError:  # pragma: no cover - callable without an introspectable signature
+        return None
+    if any(p.kind is p.VAR_POSITIONAL for p in parameters):
+        return None
+    return sum(1 for p in parameters if p.default is p.empty and p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD))
+
+
+@dataclass
+class RecoveryPolicy:
+    """How errors are classified, rendered for the model, and logged.
+
+    Holds no per-run state -- counters live on the capability so a fresh run resets them.
+    Logging is neutral stdlib `logging`; where records land (Logfire/OTLP/stderr) is the
+    composition root's decision, not the capability's.
+    """
+
+    classify: RecoveryClassifier = default_classify
+    """The `(call, error) -> RecoveryOutcome | None` policy; may take a leading `RunContext`."""
+
+    format_error: ErrorFormatter | None = None
+    """Custom renderer for the model-facing error text; `None` uses the built-in capped renderer."""
+
+    max_message_len: int = 300
+    """Cap on the built-in renderer's uncurated text; a pure `label` is exempt (see `render`)."""
+
+    include_traceback: bool = False
+    """Whether the built-in renderer appends the traceback (debugging aid; costs tokens)."""
+
+    logger: logging.Logger = field(default=_LOGGER)
+    """Where recovery events are logged."""
+
+    def __post_init__(self) -> None:
+        """Reject configuration the contract does not allow."""
+        if self.max_message_len < 1:
+            raise UserError(f'RecoveryPolicy.max_message_len must be positive, got {self.max_message_len}.')
+        required = required_positionals(self.classify)
+        if required is not None and required not in (2, 3):
+            # Caught here rather than as a TypeError inside the recovery path, at the first tool failure.
+            raise UserError(
+                f'RecoveryPolicy.classify must take (call, error) or (ctx, call, error), got {required} parameters.'
+            )
+
+    def render(
+        self, call: ToolCallPart, error: BaseException, label: str | None, *, expose_message: bool = False
+    ) -> str:
+        """Build the model-facing text for an `inform` recovery.
+
+        Never includes `str(error)` by default: exception text can carry secrets and would reach
+        the user through the model. `label`, `expose_message`, `format_error` and
+        `include_traceback` each opt out of that. `max_message_len` caps uncurated content;
+        a pure `label` is exempt.
+        """
+        if self.format_error is not None:
+            return self.format_error(call, error, label)
+        if label and not expose_message:
+            return label
+        base = label or f'Tool {call.tool_name!r} failed ({type(error).__name__})'
+        text = f'{base}: {error}' if expose_message else f'{base}.'
+        if self.include_traceback:
+            text += '\n' + ''.join(traceback.format_exception(type(error), error, error.__traceback__))
+        if len(text) > self.max_message_len:
+            text = text[: self.max_message_len - 1] + '…'
+        return text
+
+    async def run_classify(
+        self, ctx: RunContext[Any], call: ToolCallPart, error: BaseException
+    ) -> RecoveryOutcome | None:
+        """Call the classifier (passing `ctx` when declared) and await it if async."""
+        classify: Callable[..., RecoveryOutcome | None | Awaitable[RecoveryOutcome | None]] = self.classify
+        result = classify(ctx, call, error) if required_positionals(classify) == 3 else classify(call, error)
+        if inspect.isawaitable(result):
+            return await result
+        return result

--- a/tests/tool_error_recovery/_agents.py
+++ b/tests/tool_error_recovery/_agents.py
@@ -1,0 +1,35 @@
+"""Agent builders shared by the behaviour tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+
+def tool_returns(messages: list[Any]) -> int:
+    return sum(1 for m in messages for p in m.parts if isinstance(p, ToolReturnPart))
+
+
+def call_then_echo(max_calls: int = 1) -> FunctionModel:
+    """Model that calls `do_thing` up to `max_calls` times, then echoes the last tool result."""
+
+    def fn(messages: list[Any], info: AgentInfo) -> ModelResponse:
+        for m in reversed(messages):
+            for p in m.parts:
+                if isinstance(p, ToolReturnPart):
+                    if tool_returns(messages) >= max_calls:
+                        return ModelResponse(parts=[TextPart(content=f'RESULT:{p.content}')])
+                    break
+        return ModelResponse(parts=[ToolCallPart(tool_name='do_thing', args={})])
+
+    return FunctionModel(fn)
+
+
+def build(cap: AbstractCapability[Any], tool_fn: Any, *, max_calls: int = 1) -> Agent[None, str]:
+    agent: Agent[None, str] = Agent(call_then_echo(max_calls), capabilities=[cap])
+    agent.tool_plain(name='do_thing')(tool_fn)
+    return agent

--- a/tests/tool_error_recovery/test_tool_error_recovery.py
+++ b/tests/tool_error_recovery/test_tool_error_recovery.py
@@ -1,0 +1,718 @@
+"""Tests for the `ToolErrorRecovery` capability.
+
+Behaviour tests drive real agent runs with `FunctionModel` -- no API keys needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import anyio
+import pytest
+from pydantic_ai import Agent, DeferredToolRequests
+from pydantic_ai.capabilities import AbstractCapability, Hooks, HookTimeoutError
+from pydantic_ai.exceptions import ApprovalRequired, ModelRetry, ToolFailed, UserError
+from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from pydantic_ai_harness.tool_error_recovery import (
+    DEFAULT_BUG_TYPES,
+    RecoveryOutcome,
+    RecoveryPolicy,
+    ToolErrorRecovery,
+)
+from tests.tool_error_recovery._agents import build, call_then_echo  # pyright: ignore[reportMissingTypeStubs]
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run async tests on the asyncio backend (matching upstream pydantic-ai)."""
+    return 'asyncio'
+
+
+def _retry_everything(ctx: Any, call: Any, error: BaseException) -> RecoveryOutcome:
+    # Worst-case misconfiguration: retry every exception. Control flow must still pass.
+    return RecoveryOutcome.retry(5)
+
+
+# tool recovery
+
+
+async def test_retry_transient_recovers_transparently() -> None:
+    calls = [0]
+
+    def flaky() -> str:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise TimeoutError('flaky network')
+        return 'ok'
+
+    r = await build(ToolErrorRecovery(), flaky).run('hi')
+    assert 'RESULT:ok' in str(r.output)
+    assert calls[0] == 2  # retried once, no model round-trip
+
+
+async def test_retry_httpx_errors_out_of_the_box() -> None:
+    # httpx ships with pydantic-ai, so HTTP-based tools retry without any configuration.
+    import httpx
+
+    calls = [0]
+
+    def flaky_http() -> str:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise httpx.ConnectTimeout('connect timed out')
+        return 'ok'
+
+    r = await build(ToolErrorRecovery(), flaky_http).run('hi')
+    assert 'RESULT:ok' in str(r.output)
+    assert calls[0] == 2
+
+
+async def test_inform_surfaces_error_type_not_message() -> None:
+    # The model learns the tool and exception type; the exception MESSAGE never reaches
+    # it (free-form text is where secrets live -- it stays on the operator surface).
+    def bad() -> str:
+        raise ValueError('secret detail')
+
+    r = await build(ToolErrorRecovery(), bad).run('hi')
+    assert 'failed' in str(r.output)
+    assert 'ValueError' in str(r.output)
+    assert 'secret detail' not in str(r.output)
+
+
+async def test_inform_label_replaces_raw_error() -> None:
+    cap = ToolErrorRecovery(
+        RecoveryPolicy(classify=lambda ctx, call, e: RecoveryOutcome.inform(label='service unavailable'))
+    )
+
+    def bad() -> str:
+        raise ValueError('secret detail')
+
+    r = await build(cap, bad).run('hi')
+    assert 'service unavailable' in str(r.output)
+    assert 'ValueError' not in str(r.output)
+    assert 'secret detail' not in str(r.output)
+
+
+async def test_classify_without_ctx_supported() -> None:
+    # The classifier may omit the leading RunContext (optional-ctx convention).
+    def classify(call: ToolCallPart, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.inform(label=f'{call.tool_name} down')
+
+    def bad() -> str:
+        raise ValueError('x')
+
+    r = await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), bad).run('hi')
+    assert 'do_thing down' in str(r.output)
+
+
+async def test_fallback_returns_configured_value() -> None:
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=lambda ctx, call, e: RecoveryOutcome.fallback('FB')))
+
+    def bad() -> str:
+        raise ValueError('nope')
+
+    r = await build(cap, bad).run('hi')
+    assert 'FB' in str(r.output)
+
+
+async def test_bug_propagates() -> None:
+    def buggy() -> str:
+        raise KeyError('missing')
+
+    with pytest.raises(Exception) as exc_info:
+        await build(ToolErrorRecovery(), buggy).run('hi')
+    assert 'KeyError' in repr(exc_info.value)
+
+
+async def test_budget_exhausted_propagates() -> None:
+    def bad() -> str:
+        raise ValueError('nope')
+
+    cap: ToolErrorRecovery[None] = ToolErrorRecovery(max_recoveries=1)
+    with pytest.raises(Exception) as exc_info:
+        await build(cap, bad, max_calls=2).run('hi')
+    assert 'ValueError' in repr(exc_info.value)
+
+
+async def test_per_tool_budget_exhausts() -> None:
+    def bad() -> str:
+        raise ValueError('x')
+
+    cap: ToolErrorRecovery[None] = ToolErrorRecovery(per_tool_recoveries={'do_thing': 1})
+    with pytest.raises(Exception) as exc_info:
+        await build(cap, bad, max_calls=2).run('hi')
+    assert 'ValueError' in repr(exc_info.value)
+
+
+async def test_no_budget_recovers_repeatedly() -> None:
+    def bad() -> str:
+        raise ValueError('nope')
+
+    r = await build(ToolErrorRecovery(), bad, max_calls=2).run('hi')
+    assert 'failed' in str(r.output)
+
+
+async def test_control_flow_modelretry_not_swallowed() -> None:
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=_retry_everything))
+    calls = [0]
+
+    def wants_retry() -> str:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise ModelRetry('give me better input')
+        return 'ok'
+
+    r = await build(cap, wants_retry).run('hi')
+    assert 'RESULT:ok' in str(r.output)  # the model retried, was not fed an inform string
+    assert calls[0] == 2
+
+
+async def test_control_flow_approval_not_swallowed() -> None:
+    # ApprovalRequired must leave through the framework's deferred-tools mechanism --
+    # assert HOW it exits (a DeferredToolRequests output naming the call), not merely
+    # that no inform text appeared: a catch-all would also pass on a broken capability.
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=_retry_everything))
+    agent: Agent[None, str | DeferredToolRequests] = Agent(
+        call_then_echo(), output_type=[str, DeferredToolRequests], capabilities=[cap]
+    )
+
+    def needs_approval() -> str:
+        raise ApprovalRequired()
+
+    agent.tool_plain(name='do_thing')(needs_approval)
+    r = await agent.run('hi')
+    assert isinstance(r.output, DeferredToolRequests)
+    assert [c.tool_name for c in r.output.approvals] == ['do_thing']
+
+
+async def test_tool_failed_passes_through() -> None:
+    # A tool raising ToolFailed reports a terminal failure to the model itself -- recovery
+    # must NOT intercept it, even under retry-everything.
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=_retry_everything))
+    calls = [0]
+
+    def report_failure() -> str:
+        calls[0] += 1
+        raise ToolFailed('upstream unavailable')
+
+    r = await build(cap, report_failure).run('hi')
+    assert calls[0] == 1  # passed through, not retried by recovery
+    assert 'upstream unavailable' in str(r.output)
+
+
+async def test_inform_produces_failed_outcome() -> None:
+    # inform surfaces the error via ToolFailed, so the model sees a *failed* tool result.
+    outcomes: list[str] = []
+
+    def capture(messages: list[Any], info: AgentInfo) -> ModelResponse:
+        for m in messages:
+            for p in m.parts:
+                if isinstance(p, ToolReturnPart):
+                    outcomes.append(getattr(p, 'outcome', 'n/a'))
+                    return ModelResponse(parts=[TextPart(content='done')])
+        return ModelResponse(parts=[ToolCallPart(tool_name='do_thing', args={})])
+
+    def bad() -> str:
+        raise ValueError('nope')
+
+    agent: Agent[None, str] = Agent(FunctionModel(capture), capabilities=[ToolErrorRecovery()])
+    agent.tool_plain(name='do_thing')(bad)
+    await agent.run('hi')
+    assert outcomes == ['failed']
+
+
+def deadline_hooks(seconds: float) -> Hooks[None]:
+    """pydantic-ai's own per-tool deadline: a pass-through hook carrying a timeout."""
+    hooks: Hooks[None] = Hooks()
+
+    async def bounded(ctx: Any, *, call: Any, tool_def: Any, args: Any, handler: Any) -> Any:
+        return await handler(args)
+
+    hooks.on.tool_execute(tools=['do_thing'], timeout=seconds)(bounded)
+    return hooks
+
+
+def build_with_deadline(
+    seconds: float,
+    tool_fn: Any,
+    *,
+    policy: RecoveryPolicy | None = None,
+    max_calls: int = 1,
+    recovery_first: bool = True,
+) -> Agent[None, str]:
+    recovery: ToolErrorRecovery[Any] = ToolErrorRecovery(policy) if policy is not None else ToolErrorRecovery()
+    deadline = deadline_hooks(seconds)
+    caps: list[AbstractCapability[Any]] = [recovery, deadline] if recovery_first else [deadline, recovery]
+    agent: Agent[None, str] = Agent(call_then_echo(max_calls), capabilities=caps)
+    agent.tool_plain(name='do_thing')(tool_fn)
+    return agent
+
+
+async def test_deadline_informs_without_retrying_by_default() -> None:
+    # A deadline is wall-clock and may have fired after the call reached the server, so
+    # the default must not retry it -- even though HookTimeoutError subclasses TimeoutError,
+    # whose members are retried.
+    calls = [0]
+
+    async def too_slow() -> str:
+        calls[0] += 1
+        await anyio.sleep(0.3)
+        return 'never'
+
+    r = await build_with_deadline(0.05, too_slow).run('hi')
+    assert calls[0] == 1
+    assert 'HookTimeoutError' in str(r.output)
+
+
+async def test_a_deadline_listed_before_recovery_is_out_of_reach() -> None:
+    # Capabilities are middleware, so a deadline listed first wraps recovery rather than the
+    # other way round: nothing that can expire runs inside the classifier's reach, and the run
+    # ends. Nothing warns about the order, so the README states it as a rule and this pins it.
+    seen: list[str] = []
+
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        seen.append(type(error).__name__)
+        return RecoveryOutcome.inform(label='caught')
+
+    async def too_slow() -> str:
+        await anyio.sleep(0.3)
+        return 'never'
+
+    agent = build_with_deadline(0.05, too_slow, policy=RecoveryPolicy(classify=classify), recovery_first=False)
+    with pytest.raises(HookTimeoutError):
+        await agent.run('hi')
+    assert seen == []
+
+
+async def test_deadline_retry_is_opt_in() -> None:
+    # An idempotent tool can opt back into the transparent retry.
+    calls = [0]
+
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        assert isinstance(error, HookTimeoutError)
+        return RecoveryOutcome.retry(3)
+
+    async def slow_then_fast() -> str:
+        calls[0] += 1
+        if calls[0] == 1:
+            await anyio.sleep(0.3)  # exceeds the deadline on the first attempt
+        return 'ok'
+
+    r = await build_with_deadline(0.05, slow_then_fast, policy=RecoveryPolicy(classify=classify)).run('hi')
+    assert 'RESULT:ok' in str(r.output)
+    assert calls[0] == 2
+
+
+async def test_deadline_and_tool_raised_timeout_are_distinguishable() -> None:
+    # The two mean opposite things: a tool-raised timeout means the request never got
+    # through (safe to retry), a deadline may have executed.
+    seen: list[type[BaseException]] = []
+
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        seen.append(type(error))
+        return RecoveryOutcome.inform()
+
+    async def too_slow() -> str:
+        await anyio.sleep(0.3)
+        return 'never'
+
+    def raises_own_timeout() -> str:
+        raise TimeoutError('client read timeout')
+
+    policy = RecoveryPolicy(classify=classify)
+    await build_with_deadline(0.05, too_slow, policy=policy).run('hi')
+    await build(ToolErrorRecovery(policy), raises_own_timeout).run('hi')
+
+    assert seen == [HookTimeoutError, TimeoutError]
+
+
+async def test_sync_tool_deadline_has_no_effect_by_default() -> None:
+    # A sync tool runs in a worker thread the cancellation cannot reach: under the
+    # default executor the deadline never fires and the result is used. Pinned so the
+    # documented limit cannot rot silently.
+    def blocking() -> str:
+        time.sleep(0.15)
+        return 'sync-ok'
+
+    r = await build_with_deadline(0.05, blocking).run('hi')
+    assert 'RESULT:sync-ok' in str(r.output)
+
+
+async def test_async_classify_supported() -> None:
+    async def classify(ctx: Any, call: Any, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.inform(label='async ok')
+
+    def bad() -> str:
+        raise ValueError('x')
+
+    r = await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), bad).run('hi')
+    assert 'async ok' in str(r.output)
+
+
+async def test_retry_with_backoff() -> None:
+    calls = [0]
+
+    def flaky() -> str:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise TimeoutError('x')
+        return 'ok'
+
+    def classify(ctx: Any, call: Any, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.retry(3, backoff=0.001)
+
+    r = await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), flaky).run('hi')
+    assert 'RESULT:ok' in str(r.output)
+    assert calls[0] == 2
+
+
+async def test_retry_exhaustion_falls_to_inform() -> None:
+    # A tool that never recovers is retried max_attempts times, then informs the model.
+    calls = [0]
+
+    def always_timeout() -> str:
+        calls[0] += 1
+        raise TimeoutError('always')
+
+    r = await build(ToolErrorRecovery(), always_timeout).run('hi')
+    assert calls[0] == 3  # default retry(3): all attempts spent
+    assert 'failed' in str(r.output)
+    assert 'TimeoutError' in str(r.output)
+
+
+async def test_a_changed_error_type_ends_the_retrying() -> None:
+    # `classify` decides again on every attempt, so the second failure's own branch
+    # governs -- retrying stops even though the first one asked for three attempts.
+    calls = [0]
+
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        if isinstance(error, TimeoutError):
+            return RecoveryOutcome.retry(3)
+        return RecoveryOutcome.inform(label='stopped')
+
+    def timeout_then_value_error() -> str:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise TimeoutError('x')
+        raise ValueError('y')
+
+    r = await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), timeout_then_value_error).run('hi')
+    assert calls[0] == 2  # retried once for TimeoutError, then stopped on ValueError
+    assert 'stopped' in str(r.output)
+
+
+async def test_retry_custom_on_exhausted() -> None:
+    # An explicit on_exhausted outcome replaces the inform default after exhaustion.
+    calls = [0]
+
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.retry(2, on_exhausted=RecoveryOutcome.fallback('EXHAUSTED'))
+
+    def always_timeout() -> str:
+        calls[0] += 1
+        raise TimeoutError('x')
+
+    r = await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), always_timeout).run('hi')
+    assert calls[0] == 2
+    assert 'EXHAUSTED' in str(r.output)
+
+
+async def test_callable_backoff_invoked_per_attempt() -> None:
+    seen: list[int] = []
+
+    def backoff(attempt: int) -> float:
+        seen.append(attempt)
+        return 0.0
+
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.retry(3, backoff=backoff)
+
+    calls = [0]
+
+    def flaky() -> str:
+        calls[0] += 1
+        if calls[0] < 3:
+            raise TimeoutError('x')
+        return 'ok'
+
+    r = await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), flaky).run('hi')
+    assert 'RESULT:ok' in str(r.output)
+    assert seen == [0, 1]  # called once per retried attempt, 0-based
+
+
+def one_parameter(call: Any) -> RecoveryOutcome:
+    return RecoveryOutcome.inform()
+
+
+def test_classifier_arity_is_rejected_at_construction() -> None:
+    # Otherwise the mismatch surfaces as a TypeError inside the recovery path, at the first tool
+    # failure -- the worst moment to learn that the signature was wrong all along.
+    with pytest.raises(UserError):
+        RecoveryPolicy(classify=one_parameter)  # type: ignore[arg-type]
+
+
+async def test_var_positional_classifier_is_left_alone() -> None:
+    # `*args` says nothing about the shape, so no arity is enforced and the payload stays (call, error).
+    seen: list[int] = []
+
+    def classify(*args: Any) -> RecoveryOutcome:
+        seen.append(len(args))
+        return RecoveryOutcome.inform(label='varargs')
+
+    def bad() -> str:
+        raise ValueError('x')
+
+    r = await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), bad).run('hi')
+    assert 'varargs' in str(r.output)
+    assert seen == [2]
+
+
+def test_max_message_len_must_be_positive() -> None:
+    # max_message_len=0 would silently disable the cap (`text[:-1] + '…'` keeps the
+    # original length) -- reject it like the other validated public fields.
+    with pytest.raises(UserError):
+        RecoveryPolicy(max_message_len=0)
+
+
+async def test_inform_expose_message_sends_error_text() -> None:
+    # The explicit opt-in sends str(error) to the model -- for tools whose exception
+    # text is meant to be seen (validation detail the model can adapt to).
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.inform(label='lookup failed', expose_message=True)
+
+    def bad() -> str:
+        raise ValueError('item 42 is out of stock')
+
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=classify))
+    r = await build(cap, bad, max_calls=2).run('hi')
+    assert 'lookup failed' in str(r.output)
+    assert 'item 42 is out of stock' in str(r.output)
+
+
+async def test_expose_message_capped_at_max_message_len() -> None:
+    # An exposed message is uncurated content, so the renderer cap applies to it --
+    # unlike a pure label, which is curated operator config and exempt.
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.inform(expose_message=True)
+
+    def bad() -> str:
+        raise ValueError('x' * 500)
+
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=classify, max_message_len=60))
+    r = await build(cap, bad, max_calls=2).run('hi')
+    assert len(str(r.output)) == len('RESULT:') + 60  # echo prefix + capped inform text
+
+
+def test_expose_message_only_valid_for_inform() -> None:
+    with pytest.raises(UserError):
+        RecoveryOutcome(action='fallback', expose_message=True)
+
+
+async def test_on_exhausted_propagate_logged_as_propagate(caplog: pytest.LogCaptureFixture) -> None:
+    # A deliberate on_exhausted=propagate() must not be mislabeled as 'budget-exhausted'.
+    calls = [0]
+
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.retry(2, on_exhausted=RecoveryOutcome.propagate())
+
+    def always_timeout() -> str:
+        calls[0] += 1
+        raise TimeoutError('x')
+
+    with pytest.raises(Exception) as exc_info:
+        await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), always_timeout).run('hi')
+    assert calls[0] == 2
+    assert 'TimeoutError' in repr(exc_info.value)
+    actions = [getattr(rec, 'recovery_action', None) for rec in caplog.records]
+    assert 'propagate' in actions
+    assert 'budget-exhausted' not in actions
+
+
+async def test_for_run_resets_budget_across_runs() -> None:
+    # The per-run counters are re-initialized by for_run's `replace` (fresh default_factory
+    # dict, not shared) -- a second run gets its full budget again.
+    def bad() -> str:
+        raise ValueError('nope')
+
+    cap: ToolErrorRecovery[None] = ToolErrorRecovery(max_recoveries=1)
+    agent = build(cap, bad)
+    for _ in range(2):  # each run recovers its single failure; no cross-run exhaustion
+        r = await agent.run('hi')
+        assert 'failed' in str(r.output)
+
+
+# outcome & policy units
+
+
+def test_outcome_validation() -> None:
+    with pytest.raises(UserError):
+        RecoveryOutcome.retry(0)
+    with pytest.raises(UserError):
+        RecoveryOutcome.retry(3, on_exhausted=RecoveryOutcome.retry(2))
+    with pytest.raises(UserError):
+        RecoveryOutcome(action='inform', value='x')
+    with pytest.raises(UserError):
+        RecoveryOutcome(action='propagate', label='x')
+
+
+def test_render_variants() -> None:
+    call = ToolCallPart(tool_name='t', args={})
+    err = ValueError('x' * 500)
+    assert RecoveryPolicy(format_error=lambda c, e, lbl: 'CUSTOM').render(call, err, None) == 'CUSTOM'
+    out = RecoveryPolicy(include_traceback=True, max_message_len=40).render(call, err, None)
+    assert out.endswith('…')
+    assert len(out) == 40
+
+
+def test_serialization_opt_out() -> None:
+    assert ToolErrorRecovery.get_serialization_name() is None
+
+
+# callable bugs
+
+
+def unreachable() -> str:
+    raise ConnectionError('db unreachable')
+
+
+def broken_format(call: Any, error: BaseException, label: str | None) -> str:
+    raise AttributeError('formatter is buggy')
+
+
+async def test_classifier_bug_crashes_and_keeps_the_original() -> None:
+    # A bug in `classify` stays fatal, like DEFAULT_BUG_TYPES for tools -- but it must not
+    # erase the failure it was judging. Implicit chaining does not survive the task-group
+    # unwrapping around tool calls, so the original is attached explicitly.
+    def broken_classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        empty: dict[str, RecoveryOutcome] = {}
+        return empty['missing']
+
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=broken_classify))
+    with pytest.raises(KeyError) as exc_info:
+        await build(cap, unreachable).run('hi')
+    assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+
+async def test_backoff_bug_crashes_and_keeps_the_original() -> None:
+    def broken_backoff(attempt: int) -> float:
+        raise ZeroDivisionError('backoff is buggy')
+
+    def classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        return RecoveryOutcome.retry(3, backoff=broken_backoff)
+
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=classify))
+    with pytest.raises(ZeroDivisionError) as exc_info:
+        await build(cap, unreachable).run('hi')
+    assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+
+async def test_format_error_bug_crashes_and_keeps_the_original() -> None:
+    cap = ToolErrorRecovery(
+        RecoveryPolicy(classify=lambda call, e: RecoveryOutcome.inform(), format_error=broken_format)
+    )
+    with pytest.raises(AttributeError) as exc_info:
+        await build(cap, unreachable).run('hi')
+    assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+
+async def test_callable_bug_logs_both_errors(caplog: pytest.LogCaptureFixture) -> None:
+    # Reading the log alone has to show both: that the classifier is broken, and the failure
+    # it swallowed. The error dimension stays the incident, so a dashboard keeps counting
+    # ConnectionErrors rather than the classifier's KeyError.
+    def broken_classify(call: Any, error: BaseException) -> RecoveryOutcome:
+        empty: dict[str, RecoveryOutcome] = {}
+        return empty['missing']
+
+    cap = ToolErrorRecovery(RecoveryPolicy(classify=broken_classify))
+    with pytest.raises(KeyError):
+        await build(cap, unreachable).run('hi')
+    records = [r for r in caplog.records if getattr(r, 'recovery_action', None) == 'classify-failed']
+    assert len(records) == 1
+    assert records[0].levelno == logging.ERROR
+    assert getattr(records[0], 'recovery_error', None) == 'ConnectionError'
+    assert getattr(records[0], 'recovery_bug', None) == 'KeyError'
+    assert 'KeyError' in records[0].getMessage()
+    assert 'db unreachable' in records[0].getMessage()
+
+
+async def test_no_recovery_warning_when_rendering_fails(caplog: pytest.LogCaptureFixture) -> None:
+    # The WARNING states that a recovery happened, so it may only be written once the text
+    # it announces exists. Logged first, it made a crashed run look recovered.
+    cap = ToolErrorRecovery(
+        RecoveryPolicy(classify=lambda call, e: RecoveryOutcome.inform(), format_error=broken_format)
+    )
+    with pytest.raises(AttributeError):
+        await build(cap, unreachable).run('hi')
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+async def test_a_classifier_raising_control_flow_is_reported_as_a_bug(caplog: pytest.LogCaptureFixture) -> None:
+    # A classifier returns its verdict; raising `ModelRetry` is a back door around the four
+    # outcomes. The signal still reaches the framework untouched, but it is logged as a bug.
+    calls = [0]
+
+    def classify_asks_the_model(call: Any, error: BaseException) -> RecoveryOutcome:
+        raise ModelRetry('classifier wants the model to try again')
+
+    def flaky() -> str:
+        calls[0] += 1
+        if calls[0] == 1:
+            raise ConnectionError('transient')
+        return 'ok'
+
+    r = await build(ToolErrorRecovery(RecoveryPolicy(classify=classify_asks_the_model)), flaky).run('hi')
+    assert 'RESULT:ok' in str(r.output)
+    assert calls[0] == 2
+    assert [getattr(r_, 'recovery_bug', None) for r_ in caplog.records] == ['ModelRetry']
+
+
+def propagate_bugs(error: BaseException) -> RecoveryOutcome:
+    return RecoveryOutcome.propagate() if isinstance(error, DEFAULT_BUG_TYPES) else RecoveryOutcome.inform()
+
+
+# The five accepted shapes of a classifier signature. Bodies are identical; only the
+# parameters differ, which is what `ctx` detection reads.
+def plain(call: Any, error: BaseException) -> RecoveryOutcome:
+    return propagate_bugs(error)
+
+
+def with_ctx(ctx: Any, call: Any, error: BaseException) -> RecoveryOutcome:
+    return propagate_bugs(error)
+
+
+def with_default(call: Any, error: BaseException, threshold: int = 5) -> RecoveryOutcome:
+    return propagate_bugs(error)
+
+
+def with_keyword_only(call: Any, error: BaseException, *, strict: bool = True) -> RecoveryOutcome:
+    return propagate_bugs(error)
+
+
+def with_ctx_and_default(ctx: Any, call: Any, error: BaseException, threshold: int = 5) -> RecoveryOutcome:
+    return propagate_bugs(error)
+
+
+@pytest.mark.parametrize(
+    'classify',
+    [
+        pytest.param(plain, id='(call, error)'),
+        pytest.param(with_ctx, id='(ctx, call, error)'),
+        pytest.param(with_default, id='(call, error, threshold=5)'),
+        pytest.param(with_keyword_only, id='(call, error, *, strict=True)'),
+        pytest.param(with_ctx_and_default, id='(ctx, call, error, threshold=5)'),
+    ],
+)
+async def test_every_classifier_signature_receives_the_error(classify: Any) -> None:
+    # `ctx` is optional, so its presence is inferred; a wrong inference shifts the arguments and
+    # lands the `ToolCallPart` in `error`, leaving every bug check reading a part, not the exception.
+    def buggy() -> str:
+        raise KeyError('missing')
+
+    with pytest.raises(KeyError):
+        await build(ToolErrorRecovery(RecoveryPolicy(classify=classify)), buggy).run('hi')


### PR DESCRIPTION
Adds a `ToolErrorRecovery` capability that catches errors raised during tool calls and decides what to do with each one, instead of crashing the run.

A `classify` callable maps each error to one of four outcomes: `retry`(transparent, bounded), `inform` (report it to the model as a `ToolFailed` result), `fallback` (return a substitute value), or `propagate` (re-raise). By default, programming errors propagate, connection and timeout errors retry, and everything else is reported to the model. `str(error)` is kept out of the model-facing text by default, so messages can't leak through the model.

This grew out of #171 and started as a standalone package: https://github.com/aixbrain/pydantic-ai-error-recovery. 
Compared to the draft in #171, it uses a `classify` callable instead of a per-tool strategy map, a single `wrap_tool_execute` hook, and keeps `str(error)` out of the model-facing text by default. Addresses #61.

ruff, pyright strict, and the tests pass locally (100% branch coverage).
