### PR TITLE
Deploy deterministic maintainer intake and queue reports in Harness

### DIFF
--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@96f9120ff79bdc904f86b0e76141cabf321d5775
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@aa62687ba4a973ca134163e948c94b7c340d8b65
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -36,7 +36,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@96f9120ff79bdc904f86b0e76141cabf321d5775
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@aa62687ba4a973ca134163e948c94b7c340d8b65
     secrets:
       MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
 
@@ -53,6 +53,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@96f9120ff79bdc904f86b0e76141cabf321d5775
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@aa62687ba4a973ca134163e948c94b7c340d8b65
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -25,30 +25,14 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@307dac89152efd578a65f47c226b723efcf9fd32
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@5dc2363e88cad2032dee20248000e15a78badd6a
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
-  triage:
-    needs: owner-routing
-    if: >-
-      always() && !cancelled() &&
-      (github.event_name == 'workflow_dispatch' ||
-      github.event.schedule == '10 */6 * * *')
-    permissions:
-      actions: write
-      checks: read
-      contents: read
-      issues: write
-      pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@307dac89152efd578a65f47c226b723efcf9fd32
-    secrets:
-      MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
-
   operations:
-    needs: triage
-    # Existing attention requests still need reminders when a classifier run
-    # fails, so only cancellation prevents reconciliation.
+    needs: owner-routing
+    # Existing attention requests still need reminders when owner routing is
+    # skipped or fails, so only cancellation prevents reconciliation.
     if: >-
       always() && !cancelled() &&
       (github.event_name == 'workflow_dispatch' ||
@@ -58,7 +42,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@307dac89152efd578a65f47c226b723efcf9fd32
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@5dc2363e88cad2032dee20248000e15a78badd6a
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -68,6 +52,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@307dac89152efd578a65f47c226b723efcf9fd32
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@5dc2363e88cad2032dee20248000e15a78badd6a
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -45,7 +45,7 @@ jobs:
     # Existing attention requests still need reminders when a classifier run
     # fails, so only cancellation prevents reconciliation.
     if: >-
-      !cancelled() &&
+      always() && !cancelled() &&
       (github.event_name == 'workflow_dispatch' ||
       github.event.schedule == '10 */6 * * *' ||
       github.event.schedule == '47 6 * * *')

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -3,6 +3,8 @@ name: Maintainer attention
 on:
   issues:
     types: [opened, reopened]
+  issue_comment:
+    types: [created]
   pull_request_target:
     # zizmor: ignore[dangerous-triggers] -- this caller runs the base repository's pinned reusable workflow and never checks out contributor code
     types: [opened, reopened, ready_for_review]
@@ -19,13 +21,17 @@ jobs:
     if: >-
       github.event_name == 'issues' ||
       github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+      (github.event.comment.user.login == 'adtyavrdhn' ||
+      github.event.comment.user.login == 'dsfaccini' ||
+      github.event.comment.user.login == 'DouweM')) ||
       github.event_name == 'workflow_dispatch' ||
       github.event.schedule == '10 */6 * * *'
     permissions:
       contents: read
       issues: write
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@92e486243759d35d1cc68039731fdb3d4e29f649
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@8900d8b6387b4cc9e7a0e66a7ae13ab31ca9403e
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -42,7 +48,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@92e486243759d35d1cc68039731fdb3d4e29f649
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@8900d8b6387b4cc9e7a0e66a7ae13ab31ca9403e
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -52,6 +58,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@92e486243759d35d1cc68039731fdb3d4e29f649
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@8900d8b6387b4cc9e7a0e66a7ae13ab31ca9403e
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@5dc2363e88cad2032dee20248000e15a78badd6a
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@940275583c2b555895a6bc90606b00d6e7655449
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -42,7 +42,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@5dc2363e88cad2032dee20248000e15a78badd6a
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@940275583c2b555895a6bc90606b00d6e7655449
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -52,6 +52,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@5dc2363e88cad2032dee20248000e15a78badd6a
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@940275583c2b555895a6bc90606b00d6e7655449
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@6644aaad83798e2a32352a30f1e043c557032407
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@c44fbca16ef9974773b1f9c81c71e185f5892314
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -48,7 +48,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@6644aaad83798e2a32352a30f1e043c557032407
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@c44fbca16ef9974773b1f9c81c71e185f5892314
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -58,6 +58,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@6644aaad83798e2a32352a30f1e043c557032407
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@c44fbca16ef9974773b1f9c81c71e185f5892314
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@4b8a8771adb35e3eaba982d7468acde446c37948
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@a64ff816a9d6e5a38afdc896342f64953fd9147d
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -42,7 +42,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@4b8a8771adb35e3eaba982d7468acde446c37948
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@a64ff816a9d6e5a38afdc896342f64953fd9147d
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -52,6 +52,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@4b8a8771adb35e3eaba982d7468acde446c37948
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@a64ff816a9d6e5a38afdc896342f64953fd9147d
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -29,7 +29,11 @@ jobs:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
   triage:
-    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '10 */6 * * *'
+    needs: owner-routing
+    if: >-
+      always() && !cancelled() &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.schedule == '10 */6 * * *')
     permissions:
       actions: read
       checks: read

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@c44fbca16ef9974773b1f9c81c71e185f5892314
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@c44fbca16651e6dbf142228b816d686a280d1051
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -48,7 +48,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@c44fbca16ef9974773b1f9c81c71e185f5892314
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@c44fbca16651e6dbf142228b816d686a280d1051
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -58,6 +58,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@c44fbca16ef9974773b1f9c81c71e185f5892314
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@c44fbca16651e6dbf142228b816d686a280d1051
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -8,7 +8,6 @@ on:
     types: [opened, reopened, ready_for_review]
   schedule:
     - cron: '10 */6 * * *'
-    - cron: '25 */6 * * *'
     - cron: '47 6 * * *'
   workflow_dispatch: {}
 
@@ -20,14 +19,13 @@ jobs:
       github.event_name == 'issues' ||
       github.event_name == 'pull_request_target' ||
       github.event_name == 'workflow_dispatch' ||
-      github.event.schedule == '25 */6 * * *'
+      github.event.schedule == '10 */6 * * *'
     permissions:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.lock.yml@f6a4ead46af0dcab291bb61ab82b1d24f31e3b1e
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@96f9120ff79bdc904f86b0e76141cabf321d5775
     secrets:
-      MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
   triage:
@@ -38,7 +36,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@f6a4ead46af0dcab291bb61ab82b1d24f31e3b1e
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@96f9120ff79bdc904f86b0e76141cabf321d5775
     secrets:
       MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
 
@@ -55,6 +53,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@f6a4ead46af0dcab291bb61ab82b1d24f31e3b1e
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@96f9120ff79bdc904f86b0e76141cabf321d5775
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@aa62687ba4a973ca134163e948c94b7c340d8b65
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@0851d494d2a259f3b1d330a8cafebca272bb7f91
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -36,7 +36,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@aa62687ba4a973ca134163e948c94b7c340d8b65
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@0851d494d2a259f3b1d330a8cafebca272bb7f91
     secrets:
       MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
 
@@ -53,6 +53,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@aa62687ba4a973ca134163e948c94b7c340d8b65
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@0851d494d2a259f3b1d330a8cafebca272bb7f91
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@a64ff816a9d6e5a38afdc896342f64953fd9147d
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@92e486243759d35d1cc68039731fdb3d4e29f649
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -42,7 +42,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@a64ff816a9d6e5a38afdc896342f64953fd9147d
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@92e486243759d35d1cc68039731fdb3d4e29f649
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -52,6 +52,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@a64ff816a9d6e5a38afdc896342f64953fd9147d
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@92e486243759d35d1cc68039731fdb3d4e29f649
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -24,8 +24,8 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@940275583c2b555895a6bc90606b00d6e7655449
+      pull-requests: read
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@4b8a8771adb35e3eaba982d7468acde446c37948
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -42,7 +42,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@940275583c2b555895a6bc90606b00d6e7655449
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@4b8a8771adb35e3eaba982d7468acde446c37948
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -52,6 +52,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@940275583c2b555895a6bc90606b00d6e7655449
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@4b8a8771adb35e3eaba982d7468acde446c37948
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -35,7 +35,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' ||
       github.event.schedule == '10 */6 * * *')
     permissions:
-      actions: read
+      actions: write
       checks: read
       contents: read
       issues: write

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -1,21 +1,44 @@
 name: Maintainer attention
 
 on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    # zizmor: ignore[dangerous-triggers] -- this caller runs the base repository's pinned reusable workflow and never checks out contributor code
+    types: [opened, reopened, ready_for_review]
   schedule:
     - cron: '10 */6 * * *'
+    - cron: '25 */6 * * *'
+    - cron: '47 6 * * *'
   workflow_dispatch: {}
 
 permissions: {}
 
 jobs:
+  owner-routing:
+    if: >-
+      github.event_name == 'issues' ||
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event.schedule == '25 */6 * * *'
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.lock.yml@f6a4ead46af0dcab291bb61ab82b1d24f31e3b1e
+    secrets:
+      MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+      PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
+
   triage:
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '10 */6 * * *'
     permissions:
       actions: read
       checks: read
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@592d476c350b342d46403c08f4c3769b48aa2fbf
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@f6a4ead46af0dcab291bb61ab82b1d24f31e3b1e
     secrets:
       MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
 
@@ -23,11 +46,15 @@ jobs:
     needs: triage
     # Existing attention requests still need reminders when a classifier run
     # fails, so only cancellation prevents reconciliation.
-    if: ${{ !cancelled() }}
+    if: >-
+      !cancelled() &&
+      (github.event_name == 'workflow_dispatch' ||
+      github.event.schedule == '10 */6 * * *' ||
+      github.event.schedule == '47 6 * * *')
     permissions:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@592d476c350b342d46403c08f4c3769b48aa2fbf
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@f6a4ead46af0dcab291bb61ab82b1d24f31e3b1e
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -9,6 +9,7 @@ on:
   schedule:
     - cron: '10 */6 * * *'
     - cron: '47 6 * * *'
+    - cron: '23 14 * * 1'
   workflow_dispatch: {}
 
 permissions: {}
@@ -24,7 +25,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@0851d494d2a259f3b1d330a8cafebca272bb7f91
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@307dac89152efd578a65f47c226b723efcf9fd32
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -40,7 +41,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@0851d494d2a259f3b1d330a8cafebca272bb7f91
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@307dac89152efd578a65f47c226b723efcf9fd32
     secrets:
       MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
 
@@ -57,6 +58,16 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@0851d494d2a259f3b1d330a8cafebca272bb7f91
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@307dac89152efd578a65f47c226b723efcf9fd32
+    secrets:
+      PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
+
+  weekly-digest:
+    if: github.event.schedule == '23 14 * * 1'
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@307dac89152efd578a65f47c226b723efcf9fd32
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@8900d8b6387b4cc9e7a0e66a7ae13ab31ca9403e
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@6644aaad83798e2a32352a30f1e043c557032407
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -48,16 +48,16 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@8900d8b6387b4cc9e7a0e66a7ae13ab31ca9403e
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@6644aaad83798e2a32352a30f1e043c557032407
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
   weekly-digest:
-    if: github.event.schedule == '23 14 * * 1'
+    if: github.event.schedule == '23 14 * * 1' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@8900d8b6387b4cc9e7a0e66a7ae13ab31ca9403e
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@6644aaad83798e2a32352a30f1e043c557032407
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -1,0 +1,33 @@
+name: Maintainer attention
+
+on:
+  schedule:
+    - cron: '10 */6 * * *'
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  triage:
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-attention-triage.lock.yml@592d476c350b342d46403c08f4c3769b48aa2fbf
+    secrets:
+      MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+
+  operations:
+    needs: triage
+    # Existing attention requests still need reminders when a classifier run
+    # fails, so only cancellation prevents reconciliation.
+    if: ${{ !cancelled() }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@592d476c350b342d46403c08f4c3769b48aa2fbf
+    secrets:
+      PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

Deploy the deterministic maintainer intake and reporting system from pydantic/pydantic-ai#7748 in Harness.

- opened, reopened, and ready-for-review items run semantic owner routing immediately
- Aditya, David, and Douwe conversation comments claim an otherwise unowned issue or PR immediately; arbitrary commenters are rejected before a runner is allocated
- the six-hour pass recovers missed post-rollout intake one item at a time and reconciles existing attention state
- Mike remains manual-only; topic rules and participation never select him
- existing qualified maintainer assignments always win, and current GitHub state is revalidated before Slack notification and assignment
- the daily heartbeat reports the actionable attention queue and post-rollout items without a designated owner
- every Monday at 14:23 UTC, a read-only report shows each configured owner plate plus complete post-rollout, legacy, and draft queue links
- a manual workflow dispatch also produces the weekly report for an immediate smoke test or forwardable digest

Historical work remains report-only. The Harness caller does not activate the model-based stale classifier and does not receive `MINIMAX_API_KEY`; contributor prose therefore has no prompt-to-write path.

## Security and setup

- The caller never checks out or executes contributor code.
- All three reusable workflow references are pinned to reviewed core commit `c44fbca16651e6dbf142228b816d686a280d1051`.
- Top-level permissions are empty. Selection is read-only; routing receives `issues: write` plus `pull-requests: read`; weekly reporting is read-only.
- Comment bodies are never consumed. Participant identity comes from fixed event metadata, a fixed roster, refreshed maintainer permission, and bounded structured timeline events.
- Report construction cannot see the Slack webhook, and Slack-only weekly jobs have no GitHub permissions.
- Harness needs `PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL` and `PYDANTIC_AI_TRIAGE_SLACK_MENTIONS` for `adtyavrdhn`, `dsfaccini`, and `DouweM`. These must be real Slack `<@U...>` or `<@W...>` member mentions; supplied `D...` values are conversation IDs and cannot mention a member.
- A rejected webhook fails the Actions run but cannot alert through the same rejected webhook; an independent destination would be required to close that limitation.

## Deliberate simplification

The reusable implementation no longer polls formal reviews or reconstructs participation across large search samples, does not auto-route Mike, and does not split legacy work into rotating active/dormant buckets. Immediate conversation-comment ownership plus the daily and Monday inventories preserve visibility with much less API traffic and code.

## Verification

- Harness YAML formatting, pre-commit, and `zizmor` pass.
- The pinned core implementation has 215 focused tests plus Ruff, strict Pyright, full pre-commit, and `zizmor`.
- Fable/Claude Code and independent adversarial/security reviews covered the simplification boundary, reusable-workflow semantics, exact SHA pinning, event trust, prompt and Slack injection, API traffic, and least privilege.

## Linked Issue

Fixes #633

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added or updated for new behavior (workflow-only caller; reusable policy has focused tests)
- [x] Relevant lint, type, test, YAML, and security checks pass
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (no docstrings changed)
