### PR TITLE
Preserve `UserError` across Monty dispatch

### DIFF
--- a/pydantic_ai_harness/_monty_exec.py
+++ b/pydantic_ai_harness/_monty_exec.py
@@ -22,6 +22,8 @@ from collections.abc import Callable, Container, Coroutine
 from dataclasses import dataclass, field
 from typing import Any
 
+from pydantic_ai.exceptions import UserError
+
 try:
     from pydantic_monty import (
         CollectString,
@@ -45,8 +47,10 @@ DispatchFn = Callable[[str, dict[str, Any]], Coroutine[Any, Any, Any]]
 
 MontyState = FunctionSnapshot | FutureSnapshot | NameLookupSnapshot | MontyComplete
 
-# A coroutine not yet scheduled on the event loop, or its running Task.
-PendingCall = asyncio.Task[Any] | Coroutine[Any, Any, Any]
+# A dispatch coroutine kept unscheduled for global-sequential execution, or a
+# running parallel task whose ordinary outcome is already wrapped for Monty.
+DispatchCall = Coroutine[Any, Any, Any]
+PendingCall = asyncio.Task[ExternalSettledResult] | DispatchCall
 
 
 def is_sandbox_panic(exc: BaseException) -> bool:
@@ -158,7 +162,7 @@ class MontyExecutor:
             # `_pending`, so if it existed while the barrier awaits and we were cancelled
             # there, `run`'s cleanup would never close it.
             for cid in list(self._pending):
-                self._pre_resolved[cid] = await _await_external(self._pending.pop(cid))
+                self._pre_resolved[cid] = await _resolve_pending(self._pending.pop(cid))
             # The wrapped outcome (`{'return_value': ...}` / `{'exception': ...}`) is already
             # exactly the payload `resume` expects.
             return snapshot.resume(await _await_external(self.dispatch(name, snapshot.kwargs)))
@@ -170,7 +174,8 @@ class MontyExecutor:
             self._pending[snapshot.call_id] = call
         else:
             # Schedule now as a Task so concurrently-deferred calls actually run in parallel.
-            self._pending[snapshot.call_id] = asyncio.ensure_future(call)
+            # Ordinary failures settle as Monty values; UserError remains a host-side failure.
+            self._pending[snapshot.call_id] = asyncio.ensure_future(_await_external(call))
         return snapshot.resume({'future': ...})
 
     async def _resolve_futures(self, snapshot: FutureSnapshot) -> MontyState:
@@ -181,33 +186,33 @@ class MontyExecutor:
             if cid in self._pre_resolved:
                 results[cid] = self._pre_resolved.pop(cid)
             elif self.global_sequential:
-                results[cid] = await _await_external(self._pending.pop(cid))
+                results[cid] = await _resolve_pending(self._pending.pop(cid))
 
         # Gather any remaining parallel tasks concurrently. They stay in `_pending` until
         # gather returns, so the cleanup in `run` can still cancel them if this is cancelled.
         gather_ids = [cid for cid in pending_ids if cid not in results]
         if gather_ids:
-            settled = await asyncio.gather(*(self._pending[cid] for cid in gather_ids), return_exceptions=True)
+            settled = await asyncio.gather(*(self._pending[cid] for cid in gather_ids))
             for cid, outcome in zip(gather_ids, settled):
                 del self._pending[cid]
-                results[cid] = _wrap_gathered(outcome)
+                results[cid] = outcome
 
         return snapshot.resume(results)
 
 
-async def _await_external(call: PendingCall) -> ExternalReturnValue | ExternalException:
+async def _await_external(call: DispatchCall) -> ExternalReturnValue | ExternalException:
     """Await a single deferred call and wrap its outcome for Monty."""
     try:
         result = await call
+    except UserError:
+        raise
     except Exception as exc:
         return ExternalException(exception=exc)
     return ExternalReturnValue(return_value=result)
 
 
-def _wrap_gathered(outcome: Any) -> ExternalReturnValue | ExternalException:
-    """Wrap an `asyncio.gather(return_exceptions=True)` outcome for Monty."""
-    if isinstance(outcome, Exception):
-        return ExternalException(exception=outcome)
-    if isinstance(outcome, BaseException):  # pragma: no cover
-        raise outcome
-    return ExternalReturnValue(return_value=outcome)
+async def _resolve_pending(call: PendingCall) -> ExternalSettledResult:
+    """Resolve either a wrapped parallel task or a raw global-sequential coroutine."""
+    if isinstance(call, asyncio.Task):
+        return await call
+    return await _await_external(call)

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -564,9 +564,9 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
                 result = await tool_manager.handle_call(call_part, wrap_validation_errors=False)
             except (CallDeferred, ApprovalRequired) as e:
                 # No handler resolved the deferral. The sandbox can't round-trip to the
-                # caller, so we convert it to a UserError that propagates through
+                # caller, so keep this model-actionable failure on the retry path through
                 # Monty → MontyRuntimeError → ModelRetry.
-                raise UserError(
+                raise ModelRetry(
                     f'Tool {original_name!r} raised {type(e).__name__} inside code mode, '
                     'but no `HandleDeferredToolCalls` capability resolved it. Add a handler '
                     'capability on the agent so deferred and approval-required calls can '
@@ -643,13 +643,11 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             run_state.reset()
             raise ModelRetry(f'Type error in code:\n{capture.prepend_to(e.display())}') from e
         except MontyRuntimeError as e:
-            # Exceptions raised inside dispatch_tool_call (e.g. UserError from
-            # ApprovalRequired, or ModelRetry from a wrapped tool) are passed
-            # back into Monty via ExternalException. Monty re-raises them at the
-            # await site; if the sandbox code doesn't catch them, they bubble up
-            # as MontyRuntimeError. The original exception message is preserved
-            # in the display string, so the model sees a useful error. This means
-            # ModelRetry from a wrapped tool gets double-wrapped
+            # Ordinary exceptions and ModelRetry from dispatch_tool_call are passed back
+            # into Monty via ExternalException. Monty re-raises them at the await site;
+            # if the sandbox code doesn't catch them, they bubble up as MontyRuntimeError.
+            # The original exception message is preserved in the display string, so the
+            # model sees a useful error. ModelRetry from a wrapped tool gets double-wrapped
             # (ModelRetry → MontyRuntimeError → ModelRetry), but the retry
             # semantics are the same -- the model gets another chance.
             raise ModelRetry(f'Runtime error:\n{capture.prepend_to(e.display())}') from e
@@ -662,6 +660,12 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             raise ModelRetry(
                 'The code crashed the sandbox worker and the session was reset. Revise the code and try again.'
             ) from e
+        except UserError:
+            # Host configuration errors are not actionable by the model. The Monty feed
+            # remains suspended when one aborts dispatch, so discard it before preserving
+            # the original exception type for the caller.
+            run_state.reset()
+            raise
         except Exception as e:
             # The session may have been invalidated by a host-side binding or protocol failure.
             # Make the reset visible so the model can rebuild state on its next attempt. Include

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -23,7 +23,7 @@ from pydantic_ai import (
     Tool,
     ToolDefinition,
 )
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.messages import ToolCallPart
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tool_manager import ParallelExecutionMode, ToolManager
@@ -386,6 +386,46 @@ class TestCodeMode:
         code = 'import asyncio\nawait asyncio.gather(add(a=1, b=2), flaky(x=3))'
         with pytest.raises(ModelRetry, match='not allowed'):
             await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+
+    async def test_user_error_escapes_parallel_dispatch_and_resets_suspended_session(self) -> None:
+        """UserError unwinds sibling work and drops the Monty feed left awaiting a result."""
+        started = asyncio.Event()
+        unwound = asyncio.Event()
+
+        async def block() -> str:
+            """Block until the sibling dispatch fails."""
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                unwound.set()
+                raise
+            return 'unreachable'  # pragma: no cover
+
+        async def reject() -> str:
+            """Raise a caller-facing host error."""
+            await started.wait()
+            raise UserError('invalid host configuration')
+
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(block, reject))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        await wrapper.call_tool('run_code', {'code': 'x = 1'}, ctx, tools['run_code'])
+
+        call = asyncio.create_task(
+            wrapper.call_tool(
+                'run_code',
+                {'code': 'import asyncio\nawait asyncio.gather(block(), reject())'},
+                ctx,
+                tools['run_code'],
+            )
+        )
+        with pytest.raises(UserError, match='invalid host configuration'):
+            await asyncio.wait_for(call, timeout=1)
+        assert unwound.is_set()
+        with pytest.raises(ModelRetry, match='Type error in code'):
+            await wrapper.call_tool('run_code', {'code': 'x'}, ctx, tools['run_code'])
 
     async def test_run_code_renders_no_arg_tool_signature(self) -> None:
         """A no-argument tool renders as `async def name() -> ...` (without `(*, ...)`).
@@ -2114,6 +2154,38 @@ class TestCodeMode:
         with pytest.raises(ModelRetry, match='Runtime error'):
             await seq_wrapper.call_tool('run_code', {'code': "add(a='bad', b=3)"}, ctx, run_code)
 
+    async def test_user_error_escapes_inline_sequential_dispatch(self) -> None:
+        """A UserError raised by a per-tool sequential dispatch is not converted into a retry."""
+        from dataclasses import replace as dc_replace
+
+        def reject() -> str:
+            """Raise a caller-facing host error."""
+            raise UserError('invalid host configuration')
+
+        class _SeqToolset(AbstractToolset[object]):
+            def __init__(self) -> None:
+                self._inner = _build_function_toolset(reject)
+
+            @property
+            def id(self) -> str | None:
+                return None  # pragma: no cover
+
+            async def get_tools(self, ctx: RunContext[object]) -> dict[str, ToolsetTool[object]]:
+                tools = await self._inner.get_tools(ctx)
+                return {n: dc_replace(t, tool_def=dc_replace(t.tool_def, sequential=True)) for n, t in tools.items()}
+
+            async def call_tool(
+                self, name: str, tool_args: dict[str, Any], ctx: RunContext[object], tool: ToolsetTool[object]
+            ) -> Any:
+                return await self._inner.call_tool(name, tool_args, ctx, tool)
+
+        wrapper = CodeModeToolset[object](wrapped=_SeqToolset(), tool_selector='all')
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+
+        with pytest.raises(UserError, match='invalid host configuration'):
+            await wrapper.call_tool('run_code', {'code': 'reject()'}, ctx, tools['run_code'])
+
     async def test_global_sequential_mode_forces_sequential_resolution(self) -> None:
         """When the parallel execution mode is `sequential`, tool calls inside the
         sandbox are resolved sequentially via FutureSnapshot. Signatures stay `async def`."""
@@ -2139,6 +2211,22 @@ class TestCodeMode:
                 run_code,
             )
             assert result.return_value == 30
+
+    async def test_user_error_escapes_global_sequential_dispatch(self) -> None:
+        """A UserError keeps its type when global sequential mode resolves a deferred call."""
+
+        async def reject() -> str:
+            """Raise a caller-facing host error."""
+            raise UserError('invalid host configuration')
+
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(reject))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+
+        with ToolManager.parallel_execution_mode('sequential'):
+            tools = await wrapper.get_tools(ctx)
+            with pytest.raises(UserError, match='invalid host configuration'):
+                await wrapper.call_tool('run_code', {'code': 'await reject()'}, ctx, tools['run_code'])
 
     async def test_global_sequential_overrides_per_tool_sequential(self) -> None:
         """When global sequential mode is active AND a tool has `sequential=True`,


### PR DESCRIPTION
Fixes #596.

## Reproduction

Before this change, a tool dispatched from CodeMode that raises `UserError("host configuration is invalid")` exits `run_code` as `ModelRetry`. Monty exposes the cause as a plain `RuntimeError`, so the host/user configuration failure is incorrectly sent back to the model.

## Root cause and exception boundary

The shared Monty executor wrapped every dispatched `Exception` in `ExternalException`. Once `UserError` crossed that boundary, Monty erased its Python class identity and CodeMode's existing `MontyRuntimeError -> ModelRetry` handling could no longer distinguish it.

This change preserves the following taxonomy:

- `UserError` is re-raised before it enters Monty and reaches the end user unchanged.
- Ordinary dispatched tool and runtime failures still enter Monty and retain the existing `MontyRuntimeError -> ModelRetry` behavior.
- Existing approval, deferred, denial, and `ModelRetry` paths retain their retry/control semantics.

Parallel dispatch tasks now settle ordinary outcomes into Monty values before gathering. A `UserError` therefore aborts the gather while the executor's `finally` block cancels and awaits every pending sibling task.

## CodeMode session invariant

A host-side abort leaves the current Monty feed suspended, waiting for an external result. CodeMode resets its run-local session before re-raising `UserError`.

I verified this branch explicitly by removing that reset: the next `run_code` call failed with `monty worker protocol error: feed called while a suspension is awaiting an answer`. The regression test therefore checks both completed sibling-task cleanup and that the next call starts from a fresh session rather than reusing suspended state.

## Validation

- `git diff --check`
- `uv run pytest -q tests/code_mode/test_code_mode.py tests/dynamic_workflow/test_dynamic_workflow.py` — 240 passed
- `uv run pytest -q` — 4,205 passed, 51 skipped
- `uv run ruff check pydantic_ai_harness/_monty_exec.py pydantic_ai_harness/code_mode/_toolset.py tests/code_mode/test_code_mode.py`
- `uv run pyright pydantic_ai_harness/_monty_exec.py pydantic_ai_harness/code_mode/_toolset.py tests/code_mode/test_code_mode.py` — 0 errors

The branch was rebased onto `bbd773d` from upstream `main` before validation. No competing #596 PR was open at publication time.

## Non-goals

No dependency or lockfile changes, public API changes, documentation changes, unrelated CodeMode refactors, or ToolOutputLimits/#510 work.