### PR TITLE
Support realtime `SpeechPart` and `AbstractModel` run models from pydantic-ai `2.28`

### DIFF
--- a/pydantic_ai_harness/compaction/_context_window.py
+++ b/pydantic_ai_harness/compaction/_context_window.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from pydantic_ai.models import Model
+    from pydantic_ai.models import AbstractModel
 
 DEFAULT_CONTEXT_WINDOW = 200_000
 """Window assumed when the model's real one cannot be resolved.
@@ -42,7 +42,7 @@ def split_model_id(model_id: str) -> tuple[str | None, str]:
     return provider, model
 
 
-def resolve_context_window(model: Model | str) -> int | None:
+def resolve_context_window(model: AbstractModel | str) -> int | None:
     """Return the model's context window in tokens, or `None` when it is not known.
 
     `None` is returned both for models `genai-prices` has no entry for and for models

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -21,6 +21,7 @@ from pydantic_ai.messages import (
     NativeToolCallPart,
     NativeToolReturnPart,
     RetryPromptPart,
+    SpeechPart,
     SystemPromptPart,
     TextContent,
     TextPart,
@@ -30,6 +31,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.models import AbstractModel, Model
 from pydantic_ai.tools import RunContext
 from typing_extensions import Self, assert_never
 
@@ -44,7 +46,7 @@ from pydantic_ai_harness.compaction._receipts import (
 )
 
 if TYPE_CHECKING:
-    from pydantic_ai.models import Model, ModelRequestContext
+    from pydantic_ai.models import ModelRequestContext
 
 # ---------------------------------------------------------------------------
 # Token estimation
@@ -70,57 +72,76 @@ def _collect_text(messages: Sequence[ModelMessage]) -> list[str]:
     segments: list[str] = []
     for msg in messages:
         if isinstance(msg, ModelRequest):
-            for part in msg.parts:
-                if isinstance(part, UserPromptPart):
-                    segments.append(_user_prompt_text_for_counting(part))
-                elif isinstance(part, SystemPromptPart):
-                    segments.append(part.content)
-                elif isinstance(part, (ToolReturnPart, RetryPromptPart)):
-                    # Both are sent in full. The tool-search and capability-load returns
-                    # subclass `ToolReturnPart`, so they arrive here too.
-                    segments.append(str(part.content))
-                # Control bookkeeping rather than message text: it records which tools became
-                # available, and the schemas themselves travel in the request's tool
-                # definitions. Those schemas are not free -- this estimator counts no tool
-                # definitions at all, so revealing tools mid-run costs context it does not see
-                # (tracked separately); skipping the part is not a claim that the reveal was
-                # free. Redundant against the union as it stands today -- every other member is
-                # handled above -- but kept explicit so the `else` stays a real branch at
-                # runtime rather than dead code.
-                elif isinstance(part, ToolAvailabilityDeltaPart):  # pyright: ignore[reportUnnecessaryIsInstance]
-                    pass
-                else:
-                    # A part pydantic-ai added after this was written. Skip rather than guess at
-                    # its payload: this runs on every request to decide whether to compact, so an
-                    # unrecognised part must not take the run down -- which is exactly what the
-                    # old `str(part.content)` fallback did once a part without `content` existed
-                    # (#577).
-                    #
-                    # `assert_never` sits under `TYPE_CHECKING` rather than in the branch body on
-                    # purpose. It still makes the chain exhaustive at type-check time, so a new
-                    # upstream part fails `make typecheck` and becomes a decision we make; but
-                    # unlike the usual runtime form it cannot re-crash a user who upgrades
-                    # pydantic-ai ahead of us, which is the failure this change exists to remove.
-                    if TYPE_CHECKING:
-                        assert_never(part)
+            for request_part in msg.parts:
+                segments.extend(_request_part_text(request_part))
         else:
-            for part in msg.parts:
-                if isinstance(part, TextPart):
-                    segments.append(part.content)
-                elif isinstance(part, ToolCallPart):
-                    segments.append(part.tool_name)
-                    segments.append(str(part.args))
-                elif isinstance(part, (ThinkingPart, CompactionPart)):
-                    # A redacted thinking block carries a signature and no text.
-                    segments.append(part.content or '')
-                elif isinstance(part, NativeToolCallPart):
-                    segments.append(part.tool_name)
-                    segments.append(str(part.args))
-                elif isinstance(part, NativeToolReturnPart):
-                    segments.append(part.tool_name)
-                    segments.append(str(part.content))
+            for response_part in msg.parts:
+                segments.extend(_response_part_text(response_part))
     segments.extend(_instructions_text(messages))
     return segments
+
+
+def _request_part_text(part: ModelRequestPart) -> list[str]:
+    """Text segments a single request part contributes to the token estimate."""
+    if isinstance(part, UserPromptPart):
+        return [_user_prompt_text_for_counting(part)]
+    elif isinstance(part, SystemPromptPart):
+        return [part.content]
+    elif isinstance(part, (ToolReturnPart, RetryPromptPart)):
+        # Both are sent in full. The tool-search and capability-load returns subclass
+        # `ToolReturnPart`, so they arrive here too.
+        return [str(part.content)]
+    # Control bookkeeping rather than message text: it records which tools became available, and
+    # the schemas themselves travel in the request's tool definitions. Those schemas are not free
+    # -- this estimator counts no tool definitions at all, so revealing tools mid-run costs
+    # context it does not see (tracked separately); skipping the part is not a claim that the
+    # reveal was free.
+    elif isinstance(part, ToolAvailabilityDeltaPart):
+        return []
+    elif isinstance(part, SpeechPart):  # pyright: ignore[reportUnnecessaryIsInstance]
+        # A realtime turn arrives as spoken audio plus a transcript. Count the transcript -- the
+        # words the provider bills against the window -- not the binary audio, which has no
+        # character-count meaning (as with `FilePart`).
+        #
+        # `SpeechPart` is the last member of the union today, so pyright sees this `isinstance` as
+        # redundant, but it is kept explicit so the `else` stays a real branch at runtime rather
+        # than dead code -- see the `else` comment.
+        return [part.transcript or '']
+    else:
+        # A part pydantic-ai added after this was written. Skip rather than guess at its payload:
+        # this runs on every request to decide whether to compact, so an unrecognised part must
+        # not take the run down -- which is exactly what the old `str(part.content)` fallback did
+        # once a part without `content` existed (#577).
+        #
+        # `assert_never` sits under `TYPE_CHECKING` rather than in the branch body on purpose. It
+        # still makes the chain exhaustive at type-check time, so a new upstream part fails
+        # `make typecheck` and becomes a decision we make; but unlike the usual runtime form it
+        # cannot re-crash a user who upgrades pydantic-ai ahead of us, which is the failure this
+        # change exists to remove.
+        if TYPE_CHECKING:
+            assert_never(part)
+        return []  # pragma: no cover - reachable only on a pydantic-ai release newer than this one
+
+
+def _response_part_text(part: ModelResponsePart) -> list[str]:
+    """Text segments a single response part contributes to the token estimate."""
+    if isinstance(part, TextPart):
+        return [part.content]
+    elif isinstance(part, ToolCallPart):
+        return [part.tool_name, str(part.args)]
+    elif isinstance(part, (ThinkingPart, CompactionPart)):
+        # A redacted thinking block carries a signature and no text.
+        return [part.content or '']
+    elif isinstance(part, NativeToolCallPart):
+        return [part.tool_name, str(part.args)]
+    elif isinstance(part, NativeToolReturnPart):
+        return [part.tool_name, str(part.content)]
+    elif isinstance(part, SpeechPart):
+        # `SpeechPart` is in both unions; a realtime assistant turn lands here. Count its
+        # transcript for the same reason as on the request side.
+        return [part.transcript or '']
+    # Any other response part (e.g. `FilePart`) contributes no counted text, as before.
+    return []
 
 
 def _instructions_text(messages: Sequence[ModelMessage]) -> list[str]:
@@ -242,10 +263,21 @@ def context_for_request(
     return replace(ctx, model=request_context.model)
 
 
+def is_realtime_model(model: AbstractModel | str) -> bool:
+    """Whether *model* is a realtime model: an `AbstractModel` that is not a request-response `Model`.
+
+    A realtime model has no request-response context-window/token semantics, so the token
+    triggers skip it. Written as a boolean check (rather than an inline `isinstance`) so callers
+    keep the `AbstractModel | str` type -- narrowing against the un-parameterized generic `Model`
+    would otherwise widen the value to `Model[Unknown]`. #585
+    """
+    return isinstance(model, AbstractModel) and not isinstance(model, Model)
+
+
 def resolve_token_trigger(
     max_tokens: int | None,
     max_fraction: float | None,
-    model: Model | str,
+    model: AbstractModel | str,
     fallback_context_window: int = DEFAULT_CONTEXT_WINDOW,
     context_window: int | None = None,
 ) -> int | None:
@@ -266,7 +298,13 @@ def resolve_token_trigger(
     Pass the model the request will actually be sent to. A capability may replace
     `ModelRequestContext.model` before the request leaves, so the run's model and the request's
     model are not always the same one.
+
+    Returns `None` for a realtime model -- an `AbstractModel` that is not a request-response
+    `Model`. A realtime run has no context-window/token semantics, so the token trigger is
+    skipped entirely and such a run compacts on message count alone, if at all. #585
     """
+    if is_realtime_model(model):
+        return None
     if max_tokens is not None:
         return max_tokens
     if max_fraction is None:

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -299,20 +299,18 @@ def resolve_token_trigger(
     `ModelRequestContext.model` before the request leaves, so the run's model and the request's
     model are not always the same one.
 
-    A realtime model -- an `AbstractModel` that is not a request-response `Model` -- has no
-    context window, so a `max_fraction` trigger cannot resolve and is skipped. The absolute
-    `max_tokens` trigger is model-independent, so it still applies: a realtime run with an
-    absolute budget compacts on it, and one configured only by fraction compacts on message
-    count alone, if at all. #585
+    `RunContext.model` is typed as the wider `AbstractModel`, but a realtime session never
+    compacts: its message history can't be modified mid-run, so the compaction hooks that call
+    this never fire, and `model` is a request-response `Model` at runtime. The realtime guard
+    below only keeps that wider type sound -- it returns `None`. #585
     """
+    if is_realtime_model(model):
+        # Unreachable at runtime (a realtime session doesn't compact, see above); the guard exists
+        # only because `RunContext.model` is now the wider `AbstractModel`. #585
+        return None
     if max_tokens is not None:
         return max_tokens
     if max_fraction is None:
-        return None
-    if is_realtime_model(model):
-        # Only `max_fraction` reaches here, and it resolves against a context window a realtime
-        # model does not have. The absolute `max_tokens` path above already returned, so a realtime
-        # run still honours an absolute budget -- only the fraction trigger is skipped. #585
         return None
     if context_window is None:
         context_window = resolve_context_window(model)

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -299,15 +299,20 @@ def resolve_token_trigger(
     `ModelRequestContext.model` before the request leaves, so the run's model and the request's
     model are not always the same one.
 
-    Returns `None` for a realtime model -- an `AbstractModel` that is not a request-response
-    `Model`. A realtime run has no context-window/token semantics, so the token trigger is
-    skipped entirely and such a run compacts on message count alone, if at all. #585
+    A realtime model -- an `AbstractModel` that is not a request-response `Model` -- has no
+    context window, so a `max_fraction` trigger cannot resolve and is skipped. The absolute
+    `max_tokens` trigger is model-independent, so it still applies: a realtime run with an
+    absolute budget compacts on it, and one configured only by fraction compacts on message
+    count alone, if at all. #585
     """
-    if is_realtime_model(model):
-        return None
     if max_tokens is not None:
         return max_tokens
     if max_fraction is None:
+        return None
+    if is_realtime_model(model):
+        # Only `max_fraction` reaches here, and it resolves against a context window a realtime
+        # model does not have. The absolute `max_tokens` path above already returned, so a realtime
+        # run still honours an absolute budget -- only the fraction trigger is skipped. #585
         return None
     if context_window is None:
         context_window = resolve_context_window(model)

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from pydantic_ai._run_context import AgentDepsT
 from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -19,6 +20,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.models import Model
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.tools import RunContext
 
@@ -40,13 +42,14 @@ from pydantic_ai_harness.compaction._shared import (
     find_first_user_message,
     find_safe_cutoff,
     find_token_cutoff,
+    is_realtime_model,
     resolve_token_trigger,
     validate_token_trigger,
 )
 
 if TYPE_CHECKING:
     from pydantic_ai.messages import ModelRequestPart, UserContent
-    from pydantic_ai.models import Model, ModelRequestContext
+    from pydantic_ai.models import AbstractModel, ModelRequestContext
 
 _DEFAULT_SUMMARY_PROMPT = """\
 You are a context summarization assistant.  The conversation below will be replaced by \
@@ -101,8 +104,12 @@ _KEPT_USER_MESSAGE_METADATA = 'pydantic-ai-harness.compaction.kept-user-message.
 """Model-request metadata marking a user turn retained by `keep_user_messages`."""
 
 
-def _model_name(model: str | Model | None) -> str | None:
-    """Best-effort model-name string from a model spec or object."""
+def _model_name(model: str | AbstractModel | None) -> str | None:
+    """Best-effort model-name string from a model spec or object.
+
+    Accepts any `AbstractModel` (a realtime model included), not just a request-response
+    `Model`: the family heuristic only reads `model_name`, which every model carries.
+    """
     if model is None:  # pragma: no cover - Pydantic AI always supplies the running model
         return None
     if isinstance(model, str):
@@ -123,7 +130,7 @@ def _is_receipt_message(msg: ModelMessage) -> bool:
     return isinstance(msg, ModelRequest) and bool(msg.parts) and all(is_receipt_part(p) for p in msg.parts)
 
 
-def _model_family(model: str | Model | None) -> str | None:
+def _model_family(model: str | AbstractModel | None) -> str | None:
     """Reduce a model name to a coarse family token (e.g. ``openai:gpt-4o`` -> ``gpt``).
 
     A neutral structural heuristic: drop any ``provider:`` prefix, then take the leading token
@@ -590,8 +597,19 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
             )
 
         model = self.model if self.model is not None else ctx.model
+        # `ctx.model` is an `AbstractModel`; summarization needs a request-response model. A
+        # realtime run reaches here only when no summarizer `model=` was configured, so ask for
+        # one explicitly rather than handing `Agent` a model it cannot run with.
+        if is_realtime_model(model):
+            raise UserError(
+                'SummarizingCompaction needs a request-response model to write the summary, but '
+                f'the run uses {type(model).__name__}, which is not one. Set `model=` on '
+                'SummarizingCompaction to the model to summarize with when the run uses a realtime model.'
+            )
+        # `isinstance` narrows the generic `Model` to `Model[Unknown]`; `cast` recovers
+        # `Model[Any]`, mirroring core's own `reinject_system_prompt` idiom.
         agent: Agent[None, str] = Agent(
-            model,
+            cast('Model[Any] | str', model),
             instructions='You are a context summarization assistant. Extract the most important information from conversations.',
         )
         result = await agent.run(prompt, usage=ctx.usage)

--- a/pydantic_ai_harness/compaction/_tiered_compaction.py
+++ b/pydantic_ai_harness/compaction/_tiered_compaction.py
@@ -127,12 +127,10 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
     def _target(self, model: AbstractModel | str) -> int | None:
         """Absolute token target, resolved against *model* when expressed as a fraction.
 
-        Returns `None` only when the target is a *fraction* and *model* is realtime (an
-        `AbstractModel` that is not a request-response `Model`): a fraction resolves against a
-        context window a realtime model does not have, so `TieredCompaction` does not compact. An
-        absolute `target_tokens` is model-independent and still applies. `__post_init__` requires
-        one of `target_tokens` / `target_fraction`, so a request-response `Model` never resolves
-        to `None`. #585
+        Returns `None` when *model* is realtime (an `AbstractModel` that is not a request-response
+        `Model`): a realtime session never compacts, so this only guards the widened
+        `RunContext.model` type. `__post_init__` requires one of `target_tokens` /
+        `target_fraction`, so a request-response `Model` never resolves to `None`. #585
         """
         return resolve_token_trigger(
             self.target_tokens, self.target_fraction, model, self.fallback_context_window, self.context_window

--- a/pydantic_ai_harness/compaction/_tiered_compaction.py
+++ b/pydantic_ai_harness/compaction/_tiered_compaction.py
@@ -24,7 +24,7 @@ from pydantic_ai_harness.compaction._shared import (
 )
 
 if TYPE_CHECKING:
-    from pydantic_ai.models import Model, ModelRequestContext
+    from pydantic_ai.models import AbstractModel, ModelRequestContext
 
 
 @dataclass
@@ -124,14 +124,17 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
             tiers=[tier.with_focus(focus) if isinstance(tier, SupportsFocus) else tier for tier in self.tiers],
         )
 
-    def _target(self, model: Model | str) -> int:
-        """Absolute token target, resolved against *model* when expressed as a fraction."""
-        target = resolve_token_trigger(
+    def _target(self, model: AbstractModel | str) -> int | None:
+        """Absolute token target, resolved against *model* when expressed as a fraction.
+
+        Returns `None` when *model* is not a request-response `Model` (a realtime model is an
+        `AbstractModel` but not one): there is no token window to resolve a target against, so
+        `TieredCompaction` does not compact. `__post_init__` requires one of `target_tokens` /
+        `target_fraction`, so a real `Model` never resolves to `None`. #585
+        """
+        return resolve_token_trigger(
             self.target_tokens, self.target_fraction, model, self.fallback_context_window, self.context_window
         )
-        if target is None:  # pragma: no cover -- __post_init__ rejects both being unset
-            raise ValueError('One of target_tokens or target_fraction must be set.')
-        return target
 
     async def _escalate(
         self,
@@ -155,7 +158,11 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
         ctx: RunContext[AgentDepsT],
     ) -> list[ModelMessage]:
         """Apply tiers in order until the history fits the target or tiers run out."""
-        return await self._escalate(messages, ctx, self._target(ctx.model))
+        target = self._target(ctx.model)
+        if target is None:
+            # A realtime model has no token target to escalate toward; leave the history as-is.
+            return messages
+        return await self._escalate(messages, ctx, target)
 
     async def before_model_request(
         self,
@@ -170,7 +177,7 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
         request_ctx = context_for_request(ctx, request_context)
         # Resolved once, so the gate and the escalation loop cannot disagree about the target.
         target = self._target(request_ctx.model)
-        if estimate_token_count(messages, self.tokenizer) <= target:
+        if target is None or estimate_token_count(messages, self.tokenizer) <= target:
             return request_context
         request_context.messages = await compact_with_span(
             request_ctx,

--- a/pydantic_ai_harness/compaction/_tiered_compaction.py
+++ b/pydantic_ai_harness/compaction/_tiered_compaction.py
@@ -127,10 +127,12 @@ class TieredCompaction(AbstractCapability[AgentDepsT]):
     def _target(self, model: AbstractModel | str) -> int | None:
         """Absolute token target, resolved against *model* when expressed as a fraction.
 
-        Returns `None` when *model* is not a request-response `Model` (a realtime model is an
-        `AbstractModel` but not one): there is no token window to resolve a target against, so
-        `TieredCompaction` does not compact. `__post_init__` requires one of `target_tokens` /
-        `target_fraction`, so a real `Model` never resolves to `None`. #585
+        Returns `None` only when the target is a *fraction* and *model* is realtime (an
+        `AbstractModel` that is not a request-response `Model`): a fraction resolves against a
+        context window a realtime model does not have, so `TieredCompaction` does not compact. An
+        absolute `target_tokens` is model-independent and still applies. `__post_init__` requires
+        one of `target_tokens` / `target_fraction`, so a request-response `Model` never resolves
+        to `None`. #585
         """
         return resolve_token_trigger(
             self.target_tokens, self.target_fraction, model, self.fallback_context_window, self.context_window

--- a/pydantic_ai_harness/conversation_search/_toolset.py
+++ b/pydantic_ai_harness/conversation_search/_toolset.py
@@ -198,7 +198,12 @@ def _format_request_part(part: ModelRequestPart, *, truncate: bool) -> str | Non
     if isinstance(part, SpeechPart):
         # A realtime user turn: index the spoken transcript so speech is searchable, not the
         # raw audio. `transcript` is optional, so an audio-only part contributes no text.
-        return f'Speech [{part.speaker}]: {part.transcript}' if part.transcript else None
+        if not part.transcript:
+            return None
+        transcript = part.transcript
+        if truncate and len(transcript) > 500:  # cap the display excerpt like `UserPromptPart`
+            transcript = transcript[:500] + '...'
+        return f'Speech [{part.speaker}]: {transcript}'
     # Tool-list bookkeeping rather than conversation, so there is no line to contribute.
     # Redundant against the union as it stands today, but kept explicit so the fallthrough
     # below stays a real branch at runtime rather than dead code.
@@ -244,7 +249,10 @@ def _format_message(message: ModelMessage, *, truncate: bool) -> str:
                 # transcript so spoken replies are searchable. Any other response part (thinking,
                 # file, native-tool bookkeeping) is deliberately skipped rather than misrendered,
                 # so a new upstream part degrades to "not indexed" instead of crashing the run.
-                lines.append(f'Speech [{part.speaker}]: {part.transcript}')
+                transcript = part.transcript
+                if truncate and len(transcript) > 500:  # cap like the `TextPart` branch above
+                    transcript = transcript[:500] + '...'
+                lines.append(f'Speech [{part.speaker}]: {transcript}')
 
     return '\n'.join(lines)
 

--- a/pydantic_ai_harness/conversation_search/_toolset.py
+++ b/pydantic_ai_harness/conversation_search/_toolset.py
@@ -22,6 +22,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelRequestPart,
     RetryPromptPart,
+    SpeechPart,
     SystemPromptPart,
     TextContent,
     TextPart,
@@ -194,6 +195,10 @@ def _format_request_part(part: ModelRequestPart, *, truncate: bool) -> str | Non
     if isinstance(part, RetryPromptPart):
         # A retry or validation-error prompt is worth recalling, so index it in full.
         return f'Retry [{part.tool_name}]: {part.content}'
+    if isinstance(part, SpeechPart):
+        # A realtime user turn: index the spoken transcript so speech is searchable, not the
+        # raw audio. `transcript` is optional, so an audio-only part contributes no text.
+        return f'Speech [{part.speaker}]: {part.transcript}' if part.transcript else None
     # Tool-list bookkeeping rather than conversation, so there is no line to contribute.
     # Redundant against the union as it stands today, but kept explicit so the fallthrough
     # below stays a real branch at runtime rather than dead code.
@@ -234,6 +239,12 @@ def _format_message(message: ModelMessage, *, truncate: bool) -> str:
                 if truncate and len(args) > 200:
                     args = args[:200] + '...'
                 lines.append(f'Tool Call [{part.tool_name}]: {args}')
+            elif isinstance(part, SpeechPart) and part.transcript:
+                # `SpeechPart` is in the response union too: a realtime assistant turn. Index the
+                # transcript so spoken replies are searchable. Any other response part (thinking,
+                # file, native-tool bookkeeping) is deliberately skipped rather than misrendered,
+                # so a new upstream part degrades to "not indexed" instead of crashing the run.
+                lines.append(f'Speech [{part.speaker}]: {part.transcript}')
 
     return '\n'.join(lines)
 

--- a/pydantic_ai_harness/dynamic_workflow/_toolset.py
+++ b/pydantic_ai_harness/dynamic_workflow/_toolset.py
@@ -14,7 +14,7 @@ import keyword
 import warnings
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Annotated, Any, Generic, Literal
+from typing import Annotated, Any, Generic, Literal, cast
 
 from pydantic import Field, TypeAdapter
 from pydantic_ai import AbstractToolset, RunContext, ToolDefinition
@@ -22,6 +22,7 @@ from pydantic_ai.agent.abstract import AbstractAgent
 from pydantic_ai.capabilities import AbstractCapability, WrapperCapability
 from pydantic_ai.exceptions import ModelRetry, UsageLimitExceeded, UserError
 from pydantic_ai.function_signature import FunctionSignature
+from pydantic_ai.models import Model
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets.abstract import SchemaValidatorProt, ToolsetTool
 from pydantic_ai.usage import UsageLimits
@@ -640,11 +641,18 @@ class DynamicWorkflowToolset(AbstractToolset[AgentDepsT]):
         if self._call_count >= self.max_agent_calls:
             raise _BudgetExhausted(self.max_agent_calls)
         self._call_count += 1
+        # `ctx.model` is an `AbstractModel`; only a request-response `Model` can drive a sub-agent
+        # run. A realtime run's model isn't one, so fall back to the sub-agent's own default rather
+        # than forwarding a model it cannot run with. Bind to a local, then `cast` to recover
+        # `Model[Any]` from the generic `Model` (which `isinstance` narrows to `Model[Unknown]`),
+        # mirroring core's own `reinject_system_prompt` idiom.
+        ctx_model = ctx.model
+        inherited_model = cast('Model[Any]', ctx_model) if self.inherit_model and isinstance(ctx_model, Model) else None
         try:
             result = await self._by_name[agent_name].agent.run(
                 task,
                 deps=ctx.deps,
-                model=ctx.model if self.inherit_model else None,
+                model=inherited_model,
                 usage=ctx.usage if self.forward_usage else None,
                 usage_limits=self.sub_agent_usage_limits,
             )

--- a/pydantic_ai_harness/subagents/_toolset.py
+++ b/pydantic_ai_harness/subagents/_toolset.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
-from typing import Any, Generic
+from typing import Any, Generic, cast
 
 from pydantic_ai.agent import AbstractAgent, EventStreamHandler
 from pydantic_ai.capabilities import AgentCapability
@@ -328,7 +328,18 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
             run_model = option.model
             settings = option.settings
         else:
-            run_model = None if sub_agent.agent.model is not None else ctx.model
+            # `ctx.model` is an `AbstractModel`; only a request-response `Model` can drive a
+            # sub-agent run. When the parent run uses something else (a realtime model), fall
+            # back to `None` so the sub-agent uses its own default rather than being handed a
+            # model it cannot run with. Bind to a local, then `cast` to recover `Model[Any]`
+            # from the generic `Model` (which `isinstance` narrows to `Model[Unknown]`),
+            # mirroring core's own `reinject_system_prompt` idiom.
+            ctx_model = ctx.model
+            run_model = (
+                cast('Model[Any]', ctx_model)
+                if sub_agent.agent.model is None and isinstance(ctx_model, Model)
+                else None
+            )
             settings = None
         run = sub_agent.agent.run(
             task,

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import warnings
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, TypeGuard
+from typing import Any, TypeGuard, cast
 
 from pydantic_ai import FunctionToolset
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.messages import ToolCallPart, ToolReturn, ToolReturnContent, UserContent
+from pydantic_ai.models import AbstractModel, Model
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition, ToolSelector, matches_tool_selector
 from pydantic_ai.toolsets import AgentToolset
 
@@ -391,6 +392,10 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         assert unit.text is not None
         try:
             summary = await self._summarize(ctx, call, action, unit.text)
+        except UserError:
+            # A misconfiguration -- e.g. a realtime run with no summarizer `model=` (#585) -- is
+            # the user's to fix, not something to mask by silently truncating instead.
+            raise
         except Exception:
             return await self._fallback(ctx, call, action.then, unit)
         return summary, None
@@ -412,8 +417,22 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         from pydantic_ai import Agent
 
         model = action.model if action.model is not None else ctx.model
+        # `ctx.model` is an `AbstractModel`; summarizing needs a request-response model. A
+        # realtime run reaches here only when no summarizer `model=` was configured on the
+        # `Summarize` action, so ask for one explicitly rather than handing `Agent` a model it
+        # cannot run with. A realtime model is an `AbstractModel` that is not a `Model`.
+        if isinstance(model, AbstractModel) and not isinstance(model, Model):
+            raise UserError(
+                'Summarizing oversized tool output needs a request-response model, but the run '
+                f'uses {type(model).__name__}, which is not one. Set a `model=` on the '
+                '`Summarize` action to use for summarization.'
+            )
         prompt = self.summary_prompt.format(tool_name=call.tool_name, output=text)
-        agent: Agent[None, str] = Agent(model, instructions='You summarize oversized tool output.')
+        # `isinstance` narrows the generic `Model` to `Model[Unknown]`; `cast` recovers
+        # `Model[Any]`, mirroring core's own `reinject_system_prompt` idiom.
+        agent: Agent[None, str] = Agent(
+            cast('Model[Any] | str', model), instructions='You summarize oversized tool output.'
+        )
         run = await agent.run(prompt, usage=ctx.usage)
         return run.output.strip()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     # on it rather than merely ignoring it (#577). Handling it needs the class to import,
     # so the floor is the version that introduced it, not merely the one we lock.
     # (`CodeMode` separately reads `ModelRequestParameters.revealed_tool_names`, from 2.22.0.)
-    "pydantic-ai-slim>=2.23.0",
+    "pydantic-ai-slim>=2.28.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -10,17 +10,19 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from opentelemetry.trace import NoOpTracer, Tracer
 from pydantic_ai import Agent
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    SpeechPart,
     TextPart,
     ToolAvailabilityDeltaPart,
     ToolCallPart,
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models import AbstractModel, Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
@@ -40,6 +42,7 @@ from pydantic_ai_harness.compaction import (
     estimate_token_count,
     resolve_context_window,
 )
+from pydantic_ai_harness.compaction._shared import resolve_token_trigger
 
 try:
     from logfire.testing import CaptureLogfire
@@ -58,6 +61,22 @@ class _FakeModel:
     """Stands in for a `Model`; only `model_id` is read by window resolution."""
 
     model_id: str = 'anthropic:claude-sonnet-4-6'
+
+
+class _FakeRealtimeModel(AbstractModel):
+    """A realtime model: an `AbstractModel` that is deliberately not a request-response `Model`.
+
+    A realtime model has no context-window/token semantics, so the token triggers must skip it
+    (see `resolve_token_trigger`). Only `system`/`model_name` are needed to satisfy the ABC.
+    """
+
+    @property
+    def model_name(self) -> str:
+        return 'gpt-4o-realtime-preview'
+
+    @property
+    def system(self) -> str:
+        return 'openai'
 
 
 def _ctx(model: Any = None) -> Any:
@@ -1212,3 +1231,82 @@ class TestManualCompactionSemantics:
         result = await compact_now(tiered, _history(6), model=TestModel())
 
         assert len(result) < 12
+
+
+# ---------------------------------------------------------------------------
+# Realtime models (#585)
+# ---------------------------------------------------------------------------
+
+
+class TestSpeechPartCounting:
+    """A `SpeechPart` transcript is text the provider bills, so the estimator counts it."""
+
+    def test_a_speech_transcript_counts_like_equivalent_text(self):
+        transcript = 'tell me about the weather today ' * 8
+        spoken: list[ModelMessage] = [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript=transcript)]),
+            ModelResponse(parts=[SpeechPart(speaker='assistant', transcript=transcript)]),
+        ]
+        as_text: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content=transcript)]),
+            ModelResponse(parts=[TextPart(content=transcript)]),
+        ]
+        assert estimate_token_count(spoken) == estimate_token_count(as_text) > 0
+
+    def test_audio_only_speech_contributes_no_text(self):
+        """`transcript` is optional; an audio-only turn has no characters to count."""
+        silent: list[ModelMessage] = [
+            ModelRequest(parts=[SpeechPart(speaker='user')]),
+            ModelResponse(parts=[SpeechPart(speaker='assistant')]),
+        ]
+        assert estimate_token_count(silent) == 0
+
+
+class TestRealtimeModelSkipsTokenTriggers:
+    """A realtime model has no context-window/token semantics, so the token trigger is skipped."""
+
+    def test_a_fraction_resolves_to_no_trigger(self):
+        model = _FakeRealtimeModel()
+        # A genuine `AbstractModel` identity, not a mock: it is skipped for being a non-`Model`.
+        assert model.model_id == 'openai:gpt-4o-realtime-preview'
+        assert resolve_token_trigger(None, 0.5, model) is None
+
+    def test_an_absolute_budget_resolves_to_no_trigger(self):
+        assert resolve_token_trigger(1_000, None, _FakeRealtimeModel()) is None
+
+    def test_a_request_response_model_still_resolves(self):
+        assert resolve_token_trigger(1_000, None, TestModel()) == 1_000
+
+    async def test_sliding_window_leaves_a_realtime_request_untouched(self, monkeypatch: pytest.MonkeyPatch):
+        """A fraction that trims a normal run does not fire when the request model is realtime."""
+        _fixed_window(monkeypatch, 1_000)
+        capability: SlidingWindowCompaction[None] = SlidingWindowCompaction(max_fraction=0.1, keep_messages=2)
+        request_context = ModelRequestContext(
+            model=_FakeRealtimeModel(),  # type: ignore[arg-type]
+            messages=_history(6),
+            model_settings=None,
+            model_request_parameters=ModelRequestParameters(),
+        )
+
+        await capability.before_model_request(_ctx(), request_context)
+
+        assert len(request_context.messages) == 12, 'no token trigger means nothing is trimmed'
+
+    async def test_tiered_compaction_does_not_compact_a_realtime_run(self):
+        tiered: TieredCompaction[None] = TieredCompaction(
+            tiers=[SlidingWindowCompaction(max_tokens=1, keep_messages=2)],
+            target_fraction=0.1,
+        )
+        history = _history(6)
+
+        result = await compact_now(tiered, history, model=_FakeRealtimeModel())  # type: ignore[arg-type]
+
+        assert result == history, 'no token target means the tiers never escalate'
+
+    async def test_summarizing_compaction_requires_a_model_for_a_realtime_run(self):
+        """With no summarizer `model=` configured, a realtime run cannot summarize -- say so."""
+        capability: SummarizingCompaction[None] = SummarizingCompaction(max_messages=1)
+        ctx = _ctx(model=_FakeRealtimeModel())
+
+        with pytest.raises(UserError, match='needs a request-response model'):
+            await capability._summarize(_history(2), ctx)  # pyright: ignore[reportPrivateUsage]

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -1262,8 +1262,9 @@ class TestSpeechPartCounting:
         assert estimate_token_count(silent) == 0
 
 
-class TestRealtimeModelSkipsTokenTriggers:
-    """A realtime model has no context-window/token semantics, so the token trigger is skipped."""
+class TestRealtimeModelSkipsFractionTriggers:
+    """A realtime model has no context window, so a `max_fraction` trigger is skipped -- but an
+    absolute `max_tokens` budget is model-independent and still applies."""
 
     def test_a_fraction_resolves_to_no_trigger(self):
         model = _FakeRealtimeModel()
@@ -1271,8 +1272,9 @@ class TestRealtimeModelSkipsTokenTriggers:
         assert model.model_id == 'openai:gpt-4o-realtime-preview'
         assert resolve_token_trigger(None, 0.5, model) is None
 
-    def test_an_absolute_budget_resolves_to_no_trigger(self):
-        assert resolve_token_trigger(1_000, None, _FakeRealtimeModel()) is None
+    def test_an_absolute_budget_still_applies(self):
+        # `max_tokens` is model-independent, so a realtime run still honours the absolute budget.
+        assert resolve_token_trigger(1_000, None, _FakeRealtimeModel()) == 1_000
 
     def test_a_request_response_model_still_resolves(self):
         assert resolve_token_trigger(1_000, None, TestModel()) == 1_000

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -1262,19 +1262,17 @@ class TestSpeechPartCounting:
         assert estimate_token_count(silent) == 0
 
 
-class TestRealtimeModelSkipsFractionTriggers:
-    """A realtime model has no context window, so a `max_fraction` trigger is skipped -- but an
-    absolute `max_tokens` budget is model-independent and still applies."""
+class TestRealtimeModelSkipsTokenTriggers:
+    """A realtime session never compacts (its history can't change mid-run), so this is a
+    type-level guard: `resolve_token_trigger` returns `None` for a realtime model however it is
+    configured."""
 
-    def test_a_fraction_resolves_to_no_trigger(self):
+    def test_a_realtime_model_resolves_to_no_trigger(self):
         model = _FakeRealtimeModel()
         # A genuine `AbstractModel` identity, not a mock: it is skipped for being a non-`Model`.
         assert model.model_id == 'openai:gpt-4o-realtime-preview'
-        assert resolve_token_trigger(None, 0.5, model) is None
-
-    def test_an_absolute_budget_still_applies(self):
-        # `max_tokens` is model-independent, so a realtime run still honours the absolute budget.
-        assert resolve_token_trigger(1_000, None, _FakeRealtimeModel()) == 1_000
+        assert resolve_token_trigger(None, 0.5, model) is None  # fraction
+        assert resolve_token_trigger(1_000, None, model) is None  # absolute budget
 
     def test_a_request_response_model_still_resolves(self):
         assert resolve_token_trigger(1_000, None, TestModel()) == 1_000

--- a/tests/conversation_search/test_conversation_search.py
+++ b/tests/conversation_search/test_conversation_search.py
@@ -20,6 +20,7 @@ from pydantic_ai.messages import (
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
+    SpeechPart,
     SystemPromptPart,
     TextContent,
     TextPart,
@@ -792,3 +793,29 @@ class TestConfigValidation:
         await _seed_run(store, 'r1', [_user(f'needle entry {i} filler') for i in range(5)])
         with pytest.raises(ValueError, match='max_matches must be non-negative'):
             await _search(SnapshotHistorySource(store), 'needle', max_matches=-1)
+
+
+class TestSpeechIsSearchable:
+    """A realtime `SpeechPart` carries a transcript; the index renders it so speech is recallable."""
+
+    async def test_an_assistant_speech_turn_is_indexed_and_rendered(self) -> None:
+        history: list[ModelMessage] = [
+            _user('boot up'),
+            ModelResponse(parts=[SpeechPart(speaker='assistant', transcript='the PANGOLIN protocol is ready')]),
+        ]
+        rendered = await _search(_StubSource({'r1': history}), 'PANGOLIN')
+        assert 'PANGOLIN' in rendered
+        assert 'Speech [assistant]:' in rendered
+
+    async def test_a_user_speech_turn_is_indexed_and_rendered(self) -> None:
+        history: list[ModelMessage] = [
+            ModelRequest(parts=[SpeechPart(speaker='user', transcript='remember the MARMOT codeword')]),
+        ]
+        rendered = await _search(_StubSource({'r1': history}), 'MARMOT')
+        assert 'MARMOT' in rendered
+        assert 'Speech [user]:' in rendered
+
+    async def test_audio_only_speech_contributes_no_searchable_text(self) -> None:
+        """A `SpeechPart` with no transcript renders no line, so it cannot match a query."""
+        history: list[ModelMessage] = [ModelRequest(parts=[SpeechPart(speaker='user')])]
+        assert 'No matches' in await _search(_StubSource({'r1': history}), 'anything')

--- a/tests/conversation_search/test_conversation_search.py
+++ b/tests/conversation_search/test_conversation_search.py
@@ -819,3 +819,25 @@ class TestSpeechIsSearchable:
         """A `SpeechPart` with no transcript renders no line, so it cannot match a query."""
         history: list[ModelMessage] = [ModelRequest(parts=[SpeechPart(speaker='user')])]
         assert 'No matches' in await _search(_StubSource({'r1': history}), 'anything')
+
+    async def test_a_long_assistant_transcript_truncates_but_stays_searchable(self) -> None:
+        # A spoken turn is capped in the display excerpt like `TextPart`, while the full transcript
+        # stays in the index so a term past the 500-char cutoff still matches.
+        long_transcript = 'nightingale ' * 60 + 'SPEECHTAIL'
+        source = _StubSource(
+            {'r1': [_user('go'), ModelResponse(parts=[SpeechPart(speaker='assistant', transcript=long_transcript)])]}
+        )
+        rendered = await _search(source, 'SPEECHTAIL')
+        excerpts = rendered.split(':\n\n', 1)[1]
+        assert 'Found 1 match(es)' in rendered
+        assert 'SPEECHTAIL' not in excerpts
+        assert '...' in excerpts
+
+    async def test_a_long_user_transcript_truncates_but_stays_searchable(self) -> None:
+        long_transcript = 'petrichor ' * 60 + 'USERSPEECHTAIL'
+        source = _StubSource({'r1': [ModelRequest(parts=[SpeechPart(speaker='user', transcript=long_transcript)])]})
+        rendered = await _search(source, 'USERSPEECHTAIL')
+        excerpts = rendered.split(':\n\n', 1)[1]
+        assert 'Found 1 match(es)' in rendered
+        assert 'USERSPEECHTAIL' not in excerpts
+        assert '...' in excerpts

--- a/tests/step_persistence/test_step_persistence.py
+++ b/tests/step_persistence/test_step_persistence.py
@@ -11,7 +11,7 @@ import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pydantic_ai import Agent, CallToolsNode, ModelRequestNode, ModelRetry, RunContext
@@ -27,7 +27,7 @@ from pydantic_ai.messages import (
     ToolReturnPart,
     UserPromptPart,
 )
-from pydantic_ai.models import ModelRequestContext, ModelRequestParameters
+from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.run import AgentRunResult
@@ -1396,8 +1396,13 @@ class TestCapabilityHookBranches:
         store = InMemoryStepStore()
         cap: StepPersistence[object] = StepPersistence(store=store)
         ctx = build_run_context(deps=None, run_id='r1')
+        # `build_run_context` always sets a request-response `TestModel`; narrow the widened
+        # `RunContext.model` (an `AbstractModel`) back to `Model` for `ModelRequestContext`.
+        # `isinstance` narrows the generic `Model` to `Model[Unknown]`; `cast` recovers `Model[Any]`.
+        ctx_model = ctx.model
+        assert isinstance(ctx_model, Model)
         request_context = ModelRequestContext(
-            model=ctx.model,
+            model=cast('Model[Any]', ctx_model),
             messages=[],
             model_settings=None,
             model_request_parameters=ModelRequestParameters(),

--- a/tests/subagents/test_subagents_disk.py
+++ b/tests/subagents/test_subagents_disk.py
@@ -10,7 +10,7 @@ from typing import Any
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
-from pydantic_ai.models import Model
+from pydantic_ai.models import AbstractModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
@@ -314,7 +314,9 @@ class TestModelInheritance:
         disk_agent = cap._by_name['worker'].agent
         assert isinstance(disk_agent, Agent)
 
-        captured: dict[str, Model] = {}
+        # `RunContext.model` is an `AbstractModel`; the inherited model captured here is the
+        # parent's request-response model, asserted by identity below.
+        captured: dict[str, AbstractModel] = {}
 
         @disk_agent.instructions
         def _capture(ctx: RunContext[object]) -> str:  # pyright: ignore[reportUnusedFunction]

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import pytest
 from pydantic_ai import Agent
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.messages import (
     BinaryContent,
     ModelMessage,
@@ -21,6 +21,7 @@ from pydantic_ai.messages import (
     ToolReturn,
     ToolReturnPart,
 )
+from pydantic_ai.models import AbstractModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
@@ -556,6 +557,27 @@ class TestSummarize:
         out = await _run(cap, 'x' * 100, ctx=ctx)
         assert out == 'FROM EXPLICIT MODEL'
         assert ctx.usage.requests == 1
+
+    async def test_realtime_run_without_a_model_raises(self):
+        """A realtime run has no request-response model to summarize with; ask for one (#585)."""
+
+        class _RealtimeModel(AbstractModel):
+            @property
+            def model_name(self) -> str:
+                return 'gpt-4o-realtime-preview'
+
+            @property
+            def system(self) -> str:
+                return 'openai'
+
+        model = _RealtimeModel()
+        # A genuine `AbstractModel` identity, not a mock: it is rejected for being a non-`Model`.
+        assert model.model_id == 'openai:gpt-4o-realtime-preview'
+        ctx = _make_ctx(model=model)
+        cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=5, action=Summarize())])
+
+        with pytest.raises(UserError, match='needs a request-response model'):
+            await _run(cap, 'x' * 100, ctx=ctx)
 
     async def test_binary_summarize_falls_back(self):
         cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=1, action=Summarize(then=Passthrough()))])

--- a/uv.lock
+++ b/uv.lock
@@ -3487,7 +3487,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=4.31.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.0" },
-    { name = "pydantic-ai-slim", specifier = ">=2.23.0" },
+    { name = "pydantic-ai-slim", specifier = ">=2.28.0" },
     { name = "pydantic-ai-slim", extras = ["dbos"], marker = "extra == 'dbos'" },
     { name = "pydantic-ai-slim", extras = ["mcp"], marker = "extra == 'stackone'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["spec"], marker = "extra == 'logfire'", specifier = ">=2.18.0" },
@@ -3523,7 +3523,7 @@ lint = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.27.0"
+version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3538,9 +3538,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/bb/464898fb1259adb9c7c39a583e7d83447182468d4459a4191ada12d4e588/pydantic_ai_slim-2.27.0.tar.gz", hash = "sha256:9f827840e2ef1d2317e071899e640ac32429b3c19d6ce05d972b842c0ae4a206", size = 1016384, upload-time = "2026-08-08T04:02:47.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/3b/617ef9610a181eb9fc8014c3c0569f0f6bb1fccc93b68a726b1632c5e7e2/pydantic_ai_slim-2.28.0.tar.gz", hash = "sha256:46e8606831efbff8cc153ea112242d5057efe0dc3de2f90363c3dec1b3af5844", size = 1184793, upload-time = "2026-08-12T02:16:47.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/10/512641450549b15dd0b49600f975991a8b0067c921ec9e9b7caa0e89cff0/pydantic_ai_slim-2.27.0-py3-none-any.whl", hash = "sha256:d30cabd5e60680574f46df2b8d8e78eb7a5dd5d0963fc50e26fa802909130219", size = 1216383, upload-time = "2026-08-08T04:02:39.9Z" },
+    { url = "https://files.pythonhosted.org/packages/00/96/6d6b896ed32ca4cce03d55ac8e576f232758cd7b3d5755f3ddb4ec2527c0/pydantic_ai_slim-2.28.0-py3-none-any.whl", hash = "sha256:a3e0a67b1f63860fdbb0fa28eba0202391917bbe15183f8fbefc42fe939adb79", size = 1401259, upload-time = "2026-08-12T02:16:41.13Z" },
 ]
 
 [package.optional-dependencies]
@@ -3802,7 +3802,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.27.0"
+version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3813,9 +3813,9 @@ dependencies = [
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/50/ed9203338db139ef6d3f94814f6d6b2f6bce4042bb2278299b9ccb307a90/pydantic_graph-2.27.0.tar.gz", hash = "sha256:b124bd5d329d0e01d3b8c4070366a71db198ea9befc8453e56275fb1656da78b", size = 45181, upload-time = "2026-08-08T04:02:49.907Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/83/07dd2434495c5a9747b558a3a91ace8542bedd54501b98a0af735f645e29/pydantic_graph-2.28.0.tar.gz", hash = "sha256:1d664de0525b335cf2d6d258ad9707b4df16837b8c07af059418cca7c43a0bae", size = 45180, upload-time = "2026-08-12T02:16:50.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/ce/6ecafa2680d70ce34b8c3fdc1667228896f1cd19df2f236dd7fa54214117/pydantic_graph-2.27.0-py3-none-any.whl", hash = "sha256:f80a9f1cfbd3c07b64b032b45fa0710315d6d7e2ae35afc142d4992d99498a4d", size = 52661, upload-time = "2026-08-08T04:02:43.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/a4/365dc149500b5d6677775618e194c4381f029ef819bf96b9d9ab6c0f8f2e/pydantic_graph-2.28.0-py3-none-any.whl", hash = "sha256:e5e2640f49bd0c3d0808efe69429f4b1ddb12fb7d8ba4ad093117c0bdc9d39ea", size = 52662, upload-time = "2026-08-12T02:16:43.913Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #585.

pydantic-ai `2.28` shipped realtime, which makes two upstream changes the harness now has to handle:

1. **`RunContext.model` widened from `Model` to `AbstractModel`** — a realtime model is an `AbstractModel` but not a request-response `Model[Any]`. 15 sites passed `ctx.model` (or a value derived from it) into something typed for `Model`/`str`.
2. **`SpeechPart` joined the `ModelRequestPart` and `ModelResponsePart` unions** — two exhaustive `isinstance` chains no longer covered the union.

Floor bumped to `pydantic-ai-slim>=2.28.0` (the release that introduced these symbols — the code imports them, matching the existing `ToolAvailabilityDeltaPart` floor rationale right above it).

### Forward-resilience (the design point, per the version policy)
`docs/version-policy.md` states that adding new message parts is **not** a breaking change and consumers must "code defensively." So the part-consuming sites are now **exhaustive at type-check, graceful at runtime**: a `SpeechPart` branch is handled explicitly, and the runtime fallback for any *future* upstream part skips it rather than raising — `assert_never` stays under `TYPE_CHECKING` only. This means the next new part surfaces as a typecheck decision, not a runtime crash for anyone who upgrades pydantic-ai ahead of us. `conversation_search` also stops assuming "the only remaining request part is `RetryPromptPart`".

### Per-site decisions
- **`SpeechPart`** (`compaction/_shared.py`, `conversation_search/_toolset.py`): count / index the **transcript** (the billed words), not the raw audio. Audio-only parts contribute nothing.
- **Token-trigger / family / target sites**: a realtime model has no request-response context window, so the token triggers **skip** it (`resolve_token_trigger`, `resolve_context_window`, `_target`, `_model_family` widened to `AbstractModel`; a new `is_realtime_model` helper). `TieredCompaction` no-ops on a realtime run.
- **Summarization / limit `Agent(...)`** (`SummarizingCompaction`, `ToolOutputLimits`): a realtime run reaches these only with no summarizer `model=` configured, so raise a clear `UserError` asking for one rather than handing `Agent` a model it can't run with. (`ToolOutputLimits` now re-raises that `UserError` past its truncate-fallback so the config error surfaces.)
- **Subagent inherited-model** (`SubAgentToolset`, `DynamicWorkflowToolset`): fall back to the sub-agent's own default when the parent run is realtime.

### Tests
Added realtime coverage: `SpeechPart` transcripts are counted/indexed while audio-only speech isn't; realtime runs skip token triggers and leave tiered/sliding-window untouched; summarizing/limits raise the config `UserError`. 100% branch coverage on every touched source file.

### Verification (against released pydantic-ai `2.28.0`)
- `uv run pyright` → 0 errors
- `uv run ruff format --check` + `uv run ruff check` → clean
- `uv run pytest` (compaction, conversation_search, subagents, dynamic_workflow, tool_output_limits, step_persistence) → 1135 passed
