### PR TITLE
Add JSON indentation for structured tool spills

### DIFF
--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -149,6 +149,21 @@ estimated tokens (the same ~4-chars-per-token heuristic as [compaction](compacti
 character operation regardless of the threshold unit. Set `strip_ansi=True` to strip ANSI
 escape sequences from text returns before measuring and reducing.
 
+## Structured JSON layout
+
+Structured returns use compact JSON by default. Compact JSON is one line, so the line-based
+`read_tool_result` tool cannot page through a large list. Set `json_indent=2` to encode
+structured returns as pretty JSON:
+
+```python
+ToolOutputLimits(json_indent=2)
+```
+
+The capability encodes each structured return once. Measurement, previews, stored bytes, and
+read-back use that same representation. Strings and binary payloads do not change. A structured
+return below the size threshold still passes through as its original object, and its shape
+sketch still uses that object.
+
 ## Spill store
 
 Spilled payloads go through the narrow `OverflowStore` protocol. The default `LocalFileStore`

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -125,6 +125,21 @@ callable for accuracy. `Truncate.max_chars` is always characters -- truncation i
 character operation regardless of the threshold unit. Set `strip_ansi=True` to strip ANSI
 escape sequences from text returns before measuring and reducing.
 
+## Structured JSON layout
+
+Structured returns use compact JSON by default. Compact JSON is one line, so the line-based
+`read_tool_result` tool cannot page through a large list. Set `json_indent=2` to encode
+structured returns as pretty JSON:
+
+```python
+ToolOutputLimits(json_indent=2)
+```
+
+The capability encodes each structured return once. Measurement, previews, stored bytes, and
+read-back use that same representation. Strings and binary payloads do not change. A structured
+return below the size threshold still passes through as its original object, and its shape
+sketch still uses that object.
+
 ## Spill store
 
 Spilled payloads go through the narrow `OverflowStore` protocol. The default `LocalFileStore`

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -144,6 +144,9 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
     summary_prompt: str = _DEFAULT_SUMMARY_PROMPT
     """Prompt template for `Summarize`. Must contain `{tool_name}` and `{output}`."""
 
+    json_indent: int | None = None
+    """Indent structured JSON returns so `read_tool_result` can page them by line."""
+
     _store: OverflowStore = field(init=False, repr=False)
     _bands: list[Band] = field(init=False, repr=False)
     _per_tool: dict[str, list[Band]] = field(init=False, repr=False)
@@ -279,7 +282,7 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         """Pre-render a value into the text / bytes the reduction pipeline needs."""
         if is_binary(value):
             return _Unit(binary=True, text=None, data=to_bytes(value), value=value, suffix=suffix)
-        text = to_text(value)
+        text = to_text(value, json_indent=self.json_indent)
         if self.strip_ansi:
             text = strip_ansi(text)
         return _Unit(binary=False, text=text, data=text.encode('utf-8'), value=value, suffix=suffix)

--- a/pydantic_ai_harness/tool_output_limits/_payload.py
+++ b/pydantic_ai_harness/tool_output_limits/_payload.py
@@ -46,11 +46,12 @@ def is_binary(value: object) -> bool:
     return isinstance(value, (bytes, bytearray, memoryview))
 
 
-def to_bytes(value: object) -> bytes:
+def to_bytes(value: object, *, json_indent: int | None = None) -> bytes:
     """Serialize any tool return value to the bytes that get spilled.
 
     Strings spill as UTF-8 text; byte payloads spill verbatim; everything else spills as
-    JSON so the stored payload stays valid and grep-able.
+    JSON so the stored payload stays valid and grep-able. Set `json_indent` to make structured
+    payloads readable by line.
     """
     if isinstance(value, str):
         return value.encode('utf-8')
@@ -58,10 +59,12 @@ def to_bytes(value: object) -> bytes:
         return value.tobytes()
     if isinstance(value, (bytes, bytearray)):
         return bytes(value)
+    if json_indent is not None:
+        return to_json(value, indent=json_indent)
     return to_json(value)
 
 
-def to_text(value: object) -> str:
+def to_text(value: object, *, json_indent: int | None = None) -> str:
     """Render a non-binary tool return value as the text used for measuring and truncating.
 
     Strings pass through; structured values become JSON (truncating JSON is lossy, so prefer
@@ -69,7 +72,8 @@ def to_text(value: object) -> str:
     """
     if isinstance(value, str):
         return value
-    return to_json(value).decode('utf-8', errors='replace')
+    data = to_json(value, indent=json_indent) if json_indent is not None else to_json(value)
+    return data.decode('utf-8', errors='replace')
 
 
 def measure(text: str, *, over_tokens: bool, tokenizer: Callable[[str], int] | None) -> int:

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -137,9 +137,16 @@ class TestPayloadHelpers:
         assert to_bytes(bytearray(b'ba')) == b'ba'
         assert to_bytes({'a': 1}) == b'{"a":1}'
 
+    def test_to_bytes_with_json_indent(self):
+        assert to_bytes({'a': 1}, json_indent=2) == b'{\n  "a": 1\n}'
+
     def test_to_text_variants(self):
         assert to_text('hi') == 'hi'
         assert to_text({'a': 1}) == '{"a":1}'
+
+    def test_to_text_with_json_indent(self):
+        assert to_text({'a': 1}, json_indent=2) == '{\n  "a": 1\n}'
+        assert to_text('hi', json_indent=2) == 'hi'
 
     def test_measure_chars_and_tokens(self):
         assert measure('x' * 100, over_tokens=False, tokenizer=None) == 100
@@ -354,6 +361,12 @@ class TestPassthrough:
         out = await _run(cap, 'small')
         assert out == 'small'
 
+    async def test_below_threshold_structured_passthrough_with_json_indent(self):
+        result = [{'record_id': 1}]
+        cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=1000, action=Truncate())], json_indent=2)
+        out = await _run(cap, result)
+        assert out is result
+
     async def test_exception_result_passthrough(self):
         cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=1, action=Truncate(max_chars=2))])
         err = ValueError('boom')
@@ -427,6 +440,30 @@ class TestSpill:
         out = await _run(cap, {'rows': list(range(1000)), 'ok': True})
         assert isinstance(out, ToolReturn)
         assert 'shape:' in out.return_value  # type: ignore[operator]
+
+    async def test_spill_structured_with_json_indent_is_pageable(self, tmp_path: Path):
+        store = LocalFileStore(base_dir=tmp_path)
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=5, action=Spill(preview_chars=80))],
+            json_indent=2,
+            store=store,
+        )
+        records = [{'record_id': record_id, 'item': f'item-{record_id}'} for record_id in range(10)]
+
+        out = await _run(cap, records)
+
+        assert isinstance(out, ToolReturn)
+        handle = out.metadata['overflow_handle']
+        stored = await store.read(handle)
+        expected = to_bytes(records, json_indent=2)
+        assert stored == expected
+        assert b'\n' in stored
+        assert expected.decode()[:40] in out.return_value  # type: ignore[operator]
+
+        page_1 = await _read_slice(store, handle, offset=0, limit=1, from_end=False, pattern='"record_id"')
+        page_2 = await _read_slice(store, handle, offset=1, limit=1, from_end=False, pattern='"record_id"')
+        assert '"record_id": 0' in page_1
+        assert '"record_id": 1' in page_2
 
     async def test_spill_failure_falls_back_to_truncate(self):
         cap: ToolOutputLimits[object] = ToolOutputLimits(


### PR DESCRIPTION
## Summary

Add an optional `json_indent` setting to `ToolOutputLimits`.

Compact JSON stays the default. Set `json_indent=2` to encode structured spills as pretty JSON. The capability encodes each structured result once. Measurement, previews, stored bytes, and read-back use the same representation.

Strings and binary payloads do not change. Structured results below the threshold still pass through as their original objects. Shape sketches still use those objects.

The `OverflowStore` contract does not change. It receives the exact bytes used by previews and read-back.

A focused `Agent.run` check shows the paging problem. Compact JSON stores a structured list on one line, so page 2 is empty. With `json_indent=2`, separate pages return different record IDs. Literal pattern filtering still works.

Indentation affects the measured character or token count. Band selection uses that same representation.

Relates to #332 and pydantic/pydantic-ai#4352.

## Linked Issue

Fixes #614

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)