### PR TITLE
docs: sync README installation section with the index, add Slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI](https://img.shields.io/pypi/v/pydantic-ai-harness.svg)](https://pypi.python.org/pypi/pydantic-ai-harness)
 [![versions](https://img.shields.io/pypi/pyversions/pydantic-ai-harness.svg)](https://github.com/pydantic/pydantic-ai-harness)
 [![license](https://img.shields.io/github/license/pydantic/pydantic-ai-harness.svg)](https://github.com/pydantic/pydantic-ai-harness/blob/main/LICENSE)
+[![Join Slack](https://img.shields.io/badge/Slack-Join%20Slack-4A154B?logo=slack)](https://logfire.pydantic.dev/docs/join-slack/)
 
 **The official capability library and harness for Pydantic AI**
 
@@ -290,23 +291,7 @@ Everything is observable: `logfire.instrument_pydantic_ai()` gives you [a full t
 uv add pydantic-ai-harness
 ```
 
-Some capabilities need an extra for their optional dependencies:
-
-```bash
-uv add "pydantic-ai-harness[codemode]"          # Code Mode (adds the Monty sandbox)
-uv add "pydantic-ai-harness[dynamic-workflow]"  # Dynamic Workflow (adds the Monty sandbox)
-uv add "pydantic-ai-harness[researcher]"        # Researcher (local search + page-fetch fallbacks)
-uv add "pydantic-ai-harness[modal]"             # Modal Sandbox (adds the Modal SDK)
-uv add "pydantic-ai-harness[logfire]"           # Managed Prompt (Logfire-managed prompts)
-uv add "pydantic-ai-harness[exa]"               # Exa Search + Exa Agent (web research via the Exa API)
-uv add "pydantic-ai-harness[skills]"            # Skills (loads SKILL.md frontmatter)
-uv add "pydantic-ai-harness[browser-use]"       # Browser Use (autonomous web tasks; Python 3.11+)
-uv add "pydantic-ai-harness[stackone]"          # StackOne (actions on linked business applications)
-uv add "pydantic-ai-harness[acp]"               # ACP (serve an agent to editors)
-uv add "pydantic-ai-harness[mongodb]"           # MongoDB backends for step persistence + media
-```
-
-The `code-mode` extra is also supported as an alias. Requires Python 3.10+ and `pydantic-ai-slim>=2.18.0`.
+This installs [`pydantic-ai-slim`](https://ai.pydantic.dev/install/) with it, so it works on its own — you don't need to install Pydantic AI separately. Model providers and the CLI come via extras that pass through to Pydantic AI: `pydantic-ai-harness[anthropic]`, `[cli]`. Some capabilities need their own extra for optional dependencies — each capability's page gives its exact install line. Requires Python 3.10+.
 
 ## Build your own
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@ description: The official capability library and harness for Pydantic AI -- 30+ 
 
 **The official capability library and harness for Pydantic AI**
 
+[![Join Slack](https://img.shields.io/badge/Slack-Join%20Slack-4A154B?logo=slack)](https://logfire.pydantic.dev/docs/join-slack/)
+
 Every [Pydantic AI](/ai/) agent already has a light harness: the typed agent loop, [any model](/ai/models/overview/), your own tools, structured output. For simple agents that's enough. But set an agent loose on complex, long-running work — fix a codebase, research a question, run for hours unattended — and what it needs around the model grows: a [workspace](filesystem.md) to act in, a [plan](planning.md) it keeps current, [memory](memory.md) that carries across sessions, [sub-agents](subagents.md) to hand work to, [context management](compaction.md) that holds up in hour ten, and [durable execution](/ai/capabilities/durable_execution/overview/) that survives a restart. **Pydantic AI Harness** ships that harness.
 
 Everything here is one primitive: a [capability](/ai/capabilities/overview/), a self-contained unit of agent behavior you add to `capabilities=[...]` on any agent. There are [30+ of them](#capabilities), and complete agents like [Coder](coder.md) and [Researcher](researcher.md) are themselves capabilities combined — they come apart the way they went together. Snap on a single block, compose your own stack, or start from the whole coding agent and take it apart later.


### PR DESCRIPTION
The #591 front-page rework rewrote the docs index's Installation section to the short pass-through form, but the README's older Installation section further down (11 enumerated capability extras and a stale `pydantic-ai-slim>=2.18.0` floor) was outside that PR's edit zone and got out of sync.

- README Installation now mirrors the index: slim comes along, provider/CLI pass-through extras (`[anthropic]`, `[cli]`), per-capability extras live on each capability's page, Python 3.10+.
- Adds the **Join Slack** badge to the README badge row and the docs index, matching pydantic-ai's own front pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)