### PR TITLE
Pin `hatchling` below 1.32 for release builds

### DIFF
--- a/uv.toml
+++ b/uv.toml
@@ -1,1 +1,7 @@
 exclude-newer-package = { pydantic-ai = false, pydantic-ai-slim = false, pydantic-evals = false, pydantic-graph = false }
+
+# hatchling 1.32.0 (2026-08-11) bumped its default core metadata version to 2.5,
+# which the pinned gh-action-pypi-publish validator rejects as "not a valid
+# metadata version". Ceiling until the publish action (or PyPI's own validator)
+# catches up. Affects `uv build`'s PEP 517 build isolation, not runtime installs.
+build-constraint-dependencies = ['hatchling<1.32']


### PR DESCRIPTION
## Summary

`hatchling` 1.32.0 (published 2026-08-11) bumped its default core metadata version to 2.5, which the pinned `gh-action-pypi-publish` validator rejects as an invalid metadata version, breaking release publishing. This blocked tonight's `v0.19.0` release.

Adds a `build-constraint-dependencies` ceiling in `uv.toml` so `uv build`'s PEP 517 isolation resolves `hatchling < 1.32`. Note: unlike `pydantic-ai`, this repo has an adjacent `uv.toml` that takes precedence over `pyproject.toml`'s `[tool.uv]` table wholesale, so the constraint has to live there rather than in `pyproject.toml`.

Mirrors [pydantic/pydantic-ai#7395](https://github.com/pydantic/pydantic-ai/pull/7395).

Verified locally: `uv build --wheel` + `twine check` passes, `Metadata-Version: 2.4` restored.

## Checklist

- [x] No breaking changes.
- [x] PR title is fit for the release changelog.