### PR TITLE
Anchor compaction token estimates on provider-reported usage

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -32,7 +32,7 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 
 ## Triggers
 
-Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`. Token counts use a ~4-chars-per-token heuristic by default; pass a `tokenizer` callable (for example `tiktoken`) for accuracy. `DeduplicateFileReads` runs on every request when no trigger is set (it is cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` / `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` / `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a large total.
+Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`. Token counts anchor on the provider-reported usage of the most recent model response when one is available (its `input_tokens` measured the whole request that produced it, tool definitions included); only the messages added since are estimated, with a ~4-chars-per-token heuristic by default -- pass a `tokenizer` callable (for example `tiktoken`) to sharpen it. Histories with no reported usage fall back to the heuristic throughout. `DeduplicateFileReads` runs on every request when no trigger is set (it is cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` / `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` / `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a large total.
 
 ### `max_fraction`: one setting for every model
 

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -32,7 +32,7 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 
 ## Triggers
 
-Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`. Token counts anchor on the provider-reported usage of the most recent model response when one is available (its `input_tokens` measured the whole request that produced it, tool definitions included); only the messages added since are estimated, with a ~4-chars-per-token heuristic by default -- pass a `tokenizer` callable (for example `tiktoken`) to sharpen it. Histories with no reported usage fall back to the heuristic throughout. `DeduplicateFileReads` runs on every request when no trigger is set (it is cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` / `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` / `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a large total.
+Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`. Token counts anchor on the provider-reported usage of the most recent model response when one is available. That provider usage includes the instructions, tool definitions, and `FilePart` payloads sent in the anchored request; only the messages added since are estimated. The suffix after the anchor, or a history with no usage anchor, uses `tokenizer` or a ~4-chars-per-token heuristic and cannot see `FilePart` payloads. Pending tool schemas newly revealed for the request are conservatively estimated by the implementation. `DeduplicateFileReads` runs on every request when no trigger is set (it is cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` / `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` / `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a large total.
 
 ### `max_fraction`: one setting for every model
 
@@ -106,7 +106,12 @@ agent = Agent(
 
 ### What counts toward the fraction
 
-The estimator counts every part that is sent: prompts, system prompts, tool calls and their results, retry prompts, extended-thinking blocks, provider-side tool results, and the instructions, once. It is a ~4-characters-per-token approximation, not a tokenizer; pass `tokenizer=` to any strategy to measure with the real one. `FilePart` is not counted -- its payload is binary, and its length in characters would mean nothing.
+With a usage anchor, the provider-reported usage covers everything billed for the anchored request,
+including its instructions, tool definitions, and `FilePart` payloads. For the suffix after the
+anchor, and for a whole history with no usage anchor, the estimator uses `tokenizer` when supplied
+or a ~4-characters-per-token heuristic. That estimated portion cannot see `FilePart` payloads.
+Pending tool schemas newly revealed for the request are conservatively estimated by the
+implementation, since they are not covered by the earlier anchor.
 
 **If you already set an absolute `max_tokens`, re-check it.** The estimator used to count only user and system prompts, tool returns, response text, and tool calls. `ThinkingPart` / `CompactionPart` content, `RetryPromptPart` content, `NativeToolCallPart` / `NativeToolReturnPart`, and the most recent `ModelRequest.instructions` are now counted too, so the same history measures higher and an unchanged `max_tokens` compacts earlier. How much earlier depends on how much of the history is thinking blocks, retries, and instructions; on a thinking-heavy tool-calling history it can be several times the old count. What each strategy clears is unchanged -- only when it runs.
 
@@ -127,9 +132,15 @@ agent = Agent(
 )
 ```
 
-Each reading carries `used_tokens`, `window_tokens`, and `resolved` -- `False` when the window is the fallback rather than the model's real one, so a gauge can show that the percentage is a guess. `on_usage` may be a coroutine function, so a gauge that pushes over a socket does not need a sync bridge. Order matters: register the monitor *after* a compaction capability to observe the compacted history, or before it to see what triggered the compaction.
+Each reading carries `used_tokens`, `window_tokens`, and `resolved` -- `False` when the window is the fallback rather than the model's real one, so a gauge can show that the percentage is a guess. `on_usage` may be a coroutine function, so a gauge that pushes over a socket does not need a sync bridge. Order matters: register the monitor *after* a compaction capability to observe the corrected current history after same-cycle compaction, or before it to see what triggered the compaction.
 
-`used_tokens` counts the same way the triggers do: every message part that is sent, plus the most recent `ModelRequest.instructions` once. Tool schemas are outside that count, so the reading is lower than what the provider bills; tool-schema accounting is tracked in [#100](https://github.com/pydantic/pydantic-ai-harness/issues/100).
+`used_tokens` follows the accounting above: provider usage anchors include instructions, tool
+definitions, and `FilePart` payloads from the anchored request. The suffix after the anchor, or a
+history with no anchor, uses `tokenizer` or a ~4-characters-per-token heuristic and cannot see
+`FilePart` payloads. Pending newly revealed tool schemas are conservatively estimated by the
+implementation. When a compaction capability runs earlier in the same cycle, a monitor registered
+after it subtracts the rewrite's heuristic reclaim while retaining the anchor's fixed provider
+overhead.
 
 ## Compacting outside a run: `compact_now`
 

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -42,7 +42,8 @@ those, and the fallback when no response carries usage yet, is a ~4-chars-per-to
 a `tokenizer` callable (e.g. `tiktoken`) to sharpen it. The anchor is what keeps triggers honest on
 token-dense content -- minified JSON or base64 tokenizes at ~1-2 chars per token, which the
 heuristic underestimates severely enough for a history to blow the context window without any
-trigger firing. `DeduplicateFileReads` runs on every request when no trigger is set (it is
+trigger firing. Newly revealed tool schemas that are pending in the request are conservatively
+estimated by the implementation. `DeduplicateFileReads` runs on every request when no trigger is set (it is
 cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` /
 `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` /
 `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a
@@ -159,7 +160,8 @@ extended-thinking blocks, provider-side tool results, and the instructions, once
 the anchor only when they changed since it). That estimated portion is a ~4-characters-per-token
 approximation, not a tokenizer; pass `tokenizer=` to any strategy to measure with the real one.
 `FilePart` is not counted there -- its payload is binary, and its length in characters would mean
-nothing.
+nothing. Newly revealed tool schemas pending in the current request are conservatively estimated
+by the implementation, since they are not covered by the earlier anchor.
 
 **If you already set an absolute `max_tokens`, re-check it.** The estimator used to count only user
 and system prompts, tool returns, response text, and tool calls. `ThinkingPart` / `CompactionPart`
@@ -194,13 +196,14 @@ fallback rather than the model's real one, so a gauge can show that the percenta
 `on_usage` may be a coroutine function, so a gauge that pushes over a socket does not need a sync
 bridge.
 
-Order matters: register the monitor *after* a compaction capability to observe the compacted history,
-or before it to see what triggered the compaction.
+Order matters: register the monitor *after* a compaction capability to observe the corrected current
+history after same-cycle compaction, or before it to see what triggered the compaction.
 
-`used_tokens` counts the same way the triggers do: every message part that is sent, plus the most
-recent `ModelRequest.instructions` once. Tool schemas are outside that count, so the reading is lower
-than what the provider bills; tool-schema accounting is tracked in
-[#100](https://github.com/pydantic/pydantic-ai-harness/issues/100).
+`used_tokens` follows the accounting above: provider usage anchors include instructions, tool
+definitions, and `FilePart` payloads from the anchored request. The suffix after the anchor, or a
+history with no anchor, uses `tokenizer` or a ~4-characters-per-token heuristic and cannot see
+`FilePart` payloads. Pending newly revealed tool schemas are conservatively estimated by the
+implementation.
 
 ## Compacting outside a run: `compact_now`
 

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -151,11 +151,15 @@ agent = Agent(
 
 ### What counts toward the fraction
 
-The estimator counts every part that is sent: prompts, system prompts, tool calls and their
-results, retry prompts, extended-thinking blocks, provider-side tool results, and the
-instructions, once. It is a ~4-characters-per-token approximation, not a tokenizer; pass
-`tokenizer=` to any strategy to measure with the real one. `FilePart` is not counted -- its
-payload is binary, and its length in characters would mean nothing.
+With a usage anchor, everything the provider billed for the anchored request counts -- including
+tool definitions and `FilePart` payloads, which no character estimate can see. For the messages
+after the anchor (and for whole histories with no reported usage), the estimator counts every part
+that is sent: prompts, system prompts, tool calls and their results, retry prompts,
+extended-thinking blocks, provider-side tool results, and the instructions, once (or again after
+the anchor only when they changed since it). That estimated portion is a ~4-characters-per-token
+approximation, not a tokenizer; pass `tokenizer=` to any strategy to measure with the real one.
+`FilePart` is not counted there -- its payload is binary, and its length in characters would mean
+nothing.
 
 **If you already set an absolute `max_tokens`, re-check it.** The estimator used to count only user
 and system prompts, tool returns, response text, and tool calls. `ThinkingPart` / `CompactionPart`

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -35,8 +35,14 @@ provider rejects an orphaned pair. The zero-LLM strategies never call a model.
 ## Triggers
 
 Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`.
-Token counts use a ~4-chars-per-token heuristic by default; pass a `tokenizer` callable (e.g.
-`tiktoken`) for accuracy. `DeduplicateFileReads` runs on every request when no trigger is set (it is
+Token counts anchor on the provider-reported usage of the most recent model response when one is
+available: its `input_tokens` measured the whole request that produced it (instructions, tool
+definitions, every prior message), so only the messages added since are estimated. The estimate for
+those, and the fallback when no response carries usage yet, is a ~4-chars-per-token heuristic; pass
+a `tokenizer` callable (e.g. `tiktoken`) to sharpen it. The anchor is what keeps triggers honest on
+token-dense content -- minified JSON or base64 tokenizes at ~1-2 chars per token, which the
+heuristic underestimates severely enough for a history to blow the context window without any
+trigger firing. `DeduplicateFileReads` runs on every request when no trigger is set (it is
 cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` /
 `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` /
 `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a

--- a/pydantic_ai_harness/compaction/__init__.py
+++ b/pydantic_ai_harness/compaction/__init__.py
@@ -16,7 +16,12 @@ from pydantic_ai_harness.compaction._manual import compact_now
 from pydantic_ai_harness.compaction._pinning import is_pinned, pin, reinject_pinned
 from pydantic_ai_harness.compaction._receipts import TranscriptHandleProvider
 from pydantic_ai_harness.compaction._report_context_usage import ContextUsage, ReportContextUsage
-from pydantic_ai_harness.compaction._shared import CompactionStrategy, SupportsFocus, estimate_token_count
+from pydantic_ai_harness.compaction._shared import (
+    CompactionStrategy,
+    SupportsFocus,
+    estimate_context_tokens,
+    estimate_token_count,
+)
 from pydantic_ai_harness.compaction._sliding_window_compaction import SlidingWindowCompaction
 from pydantic_ai_harness.compaction._summarizing_compaction import SummarizingCompaction
 from pydantic_ai_harness.compaction._tiered_compaction import TieredCompaction
@@ -38,6 +43,7 @@ __all__ = [
     'WarnNearLimits',
     'WarningKind',
     'compact_now',
+    'estimate_context_tokens',
     'estimate_token_count',
     'is_pinned',
     'pin',

--- a/pydantic_ai_harness/compaction/_clear_tool_results.py
+++ b/pydantic_ai_harness/compaction/_clear_tool_results.py
@@ -19,6 +19,7 @@ from pydantic_ai_harness.compaction._shared import (
     exceeds,
     iter_tool_pairs,
     rebuild_with_cleared,
+    record_compaction_reclaim,
     resolve_token_trigger,
     validate_token_trigger,
 )
@@ -157,13 +158,25 @@ class ClearToolResults(AbstractCapability[AgentDepsT]):
         token_trigger = resolve_token_trigger(
             self.max_tokens, self.max_fraction, request_ctx.model, self.fallback_context_window, self.context_window
         )
-        if not exceeds(messages, self.max_messages, token_trigger, self.tokenizer):
+        if not exceeds(
+            messages,
+            self.max_messages,
+            token_trigger,
+            self.tokenizer,
+            model_request_parameters=request_context.model_request_parameters,
+        ):
             return request_context
-        request_context.messages = await compact_with_span(
+        compacted = await compact_with_span(
             request_ctx,
             strategy='ClearToolResults',
             messages=messages,
             compact=lambda: self.compact(messages, request_ctx),
             tokenizer=self.tokenizer,
         )
+        record_compaction_reclaim(
+            request_context,
+            estimate_token_count(messages, self.tokenizer),
+            estimate_token_count(compacted, self.tokenizer),
+        )
+        request_context.messages = compacted
         return request_context

--- a/pydantic_ai_harness/compaction/_deduplicate_file_reads.py
+++ b/pydantic_ai_harness/compaction/_deduplicate_file_reads.py
@@ -15,9 +15,11 @@ from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDO
 from pydantic_ai_harness.compaction._shared import (
     compact_with_span,
     context_for_request,
+    estimate_token_count,
     exceeds,
     iter_tool_pairs,
     rebuild_with_cleared,
+    record_compaction_reclaim,
     resolve_token_trigger,
     validate_token_trigger,
 )
@@ -139,13 +141,25 @@ class DeduplicateFileReads(AbstractCapability[AgentDepsT]):
                 self.fallback_context_window,
                 self.context_window,
             )
-            if not exceeds(messages, self.max_messages, token_trigger, self.tokenizer):
+            if not exceeds(
+                messages,
+                self.max_messages,
+                token_trigger,
+                self.tokenizer,
+                model_request_parameters=request_context.model_request_parameters,
+            ):
                 return request_context
-        request_context.messages = await compact_with_span(
+        compacted = await compact_with_span(
             request_ctx,
             strategy='DeduplicateFileReads',
             messages=messages,
             compact=lambda: self.compact(messages, request_ctx),
             tokenizer=self.tokenizer,
         )
+        record_compaction_reclaim(
+            request_context,
+            estimate_token_count(messages, self.tokenizer),
+            estimate_token_count(compacted, self.tokenizer),
+        )
+        request_context.messages = compacted
         return request_context

--- a/pydantic_ai_harness/compaction/_report_context_usage.py
+++ b/pydantic_ai_harness/compaction/_report_context_usage.py
@@ -12,7 +12,7 @@ from pydantic_ai.messages import ModelMessage
 from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW, resolve_context_window
-from pydantic_ai_harness.compaction._shared import estimate_context_tokens
+from pydantic_ai_harness.compaction._shared import estimate_context_tokens, get_compaction_reclaim
 
 if TYPE_CHECKING:
     from pydantic_ai.models import ModelRequestContext
@@ -26,12 +26,10 @@ class ContextUsage:
     """Estimated tokens in the message history about to be sent.
 
     Counted by `estimate_context_tokens`: the provider-reported usage of the most recent model
-    response (tool schemas included) plus an estimate of the messages added since. Histories
-    with no reported usage fall back to `estimate_token_count`, whose character heuristic
-    cannot see tool schemas (pydantic/pydantic-ai-harness#100) and so reads lower than what the
-    provider bills. When a compactor registered *before* this capability rewrote messages older
-    than the anchor this same cycle, the reading stays at the pre-compaction size until the
-    next response re-anchors it.
+    response (tool schemas included) plus an estimate of messages and newly revealed tool schemas
+    added since. With no reported usage, message text falls back to the character heuristic;
+    schemas named by availability deltas are still estimated from the pending request
+    parameters, but other tool schemas remain outside that heuristic.
     """
 
     window_tokens: int
@@ -62,7 +60,9 @@ class ReportContextUsage(AbstractCapability[AgentDepsT]):
     It only observes -- it never edits the history.
 
     Order matters: register it *after* a compaction capability to see the compacted history,
-    or before it to see what triggered the compaction.
+    or before it to see what triggered the compaction. After a preceding compactor rewrites
+    anchored history, the reading subtracts that compactor's heuristic reclaim while retaining
+    the anchor's fixed provider overhead.
 
     Example:
         ```python
@@ -104,7 +104,12 @@ class ReportContextUsage(AbstractCapability[AgentDepsT]):
     def _measure(self, request_context: ModelRequestContext) -> ContextUsage:
         """Build a reading for the request as it stands."""
         messages: list[ModelMessage] = list(request_context.messages)
-        used = estimate_context_tokens(messages, self.tokenizer)
+        used = estimate_context_tokens(
+            messages,
+            self.tokenizer,
+            model_request_parameters=request_context.model_request_parameters,
+        )
+        used = max(used - get_compaction_reclaim(request_context), 0)
         if self.context_window is not None:
             return ContextUsage(used_tokens=used, window_tokens=self.context_window, resolved=True)
         # Resolved from the request's model rather than the run's: a capability may replace

--- a/pydantic_ai_harness/compaction/_report_context_usage.py
+++ b/pydantic_ai_harness/compaction/_report_context_usage.py
@@ -12,7 +12,7 @@ from pydantic_ai.messages import ModelMessage
 from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW, resolve_context_window
-from pydantic_ai_harness.compaction._shared import estimate_context_tokens, get_compaction_reclaim
+from pydantic_ai_harness.compaction._shared import estimate_context_tokens, get_compaction_reclaim, has_context_usage_anchor
 
 if TYPE_CHECKING:
     from pydantic_ai.models import ModelRequestContext
@@ -109,7 +109,8 @@ class ReportContextUsage(AbstractCapability[AgentDepsT]):
             self.tokenizer,
             model_request_parameters=request_context.model_request_parameters,
         )
-        used = max(used - get_compaction_reclaim(request_context), 0)
+        if has_context_usage_anchor(messages):
+            used = max(used - get_compaction_reclaim(request_context), 0)
         if self.context_window is not None:
             return ContextUsage(used_tokens=used, window_tokens=self.context_window, resolved=True)
         # Resolved from the request's model rather than the run's: a capability may replace

--- a/pydantic_ai_harness/compaction/_report_context_usage.py
+++ b/pydantic_ai_harness/compaction/_report_context_usage.py
@@ -12,7 +12,7 @@ from pydantic_ai.messages import ModelMessage
 from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW, resolve_context_window
-from pydantic_ai_harness.compaction._shared import estimate_token_count
+from pydantic_ai_harness.compaction._shared import estimate_context_tokens
 
 if TYPE_CHECKING:
     from pydantic_ai.models import ModelRequestContext
@@ -101,7 +101,7 @@ class ReportContextUsage(AbstractCapability[AgentDepsT]):
     def _measure(self, request_context: ModelRequestContext) -> ContextUsage:
         """Build a reading for the request as it stands."""
         messages: list[ModelMessage] = list(request_context.messages)
-        used = estimate_token_count(messages, self.tokenizer)
+        used = estimate_context_tokens(messages, self.tokenizer)
         if self.context_window is not None:
             return ContextUsage(used_tokens=used, window_tokens=self.context_window, resolved=True)
         # Resolved from the request's model rather than the run's: a capability may replace

--- a/pydantic_ai_harness/compaction/_report_context_usage.py
+++ b/pydantic_ai_harness/compaction/_report_context_usage.py
@@ -25,10 +25,13 @@ class ContextUsage:
     used_tokens: int
     """Estimated tokens in the message history about to be sent.
 
-    Counted by `estimate_token_count`: every message part that is sent, plus the most recent
-    `ModelRequest.instructions` once. Tool schemas are outside the count, so a gauge built on
-    this reads lower than what the provider bills. Tool-schema accounting is tracked separately
-    in pydantic/pydantic-ai-harness#100.
+    Counted by `estimate_context_tokens`: the provider-reported usage of the most recent model
+    response (tool schemas included) plus an estimate of the messages added since. Histories
+    with no reported usage fall back to `estimate_token_count`, whose character heuristic
+    cannot see tool schemas (pydantic/pydantic-ai-harness#100) and so reads lower than what the
+    provider bills. When a compactor registered *before* this capability rewrote messages older
+    than the anchor this same cycle, the reading stays at the pre-compaction size until the
+    next response re-anchors it.
     """
 
     window_tokens: int

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -205,15 +205,23 @@ def estimate_context_tokens(
     A history rewritten *after* the anchor's request went out (a compaction strategy editing
     older messages mid-cycle) is overestimated, because the anchor still describes the
     pre-rewrite request; the next real response re-anchors it. `TieredCompaction` compensates
-    inside its escalation loop by scaling its anchored baseline by the heuristic shrink.
-    Compacting slightly early is the cheap failure mode; the heuristic's multi-x underestimate
-    on dense content, which lets the history blow the context window, is the expensive one.
+    inside its escalation loop by subtracting each tier's estimated reclaim from its anchored
+    baseline. Compacting slightly early is the cheap failure mode; the heuristic's multi-x
+    underestimate on dense content, which lets the history blow the context window, is the
+    expensive one.
     """
     for index in range(len(messages) - 1, -1, -1):
         message = messages[index]
         if isinstance(message, ModelResponse) and message.usage.input_tokens:
             anchored = message.usage.input_tokens + message.usage.output_tokens
             segments = _collect_message_text(messages[index + 1 :])
+            # The anchor paid for the instructions in force when its request was made. When the
+            # latest instructions differ (dynamic instructions, or a persisted history resumed
+            # under a new prompt), the new set is absent from both the anchor and the message
+            # text, so count it; when unchanged, counting it would double what the anchor holds.
+            current_instructions = _instructions_text(messages)
+            if current_instructions != _instructions_text(messages[: index + 1]):
+                segments = [*segments, *current_instructions]
             if tokenizer is not None:
                 return anchored + sum(tokenizer(s) for s in segments)
             return anchored + sum(len(s) for s in segments) // _CHARS_PER_TOKEN

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -223,26 +223,39 @@ def estimate_context_tokens(
     underestimate on dense content, which lets the history blow the context window, is the
     expensive one.
     """
-    for index in range(len(messages) - 1, -1, -1):
-        message = messages[index]
-        if isinstance(message, ModelResponse) and message.usage.input_tokens:
-            anchored = message.usage.input_tokens + message.usage.output_tokens
-            segments = _collect_message_text(messages[index + 1 :])
-            # The anchor paid for the instructions in force when its request was made. When the
-            # latest instructions differ (dynamic instructions, or a persisted history resumed
-            # under a new prompt), the new set is absent from both the anchor and the message
-            # text, so count it; when unchanged, counting it would double what the anchor holds.
-            current_instructions = _instructions_text(messages)
-            if current_instructions != _instructions_text(messages[: index + 1]):
-                segments = [*segments, *current_instructions]
-            segments.extend(_revealed_tool_schema_text(messages[index + 1 :], model_request_parameters))
-            if tokenizer is not None:
-                return anchored + sum(tokenizer(s) for s in segments)
-            return anchored + sum(len(s) for s in segments) // _CHARS_PER_TOKEN
+    if anchor := _latest_usage_anchor(messages):
+        index, message = anchor
+        anchored = message.usage.input_tokens + message.usage.output_tokens
+        segments = _collect_message_text(messages[index + 1 :])
+        # The anchor paid for the instructions in force when its request was made. When the
+        # latest instructions differ (dynamic instructions, or a persisted history resumed
+        # under a new prompt), the new set is absent from both the anchor and the message
+        # text, so count it; when unchanged, counting it would double what the anchor holds.
+        current_instructions = _instructions_text(messages)
+        if current_instructions != _instructions_text(messages[: index + 1]):
+            segments = [*segments, *current_instructions]
+        segments.extend(_revealed_tool_schema_text(messages[index + 1 :], model_request_parameters))
+        if tokenizer is not None:
+            return anchored + sum(tokenizer(s) for s in segments)
+        return anchored + sum(len(s) for s in segments) // _CHARS_PER_TOKEN
     segments = [*_collect_text(messages), *_revealed_tool_schema_text(messages, model_request_parameters)]
     if tokenizer is not None:
         return sum(tokenizer(s) for s in segments)
     return sum(len(s) for s in segments) // _CHARS_PER_TOKEN
+
+
+def has_context_usage_anchor(messages: Sequence[ModelMessage]) -> bool:
+    """Return whether `estimate_context_tokens` uses provider-reported usage for *messages*."""
+    return _latest_usage_anchor(messages) is not None
+
+
+def _latest_usage_anchor(messages: Sequence[ModelMessage]) -> tuple[int, ModelResponse] | None:
+    """Return the most recent response with provider-reported input usage."""
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if isinstance(message, ModelResponse) and message.usage.input_tokens:
+            return index, message
+    return None
 
 
 def _revealed_tool_names(messages: Sequence[ModelMessage]) -> set[str]:

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -54,8 +54,8 @@ _CHARS_PER_TOKEN = 4
 """Rough approximation: ~4 characters per token on average."""
 
 
-def _collect_text(messages: Sequence[ModelMessage]) -> list[str]:
-    """Collect all text segments from a sequence of messages.
+def _collect_message_text(messages: Sequence[ModelMessage]) -> list[str]:
+    """Collect all text segments from a sequence of messages, excluding instructions.
 
     Every part that carries text the provider is sent counts, including the ones a run only
     grows under load: a retry prompt, an extended-thinking block, the result of a
@@ -119,6 +119,12 @@ def _collect_text(messages: Sequence[ModelMessage]) -> list[str]:
                 elif isinstance(part, NativeToolReturnPart):
                     segments.append(part.tool_name)
                     segments.append(str(part.content))
+    return segments
+
+
+def _collect_text(messages: Sequence[ModelMessage]) -> list[str]:
+    """Collect all text segments from a sequence of messages, instructions included."""
+    segments = _collect_message_text(messages)
     segments.extend(_instructions_text(messages))
     return segments
 
@@ -177,6 +183,43 @@ def estimate_token_count(
     return sum(len(s) for s in segments) // _CHARS_PER_TOKEN
 
 
+def estimate_context_tokens(
+    messages: Sequence[ModelMessage],
+    tokenizer: Callable[[str], int] | None = None,
+) -> int:
+    """Best-available token count for the request this history would produce.
+
+    Anchors on the most recent `ModelResponse` carrying provider-reported usage: its
+    `input_tokens` measured everything the provider was actually sent for that request --
+    instructions, tool definitions, and every prior message -- and its `output_tokens` measured
+    the response's own parts, so their sum is ground truth for the history up to and including
+    that response. Only the messages after the anchor are estimated with the character
+    heuristic (or *tokenizer*), without re-counting instructions, which the anchor already
+    covers. This is what makes the estimate robust where the pure heuristic is not: token-dense
+    content (minified JSON, base64, non-Latin scripts) and the tool definitions the heuristic
+    cannot see at all are both inside the provider's number.
+
+    Falls back to `estimate_token_count` when no response carries usage: a fresh history, or
+    test models that report none.
+
+    A history rewritten *after* the anchor's request went out (a compaction strategy editing
+    older messages mid-cycle) is overestimated, because the anchor still describes the
+    pre-rewrite request; the next real response re-anchors it. `TieredCompaction` compensates
+    inside its escalation loop by scaling its anchored baseline by the heuristic shrink.
+    Compacting slightly early is the cheap failure mode; the heuristic's multi-x underestimate
+    on dense content, which lets the history blow the context window, is the expensive one.
+    """
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if isinstance(message, ModelResponse) and message.usage.input_tokens:
+            anchored = message.usage.input_tokens + message.usage.output_tokens
+            segments = _collect_message_text(messages[index + 1 :])
+            if tokenizer is not None:
+                return anchored + sum(tokenizer(s) for s in segments)
+            return anchored + sum(len(s) for s in segments) // _CHARS_PER_TOKEN
+    return estimate_token_count(messages, tokenizer)
+
+
 def exceeds(
     messages: Sequence[ModelMessage],
     max_messages: int | None,
@@ -186,7 +229,7 @@ def exceeds(
     """Return True if *messages* exceeds either configured size threshold."""
     if max_messages is not None and len(messages) > max_messages:
         return True
-    if max_tokens is not None and estimate_token_count(messages, tokenizer) > max_tokens:
+    if max_tokens is not None and estimate_context_tokens(messages, tokenizer) > max_tokens:
         return True
     return False
 

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -7,8 +7,11 @@ preservation, and in-place tool-result clearing -- anything used by more than on
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Sequence
+from contextvars import ContextVar
 from dataclasses import dataclass, replace
+from json import dumps
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from weakref import ReferenceType, ref
 
 from pydantic_ai._run_context import AgentDepsT
 from pydantic_ai.messages import (
@@ -44,7 +47,8 @@ from pydantic_ai_harness.compaction._receipts import (
 )
 
 if TYPE_CHECKING:
-    from pydantic_ai.models import Model, ModelRequestContext
+    from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
+    from pydantic_ai.tools import ToolDefinition
 
 # ---------------------------------------------------------------------------
 # Token estimation
@@ -52,6 +56,11 @@ if TYPE_CHECKING:
 
 _CHARS_PER_TOKEN = 4
 """Rough approximation: ~4 characters per token on average."""
+
+_COMPACTION_RECLAIM: ContextVar[tuple[ReferenceType[object], int] | None] = ContextVar(
+    'pydantic_ai_harness.compaction.reclaim', default=None
+)
+"""Heuristic reclaim from compaction that ran earlier in this request's hook chain."""
 
 
 def _collect_message_text(messages: Sequence[ModelMessage]) -> list[str]:
@@ -186,6 +195,8 @@ def estimate_token_count(
 def estimate_context_tokens(
     messages: Sequence[ModelMessage],
     tokenizer: Callable[[str], int] | None = None,
+    *,
+    model_request_parameters: ModelRequestParameters | None = None,
 ) -> int:
     """Best-available token count for the request this history would produce.
 
@@ -195,12 +206,14 @@ def estimate_context_tokens(
     the response's own parts, so their sum is ground truth for the history up to and including
     that response. Only the messages after the anchor are estimated with the character
     heuristic (or *tokenizer*), without re-counting instructions, which the anchor already
-    covers. This is what makes the estimate robust where the pure heuristic is not: token-dense
-    content (minified JSON, base64, non-Latin scripts) and the tool definitions the heuristic
-    cannot see at all are both inside the provider's number.
+    covers. Tool schemas named by availability deltas after the anchor are estimated from the
+    pending request parameters. This is what makes the estimate robust where the pure heuristic
+    is not: token-dense content (minified JSON, base64, non-Latin scripts) and the tool
+    definitions the heuristic cannot see at all are both inside the provider's number.
 
-    Falls back to `estimate_token_count` when no response carries usage: a fresh history, or
-    test models that report none.
+    Without provider usage, the history's message text falls back to `estimate_token_count`,
+    while schemas named by availability deltas are still estimated from the pending request
+    parameters.
 
     A history rewritten *after* the anchor's request went out (a compaction strategy editing
     older messages mid-cycle) is overestimated, because the anchor still describes the
@@ -222,10 +235,61 @@ def estimate_context_tokens(
             current_instructions = _instructions_text(messages)
             if current_instructions != _instructions_text(messages[: index + 1]):
                 segments = [*segments, *current_instructions]
+            segments.extend(_revealed_tool_schema_text(messages[index + 1 :], model_request_parameters))
             if tokenizer is not None:
                 return anchored + sum(tokenizer(s) for s in segments)
             return anchored + sum(len(s) for s in segments) // _CHARS_PER_TOKEN
-    return estimate_token_count(messages, tokenizer)
+    segments = [*_collect_text(messages), *_revealed_tool_schema_text(messages, model_request_parameters)]
+    if tokenizer is not None:
+        return sum(tokenizer(s) for s in segments)
+    return sum(len(s) for s in segments) // _CHARS_PER_TOKEN
+
+
+def _revealed_tool_names(messages: Sequence[ModelMessage]) -> set[str]:
+    """Return tool names recorded as newly available in *messages*."""
+    return {
+        tool_name
+        for message in messages
+        if isinstance(message, ModelRequest)
+        for part in message.parts
+        if isinstance(part, ToolAvailabilityDeltaPart)
+        for tool_name in part.tools_added
+    }
+
+
+def _revealed_tool_schema_text(
+    messages: Sequence[ModelMessage], model_request_parameters: ModelRequestParameters | None
+) -> list[str]:
+    """Return schemas added to the request by availability deltas in *messages*."""
+    if model_request_parameters is None:
+        return []
+    return [
+        _tool_schema_text(tool)
+        for tool_name in _revealed_tool_names(messages)
+        if (tool := model_request_parameters.tool_defs.get(tool_name)) is not None
+    ]
+
+
+def _tool_schema_text(tool: ToolDefinition) -> str:
+    """Return the model-visible text fields of a tool definition for local estimation."""
+    return ''.join((tool.name, tool.description or '', dumps(tool.parameters_json_schema, sort_keys=True)))
+
+
+def record_compaction_reclaim(request_context: ModelRequestContext, before: int, after: int) -> None:
+    """Record a conservative correction for a later usage reporter in this hook chain."""
+    previous = _COMPACTION_RECLAIM.get()
+    reclaimed = max(before - after, 0)
+    if previous is not None and previous[0]() is request_context:
+        reclaimed += previous[1]
+    _COMPACTION_RECLAIM.set((ref(request_context), reclaimed))
+
+
+def get_compaction_reclaim(request_context: ModelRequestContext) -> int:
+    """Return the reclaim recorded for *request_context*, if it is still current."""
+    previous = _COMPACTION_RECLAIM.get()
+    if previous is None or previous[0]() is not request_context:
+        return 0
+    return previous[1]
 
 
 def exceeds(
@@ -233,11 +297,16 @@ def exceeds(
     max_messages: int | None,
     max_tokens: int | None,
     tokenizer: Callable[[str], int] | None,
+    *,
+    model_request_parameters: ModelRequestParameters | None = None,
 ) -> bool:
     """Return True if *messages* exceeds either configured size threshold."""
     if max_messages is not None and len(messages) > max_messages:
         return True
-    if max_tokens is not None and estimate_context_tokens(messages, tokenizer) > max_tokens:
+    if (
+        max_tokens is not None
+        and estimate_context_tokens(messages, tokenizer, model_request_parameters=model_request_parameters) > max_tokens
+    ):
         return True
     return False
 

--- a/pydantic_ai_harness/compaction/_sliding_window_compaction.py
+++ b/pydantic_ai_harness/compaction/_sliding_window_compaction.py
@@ -29,6 +29,7 @@ from pydantic_ai_harness.compaction._shared import (
     find_safe_cutoff,
     find_token_cutoff,
     prepend_first_user_message,
+    record_compaction_reclaim,
     resolve_token_trigger,
     validate_token_trigger,
 )
@@ -227,13 +228,25 @@ class SlidingWindowCompaction(AbstractCapability[AgentDepsT]):
         token_trigger = resolve_token_trigger(
             self.max_tokens, self.max_fraction, request_ctx.model, self.fallback_context_window, self.context_window
         )
-        if not exceeds(messages, self.max_messages, token_trigger, self.tokenizer):
+        if not exceeds(
+            messages,
+            self.max_messages,
+            token_trigger,
+            self.tokenizer,
+            model_request_parameters=request_context.model_request_parameters,
+        ):
             return request_context
-        request_context.messages = await compact_with_span(
+        compacted = await compact_with_span(
             request_ctx,
             strategy='SlidingWindowCompaction',
             messages=messages,
             compact=lambda: self.compact(messages, request_ctx),
             tokenizer=self.tokenizer,
         )
+        record_compaction_reclaim(
+            request_context,
+            estimate_token_count(messages, self.tokenizer),
+            estimate_token_count(compacted, self.tokenizer),
+        )
+        request_context.messages = compacted
         return request_context

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -40,6 +40,7 @@ from pydantic_ai_harness.compaction._shared import (
     find_first_user_message,
     find_safe_cutoff,
     find_token_cutoff,
+    record_compaction_reclaim,
     resolve_token_trigger,
     validate_token_trigger,
 )
@@ -559,15 +560,27 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
         token_trigger = resolve_token_trigger(
             self.max_tokens, self.max_fraction, request_ctx.model, self.fallback_context_window, self.context_window
         )
-        if not exceeds(messages, self.max_messages, token_trigger, self.tokenizer):
+        if not exceeds(
+            messages,
+            self.max_messages,
+            token_trigger,
+            self.tokenizer,
+            model_request_parameters=request_context.model_request_parameters,
+        ):
             return request_context
-        request_context.messages = await compact_with_span(
+        compacted = await compact_with_span(
             request_ctx,
             strategy='SummarizingCompaction',
             messages=messages,
             compact=lambda: self.compact(messages, request_ctx),
             tokenizer=self.tokenizer,
         )
+        record_compaction_reclaim(
+            request_context,
+            estimate_token_count(messages, self.tokenizer),
+            estimate_token_count(compacted, self.tokenizer),
+        )
+        request_context.messages = compacted
         return request_context
 
     async def _summarize(

--- a/pydantic_ai_harness/compaction/_tiered_compaction.py
+++ b/pydantic_ai_harness/compaction/_tiered_compaction.py
@@ -18,6 +18,7 @@ from pydantic_ai_harness.compaction._shared import (
     SupportsFocus,
     compact_with_span,
     context_for_request,
+    estimate_context_tokens,
     estimate_token_count,
     resolve_token_trigger,
     validate_token_trigger,
@@ -141,12 +142,20 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
     ) -> list[ModelMessage]:
         """Apply tiers in order until the history fits *target* or tiers run out."""
         original = messages
+        # The usage anchor describes the request as it was sent, so a tier's rewrite of older
+        # messages is invisible to re-anchoring; scale the anchored baseline by the heuristic
+        # shrink instead, so tier reclaim registers against real-token accounting.
+        baseline = estimate_context_tokens(messages, self.tokenizer)
+        heuristic_baseline = estimate_token_count(messages, self.tokenizer)
+        estimate = baseline
         for tier in self.tiers:
-            if estimate_token_count(messages, self.tokenizer) <= target:
+            if estimate <= target:
                 break
             messages = await tier.compact(messages, ctx)
             # Before the next stop decision, so escalation measures the history it would return.
             messages = reinject_pinned(original, messages)
+            heuristic_now = estimate_token_count(messages, self.tokenizer)
+            estimate = baseline * heuristic_now // heuristic_baseline if heuristic_baseline else heuristic_now
         return messages
 
     async def compact(
@@ -170,7 +179,7 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
         request_ctx = context_for_request(ctx, request_context)
         # Resolved once, so the gate and the escalation loop cannot disagree about the target.
         target = self._target(request_ctx.model)
-        if estimate_token_count(messages, self.tokenizer) <= target:
+        if estimate_context_tokens(messages, self.tokenizer) <= target:
             return request_context
         request_context.messages = await compact_with_span(
             request_ctx,

--- a/pydantic_ai_harness/compaction/_tiered_compaction.py
+++ b/pydantic_ai_harness/compaction/_tiered_compaction.py
@@ -143,8 +143,11 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
         """Apply tiers in order until the history fits *target* or tiers run out."""
         original = messages
         # The usage anchor describes the request as it was sent, so a tier's rewrite of older
-        # messages is invisible to re-anchoring; scale the anchored baseline by the heuristic
-        # shrink instead, so tier reclaim registers against real-token accounting.
+        # messages is invisible to re-anchoring. Subtract the estimated tokens of the text a
+        # tier removed from the anchored baseline instead: the reclaim is measured only on
+        # message text, so the baseline's fixed overhead (tool definitions, instructions) is
+        # never treated as compacted away. On content the estimator undercounts, this
+        # understates the reclaim and escalates a tier early -- the cheap direction.
         baseline = estimate_context_tokens(messages, self.tokenizer)
         heuristic_baseline = estimate_token_count(messages, self.tokenizer)
         estimate = baseline
@@ -154,8 +157,8 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
             messages = await tier.compact(messages, ctx)
             # Before the next stop decision, so escalation measures the history it would return.
             messages = reinject_pinned(original, messages)
-            heuristic_now = estimate_token_count(messages, self.tokenizer)
-            estimate = baseline * heuristic_now // heuristic_baseline if heuristic_baseline else heuristic_now
+            reclaimed = heuristic_baseline - estimate_token_count(messages, self.tokenizer)
+            estimate = max(baseline - reclaimed, 0)
         return messages
 
     async def compact(

--- a/pydantic_ai_harness/compaction/_tiered_compaction.py
+++ b/pydantic_ai_harness/compaction/_tiered_compaction.py
@@ -20,12 +20,13 @@ from pydantic_ai_harness.compaction._shared import (
     context_for_request,
     estimate_context_tokens,
     estimate_token_count,
+    record_compaction_reclaim,
     resolve_token_trigger,
     validate_token_trigger,
 )
 
 if TYPE_CHECKING:
-    from pydantic_ai.models import Model, ModelRequestContext
+    from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
 
 
 @dataclass
@@ -139,6 +140,7 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
         messages: list[ModelMessage],
         ctx: RunContext[AgentDepsT],
         target: int,
+        model_request_parameters: ModelRequestParameters | None = None,
     ) -> list[ModelMessage]:
         """Apply tiers in order until the history fits *target* or tiers run out."""
         original = messages
@@ -148,7 +150,7 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
         # message text, so the baseline's fixed overhead (tool definitions, instructions) is
         # never treated as compacted away. On content the estimator undercounts, this
         # understates the reclaim and escalates a tier early -- the cheap direction.
-        baseline = estimate_context_tokens(messages, self.tokenizer)
+        baseline = estimate_context_tokens(messages, self.tokenizer, model_request_parameters=model_request_parameters)
         heuristic_baseline = estimate_token_count(messages, self.tokenizer)
         estimate = baseline
         for tier in self.tiers:
@@ -182,13 +184,26 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
         request_ctx = context_for_request(ctx, request_context)
         # Resolved once, so the gate and the escalation loop cannot disagree about the target.
         target = self._target(request_ctx.model)
-        if estimate_context_tokens(messages, self.tokenizer) <= target:
+        if (
+            estimate_context_tokens(
+                messages,
+                self.tokenizer,
+                model_request_parameters=request_context.model_request_parameters,
+            )
+            <= target
+        ):
             return request_context
-        request_context.messages = await compact_with_span(
+        compacted = await compact_with_span(
             request_ctx,
             strategy='TieredCompaction',
             messages=messages,
-            compact=lambda: self._escalate(messages, request_ctx, target),
+            compact=lambda: self._escalate(messages, request_ctx, target, request_context.model_request_parameters),
             tokenizer=self.tokenizer,
         )
+        record_compaction_reclaim(
+            request_context,
+            estimate_token_count(messages, self.tokenizer),
+            estimate_token_count(compacted, self.tokenizer),
+        )
+        request_context.messages = compacted
         return request_context

--- a/pydantic_ai_harness/compaction/_warn_near_limits.py
+++ b/pydantic_ai_harness/compaction/_warn_near_limits.py
@@ -12,7 +12,7 @@ from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW
 from pydantic_ai_harness.compaction._shared import (
-    estimate_token_count,
+    estimate_context_tokens,
     resolve_token_trigger,
     validate_token_trigger,
 )
@@ -248,7 +248,7 @@ class WarnNearLimits(AbstractCapability[AgentDepsT]):
                 self.context_window,
             )
             if context_limit is not None:  # pragma: no branch -- the kind is only active when one is set
-                w = self._build_context_warning(estimate_token_count(messages), context_limit)
+                w = self._build_context_warning(estimate_context_tokens(messages), context_limit)
                 if w is not None:
                     active.append(w)
 

--- a/pydantic_ai_harness/compaction/_warn_near_limits.py
+++ b/pydantic_ai_harness/compaction/_warn_near_limits.py
@@ -248,7 +248,13 @@ class WarnNearLimits(AbstractCapability[AgentDepsT]):
                 self.context_window,
             )
             if context_limit is not None:  # pragma: no branch -- the kind is only active when one is set
-                w = self._build_context_warning(estimate_context_tokens(messages), context_limit)
+                w = self._build_context_warning(
+                    estimate_context_tokens(
+                        messages,
+                        model_request_parameters=request_context.model_request_parameters,
+                    ),
+                    context_limit,
+                )
                 if w is not None:
                     active.append(w)
 

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -30,7 +30,7 @@ from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameter
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RequestUsage, RunUsage
 
 from pydantic_ai_harness.compaction import (
     ClampOversizedMessages,
@@ -41,6 +41,7 @@ from pydantic_ai_harness.compaction import (
     TieredCompaction,
     TranscriptHandleProvider,
     WarnNearLimits,
+    estimate_context_tokens,
     estimate_token_count,
     is_pinned,
     pin,
@@ -167,6 +168,64 @@ class TestEstimateTokenCount:
             _tool_return('search', 'tc1', 'result text here'),
         ]
         assert estimate_token_count(msgs) > 0
+
+
+# ---------------------------------------------------------------------------
+# estimate_context_tokens
+# ---------------------------------------------------------------------------
+
+
+def _assistant_with_usage(text: str, input_tokens: int, output_tokens: int) -> ModelResponse:
+    return ModelResponse(
+        parts=[TextPart(content=text)],
+        usage=RequestUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+    )
+
+
+class TestEstimateContextTokens:
+    def test_no_usage_falls_back_to_heuristic(self):
+        msgs: list[ModelMessage] = [_user('x' * 40), _assistant('y' * 40)]
+        assert estimate_context_tokens(msgs) == estimate_token_count(msgs)
+
+    def test_anchors_on_reported_usage(self):
+        # The heuristic would say ~12 tokens; the provider said the request was 50K.
+        msgs: list[ModelMessage] = [_user('x' * 40), _assistant_with_usage('short', 50_000, 500)]
+        assert estimate_context_tokens(msgs) == 50_500
+
+    def test_counts_only_messages_after_the_anchor(self):
+        msgs: list[ModelMessage] = [
+            _user('x' * 40),
+            _assistant_with_usage('short', 50_000, 500),
+            _tool_return('search', 'tc1', 'z' * 400),
+        ]
+        assert estimate_context_tokens(msgs) == 50_500 + 100
+
+    def test_anchors_on_the_most_recent_usage(self):
+        msgs: list[ModelMessage] = [
+            _assistant_with_usage('a', 10_000, 100),
+            _user('x' * 40),
+            _assistant_with_usage('b', 50_000, 1_000),
+        ]
+        assert estimate_context_tokens(msgs) == 51_000
+
+    def test_zero_usage_response_is_not_an_anchor(self):
+        # TestModel/FunctionModel histories report no usage; the whole history falls back.
+        msgs: list[ModelMessage] = [_user('x' * 40), _assistant('y' * 40)]
+        assert estimate_context_tokens(msgs) == estimate_token_count(msgs) > 0
+
+    def test_suffix_does_not_recount_instructions(self):
+        # Instructions travelled inside the anchor's input_tokens; counting the copy carried
+        # by a later request would double them.
+        request_after = ModelRequest(parts=[UserPromptPart(content='a' * 40)], instructions='i' * 4_000)
+        msgs: list[ModelMessage] = [_assistant_with_usage('short', 50_000, 500), request_after]
+        assert estimate_context_tokens(msgs) == 50_500 + 10
+
+    def test_tokenizer_applies_to_the_suffix(self):
+        msgs: list[ModelMessage] = [
+            _assistant_with_usage('short', 50_000, 500),
+            _user('three short words'),
+        ]
+        assert estimate_context_tokens(msgs, tokenizer=lambda s: len(s.split())) == 50_503
 
 
 # ---------------------------------------------------------------------------
@@ -1808,6 +1867,36 @@ class TestTieredCompaction:
         result = await cap.before_model_request(_make_ctx(), rc)
         assert calls == ['t1']  # t2 never reached
         assert len(result.messages) == 1
+
+    @pytest.mark.anyio
+    async def test_triggers_on_anchored_usage_the_heuristic_cannot_see(self):
+        # ~101 tokens by the heuristic, but the provider reported the request at 90K:
+        # dense content the character estimate is blind to. The anchored gate must fire.
+        calls: list[str] = []
+        t1 = _RecordingTier('t1', calls, drop=1)
+        cap = TieredCompaction(tiers=[t1], target_tokens=50_000)
+        messages: list[ModelMessage] = [_user('x' * 400), _assistant_with_usage('short', 90_000, 100)]
+        rc = _make_request_context(messages)
+        result = await cap.before_model_request(_make_ctx(), rc)
+        assert calls == ['t1']
+        assert len(result.messages) == 1
+
+    @pytest.mark.anyio
+    async def test_escalation_scales_anchored_baseline_by_tier_reclaim(self):
+        # The anchor predates any tier rewrite, so re-anchoring would show no reclaim and
+        # always escalate to the last tier. Scaling by the heuristic shrink must register
+        # t1's reclaim (101K -> ~50.5K <= 60K target) and never reach t2.
+        calls: list[str] = []
+        t1 = _RecordingTier('t1', calls, drop=6)
+        t2 = _RecordingTier('t2', calls)
+        cap = TieredCompaction(tiers=[t1, t2], target_tokens=60_000)
+        messages: list[ModelMessage] = [_assistant_with_usage('', 100_000, 0)] + [
+            _tool_return('search', f'tc{i}', 'z' * 400) for i in range(10)
+        ]
+        rc = _make_request_context(messages)
+        result = await cap.before_model_request(_make_ctx(), rc)
+        assert calls == ['t1']
+        assert len(result.messages) == 5
 
     @pytest.mark.anyio
     async def test_full_escalation(self):

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -213,12 +213,21 @@ class TestEstimateContextTokens:
         msgs: list[ModelMessage] = [_user('x' * 40), _assistant('y' * 40)]
         assert estimate_context_tokens(msgs) == estimate_token_count(msgs) > 0
 
-    def test_suffix_does_not_recount_instructions(self):
+    def test_suffix_does_not_recount_unchanged_instructions(self):
         # Instructions travelled inside the anchor's input_tokens; counting the copy carried
         # by a later request would double them.
+        request_before = ModelRequest(parts=[UserPromptPart(content='q')], instructions='i' * 4_000)
         request_after = ModelRequest(parts=[UserPromptPart(content='a' * 40)], instructions='i' * 4_000)
-        msgs: list[ModelMessage] = [_assistant_with_usage('short', 50_000, 500), request_after]
+        msgs: list[ModelMessage] = [request_before, _assistant_with_usage('short', 50_000, 500), request_after]
         assert estimate_context_tokens(msgs) == 50_500 + 10
+
+    def test_instructions_changed_after_the_anchor_are_counted(self):
+        # The anchor paid for the old instructions only; a new set (dynamic instructions, or a
+        # resumed history under a new prompt) must be added to the estimate.
+        request_before = ModelRequest(parts=[UserPromptPart(content='q')], instructions='old')
+        request_after = ModelRequest(parts=[UserPromptPart(content='a' * 40)], instructions='i' * 4_000)
+        msgs: list[ModelMessage] = [request_before, _assistant_with_usage('short', 50_000, 500), request_after]
+        assert estimate_context_tokens(msgs) == 50_500 + 10 + 1_000
 
     def test_tokenizer_applies_to_the_suffix(self):
         msgs: list[ModelMessage] = [
@@ -1882,21 +1891,37 @@ class TestTieredCompaction:
         assert len(result.messages) == 1
 
     @pytest.mark.anyio
-    async def test_escalation_scales_anchored_baseline_by_tier_reclaim(self):
+    async def test_escalation_subtracts_tier_reclaim_from_anchored_baseline(self):
         # The anchor predates any tier rewrite, so re-anchoring would show no reclaim and
-        # always escalate to the last tier. Scaling by the heuristic shrink must register
-        # t1's reclaim (101K -> ~50.5K <= 60K target) and never reach t2.
+        # always escalate to the last tier. Subtracting the removed text's estimate must
+        # register t1's reclaim (14K -> 12K <= 13K target) and never reach t2.
         calls: list[str] = []
         t1 = _RecordingTier('t1', calls, drop=6)
         t2 = _RecordingTier('t2', calls)
-        cap = TieredCompaction(tiers=[t1, t2], target_tokens=60_000)
-        messages: list[ModelMessage] = [_assistant_with_usage('', 100_000, 0)] + [
+        cap = TieredCompaction(tiers=[t1, t2], target_tokens=13_000, tokenizer=len)
+        messages: list[ModelMessage] = [_assistant_with_usage('', 10_000, 0)] + [
             _tool_return('search', f'tc{i}', 'z' * 400) for i in range(10)
         ]
         rc = _make_request_context(messages)
         result = await cap.before_model_request(_make_ctx(), rc)
         assert calls == ['t1']
         assert len(result.messages) == 5
+
+    @pytest.mark.anyio
+    async def test_escalation_never_counts_fixed_overhead_as_reclaimed(self):
+        # 100K of the baseline is anchored overhead (tool definitions, instructions) that no
+        # tier can touch. Halving the 4K of message text must leave the estimate at ~102K,
+        # not the ~52K a proportional rescale would claim, so escalation continues to t2.
+        calls: list[str] = []
+        t1 = _RecordingTier('t1', calls, drop=6)
+        t2 = _RecordingTier('t2', calls)
+        cap = TieredCompaction(tiers=[t1, t2], target_tokens=60_000, tokenizer=len)
+        messages: list[ModelMessage] = [_assistant_with_usage('', 100_000, 0)] + [
+            _tool_return('search', f'tc{i}', 'z' * 400) for i in range(10)
+        ]
+        rc = _make_request_context(messages)
+        await cap.before_model_request(_make_ctx(), rc)
+        assert calls == ['t1', 't2']
 
     @pytest.mark.anyio
     async def test_full_escalation(self):

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -906,6 +906,62 @@ class TestReportContextUsage:
         expected = estimate_context_tokens(messages) - (before - estimate_token_count(request_context.messages))
         assert [usage.used_tokens for usage in seen] == [expected, expected]
 
+    async def test_accumulates_reclaim_from_multiple_compactors(self, monkeypatch: pytest.MonkeyPatch):
+        _fixed_window(monkeypatch, 1_000)
+        seen: list[ContextUsage] = []
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='x' * 4_000)]),
+            ModelResponse(parts=[TextPart(content='old reply ' + 'x' * 4_000)]),
+            ModelRequest(parts=[UserPromptPart(content='before anchor ' + 'x' * 4_000)]),
+            ModelResponse(parts=[TextPart(content='done')], usage=RequestUsage(input_tokens=10_000, output_tokens=0)),
+            ModelRequest(parts=[UserPromptPart(content='after anchor ' + 'x' * 4_000)]),
+            ModelResponse(parts=[TextPart(content='new reply ' + 'x' * 4_000)]),
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+        ]
+        request_context = _request_context(messages)
+        first_compactor: SlidingWindowCompaction[None] = SlidingWindowCompaction(
+            max_messages=6, keep_messages=6, preserve_first_user_message=False
+        )
+        second_compactor: SlidingWindowCompaction[None] = SlidingWindowCompaction(
+            max_messages=4, keep_messages=4, preserve_first_user_message=False
+        )
+        monitor: ReportContextUsage[None] = ReportContextUsage(on_usage=seen.append)
+        before = estimate_token_count(messages)
+
+        await first_compactor.before_model_request(_ctx(), request_context)
+        await second_compactor.before_model_request(_ctx(), request_context)
+        await monitor.before_model_request(_ctx(), request_context)
+
+        expected = estimate_context_tokens(messages) - (before - estimate_token_count(request_context.messages))
+        assert [usage.used_tokens for usage in seen] == [expected]
+
+    async def test_ignores_reclaim_from_a_different_request_context(self, monkeypatch: pytest.MonkeyPatch):
+        _fixed_window(monkeypatch, 1_000)
+        compacted_context = _request_context(
+            [
+                ModelRequest(parts=[UserPromptPart(content='x' * 4_000)]),
+                ModelResponse(parts=[TextPart(content='done')], usage=RequestUsage(input_tokens=10_000, output_tokens=0)),
+                ModelRequest(parts=[UserPromptPart(content='continue')]),
+            ]
+        )
+        compactor: SlidingWindowCompaction[None] = SlidingWindowCompaction(
+            max_messages=2, keep_messages=2, preserve_first_user_message=False
+        )
+        seen: list[ContextUsage] = []
+        monitor: ReportContextUsage[None] = ReportContextUsage(on_usage=seen.append)
+        unrelated_context = _request_context(
+            [
+                ModelRequest(parts=[UserPromptPart(content='different request')]),
+                ModelResponse(parts=[TextPart(content='done')], usage=RequestUsage(input_tokens=500, output_tokens=0)),
+                ModelRequest(parts=[UserPromptPart(content='continue')]),
+            ]
+        )
+
+        await compactor.before_model_request(_ctx(), compacted_context)
+        await monitor.before_model_request(_ctx(), unrelated_context)
+
+        assert [usage.used_tokens for usage in seen] == [estimate_context_tokens(unrelated_context.messages)]
+
     async def test_after_a_compactor_reports_the_rewritten_unanchored_history(self, monkeypatch: pytest.MonkeyPatch):
         _fixed_window(monkeypatch, 1_000)
         seen: list[ContextUsage] = []

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -940,7 +940,9 @@ class TestReportContextUsage:
         compacted_context = _request_context(
             [
                 ModelRequest(parts=[UserPromptPart(content='x' * 4_000)]),
-                ModelResponse(parts=[TextPart(content='done')], usage=RequestUsage(input_tokens=10_000, output_tokens=0)),
+                ModelResponse(
+                    parts=[TextPart(content='done')], usage=RequestUsage(input_tokens=10_000, output_tokens=0)
+                ),
                 ModelRequest(parts=[UserPromptPart(content='continue')]),
             ]
         )

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -23,7 +23,8 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.usage import RequestUsage, RunUsage
 
 from pydantic_ai_harness.compaction import (
     DEFAULT_CONTEXT_WINDOW,
@@ -37,6 +38,7 @@ from pydantic_ai_harness.compaction import (
     TieredCompaction,
     WarnNearLimits,
     compact_now,
+    estimate_context_tokens,
     estimate_token_count,
     resolve_context_window,
 )
@@ -73,12 +75,16 @@ def _ctx(model: Any = None) -> Any:
     return _FakeCtx(model=model) if model is not None else _FakeCtx()
 
 
-def _request_context(messages: list[ModelMessage], model: _FakeModel | None = None) -> ModelRequestContext:
+def _request_context(
+    messages: list[ModelMessage],
+    model: _FakeModel | None = None,
+    model_request_parameters: ModelRequestParameters | None = None,
+) -> ModelRequestContext:
     return ModelRequestContext(
         model=model if model is not None else _FakeModel(),  # type: ignore[arg-type]
         messages=messages,
         model_settings=None,
-        model_request_parameters=ModelRequestParameters(),
+        model_request_parameters=model_request_parameters or ModelRequestParameters(),
     )
 
 
@@ -665,6 +671,45 @@ def test_tool_availability_delta_adds_nothing_to_the_estimate():
     assert estimate_token_count(augmented) == estimate_token_count(messages)
 
 
+class TestProgressiveToolSchemas:
+    async def test_first_request_after_a_tool_reveal_counts_the_new_schema(self):
+        tool = ToolDefinition(
+            name='read_workspace',
+            description='x' * 1_000,
+            parameters_json_schema={'type': 'object', 'properties': {'path': {'type': 'string'}}},
+            defer_loading=True,
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='start')]),
+            ModelResponse(parts=[TextPart(content='done')], usage=RequestUsage(input_tokens=100, output_tokens=10)),
+            ModelRequest(parts=[ToolAvailabilityDeltaPart(tools_added=['read_workspace'])]),
+        ]
+        parameters = ModelRequestParameters(function_tools=[tool])
+        capability: SlidingWindowCompaction[None] = SlidingWindowCompaction(
+            max_tokens=200, keep_messages=1, preserve_first_user_message=False
+        )
+        request_context = _request_context(messages, model_request_parameters=parameters)
+
+        await capability.before_model_request(_ctx(), request_context)
+
+        assert len(request_context.messages) == 1
+
+    def test_a_tool_reveal_without_usage_counts_the_new_schema(self):
+        tool = ToolDefinition(
+            name='read_workspace',
+            description='x' * 1_000,
+            parameters_json_schema={'type': 'object', 'properties': {'path': {'type': 'string'}}},
+            defer_loading=True,
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='start')]),
+            ModelRequest(parts=[ToolAvailabilityDeltaPart(tools_added=['read_workspace'])]),
+        ]
+        parameters = ModelRequestParameters(function_tools=[tool])
+
+        assert estimate_context_tokens(messages, model_request_parameters=parameters) > estimate_token_count(messages)
+
+
 class TestStrategyWindowOverride:
     """A window the registry resolves *wrongly* is the caller's to correct.
 
@@ -818,6 +863,29 @@ class TestReportContextUsage:
         await monitor.before_model_request(_ctx(), request_context)
 
         assert request_context.messages == messages
+
+    async def test_after_a_compactor_reports_the_rewritten_anchored_history(self, monkeypatch: pytest.MonkeyPatch):
+        _fixed_window(monkeypatch, 1_000)
+        seen: list[ContextUsage] = []
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='x' * 4_000)]),
+            ModelResponse(parts=[TextPart(content='done')], usage=RequestUsage(input_tokens=10_000, output_tokens=0)),
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+        ]
+        request_context = _request_context(messages)
+        compactor: SlidingWindowCompaction[None] = SlidingWindowCompaction(
+            max_messages=2, keep_messages=2, preserve_first_user_message=False
+        )
+        monitor: ReportContextUsage[None] = ReportContextUsage(on_usage=seen.append)
+        second_monitor: ReportContextUsage[None] = ReportContextUsage(on_usage=seen.append)
+        before = estimate_token_count(messages)
+
+        await compactor.before_model_request(_ctx(), request_context)
+        await monitor.before_model_request(_ctx(), request_context)
+        await second_monitor.before_model_request(_ctx(), request_context)
+
+        expected = estimate_context_tokens(messages) - (before - estimate_token_count(request_context.messages))
+        assert [usage.used_tokens for usage in seen] == [expected, expected]
 
     async def test_an_async_callback_is_awaited(self, monkeypatch: pytest.MonkeyPatch):
         _fixed_window(monkeypatch, 1_000)

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -887,6 +887,25 @@ class TestReportContextUsage:
         expected = estimate_context_tokens(messages) - (before - estimate_token_count(request_context.messages))
         assert [usage.used_tokens for usage in seen] == [expected, expected]
 
+    async def test_after_a_compactor_reports_the_rewritten_unanchored_history(self, monkeypatch: pytest.MonkeyPatch):
+        _fixed_window(monkeypatch, 1_000)
+        seen: list[ContextUsage] = []
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content='x' * 4_000)]),
+            ModelResponse(parts=[TextPart(content='done')]),
+            ModelRequest(parts=[UserPromptPart(content='continue')]),
+        ]
+        request_context = _request_context(messages)
+        compactor: SlidingWindowCompaction[None] = SlidingWindowCompaction(
+            max_messages=2, keep_messages=2, preserve_first_user_message=False
+        )
+        monitor: ReportContextUsage[None] = ReportContextUsage(on_usage=seen.append)
+
+        await compactor.before_model_request(_ctx(), request_context)
+        await monitor.before_model_request(_ctx(), request_context)
+
+        assert seen[0].used_tokens == estimate_context_tokens(request_context.messages)
+
     async def test_an_async_callback_is_awaited(self, monkeypatch: pytest.MonkeyPatch):
         _fixed_window(monkeypatch, 1_000)
         seen: list[ContextUsage] = []


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Problem

Every size trigger in the compaction module measured history with a ~4-characters-per-token heuristic. That calibration is least reliable where compaction matters most: token-dense tool results such as minified JSON, telemetry payloads, and base64 can tokenize at roughly 1-2 characters per token, causing the estimate to run several times low. The heuristic also cannot see provider-billed request content such as tool definitions and binary `FilePart` payloads.

Provider-reported usage already supplies a better baseline. A `ModelResponse` reports the input tokens for the request that produced it, including instructions, tool definitions, and prior messages, plus the output tokens for the response itself.

## Change

Add the shared `estimate_context_tokens` estimator and use it for all context-size gates, `TieredCompaction`, `WarnNearLimits`, and `ReportContextUsage`.

The estimator:

- Anchors on the most recent `ModelResponse` with non-zero input usage. `input_tokens + output_tokens` covers the history through that response.
- Estimates only content not covered by the anchor, including messages added afterward and instructions that changed since the anchored request.
- Conservatively estimates schemas for tools newly revealed by `ToolAvailabilityDeltaPart` from the pending request parameters.
- Falls back to the configured `tokenizer` or the ~4-characters-per-token heuristic when no response carries usage.
- Counts the model-visible text of supported message parts in the fallback, while leaving binary `FilePart` payloads and tool schemas not exposed by availability deltas outside the estimate.

`TieredCompaction` retains the anchored provider overhead while subtracting each tier's heuristic reclaim from the anchored baseline. This lets the escalation loop observe compaction without treating fixed request overhead as content a tier removed.

Compaction strategies also record their heuristic reclaim for later capabilities in the same request hook chain. A `ReportContextUsage` registered after one or more compactors subtracts that reclaim from anchored history, so it reports the corrected current history rather than the pre-compaction anchor. Multiple usage monitors can observe the same correction. Without a provider usage anchor, no correction is applied because the fallback already measures the rewritten history directly.

## Tradeoffs

The provider anchor is exact for the request it describes, but content added or rewritten afterward still requires estimation until the next model response supplies a new anchor. A later size-based strategy in the same hook chain can therefore compact early after an earlier strategy rewrites anchored history. This is the conservative failure direction: it avoids the large underestimate that can let a run exceed its context window without triggering compaction.

Slice-local measurements that have no provider anchor remain heuristic, including `find_token_cutoff` tails, `min_clear_tokens` reclaim deltas, summarizer per-message counts, and the mutually comparable before/after `compact_messages` span attributes.

## Verification

- Added coverage for anchored and unanchored histories, changed instructions, progressive tool reveal, same-cycle compaction reporting, stacked compactors, multiple monitors, and stale request contexts.
- Updated the package README and unified compaction documentation to match the estimator and reporting behavior.
- The full CI matrix, type checking, linting, and the 100% coverage gate pass.

## AI Disclaimer

This PR was developed with AI assistance. The changes were independently reviewed and verified by the test suite.
