### PR TITLE
Stop `FileSystem` tools from leaking absolute host paths to the model

### DIFF
--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -579,6 +579,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
                 parts.append(f'hash: {_content_hash(text)}')
 
         if is_link:
-            parts.append(f'symlink_target: {os.readlink(original)}')
+            target = _model_safe_filename(os.readlink(original), self._real_root)
+            parts.append(f'symlink_target: {target}')
 
         return '\n'.join(parts)

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -54,19 +54,14 @@ def _model_safe_filename(filename: str | bytes, real_root: Path) -> str:
 def _sanitize_recoverable_error(error: BaseException, real_root: Path) -> str:
     """Render a recoverable error without exposing absolute host paths.
 
-    Non-`OSError` exceptions and `OSError` instances with no `filename` are
-    returned as `str(error)`, preserving tool-authored messages. OS-raised
-    errors keep `errno` and `strerror`, and rewrite `filename`/`filename2` to
-    workspace-relative paths. Paths that cannot be represented relative to
-    `real_root` become `_OUTSIDE_WORKSPACE`.
+    Errors without an OS-supplied `filename` keep their original message.
+    OS errors keep `errno` and `strerror`, and the path is rewritten relative
+    to `real_root`, or replaced with `_OUTSIDE_WORKSPACE` when it cannot be.
     """
     if not isinstance(error, OSError) or error.filename is None:
         return str(error)
 
     filename = _model_safe_filename(error.filename, real_root)
-    if error.filename2 is not None:
-        filename2 = _model_safe_filename(error.filename2, real_root)
-        return f'[Errno {error.errno}] {error.strerror}: {filename!r} -> {filename2!r}'
     return f'[Errno {error.errno}] {error.strerror}: {filename!r}'
 
 
@@ -80,8 +75,7 @@ def _recoverable(
         try:
             return await fn(self, *args, **kwargs)
         except _RECOVERABLE_ERRORS as e:
-            # `_recoverable` is module-level, so `self._real_root` trips reportPrivateUsage.
-            real_root: Path = getattr(self, '_real_root')
+            real_root = self._real_root  # pyright: ignore[reportPrivateUsage]
             raise ModelRetry(_sanitize_recoverable_error(e, real_root)) from e
 
     return wrapper

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -28,6 +28,47 @@ READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
 # converts these so the agent can correct itself and continue.
 _RECOVERABLE_ERRORS = (PermissionError, FileNotFoundError, NotADirectoryError, IsADirectoryError, ValueError)
 
+_OUTSIDE_WORKSPACE = '<outside-workspace>'
+"""Placeholder used when an OS path cannot be shown relative to the workspace root."""
+
+
+def _model_safe_filename(filename: str | bytes, real_root: Path) -> str:
+    """Return a workspace-relative path, or `_OUTSIDE_WORKSPACE` if that is unsafe."""
+    try:
+        raw = os.fsdecode(filename)
+    except TypeError:
+        return _OUTSIDE_WORKSPACE
+    path = Path(raw)
+    if not path.is_absolute():
+        return path.as_posix()
+    try:
+        return path.relative_to(real_root).as_posix()
+    except ValueError:
+        pass
+    try:
+        return Path(os.path.realpath(path)).relative_to(real_root).as_posix()
+    except (ValueError, OSError):
+        return _OUTSIDE_WORKSPACE
+
+
+def _sanitize_recoverable_error(error: BaseException, real_root: Path) -> str:
+    """Render a recoverable error without exposing absolute host paths.
+
+    Non-`OSError` exceptions and `OSError` instances with no `filename` are
+    returned as `str(error)`, preserving tool-authored messages. OS-raised
+    errors keep `errno` and `strerror`, and rewrite `filename`/`filename2` to
+    workspace-relative paths. Paths that cannot be represented relative to
+    `real_root` become `_OUTSIDE_WORKSPACE`.
+    """
+    if not isinstance(error, OSError) or error.filename is None:
+        return str(error)
+
+    filename = _model_safe_filename(error.filename, real_root)
+    if error.filename2 is not None:
+        filename2 = _model_safe_filename(error.filename2, real_root)
+        return f'[Errno {error.errno}] {error.strerror}: {filename!r} -> {filename2!r}'
+    return f'[Errno {error.errno}] {error.strerror}: {filename!r}'
+
 
 def _recoverable(
     fn: Callable[Concatenate[FileSystemToolset, _P], Awaitable[str]],
@@ -39,7 +80,9 @@ def _recoverable(
         try:
             return await fn(self, *args, **kwargs)
         except _RECOVERABLE_ERRORS as e:
-            raise ModelRetry(str(e)) from e
+            # `_recoverable` is module-level, so `self._real_root` trips reportPrivateUsage.
+            real_root: Path = getattr(self, '_real_root')
+            raise ModelRetry(_sanitize_recoverable_error(e, real_root)) from e
 
     return wrapper
 

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -29,15 +29,22 @@ READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
 _RECOVERABLE_ERRORS = (PermissionError, FileNotFoundError, NotADirectoryError, IsADirectoryError, ValueError)
 
 _OUTSIDE_WORKSPACE = '<outside-workspace>'
-"""Placeholder used when an OS path cannot be shown relative to the workspace root."""
+"""Shown instead of an absolute path that is not inside the workspace root."""
+
+_NOT_A_PATH = '<not-a-path>'
+"""Shown when an error's `filename` is not a path value at all."""
 
 
 def _model_safe_filename(filename: str | bytes, real_root: Path) -> str:
-    """Return a workspace-relative path, or `_OUTSIDE_WORKSPACE` if that is unsafe."""
+    """Return the path relative to the workspace root.
+
+    Paths not inside the root become `_OUTSIDE_WORKSPACE`; values that are
+    not paths at all become `_NOT_A_PATH`.
+    """
     try:
         raw = os.fsdecode(filename)
     except TypeError:
-        return _OUTSIDE_WORKSPACE
+        return _NOT_A_PATH
     path = Path(raw)
     if not path.is_absolute():
         return path.as_posix()
@@ -55,8 +62,8 @@ def _sanitize_recoverable_error(error: BaseException, real_root: Path) -> str:
     """Render a recoverable error without exposing absolute host paths.
 
     Errors without an OS-supplied `filename` keep their original message.
-    OS errors keep `errno` and `strerror`, and the path is rewritten relative
-    to `real_root`, or replaced with `_OUTSIDE_WORKSPACE` when it cannot be.
+    OS errors keep `errno` and `strerror`, with the path rewritten relative
+    to `real_root` (see `_model_safe_filename` for the fallback placeholders).
     """
     if not isinstance(error, OSError) or error.filename is None:
         return str(error)

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import errno
 import os
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pydantic_ai import Agent
@@ -15,11 +16,13 @@ from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness.filesystem import READ_ONLY_TOOL_NAMES, FileSystem
 from pydantic_ai_harness.filesystem._toolset import (
+    _OUTSIDE_WORKSPACE,
     FileSystemToolset,
     _content_hash,
     _format_lines,
     _is_binary,
     _recoverable,
+    _sanitize_recoverable_error,
 )
 
 
@@ -1166,9 +1169,7 @@ def _assert_no_host_root(message: str, root: Path) -> None:
 class TestModelSafeRecoverableErrors:
     """OS-raised filesystem errors must not leak absolute host paths into `ModelRetry`."""
 
-    async def test_write_through_file_hides_host_path(
-        self, toolset: FileSystemToolset[None], fs_root: Path
-    ) -> None:
+    async def test_write_through_file_hides_host_path(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
         # `read_file('hello.txt/nested')` is the issue reproduction on macOS, where
         # `Path.resolve()` raises `NotADirectoryError`. On Linux and Windows, resolve
         # succeeds and `read_file` returns a tool-authored relative message instead.
@@ -1201,13 +1202,104 @@ class TestModelSafeRecoverableErrors:
         absolute = str(fs_root / 'hello.txt' / 'nested')
 
         @_recoverable
-        async def boom(self: FileSystemToolset[None]) -> str:
+        async def boom(self: FileSystemToolset[Any]) -> str:
             raise error_type(err_no, strerror, absolute)
 
         with pytest.raises(ModelRetry) as exc_info:
-            await boom(toolset)
+            await boom(toolset)  # type: ignore[arg-type]
         message = str(exc_info.value)
         _assert_no_host_root(message, fs_root)
         assert 'hello.txt/nested' in message.replace('\\', '/')
         assert strerror in message
         assert f'[Errno {err_no}]' in message
+
+    def test_filename2_is_root_relative(self, fs_root: Path) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        source = str(fs_root / 'src.txt')
+        destination = str(fs_root / 'dst.txt')
+        error = OSError(errno.EXDEV, 'Invalid cross-device link', source, None, destination)
+        message = _sanitize_recoverable_error(error, real_root)
+        _assert_no_host_root(message, fs_root)
+        assert 'src.txt' in message
+        assert 'dst.txt' in message
+        assert 'Invalid cross-device link' in message
+
+    def test_outside_root_path_is_redacted(self, fs_root: Path) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        outside = fs_root.parent / 'private' / 'secret.txt'
+        error = FileNotFoundError(errno.ENOENT, 'No such file or directory', str(outside))
+        message = _sanitize_recoverable_error(error, real_root)
+        _assert_no_host_root(message, fs_root)
+        assert str(outside) not in message
+        assert str(fs_root.parent) not in message
+        assert str(fs_root.parent).replace('\\', '\\\\') not in message
+        assert _OUTSIDE_WORKSPACE in message
+
+    def test_tool_authored_value_error_is_unchanged(self, fs_root: Path) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        error = ValueError('old_text not found in hello.txt.')
+        assert _sanitize_recoverable_error(error, real_root) == str(error)
+
+    def test_oserror_without_filename_is_unchanged(self, fs_root: Path) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        error = FileNotFoundError('File not found: hello.txt')
+        assert error.filename is None
+        assert _sanitize_recoverable_error(error, real_root) == 'File not found: hello.txt'
+
+    def test_relative_filename_is_preserved(self, fs_root: Path) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        error = PermissionError(errno.EACCES, 'Permission denied', 'hello.txt')
+        message = _sanitize_recoverable_error(error, real_root)
+        assert message == f"[Errno {errno.EACCES}] Permission denied: 'hello.txt'"
+
+    def test_errno_none_does_not_leak_path(self, fs_root: Path) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        error = OSError()
+        error.filename = str(fs_root / 'hello.txt')
+        error.errno = None
+        error.strerror = None
+        message = _sanitize_recoverable_error(error, real_root)
+        _assert_no_host_root(message, fs_root)
+        assert 'hello.txt' in message
+        assert _OUTSIDE_WORKSPACE not in message
+
+    def test_unpathlike_filename_is_redacted(self, fs_root: Path) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        error = OSError(errno.ENOENT, 'No such file or directory')
+        error.filename = object()
+        message = _sanitize_recoverable_error(error, real_root)
+        assert _OUTSIDE_WORKSPACE in message
+        assert str(fs_root) not in message
+
+    def test_realpath_alias_is_normalized(self, fs_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        alias = fs_root.parent / 'alias-root'
+        filename = str(alias / 'hello.txt')
+
+        def fake_realpath(path: object, *args: object, **kwargs: object) -> str:
+            text = os.fsdecode(os.fspath(path))  # type: ignore[arg-type]
+            alias_text = str(alias)
+            if text == alias_text or text.startswith(alias_text + os.sep):
+                return str(real_root / Path(text).relative_to(alias))
+            return os.path.normpath(text)
+
+        monkeypatch.setattr(os.path, 'realpath', fake_realpath)
+        error = FileNotFoundError(errno.ENOENT, 'No such file or directory', filename)
+        message = _sanitize_recoverable_error(error, real_root)
+        assert str(alias) not in message
+        assert str(alias).replace('\\', '\\\\') not in message
+        assert 'hello.txt' in message
+        assert _OUTSIDE_WORKSPACE not in message
+
+    def test_realpath_oserror_redacts_outside_path(self, fs_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_root = Path(os.path.realpath(fs_root))
+        outside = fs_root.parent / 'secret.txt'
+
+        def boom(path: object) -> str:
+            raise OSError('realpath failed')
+
+        monkeypatch.setattr(os.path, 'realpath', boom)
+        error = FileNotFoundError(errno.ENOENT, 'No such file or directory', str(outside))
+        message = _sanitize_recoverable_error(error, real_root)
+        assert _OUTSIDE_WORKSPACE in message
+        assert str(outside) not in message

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -15,6 +15,7 @@ from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness.filesystem import READ_ONLY_TOOL_NAMES, FileSystem
 from pydantic_ai_harness.filesystem._toolset import (
+    _NOT_A_PATH,
     _OUTSIDE_WORKSPACE,
     FileSystemToolset,
     _content_hash,
@@ -1434,12 +1435,12 @@ class TestModelSafeRecoverableErrors:
         message = _sanitize_recoverable_error(error, real_root)
         assert message == f"[Errno {errno.EACCES}] Permission denied: 'hello.txt'"
 
-    def test_unpathlike_filename_is_redacted(self, fs_root: Path) -> None:
+    def test_non_path_filename_is_labeled(self, fs_root: Path) -> None:
         real_root = Path(os.path.realpath(fs_root))
         error = OSError(errno.ENOENT, 'No such file or directory')
         error.filename = object()
         message = _sanitize_recoverable_error(error, real_root)
-        assert _OUTSIDE_WORKSPACE in message
+        assert _NOT_A_PATH in message
 
     def test_symlink_alias_is_normalized(self, fs_root: Path) -> None:
         # macOS reports tmp paths through a symlink alias (`/var` vs `/private/var`);

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -978,11 +978,14 @@ class TestFileInfo:
             await toolset.file_info('nonexistent')
 
     async def test_info_symlink(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        # The link target is stored as an absolute path; the tool must report
+        # it relative to the root, never as the absolute host path.
         link = fs_root / 'link.txt'
         link.symlink_to(fs_root / 'hello.txt')
         result = await toolset.file_info('link.txt')
         assert 'type: file' in result
-        assert 'symlink_target:' in result
+        assert 'symlink_target: hello.txt' in result
+        _assert_no_host_root(result, fs_root)
 
 
 class TestMutationKillers:

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import errno
+import os
 from pathlib import Path
 
 import pytest
@@ -12,7 +14,13 @@ from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness.filesystem import READ_ONLY_TOOL_NAMES, FileSystem
-from pydantic_ai_harness.filesystem._toolset import FileSystemToolset, _content_hash, _format_lines, _is_binary
+from pydantic_ai_harness.filesystem._toolset import (
+    FileSystemToolset,
+    _content_hash,
+    _format_lines,
+    _is_binary,
+    _recoverable,
+)
 
 
 class TestFormatLines:
@@ -1144,3 +1152,62 @@ class TestPatternCanonicalization:
         # `**/secrets*` must protect a root-level secrets file, not just nested ones.
         result = await ts.search_files('PRIVATE KEY')
         assert 'secrets.yaml' not in result
+
+
+def _assert_no_host_root(message: str, root: Path) -> None:
+    """Fail if `message` names the host workspace root in any common spelling."""
+    variants = {str(root), str(root.resolve()), os.path.realpath(root)}
+    for variant in variants:
+        assert variant not in message
+        assert variant.replace('\\', '/') not in message
+        assert variant.replace('\\', '\\\\') not in message
+
+
+class TestModelSafeRecoverableErrors:
+    """OS-raised filesystem errors must not leak absolute host paths into `ModelRetry`."""
+
+    async def test_write_through_file_hides_host_path(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        # `read_file('hello.txt/nested')` is the issue reproduction on macOS, where
+        # `Path.resolve()` raises `NotADirectoryError`. On Linux and Windows, resolve
+        # succeeds and `read_file` returns a tool-authored relative message instead.
+        # `write_file` still hits the OS (`parent` exists as a file), so it is the
+        # public operation that leaks on every supported platform.
+        with pytest.raises(ModelRetry) as exc_info:
+            await toolset.write_file('hello.txt/nested', 'x')
+        message = str(exc_info.value)
+        _assert_no_host_root(message, fs_root)
+        assert 'hello.txt/nested' in message.replace('\\', '/')
+        assert 'Errno' in message
+
+    @pytest.mark.parametrize(
+        ('error_type', 'err_no', 'strerror'),
+        [
+            (PermissionError, errno.EACCES, 'Permission denied'),
+            (FileNotFoundError, errno.ENOENT, 'No such file or directory'),
+            (NotADirectoryError, errno.ENOTDIR, 'Not a directory'),
+            (IsADirectoryError, errno.EISDIR, 'Is a directory'),
+        ],
+    )
+    async def test_os_raised_subclasses_are_root_relative(
+        self,
+        toolset: FileSystemToolset[None],
+        fs_root: Path,
+        error_type: type[OSError],
+        err_no: int,
+        strerror: str,
+    ) -> None:
+        absolute = str(fs_root / 'hello.txt' / 'nested')
+
+        @_recoverable
+        async def boom(self: FileSystemToolset[None]) -> str:
+            raise error_type(err_no, strerror, absolute)
+
+        with pytest.raises(ModelRetry) as exc_info:
+            await boom(toolset)
+        message = str(exc_info.value)
+        _assert_no_host_root(message, fs_root)
+        assert 'hello.txt/nested' in message.replace('\\', '/')
+        assert strerror in message
+        assert f'[Errno {err_no}]' in message

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import errno
 import os
 from pathlib import Path
-from typing import Any
 
 import pytest
 from pydantic_ai import Agent
@@ -21,7 +20,6 @@ from pydantic_ai_harness.filesystem._toolset import (
     _content_hash,
     _format_lines,
     _is_binary,
-    _recoverable,
     _sanitize_recoverable_error,
 )
 
@@ -1401,93 +1399,31 @@ class TestPatternCanonicalization:
 
 
 def _assert_no_host_root(message: str, root: Path) -> None:
-    """Fail if `message` names the host workspace root in any common spelling."""
-    variants = {str(root), str(root.resolve()), os.path.realpath(root)}
-    for variant in variants:
-        assert variant not in message
-        assert variant.replace('\\', '/') not in message
-        assert variant.replace('\\', '\\\\') not in message
+    """Fail if `message` contains the absolute workspace root."""
+    assert str(root) not in message
+    assert str(root.resolve()) not in message
 
 
 class TestModelSafeRecoverableErrors:
     """OS-raised filesystem errors must not leak absolute host paths into `ModelRetry`."""
 
     async def test_write_through_file_hides_host_path(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
-        # `read_file('hello.txt/nested')` is the issue reproduction on macOS, where
-        # `Path.resolve()` raises `NotADirectoryError`. On Linux and Windows, resolve
-        # succeeds and `read_file` returns a tool-authored relative message instead.
-        # `write_file` still hits the OS (`parent` exists as a file), so it is the
-        # public operation that leaks on every supported platform.
+        # The parent path 'hello.txt' exists as a file, so the OS itself raises
+        # the error, with the absolute host path as its filename.
         with pytest.raises(ModelRetry) as exc_info:
             await toolset.write_file('hello.txt/nested', 'x')
         message = str(exc_info.value)
         _assert_no_host_root(message, fs_root)
-        assert 'hello.txt/nested' in message.replace('\\', '/')
+        assert "'hello.txt/nested'" in message
         assert 'Errno' in message
-
-    @pytest.mark.parametrize(
-        ('error_type', 'err_no', 'strerror'),
-        [
-            (PermissionError, errno.EACCES, 'Permission denied'),
-            (FileNotFoundError, errno.ENOENT, 'No such file or directory'),
-            (NotADirectoryError, errno.ENOTDIR, 'Not a directory'),
-            (IsADirectoryError, errno.EISDIR, 'Is a directory'),
-        ],
-    )
-    async def test_os_raised_subclasses_are_root_relative(
-        self,
-        toolset: FileSystemToolset[None],
-        fs_root: Path,
-        error_type: type[OSError],
-        err_no: int,
-        strerror: str,
-    ) -> None:
-        absolute = str(fs_root / 'hello.txt' / 'nested')
-
-        @_recoverable
-        async def boom(self: FileSystemToolset[Any]) -> str:
-            raise error_type(err_no, strerror, absolute)
-
-        with pytest.raises(ModelRetry) as exc_info:
-            await boom(toolset)  # type: ignore[arg-type]
-        message = str(exc_info.value)
-        _assert_no_host_root(message, fs_root)
-        assert 'hello.txt/nested' in message.replace('\\', '/')
-        assert strerror in message
-        assert f'[Errno {err_no}]' in message
-
-    def test_filename2_is_root_relative(self, fs_root: Path) -> None:
-        real_root = Path(os.path.realpath(fs_root))
-        source = str(fs_root / 'src.txt')
-        destination = str(fs_root / 'dst.txt')
-        error = OSError(errno.EXDEV, 'Invalid cross-device link', source, None, destination)
-        message = _sanitize_recoverable_error(error, real_root)
-        _assert_no_host_root(message, fs_root)
-        assert 'src.txt' in message
-        assert 'dst.txt' in message
-        assert 'Invalid cross-device link' in message
 
     def test_outside_root_path_is_redacted(self, fs_root: Path) -> None:
         real_root = Path(os.path.realpath(fs_root))
         outside = fs_root.parent / 'private' / 'secret.txt'
         error = FileNotFoundError(errno.ENOENT, 'No such file or directory', str(outside))
         message = _sanitize_recoverable_error(error, real_root)
-        _assert_no_host_root(message, fs_root)
         assert str(outside) not in message
-        assert str(fs_root.parent) not in message
-        assert str(fs_root.parent).replace('\\', '\\\\') not in message
         assert _OUTSIDE_WORKSPACE in message
-
-    def test_tool_authored_value_error_is_unchanged(self, fs_root: Path) -> None:
-        real_root = Path(os.path.realpath(fs_root))
-        error = ValueError('old_text not found in hello.txt.')
-        assert _sanitize_recoverable_error(error, real_root) == str(error)
-
-    def test_oserror_without_filename_is_unchanged(self, fs_root: Path) -> None:
-        real_root = Path(os.path.realpath(fs_root))
-        error = FileNotFoundError('File not found: hello.txt')
-        assert error.filename is None
-        assert _sanitize_recoverable_error(error, real_root) == 'File not found: hello.txt'
 
     def test_relative_filename_is_preserved(self, fs_root: Path) -> None:
         real_root = Path(os.path.realpath(fs_root))
@@ -1495,54 +1431,20 @@ class TestModelSafeRecoverableErrors:
         message = _sanitize_recoverable_error(error, real_root)
         assert message == f"[Errno {errno.EACCES}] Permission denied: 'hello.txt'"
 
-    def test_errno_none_does_not_leak_path(self, fs_root: Path) -> None:
-        real_root = Path(os.path.realpath(fs_root))
-        error = OSError()
-        error.filename = str(fs_root / 'hello.txt')
-        error.errno = None
-        error.strerror = None
-        message = _sanitize_recoverable_error(error, real_root)
-        _assert_no_host_root(message, fs_root)
-        assert 'hello.txt' in message
-        assert _OUTSIDE_WORKSPACE not in message
-
     def test_unpathlike_filename_is_redacted(self, fs_root: Path) -> None:
         real_root = Path(os.path.realpath(fs_root))
         error = OSError(errno.ENOENT, 'No such file or directory')
         error.filename = object()
         message = _sanitize_recoverable_error(error, real_root)
         assert _OUTSIDE_WORKSPACE in message
-        assert str(fs_root) not in message
 
-    def test_realpath_alias_is_normalized(self, fs_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_symlink_alias_is_normalized(self, fs_root: Path) -> None:
+        # macOS reports tmp paths through a symlink alias (`/var` vs `/private/var`);
+        # `realpath` maps such an alias back under the real root.
         real_root = Path(os.path.realpath(fs_root))
         alias = fs_root.parent / 'alias-root'
-        filename = str(alias / 'hello.txt')
-
-        def fake_realpath(path: object, *args: object, **kwargs: object) -> str:
-            text = os.fsdecode(os.fspath(path))  # type: ignore[arg-type]
-            alias_text = str(alias)
-            if text == alias_text or text.startswith(alias_text + os.sep):
-                return str(real_root / Path(text).relative_to(alias))
-            return os.path.normpath(text)
-
-        monkeypatch.setattr(os.path, 'realpath', fake_realpath)
-        error = FileNotFoundError(errno.ENOENT, 'No such file or directory', filename)
+        alias.symlink_to(fs_root)
+        error = FileNotFoundError(errno.ENOENT, 'No such file or directory', str(alias / 'hello.txt'))
         message = _sanitize_recoverable_error(error, real_root)
         assert str(alias) not in message
-        assert str(alias).replace('\\', '\\\\') not in message
-        assert 'hello.txt' in message
-        assert _OUTSIDE_WORKSPACE not in message
-
-    def test_realpath_oserror_redacts_outside_path(self, fs_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        real_root = Path(os.path.realpath(fs_root))
-        outside = fs_root.parent / 'secret.txt'
-
-        def boom(path: object) -> str:
-            raise OSError('realpath failed')
-
-        monkeypatch.setattr(os.path, 'realpath', boom)
-        error = FileNotFoundError(errno.ENOENT, 'No such file or directory', str(outside))
-        message = _sanitize_recoverable_error(error, real_root)
-        assert _OUTSIDE_WORKSPACE in message
-        assert str(outside) not in message
+        assert "'hello.txt'" in message


### PR DESCRIPTION
## Summary

`str(OSError)` embeds the absolute host filename. Two model-visible surfaces forwarded it verbatim:

- `_recoverable` passed `str(e)` into `ModelRetry`, so OS-raised errors named the host filesystem layout. OS errors now keep `errno` and `strerror`, with the path rewritten relative to the configured root, or `<outside-workspace>` when it cannot be represented there.
- `file_info` returned the raw `os.readlink` target, so a symlink stored with an absolute target showed the host path in the tool result. Targets now go through the same helper.

Tool-authored error messages are unchanged. No changes to path authorization, containment, public APIs, or dependencies.

## Linked Issue

Closes #616.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)
