### PR TITLE
Bind `FileSystem` containment to descriptors with `openat`-style traversal

### DIFF
--- a/docs/filesystem.md
+++ b/docs/filesystem.md
@@ -70,14 +70,18 @@ the run.
 ## Security model
 
 - **Containment.** Paths resolve relative to `root_dir`; anything resolving
-  outside -- via `..`, an absolute path, or a symlink -- is rejected. Symlinks
-  are resolved with `os.path.realpath` *before* the containment check, and I/O
-  then uses the resolved path. Directory walks (`list_directory`,
-  `search_files`, `find_files`) resolve each entry the same way and match the
-  patterns against that resolved target, so a symlink cannot name a file
-  outside the tree or present a denied file under a permitted name. These
-  checks are pathname-based: if another process mutates the tree between
-  resolution and I/O, the path read can differ from the path checked.
+  outside -- via `..`, an absolute path, or a symlink -- is rejected. On Linux
+  and macOS every path component is opened `O_NOFOLLOW` relative to its parent
+  directory (`openat`-style), symlinks are resolved through the same walk, and
+  all I/O happens on the descriptor those checks authorized -- so a path
+  swapped for a symlink mid-operation cannot redirect the I/O outside the
+  root. Directory walks (`list_directory`, `search_files`, `find_files`)
+  authorize each entry the same way and match the patterns against the
+  resolved target, so a symlink cannot name a file outside the tree or present
+  a denied file under a permitted name. On platforms without `dir_fd` support
+  (Windows), symlinks are instead resolved with `os.path.realpath` before the
+  containment check; those checks are pathname-based and best-effort under
+  concurrent mutation of the workspace.
 - **Binary detection.** `read_file` returns a placeholder instead of dumping
   binary bytes into the model context.
 - **Optimistic concurrency.** `write_file`/`edit_file` accept an

--- a/pydantic_ai_harness/filesystem/README.md
+++ b/pydantic_ai_harness/filesystem/README.md
@@ -47,14 +47,18 @@ print(result.output)
 ## Security model
 
 - **Containment.** Paths resolve relative to `root_dir`; anything resolving
-  outside -- via `..`, an absolute path, or a symlink -- is rejected. Symlinks
-  are resolved with `os.path.realpath` *before* the containment check, and I/O
-  then uses the resolved path. Directory walks (`list_directory`,
-  `search_files`, `find_files`) resolve each entry the same way and match the
-  patterns against that resolved target, so a symlink cannot name a file
-  outside the tree or present a denied file under a permitted name. These
-  checks are pathname-based: if another process mutates the tree between
-  resolution and I/O, the path read can differ from the path checked.
+  outside -- via `..`, an absolute path, or a symlink -- is rejected. On Linux
+  and macOS every path component is opened `O_NOFOLLOW` relative to its parent
+  directory (`openat`-style), symlinks are resolved through the same walk, and
+  all I/O happens on the descriptor those checks authorized -- so a path
+  swapped for a symlink mid-operation cannot redirect the I/O outside the
+  root. Directory walks (`list_directory`, `search_files`, `find_files`)
+  authorize each entry the same way and match the patterns against the
+  resolved target, so a symlink cannot name a file outside the tree or present
+  a denied file under a permitted name. On platforms without `dir_fd` support
+  (Windows), symlinks are instead resolved with `os.path.realpath` before the
+  containment check; those checks are pathname-based and best-effort under
+  concurrent mutation of the workspace.
 - **Binary detection.** `read_file` returns a placeholder instead of dumping
   binary bytes into the model context.
 - **Optimistic concurrency.** `write_file`/`edit_file` accept an

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -55,6 +55,10 @@ _FILE_OPEN_FLAGS = (os.O_NOFOLLOW | os.O_NONBLOCK) if _HAS_FD_TRAVERSAL else 0
 # as `EMLINK` on some BSDs.
 _SYMLINK_ERRNOS = frozenset({errno.ELOOP, errno.EMLINK})
 
+# Entries that exist but cannot be opened as files: sockets (`EOPNOTSUPP` on
+# macOS, `ENXIO` on Linux) and device nodes without a driver (`ENODEV`).
+_SPECIAL_FILE_ERRNOS = frozenset({errno.ENXIO, errno.ENODEV, getattr(errno, 'EOPNOTSUPP', errno.ENXIO)})
+
 _MAX_SYMLINK_HOPS = 40
 """Symlink resolutions allowed per lookup before reporting a loop, mirroring the kernel's own bound."""
 
@@ -151,6 +155,15 @@ def _readlink_or_none(name: str, dir_fd: int) -> str | None:
         raise  # pragma: no cover
 
 
+class _SpecialFileError(Exception):
+    """Internal: the walk's final component exists but cannot be opened (socket, device node)."""
+
+
+def _too_many_links(path: str) -> PermissionError:
+    """The error for a lookup that exhausted the symlink budget (a loop, or an absurd chain)."""
+    return PermissionError(f'Path {path!r} resolves through too many levels of symbolic links.')
+
+
 def _normalized_remainder(path: str, canonical: list[str], name: str, pending: list[str]) -> str:
     """Lexically collapse the un-walked tail of a missing path for pattern checks and messages.
 
@@ -158,9 +171,19 @@ def _normalized_remainder(path: str, canonical: list[str], name: str, pending: l
     them lexically matches what `realpath` would have produced.
     """
     remainder = posixpath.normpath('/'.join([*canonical, name, *reversed(pending)]))
-    if remainder.startswith('..'):
+    if remainder == '..' or remainder.startswith('../'):
         raise PermissionError(f'Path {path!r} resolves outside the root directory.')
     return remainder
+
+
+def _restart_collapsed(remainder: str, fds: list[int], canonical: list[str], pending: list[str]) -> None:
+    """Restart the walk from the root on a lexically collapsed remainder."""
+    while len(fds) > 1:
+        os.close(fds.pop())
+    canonical.clear()
+    pending.clear()
+    if remainder != '.':
+        pending.extend(reversed(remainder.split('/')))
 
 
 class _Resolved:
@@ -331,15 +354,21 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         """Split a tool path into components to walk from the root.
 
         `..` components are kept for the walk to apply physically. An absolute
-        path is accepted only when it lexically names a location under the
-        root; the walk still verifies every component of it.
+        path is accepted only when it names a location under the root; the
+        walk still verifies every component of it.
         """
         pure = PurePath(path)
         if pure.is_absolute():
             try:
                 pure = pure.relative_to(self._real_root)
             except ValueError:
-                raise PermissionError(f'Path {path!r} resolves outside the root directory.') from None
+                # The absolute spelling may reach the root through symlinks
+                # (e.g. macOS `/tmp` vs `/private/tmp`). `realpath` here is
+                # advisory: the walk still verifies every component it yields.
+                try:
+                    pure = PurePath(os.path.realpath(path)).relative_to(self._real_root)
+                except ValueError:
+                    raise PermissionError(f'Path {path!r} resolves outside the root directory.') from None
         return [c for c in pure.parts if c != '.']
 
     def _resolve_for(
@@ -398,7 +427,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         missing: str,
         missing_parent: Callable[[str], str] | None,
         need_read: bool,
-    ) -> tuple[int, str, bool]:
+    ) -> tuple[int | None, str, bool]:
         """Open `path` by walking each component relative to the previous one.
 
         Every step uses `os.open(..., O_NOFOLLOW, dir_fd=parent)`, symlinks are
@@ -407,7 +436,9 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         descriptor is therefore the object the checks authorized, closing the
         gap between pathname authorization and pathname I/O (#632).
 
-        Returns `(fd, canonical_relative_path, created)`.
+        Returns `(fd, canonical_relative_path, created)`. `fd` is None only for
+        a special file (socket, device node) that exists but cannot be opened;
+        the caller falls back to metadata-only handling for it.
         """
         pending = list(reversed(self._split_components(path)))
         hops = _MAX_SYMLINK_HOPS
@@ -426,11 +457,11 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
                 if target is not None:
                     hops -= 1
                     if hops <= 0:
-                        raise PermissionError(f'Path {path!r} resolves through a symlink loop.')
+                        raise _too_many_links(path)
                     self._splice_link(target, path, fds, canonical, pending)
                     continue
                 if pending:
-                    self._descend(
+                    outcome = self._descend(
                         name,
                         fds,
                         canonical,
@@ -442,16 +473,25 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
                         missing=missing,
                         missing_parent=missing_parent,
                     )
+                    if outcome == 'retry_symlink':
+                        hops -= 1
+                        if hops <= 0:
+                            raise _too_many_links(path)
                     continue
                 rel = '/'.join([*canonical, name])
                 self._check_access(rel, write=write, check_allowed=check_allowed)
-                opened = self._open_final(name, fds[-1], path=path, intent=intent, missing=missing, need_read=need_read)
+                try:
+                    opened = self._open_final(
+                        name, fds[-1], rel=rel, path=path, intent=intent, missing=missing, need_read=need_read
+                    )
+                except _SpecialFileError:
+                    return None, rel, False
                 if opened is None:
                     # The component turned into a symlink after it was resolved
                     # as a plain entry; go around to resolve it safely.
                     hops -= 1
                     if hops <= 0:
-                        raise PermissionError(f'Path {path!r} resolves through a symlink loop.')
+                        raise _too_many_links(path)
                     pending.append(name)
                     continue
                 return opened[0], rel, opened[1]
@@ -499,52 +539,58 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         check_allowed: bool,
         missing: str,
         missing_parent: Callable[[str], str] | None,
-    ) -> None:
+    ) -> Literal['descended', 'retry', 'retry_symlink']:
         """Open intermediate directory `name` and push it onto the walk stack.
 
-        May instead push `name` back onto `pending` (to re-resolve a component
-        that changed underneath the walk, or to reopen a directory just created
-        for `create_directory`) or raise for a missing or non-directory
-        component.
+        Returns 'descended' after pushing the opened directory, 'retry' when
+        the queue should simply be reprocessed (a directory was created for
+        `create_directory`, or a lexical `..` past an un-walkable component was
+        collapsed), and 'retry_symlink' when the component changed into a
+        symlink underneath the walk, which must count against the symlink
+        budget. Raises for a missing or non-directory component.
         """
         try:
             fd = os.open(name, _DIR_OPEN_FLAGS, dir_fd=fds[-1])
         except OSError as e:
             if e.errno in _SYMLINK_ERRNOS:
                 pending.append(name)
-                return
+                return 'retry_symlink'
+            if e.errno in (errno.ENOENT, errno.ENOTDIR) and '..' in pending:
+                # A lexical `..` beyond a missing or non-directory component:
+                # restart the walk on the collapsed path, matching what
+                # `realpath` produces for a tail that cannot be walked.
+                _restart_collapsed(_normalized_remainder(path, canonical, name, pending), fds, canonical, pending)
+                return 'retry'
             if e.errno == errno.ENOENT:
                 remainder = _normalized_remainder(path, canonical, name, pending)
                 self._check_access(remainder, write=write, check_allowed=check_allowed)
                 if intent == 'mkdir':
-                    if '..' in pending:
-                        # A lexical `..` beyond the missing directory: restart
-                        # the walk on the collapsed path, so only the
-                        # directories `realpath` would name get created.
-                        while len(fds) > 1:
-                            os.close(fds.pop())
-                        canonical.clear()
-                        pending.clear()
-                        if remainder != '.':
-                            pending.extend(reversed(remainder.split('/')))
-                        return
-                    os.mkdir(name, dir_fd=fds[-1])
+                    try:
+                        os.mkdir(name, dir_fd=fds[-1])
+                    except FileExistsError:
+                        # Created concurrently; reopening it below is fine.
+                        pass
                     pending.append(name)
-                    return
+                    return 'retry'
                 if missing_parent is not None:
                     raise FileNotFoundError(missing_parent(posixpath.dirname(remainder))) from e
                 raise FileNotFoundError(missing) from e
             if e.errno == errno.ENOTDIR:
+                remainder = _normalized_remainder(path, canonical, name, pending)
+                self._check_access(remainder, write=write, check_allowed=check_allowed)
                 raise NotADirectoryError(f'Not a directory: {"/".join([*canonical, name])}') from e
+            e.filename = '/'.join([*canonical, name])
             raise
         fds.append(fd)
         canonical.append(name)
+        return 'descended'
 
     def _open_final(
         self,
         name: str,
         dir_fd: int,
         *,
+        rel: str,
         path: str,
         intent: _Intent,
         missing: str,
@@ -553,12 +599,13 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         """Open the walk's fully resolved final component, `O_NOFOLLOW`.
 
         Returns `(fd, created)`, or None when the component became a symlink
-        (or vanished mid-create) and the walk must re-resolve it.
+        (or vanished mid-create) and the walk must re-resolve it. Raises
+        `_SpecialFileError` for an entry that exists but cannot be opened.
         """
         if intent == 'mkdir':
             return self._open_final_dir(name, dir_fd)
         if intent == 'write':
-            return self._open_final_write(name, dir_fd, path=path, need_read=need_read)
+            return self._open_final_write(name, dir_fd, rel=rel, path=path, need_read=need_read)
         flags = os.O_RDWR if intent == 'edit' else os.O_RDONLY
         try:
             return os.open(name, flags | _FILE_OPEN_FLAGS, dir_fd=dir_fd), False
@@ -569,9 +616,14 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
                 # `EISDIR` is `edit` only: a directory cannot be edited, and
                 # the tool reports that the same way as a missing file.
                 raise FileNotFoundError(missing) from e
+            if e.errno in _SPECIAL_FILE_ERRNOS:
+                raise _SpecialFileError from e
+            e.filename = rel
             raise
 
-    def _open_final_write(self, name: str, dir_fd: int, *, path: str, need_read: bool) -> tuple[int, bool] | None:
+    def _open_final_write(
+        self, name: str, dir_fd: int, *, rel: str, path: str, need_read: bool
+    ) -> tuple[int, bool] | None:
         """Open (or create) the final component for `write_file`.
 
         Creation is attempted first with `O_EXCL` so the caller knows whether
@@ -592,9 +644,11 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
                 return None
             if e.errno == errno.EISDIR:
                 raise IsADirectoryError(f'Is a directory: {path}') from e
-            if e.errno == errno.ENXIO:
-                # A FIFO with no reader; without `O_NONBLOCK` this open would hang.
+            if e.errno in _SPECIAL_FILE_ERRNOS:
+                # For example a FIFO with no reader, or a socket; without
+                # `O_NONBLOCK` the FIFO open would hang.
                 raise ValueError(f'Path {path!r} exists and is not a regular file.') from e
+            e.filename = rel
             raise
 
     def _open_final_dir(self, name: str, dir_fd: int) -> tuple[int, bool]:
@@ -807,7 +861,8 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             with self._resolve_for(path, check_allowed=False, missing=f'File not found: {path}') as resolved:
                 root_kind = _kind_of(resolved.stat())
                 base = resolved.path
-        except FileNotFoundError:
+        except (FileNotFoundError, NotADirectoryError):
+            # A root that does not name a directory tree has no matches in it.
             pass
         try:
             compiled = re.compile(pattern)

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import errno
 import fnmatch
 import functools
 import hashlib
 import os
+import posixpath
 import re
+import stat
 from collections.abc import Awaitable, Callable, Sequence
-from pathlib import Path
-from typing import Concatenate, ParamSpec
+from pathlib import Path, PurePath
+from typing import Concatenate, Literal, ParamSpec
 
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import AgentDepsT
@@ -27,6 +30,37 @@ READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
 # to the model; any other exception aborts the whole run. `_recoverable`
 # converts these so the agent can correct itself and continue.
 _RECOVERABLE_ERRORS = (PermissionError, FileNotFoundError, NotADirectoryError, IsADirectoryError, ValueError)
+
+_HAS_FD_TRAVERSAL = (
+    {os.open, os.mkdir, os.readlink} <= os.supports_dir_fd and hasattr(os, 'O_NOFOLLOW') and hasattr(os, 'O_DIRECTORY')
+)
+"""Whether the platform can walk paths descriptor-relative (`openat` style).
+
+True on Linux and macOS. Where it is False (Windows), containment falls back
+to the pathname-based `realpath` check, which cannot bind the check to the
+object the I/O later touches.
+"""
+
+# Directories along the walk only anchor the next `dir_fd` step. `O_PATH`
+# (Linux) grants exactly that without needing read permission; platforms
+# without it fall back to `O_RDONLY`.
+_DIR_OPEN_FLAGS = (getattr(os, 'O_PATH', os.O_RDONLY) | os.O_DIRECTORY | os.O_NOFOLLOW) if _HAS_FD_TRAVERSAL else 0
+
+# `O_NONBLOCK` keeps an open from waiting on a FIFO; it has no effect on
+# regular files. `O_NOFOLLOW` refuses a symlink swapped in after the walk
+# resolved the component.
+_FILE_OPEN_FLAGS = (os.O_NOFOLLOW | os.O_NONBLOCK) if _HAS_FD_TRAVERSAL else 0
+
+# A symlink refused by `O_NOFOLLOW` surfaces as `ELOOP` on Linux and macOS and
+# as `EMLINK` on some BSDs.
+_SYMLINK_ERRNOS = frozenset({errno.ELOOP, errno.EMLINK})
+
+_MAX_SYMLINK_HOPS = 40
+"""Symlink resolutions allowed per lookup before reporting a loop, mirroring the kernel's own bound."""
+
+_Intent = Literal['read', 'write', 'edit', 'mkdir']
+
+_Kind = Literal['missing', 'dir', 'file', 'other']
 
 
 def _recoverable(
@@ -94,13 +128,110 @@ def _content_hash(content: str) -> str:
     return hashlib.sha256(content.encode('utf-8')).hexdigest()[:12]
 
 
+def _kind_of(st: os.stat_result | None) -> _Kind:
+    """Classify a stat result by what I/O the target supports."""
+    if st is None:
+        return 'missing'
+    if stat.S_ISDIR(st.st_mode):
+        return 'dir'
+    if stat.S_ISREG(st.st_mode):
+        return 'file'
+    return 'other'
+
+
+def _readlink_or_none(name: str, dir_fd: int) -> str | None:
+    """The symlink target of `name` in the directory `dir_fd`, or None when it is not a symlink."""
+    try:
+        return os.readlink(name, dir_fd=dir_fd)
+    except OSError as e:
+        # `EINVAL`: a real (non-symlink) entry. `ENOENT`: nothing there; the
+        # open step reports it with the caller's message.
+        if e.errno in (errno.EINVAL, errno.ENOENT):
+            return None
+        raise  # pragma: no cover
+
+
+def _normalized_remainder(path: str, canonical: list[str], name: str, pending: list[str]) -> str:
+    """Lexically collapse the un-walked tail of a missing path for pattern checks and messages.
+
+    Components past a missing directory cannot contain symlinks, so collapsing
+    them lexically matches what `realpath` would have produced.
+    """
+    remainder = posixpath.normpath('/'.join([*canonical, name, *reversed(pending)]))
+    if remainder.startswith('..'):
+        raise PermissionError(f'Path {path!r} resolves outside the root directory.')
+    return remainder
+
+
+class _Resolved:
+    """One authorized filesystem location, ready for I/O.
+
+    With descriptor traversal, `fd` was opened by walking every component
+    `O_NOFOLLOW` relative to its parent, so the object the checks authorized is
+    the object the I/O touches. On fallback platforms `fd` is None and I/O uses
+    the pathname, keeping the legacy best-effort guarantee.
+    """
+
+    __slots__ = ('fd', 'path', 'canonical', 'created')
+
+    def __init__(self, fd: int | None, path: Path, canonical: str, *, created: bool = False) -> None:
+        self.fd = fd
+        self.path = path
+        self.canonical = canonical
+        self.created = created
+
+    def __enter__(self) -> _Resolved:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+    def stat(self) -> os.stat_result | None:
+        """Stat the target, or None when it does not exist."""
+        try:
+            return os.fstat(self.fd) if self.fd is not None else os.stat(self.path)
+        except OSError:
+            return None
+
+    def read_bytes(self) -> bytes:
+        """Read the target's full content as bytes."""
+        if self.fd is None:
+            return self.path.read_bytes()
+        os.lseek(self.fd, 0, os.SEEK_SET)
+        chunks = bytearray()
+        while chunk := os.read(self.fd, 1 << 16):
+            chunks += chunk
+        return bytes(chunks)
+
+    def read_text(self) -> str:
+        """Strict UTF-8 text with universal newlines, matching `Path.read_text`."""
+        if self.fd is None:
+            return self.path.read_text(encoding='utf-8')
+        return self.read_bytes().decode('utf-8').replace('\r\n', '\n').replace('\r', '\n')
+
+    def replace_text(self, content: str) -> None:
+        """Replace the target's content, through the descriptor when there is one."""
+        if self.fd is None:
+            self.path.write_text(content, encoding='utf-8')
+            return
+        os.lseek(self.fd, 0, os.SEEK_SET)
+        os.truncate(self.fd, 0)
+        data = content.encode('utf-8')
+        while data:
+            data = data[os.write(self.fd, data) :]
+
+
 class FileSystemToolset(FunctionToolset[AgentDepsT]):
     """Toolset providing filesystem operations scoped to a root directory.
 
     Security model:
     - All paths resolved relative to root with canonical path checks
-    - Symlinks resolved before authorization (prevents TOCTTOU)
-    - Glob-based allow/deny filtering
+    - Where the platform supports `openat`-style traversal, every path
+      component is opened `O_NOFOLLOW` relative to its parent and I/O happens
+      on that descriptor, so a path swapped mid-operation cannot redirect it
+    - Glob-based allow/deny filtering, matched against resolved locations
     - Protected path patterns (e.g. `.git/`, `.env`)
     - Binary file detection blocks text operations
     """
@@ -155,9 +286,11 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         return next((p for p in patterns if self._matches(path, p)), None)
 
     def _resolve_path(self, path: str) -> Path:
-        """Resolve path relative to root, rejecting traversal.
+        """Resolve path relative to root the legacy way, rejecting traversal.
 
-        Uses os.path.realpath for symlink resolution before checking containment.
+        Fallback for platforms without descriptor traversal: `os.path.realpath`
+        resolves symlinks before the containment check, but nothing binds that
+        check to the object later I/O touches.
         """
         candidate = (self._root / path).resolve()
         real = Path(os.path.realpath(candidate))
@@ -174,7 +307,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         directory isn't required to match `allowed_patterns` itself -- `.` or
         `src` would never match a file pattern like `src/*.py`. The walk's
         entries are still filtered against `allowed_patterns` per-entry via
-        `_resolve_walk_entry`. Denied patterns continue to gate the root.
+        `_resolve_entry`. Denied patterns continue to gate the root.
         """
         if write and self._protected_patterns:
             matched = self._first_matching_pattern(path, self._protected_patterns)
@@ -190,50 +323,293 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             if not any(self._matches(path, p) for p in self._allowed_patterns):
                 raise PermissionError(f'Path {path!r} does not match any allowed pattern.')
 
-    def _is_accessible(self, path: str) -> bool:
-        """Predicate form of the read-level `_check_access` checks.
-
-        Protected patterns are not consulted: they gate writes, and the walkers
-        only read.
-        """
-        if self._denied_patterns:
-            if self._first_matching_pattern(path, self._denied_patterns) is not None:
-                return False
-        if self._allowed_patterns and not any(self._matches(path, p) for p in self._allowed_patterns):
-            return False
-        return True
-
-    def _resolve_walk_entry(self, entry: Path) -> Path | None:
-        """Authorize one entry of a directory walk, or return `None` to skip it.
-
-        Callers must do their I/O on the returned path. Resolving once means the
-        path that was authorized is the path that gets read, and matching the
-        patterns against the resolved location keeps the walkers in step with
-        direct access: a symlink can neither escape the root nor alias a file
-        past a rule its own name would trip.
-        """
-        target = Path(os.path.realpath(entry))
-        if not target.is_relative_to(self._real_root):
-            return None
-        if not self._is_accessible(self._relative_to_root(target)):
-            return None
-        return target
-
     def _relative_to_root(self, resolved: Path) -> str:
         """Canonical path of a resolved location relative to the real root."""
         return str(resolved.relative_to(self._real_root))
 
-    def _safe_resolve(self, path: str, *, write: bool = False, check_allowed: bool = True) -> Path:
-        """Resolve and access-check a path in one step.
+    def _split_components(self, path: str) -> list[str]:
+        """Split a tool path into components to walk from the root.
 
-        Resolution happens first so the access check matches patterns against
-        the canonical path relative to the root, collapsing `.`/`..`/`//`
-        segments that would otherwise slip past a literal pattern (e.g.
-        `config/./secret.txt` evading a `config/secret.txt` deny rule).
+        `..` components are kept for the walk to apply physically. An absolute
+        path is accepted only when it lexically names a location under the
+        root; the walk still verifies every component of it.
         """
-        resolved = self._resolve_path(path)
-        self._check_access(self._relative_to_root(resolved), write=write, check_allowed=check_allowed)
-        return resolved
+        pure = PurePath(path)
+        if pure.is_absolute():
+            try:
+                pure = pure.relative_to(self._real_root)
+            except ValueError:
+                raise PermissionError(f'Path {path!r} resolves outside the root directory.') from None
+        return [c for c in pure.parts if c != '.']
+
+    def _resolve_for(
+        self,
+        path: str,
+        *,
+        intent: _Intent = 'read',
+        write: bool = False,
+        check_allowed: bool = True,
+        missing: str,
+        missing_parent: Callable[[str], str] | None = None,
+        need_read: bool = False,
+    ) -> _Resolved:
+        """Authorize `path` and open it for the given intent.
+
+        With descriptor traversal, the returned handle's descriptor is the very
+        object the containment and pattern checks authorized. On fallback
+        platforms the handle is pathname-bound and the checks stay best-effort.
+        """
+        if not _HAS_FD_TRAVERSAL:
+            resolved = self._resolve_path(path)
+            canonical = self._relative_to_root(resolved)
+            self._check_access(canonical, write=write, check_allowed=check_allowed)
+            return _Resolved(None, resolved, canonical)
+        fd, canonical, created = self._walk_beneath(
+            path,
+            intent=intent,
+            write=write,
+            check_allowed=check_allowed,
+            missing=missing,
+            missing_parent=missing_parent,
+            need_read=need_read,
+        )
+        return _Resolved(fd, self._real_root / canonical, canonical, created=created)
+
+    def _resolve_entry(self, rel: str) -> _Resolved | None:
+        """Authorize one entry of a directory walk, or return None to skip it.
+
+        Callers must do their I/O through the returned handle. Resolving and
+        opening in one authorized step means a symlink can neither escape the
+        root nor alias a file past a rule its own name would trip, since the
+        patterns are matched against the resolved location.
+        """
+        try:
+            return self._resolve_for(rel, missing=f'File not found: {rel}')
+        except OSError:
+            return None
+
+    def _walk_beneath(
+        self,
+        path: str,
+        *,
+        intent: _Intent,
+        write: bool,
+        check_allowed: bool,
+        missing: str,
+        missing_parent: Callable[[str], str] | None,
+        need_read: bool,
+    ) -> tuple[int, str, bool]:
+        """Open `path` by walking each component relative to the previous one.
+
+        Every step uses `os.open(..., O_NOFOLLOW, dir_fd=parent)`, symlinks are
+        resolved manually and re-checked for containment, and `..` pops the
+        directory stack so it can never climb past the root. The returned
+        descriptor is therefore the object the checks authorized, closing the
+        gap between pathname authorization and pathname I/O (#632).
+
+        Returns `(fd, canonical_relative_path, created)`.
+        """
+        pending = list(reversed(self._split_components(path)))
+        hops = _MAX_SYMLINK_HOPS
+        fds = [os.open(self._real_root, os.O_RDONLY | os.O_DIRECTORY)]
+        canonical: list[str] = []
+        try:
+            while pending:
+                name = pending.pop()
+                if name == '..':
+                    if len(fds) == 1:
+                        raise PermissionError(f'Path {path!r} resolves outside the root directory.')
+                    os.close(fds.pop())
+                    canonical.pop()
+                    continue
+                target = _readlink_or_none(name, fds[-1])
+                if target is not None:
+                    hops -= 1
+                    if hops <= 0:
+                        raise PermissionError(f'Path {path!r} resolves through a symlink loop.')
+                    self._splice_link(target, path, fds, canonical, pending)
+                    continue
+                if pending:
+                    self._descend(
+                        name,
+                        fds,
+                        canonical,
+                        pending,
+                        path=path,
+                        intent=intent,
+                        write=write,
+                        check_allowed=check_allowed,
+                        missing=missing,
+                        missing_parent=missing_parent,
+                    )
+                    continue
+                rel = '/'.join([*canonical, name])
+                self._check_access(rel, write=write, check_allowed=check_allowed)
+                opened = self._open_final(name, fds[-1], path=path, intent=intent, missing=missing, need_read=need_read)
+                if opened is None:
+                    # The component turned into a symlink after it was resolved
+                    # as a plain entry; go around to resolve it safely.
+                    hops -= 1
+                    if hops <= 0:
+                        raise PermissionError(f'Path {path!r} resolves through a symlink loop.')
+                    pending.append(name)
+                    continue
+                return opened[0], rel, opened[1]
+            # No components left: the path names the walked directory itself.
+            rel = '/'.join(canonical) or '.'
+            self._check_access(rel, write=write, check_allowed=check_allowed)
+            if intent == 'write':
+                raise IsADirectoryError(f'Is a directory: {path}')
+            if intent == 'edit':
+                raise FileNotFoundError(missing)
+            return os.dup(fds[-1]), rel, False
+        finally:
+            for fd in fds:
+                os.close(fd)
+
+    def _splice_link(self, target: str, path: str, fds: list[int], canonical: list[str], pending: list[str]) -> None:
+        """Queue a symlink target's components for the walk.
+
+        An absolute target restarts the walk at the root. `realpath` here is
+        advisory -- it produces the canonical candidate to compare and walk --
+        while enforcement stays with the `O_NOFOLLOW` open of each component.
+        """
+        if os.path.isabs(target):
+            real_target = Path(os.path.realpath(target))
+            if not real_target.is_relative_to(self._real_root):
+                raise PermissionError(f'Path {path!r} resolves outside the root directory.')
+            while len(fds) > 1:
+                os.close(fds.pop())
+            canonical.clear()
+            parts: Sequence[str] = real_target.relative_to(self._real_root).parts
+        else:
+            parts = [c for c in PurePath(target).parts if c != '.']
+        pending.extend(reversed(parts))
+
+    def _descend(
+        self,
+        name: str,
+        fds: list[int],
+        canonical: list[str],
+        pending: list[str],
+        *,
+        path: str,
+        intent: _Intent,
+        write: bool,
+        check_allowed: bool,
+        missing: str,
+        missing_parent: Callable[[str], str] | None,
+    ) -> None:
+        """Open intermediate directory `name` and push it onto the walk stack.
+
+        May instead push `name` back onto `pending` (to re-resolve a component
+        that changed underneath the walk, or to reopen a directory just created
+        for `create_directory`) or raise for a missing or non-directory
+        component.
+        """
+        try:
+            fd = os.open(name, _DIR_OPEN_FLAGS, dir_fd=fds[-1])
+        except OSError as e:
+            if e.errno in _SYMLINK_ERRNOS:
+                pending.append(name)
+                return
+            if e.errno == errno.ENOENT:
+                remainder = _normalized_remainder(path, canonical, name, pending)
+                self._check_access(remainder, write=write, check_allowed=check_allowed)
+                if intent == 'mkdir':
+                    if '..' in pending:
+                        # A lexical `..` beyond the missing directory: restart
+                        # the walk on the collapsed path, so only the
+                        # directories `realpath` would name get created.
+                        while len(fds) > 1:
+                            os.close(fds.pop())
+                        canonical.clear()
+                        pending.clear()
+                        if remainder != '.':
+                            pending.extend(reversed(remainder.split('/')))
+                        return
+                    os.mkdir(name, dir_fd=fds[-1])
+                    pending.append(name)
+                    return
+                if missing_parent is not None:
+                    raise FileNotFoundError(missing_parent(posixpath.dirname(remainder))) from e
+                raise FileNotFoundError(missing) from e
+            if e.errno == errno.ENOTDIR:
+                raise NotADirectoryError(f'Not a directory: {"/".join([*canonical, name])}') from e
+            raise
+        fds.append(fd)
+        canonical.append(name)
+
+    def _open_final(
+        self,
+        name: str,
+        dir_fd: int,
+        *,
+        path: str,
+        intent: _Intent,
+        missing: str,
+        need_read: bool,
+    ) -> tuple[int, bool] | None:
+        """Open the walk's fully resolved final component, `O_NOFOLLOW`.
+
+        Returns `(fd, created)`, or None when the component became a symlink
+        (or vanished mid-create) and the walk must re-resolve it.
+        """
+        if intent == 'mkdir':
+            return self._open_final_dir(name, dir_fd)
+        if intent == 'write':
+            return self._open_final_write(name, dir_fd, path=path, need_read=need_read)
+        flags = os.O_RDWR if intent == 'edit' else os.O_RDONLY
+        try:
+            return os.open(name, flags | _FILE_OPEN_FLAGS, dir_fd=dir_fd), False
+        except OSError as e:
+            if e.errno in _SYMLINK_ERRNOS:
+                return None
+            if e.errno in (errno.ENOENT, errno.EISDIR):
+                # `EISDIR` is `edit` only: a directory cannot be edited, and
+                # the tool reports that the same way as a missing file.
+                raise FileNotFoundError(missing) from e
+            raise
+
+    def _open_final_write(self, name: str, dir_fd: int, *, path: str, need_read: bool) -> tuple[int, bool] | None:
+        """Open (or create) the final component for `write_file`.
+
+        Creation is attempted first with `O_EXCL` so the caller knows whether
+        the file existed and an `expected_hash` must be honored. Opening
+        without truncation lets the caller classify the descriptor and check
+        the hash before any content changes.
+        """
+        base = (os.O_RDWR if need_read else os.O_WRONLY) | _FILE_OPEN_FLAGS
+        try:
+            return os.open(name, base | os.O_CREAT | os.O_EXCL, 0o666, dir_fd=dir_fd), True
+        except FileExistsError:
+            pass
+        try:
+            return os.open(name, base, dir_fd=dir_fd), False
+        except OSError as e:
+            if e.errno in _SYMLINK_ERRNOS or e.errno == errno.ENOENT:
+                # Swapped for a symlink, or deleted between the two opens.
+                return None
+            if e.errno == errno.EISDIR:
+                raise IsADirectoryError(f'Is a directory: {path}') from e
+            if e.errno == errno.ENXIO:
+                # A FIFO with no reader; without `O_NONBLOCK` this open would hang.
+                raise ValueError(f'Path {path!r} exists and is not a regular file.') from e
+            raise
+
+    def _open_final_dir(self, name: str, dir_fd: int) -> tuple[int, bool]:
+        """Create (or reuse) the final directory for `create_directory`."""
+        try:
+            os.mkdir(name, dir_fd=dir_fd)
+        except FileExistsError as exists_error:
+            try:
+                return os.open(name, _DIR_OPEN_FLAGS, dir_fd=dir_fd), False
+            except OSError as e:
+                if e.errno == errno.ENOTDIR or e.errno in _SYMLINK_ERRNOS:
+                    # Exists but is not a directory: report it as `mkdir` would.
+                    raise exists_error from e
+                raise  # pragma: no cover
+        return os.open(name, _DIR_OPEN_FLAGS, dir_fd=dir_fd), True
 
     @_recoverable
     async def read_file(self, path: str, *, offset: int = 0, limit: int | None = None) -> str:
@@ -249,13 +625,14 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         """
         if limit is None:
             limit = self._max_read_lines
-        resolved = self._safe_resolve(path)
-        if not resolved.is_file():
-            if resolved.is_dir():
+        with self._resolve_for(path, missing=f'File not found: {path}') as resolved:
+            kind = _kind_of(resolved.stat())
+            if kind == 'dir':
                 raise FileNotFoundError(f"'{path}' is a directory, not a file.")
-            raise FileNotFoundError(f'File not found: {path}')
+            if kind != 'file':
+                raise FileNotFoundError(f'File not found: {path}')
+            raw = resolved.read_bytes()
 
-        raw = resolved.read_bytes()
         if _is_binary(raw):
             size = len(raw)
             return f'[Binary file: {size} bytes. Use a binary-aware tool to inspect.]'
@@ -280,25 +657,43 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         Returns:
             Confirmation message with new hash.
         """
-        resolved = self._safe_resolve(path, write=True)
 
-        # Optimistic concurrency: reject stale writes
-        if expected_hash is not None and resolved.is_file():
-            current = resolved.read_text(encoding='utf-8')
-            current_hash = _content_hash(current)
-            if current_hash != expected_hash:
-                raise ValueError(
-                    f'Conflict: file {path!r} has changed (expected hash:{expected_hash}, '
-                    f'got hash:{current_hash}). Re-read the file and retry.'
-                )
+        def missing_parent(parent: str) -> str:
+            return f"Parent directory '{parent}' does not exist. Use create_directory first."
 
-        if not resolved.parent.exists():
-            parent_rel = str(resolved.parent.relative_to(self._root))
-            raise FileNotFoundError(f"Parent directory '{parent_rel}' does not exist. Use create_directory first.")
-        resolved.write_text(content, encoding='utf-8')
+        with self._resolve_for(
+            path,
+            intent='write',
+            write=True,
+            missing=f'File not found: {path}',
+            missing_parent=missing_parent,
+            need_read=expected_hash is not None,
+        ) as resolved:
+            if resolved.fd is None:
+                # Pathname fallback: the same checks, without descriptor binding.
+                if expected_hash is not None and resolved.path.is_file():
+                    self._check_expected_hash(path, expected_hash, resolved.read_text())
+                if not resolved.path.parent.exists():
+                    parent_rel = str(resolved.path.parent.relative_to(self._root))
+                    raise FileNotFoundError(missing_parent(parent_rel))
+            else:
+                if _kind_of(resolved.stat()) == 'other':
+                    raise ValueError(f'Path {path!r} exists and is not a regular file.')
+                if expected_hash is not None and not resolved.created:
+                    self._check_expected_hash(path, expected_hash, resolved.read_text())
+            resolved.replace_text(content)
         new_hash = _content_hash(content)
         lines = len(content.splitlines())
         return f'Wrote {len(content)} chars ({lines} lines) to {path}. [hash:{new_hash}]'
+
+    def _check_expected_hash(self, path: str, expected_hash: str, current: str) -> None:
+        """Reject a stale write or edit (optimistic concurrency)."""
+        current_hash = _content_hash(current)
+        if current_hash != expected_hash:
+            raise ValueError(
+                f'Conflict: file {path!r} has changed (expected hash:{expected_hash}, '
+                f'got hash:{current_hash}). Re-read the file and retry.'
+            )
 
     @_recoverable
     async def edit_file(self, path: str, old_text: str, new_text: str, *, expected_hash: str | None = None) -> str:
@@ -317,30 +712,28 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         Returns:
             Summary with new hash for subsequent operations.
         """
-        resolved = self._safe_resolve(path, write=True)
-        if not resolved.is_file():
-            raise FileNotFoundError(f'File not found: {path}')
+        with self._resolve_for(
+            path, intent='edit', write=True, missing=f'File not found: {path}', need_read=True
+        ) as resolved:
+            if _kind_of(resolved.stat()) != 'file':
+                raise FileNotFoundError(f'File not found: {path}')
 
-        text = resolved.read_text(encoding='utf-8')
-        current_hash = _content_hash(text)
+            text = resolved.read_text()
 
-        # Optimistic concurrency check
-        if expected_hash is not None and current_hash != expected_hash:
-            raise ValueError(
-                f'Conflict: file {path!r} has changed (expected hash:{expected_hash}, '
-                f'got hash:{current_hash}). Re-read the file and retry.'
-            )
+            if expected_hash is not None:
+                self._check_expected_hash(path, expected_hash, text)
 
-        count = text.count(old_text)
-        if count == 0:
-            raise ValueError(f'old_text not found in {path}.')
-        if count > 1:
-            raise ValueError(
-                f'old_text found {count} times in {path}. Include more surrounding context to make the match unique.'
-            )
+            count = text.count(old_text)
+            if count == 0:
+                raise ValueError(f'old_text not found in {path}.')
+            if count > 1:
+                raise ValueError(
+                    f'old_text found {count} times in {path}. '
+                    'Include more surrounding context to make the match unique.'
+                )
 
-        new_content = text.replace(old_text, new_text, 1)
-        resolved.write_text(new_content, encoding='utf-8')
+            new_content = text.replace(old_text, new_text, 1)
+            resolved.replace_text(new_content)
         new_hash = _content_hash(new_content)
         return f'Edited {path}. [hash:{new_hash}]'
 
@@ -357,12 +750,13 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         # The listing root is gated by denied patterns but not by
         # allowed_patterns: a directory like '.' never matches a file pattern.
         # Entries are filtered per-entry against allowed_patterns below.
-        resolved = self._safe_resolve(path, check_allowed=False)
-        if not resolved.is_dir():
-            raise NotADirectoryError(f'Not a directory: {path}')
+        with self._resolve_for(path, check_allowed=False, missing=f'Not a directory: {path}') as resolved:
+            if _kind_of(resolved.stat()) != 'dir':
+                raise NotADirectoryError(f'Not a directory: {path}')
+            base = resolved.path
 
         entries: list[str] = []
-        for entry in sorted(resolved.iterdir()):
+        for entry in sorted(base.iterdir()):
             try:
                 rel_path = entry.relative_to(self._real_root)
             except ValueError:  # pragma: no cover
@@ -371,20 +765,20 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             # find_files so the three walkers agree on what exists.
             if any(part.startswith('.') for part in rel_path.parts):
                 continue
-            target = self._resolve_walk_entry(entry)
+            target = self._resolve_entry(str(rel_path))
             if target is None:
                 continue
+            with target:
+                st = target.stat()
+            if st is None:
+                # A dangling symlink, or an entry deleted mid-walk: it has
+                # no size to report, so leave it out of the listing.
+                continue
             rel = str(rel_path)
-            if target.is_dir():
+            if _kind_of(st) == 'dir':
                 line = f'{rel}/'
             else:
-                try:
-                    size = target.stat().st_size
-                except OSError:
-                    # A dangling symlink, or an entry deleted mid-walk: it has
-                    # no size to report, so leave it out of the listing.
-                    continue
-                line = f'{rel}  ({size} bytes)'
+                line = f'{rel}  ({st.st_size} bytes)'
             # Only a listing that actually dropped an entry is marked truncated,
             # so one that merely fills the cap reads as complete.
             if len(entries) >= self._max_list_results:
@@ -407,7 +801,14 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         """
         # See list_directory: the search root isn't gated by allowed_patterns;
         # matched files are filtered per-entry below.
-        resolved = self._safe_resolve(path, check_allowed=False)
+        root_kind: _Kind = 'missing'
+        base: Path | None = None
+        try:
+            with self._resolve_for(path, check_allowed=False, missing=f'File not found: {path}') as resolved:
+                root_kind = _kind_of(resolved.stat())
+                base = resolved.path
+        except FileNotFoundError:
+            pass
         try:
             compiled = re.compile(pattern)
         except re.error as e:
@@ -415,10 +816,12 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
 
         results: list[str] = []
 
-        if resolved.is_file():
-            files = [resolved]
+        if base is None or root_kind in ('missing', 'other'):
+            files: list[Path] = []
+        elif root_kind == 'file':
+            files = [base]
         else:
-            files = sorted(resolved.rglob('*'))
+            files = sorted(base.rglob('*'))
 
         for file_path in files:
             try:
@@ -430,15 +833,16 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             rel_str = str(rel_path)
             if include_glob and not fnmatch.fnmatch(rel_str, include_glob):
                 continue
-            target = self._resolve_walk_entry(file_path)
+            target = self._resolve_entry(rel_str)
             if target is None:
                 continue
-            if not target.is_file():
-                continue
-            try:
-                raw = target.read_bytes()
-            except OSError:  # pragma: no cover
-                continue
+            with target:
+                if _kind_of(target.stat()) != 'file':
+                    continue
+                try:
+                    raw = target.read_bytes()
+                except OSError:  # pragma: no cover
+                    continue
             if _is_binary(raw):
                 continue
             text = raw.decode('utf-8', errors='replace')
@@ -467,29 +871,32 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
 
         # See list_directory: the find root isn't gated by allowed_patterns;
         # matched entries are filtered per-entry below.
-        resolved = self._safe_resolve(path, check_allowed=False)
-        if not resolved.is_dir():
-            raise NotADirectoryError(f'Not a directory: {path}')
+        with self._resolve_for(path, check_allowed=False, missing=f'Not a directory: {path}') as resolved:
+            if _kind_of(resolved.stat()) != 'dir':
+                raise NotADirectoryError(f'Not a directory: {path}')
+            base = resolved.path
 
         matches: list[str] = []
-        for match in sorted(resolved.glob(pattern)):
+        for match in sorted(base.glob(pattern)):
             try:
                 rel_path = match.relative_to(self._real_root)
             except ValueError:  # pragma: no cover
                 continue
             if any(part.startswith('.') for part in rel_path.parts):
                 continue
-            target = self._resolve_walk_entry(match)
+            target = self._resolve_entry(str(rel_path))
             if target is None:
                 continue
-            if not target.exists():
+            with target:
+                kind = _kind_of(target.stat())
+            if kind == 'missing':
                 # A dangling symlink resolves inside the root but names nothing.
                 continue
             if len(matches) >= self._max_find_results:
                 matches.append(f'[... truncated at {self._max_find_results} matches]')
                 break
             rel = str(rel_path)
-            suffix = '/' if target.is_dir() else ''
+            suffix = '/' if kind == 'dir' else ''
             matches.append(f'{rel}{suffix}')
 
         return '\n'.join(matches) if matches else 'No matches found.'
@@ -504,8 +911,9 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         Returns:
             Confirmation message.
         """
-        resolved = self._safe_resolve(path, write=True)
-        resolved.mkdir(parents=True, exist_ok=True)
+        with self._resolve_for(path, intent='mkdir', write=True, missing=f'Path not found: {path}') as resolved:
+            if resolved.fd is None:
+                resolved.path.mkdir(parents=True, exist_ok=True)
         return f'Created directory: {path}'
 
     @_recoverable
@@ -518,30 +926,30 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         Returns:
             Formatted metadata including size, type, and permissions.
         """
-        resolved = self._safe_resolve(path)
-        if not resolved.exists():
-            raise FileNotFoundError(f'Path not found: {path}')
+        with self._resolve_for(path, missing=f'Path not found: {path}') as resolved:
+            st = resolved.stat()
+            if st is None:
+                raise FileNotFoundError(f'Path not found: {path}')
+            kind = _kind_of(st)
 
-        # Check if the original (pre-resolve) path is a symlink
-        original = self._root / path
-        is_link = original.is_symlink()
+            # Whether the path as given is a symlink, and where it points. This
+            # is display-only metadata about the name, not the object read, so
+            # a pathname lookup is fine here.
+            original = self._root / path
+            is_link = original.is_symlink()
 
-        stat = resolved.stat()
-        kind = 'directory' if resolved.is_dir() else 'file'
-        size = stat.st_size
+            parts = [f'path: {path}', f'type: {"directory" if kind == "dir" else "file"}', f'size: {st.st_size} bytes']
 
-        parts = [f'path: {path}', f'type: {kind}', f'size: {size} bytes']
+            if kind == 'file':
+                raw = resolved.read_bytes()
+                is_bin = _is_binary(raw)
+                parts.append(f'binary: {is_bin}')
+                if not is_bin:
+                    text = raw.decode('utf-8', errors='replace')
+                    parts.append(f'lines: {len(text.splitlines())}')
+                    parts.append(f'hash: {_content_hash(text)}')
 
-        if resolved.is_file():
-            raw = resolved.read_bytes()
-            is_bin = _is_binary(raw)
-            parts.append(f'binary: {is_bin}')
-            if not is_bin:
-                text = raw.decode('utf-8', errors='replace')
-                parts.append(f'lines: {len(text.splitlines())}')
-                parts.append(f'hash: {_content_hash(text)}')
-
-        if is_link:
-            parts.append(f'symlink_target: {os.readlink(original)}')
+            if is_link:
+                parts.append(f'symlink_target: {os.readlink(original)}')
 
         return '\n'.join(parts)

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import errno
 import os
+import shutil
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -1399,6 +1402,11 @@ class TestPatternCanonicalization:
             await ts.write_file('secrets.yaml', 'changed\n')
 
 
+_needs_effective_permissions = pytest.mark.skipif(
+    hasattr(os, 'geteuid') and os.geteuid() == 0, reason='chmod does not restrict root'
+)
+
+
 def _plain_toolset(root: Path) -> FileSystemToolset[None]:
     return FileSystemToolset(
         root_dir=root,
@@ -1647,6 +1655,7 @@ class TestDescriptorBinding:
         # The walk already holds the original directory's descriptor, so the
         # read lands on the object that was authorized, not the swapped-in one.
         result = await ts.read_file('sub/inner.txt')
+        assert swapped
         assert 'original content' in result
         assert 'outside secret' not in result
 
@@ -1656,7 +1665,7 @@ class TestDescriptorBinding:
         (root / 'a').symlink_to(root / 'b')
         (root / 'b').symlink_to(root / 'a')
         ts = _plain_toolset(root)
-        with pytest.raises(ModelRetry, match='symlink loop'):
+        with pytest.raises(ModelRetry, match='too many levels of symbolic links'):
             await ts.read_file('a')
 
     async def test_symlink_loop_skipped_by_search(self, tmp_path: Path) -> None:
@@ -1676,15 +1685,18 @@ class TestDescriptorBinding:
         with pytest.raises(ModelRetry, match='Not a directory: file.txt'):
             await ts.read_file('file.txt/impossible')
 
+    @_needs_effective_permissions
     async def test_unreadable_intermediate_reports_permission(self, tmp_path: Path) -> None:
+        # The nesting matters: on Linux `O_PATH` opens the unreadable
+        # directory itself, so the `EACCES` surfaces when descending FROM it.
         root = tmp_path / 'root'
-        (root / 'locked').mkdir(parents=True)
-        (root / 'locked' / 'f.txt').write_text('x\n')
+        (root / 'locked' / 'sub').mkdir(parents=True)
+        (root / 'locked' / 'sub' / 'f.txt').write_text('x\n')
         ts = _plain_toolset(root)
         os.chmod(root / 'locked', 0o000)
         try:
             with pytest.raises(ModelRetry, match='[Pp]ermission denied'):
-                await ts.read_file('locked/f.txt')
+                await ts.read_file('locked/sub/f.txt')
         finally:
             os.chmod(root / 'locked', 0o755)
 
@@ -1712,6 +1724,7 @@ class TestWalkRaces:
         monkeypatch.setattr(os, 'open', flaky_open)
         result = await ts.read_file('data.txt')
         assert 'content' in result
+        assert not failures
 
     async def test_final_component_kept_swapping_reports_loop(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1729,7 +1742,7 @@ class TestWalkRaces:
             return real_open(path, flags, mode, dir_fd=dir_fd)
 
         monkeypatch.setattr(os, 'open', always_swapped_open)
-        with pytest.raises(ModelRetry, match='symlink loop'):
+        with pytest.raises(ModelRetry, match='too many levels of symbolic links'):
             await ts.read_file('data.txt')
 
     async def test_intermediate_became_symlink_retries_and_succeeds(
@@ -1751,6 +1764,7 @@ class TestWalkRaces:
         monkeypatch.setattr(os, 'open', flaky_open)
         result = await ts.read_file('sub/inner.txt')
         assert 'content' in result
+        assert not failures
 
     async def test_write_target_vanishing_between_opens_retries(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1771,6 +1785,7 @@ class TestWalkRaces:
         result = await ts.write_file('v.txt', 'content\n')
         assert 'Wrote' in result
         assert (root / 'v.txt').read_text() == 'content\n'
+        assert not failures
 
 
 @_needs_fd_traversal
@@ -1824,6 +1839,7 @@ class TestWalkCoverageEdges:
         with pytest.raises(ModelRetry, match='File not found: ghost-dir/f.txt'):
             await toolset.read_file('ghost-dir/f.txt')
 
+    @_needs_effective_permissions
     async def test_read_unreadable_file_reports_permission(
         self, toolset: FileSystemToolset[None], fs_root: Path
     ) -> None:
@@ -1835,6 +1851,7 @@ class TestWalkCoverageEdges:
         finally:
             os.chmod(fs_root / 'noread.txt', 0o644)
 
+    @_needs_effective_permissions
     async def test_write_unwritable_file_reports_permission(
         self, toolset: FileSystemToolset[None], fs_root: Path
     ) -> None:
@@ -1848,3 +1865,307 @@ class TestWalkCoverageEdges:
 
     async def test_search_missing_directory_finds_nothing(self, toolset: FileSystemToolset[None]) -> None:
         assert await toolset.search_files('anything', path='ghost-dir') == 'No matches found.'
+
+
+class TestReviewRoundParity:
+    """Cases surfaced by adversarial review: identical behavior in both modes."""
+
+    async def test_absolute_path_through_symlinked_prefix(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        alias = fs_root.parent / f'{fs_root.name}-alias'
+        alias.symlink_to(fs_root)
+        result = await toolset.read_file(str(alias / 'hello.txt'))
+        assert 'Hello, world!' in result
+
+    async def test_dotdot_after_missing_component_collapses(self, toolset: FileSystemToolset[None]) -> None:
+        result = await toolset.read_file('missing/../hello.txt')
+        assert 'Hello, world!' in result
+
+    async def test_dotdot_after_file_component_collapses(self, toolset: FileSystemToolset[None]) -> None:
+        result = await toolset.read_file('hello.txt/../multi.txt')
+        assert 'line1' in result
+
+    async def test_list_missing_then_dotdot_lists_root(self, toolset: FileSystemToolset[None]) -> None:
+        result = await toolset.list_directory('missing/..')
+        assert 'hello.txt' in result
+
+    async def test_search_through_file_component_finds_nothing(self, toolset: FileSystemToolset[None]) -> None:
+        assert await toolset.search_files('Hello', path='hello.txt/sub') == 'No matches found.'
+
+    async def test_names_starting_with_dots_are_not_traversal(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        await toolset.create_directory('..data/sub')
+        assert (fs_root / '..data' / 'sub').is_dir()
+        with pytest.raises(ModelRetry, match="Parent directory '..bar' does not exist"):
+            await toolset.write_file('..bar/baz', 'x\n')
+        with pytest.raises(ModelRetry, match=r'File not found: \.\.\.'):
+            await toolset.read_file('...')
+
+    async def test_denied_pattern_wins_over_file_as_directory(self, fs_root: Path) -> None:
+        (fs_root / 'secretdir').write_text('a file, not a directory\n')
+        ts = FileSystemToolset(
+            root_dir=fs_root,
+            allowed_patterns=[],
+            denied_patterns=['secret*'],
+            protected_patterns=[],
+            max_read_lines=2000,
+            max_list_results=1000,
+            max_search_results=1000,
+            max_find_results=1000,
+        )
+        with pytest.raises(ModelRetry, match='denied by pattern'):
+            await ts.read_file('secretdir/inner.txt')
+
+    async def test_edit_through_in_root_alias_updates_target(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'alias.txt').symlink_to(fs_root / 'hello.txt')
+        await toolset.edit_file('alias.txt', 'Hello, world!', 'Goodbye!')
+        assert (fs_root / 'hello.txt').read_text() == 'Goodbye!\n'
+
+    async def test_edit_through_escape_symlink_rejected(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        target = fs_root.parent / 'edit-escape-target'
+        target.write_text('untouched\n')
+        (fs_root / 'out.txt').symlink_to(target)
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await toolset.edit_file('out.txt', 'untouched', 'HACKED')
+        assert target.read_text() == 'untouched\n'
+
+    async def test_file_info_out_of_root_symlink_rejected(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'out.txt').symlink_to(fs_root.parent)
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await toolset.file_info('out.txt')
+
+    async def test_create_directory_through_in_root_symlinked_parent(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'dirlink').symlink_to(fs_root / 'subdir')
+        await toolset.create_directory('dirlink/newdir')
+        assert (fs_root / 'subdir' / 'newdir').is_dir()
+
+    async def test_write_creates_through_symlinked_parent(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'dirlink').symlink_to(fs_root / 'subdir')
+        await toolset.write_file('dirlink/new.txt', 'content\n')
+        assert (fs_root / 'subdir' / 'new.txt').read_text() == 'content\n'
+
+
+class TestMutationKillers632:
+    """Each case kills a mutant of the walk that the rest of the suite misses."""
+
+    async def test_relative_link_target_resolves_against_link_directory(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'subdir' / 'up_link.txt').symlink_to('../hello.txt')
+        result = await toolset.read_file('subdir/up_link.txt')
+        assert 'Hello, world!' in result
+
+    async def test_dotdot_pops_canonical_for_pattern_checks(self, fs_root: Path) -> None:
+        ts = FileSystemToolset(
+            root_dir=fs_root,
+            allowed_patterns=[],
+            denied_patterns=['subdir/*'],
+            protected_patterns=[],
+            max_read_lines=2000,
+            max_list_results=1000,
+            max_search_results=1000,
+            max_find_results=1000,
+        )
+        result = await ts.read_file('subdir/../hello.txt')
+        assert 'Hello, world!' in result
+
+    async def test_absolute_link_resets_canonical_for_pattern_checks(self, fs_root: Path) -> None:
+        (fs_root / 'subdir' / 'abs_link.txt').symlink_to(fs_root / 'hello.txt')
+        ts = FileSystemToolset(
+            root_dir=fs_root,
+            allowed_patterns=[],
+            denied_patterns=['subdir/hello*'],
+            protected_patterns=[],
+            max_read_lines=2000,
+            max_list_results=1000,
+            max_search_results=1000,
+            max_find_results=1000,
+        )
+        result = await ts.read_file('subdir/abs_link.txt')
+        assert 'Hello, world!' in result
+
+    async def test_five_hop_symlink_chain_resolves(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        # Relative targets, so each hop is resolved by the walk itself.
+        previous = 'hello.txt'
+        for i in range(5):
+            (fs_root / f'chain{i}').symlink_to(previous)
+            previous = f'chain{i}'
+        result = await toolset.read_file(previous)
+        assert 'Hello, world!' in result
+
+    @_needs_fd_traversal
+    async def test_chain_beyond_hop_budget_rejected(self, tmp_path: Path) -> None:
+        # The budget exists only in the descriptor walk; realpath has no cap.
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'target.txt').write_text('x\n')
+        previous = 'target.txt'
+        for i in range(45):
+            (root / f'chain{i}').symlink_to(previous)
+            previous = f'chain{i}'
+        ts = _plain_toolset(root)
+        with pytest.raises(ModelRetry, match='too many levels of symbolic links'):
+            await ts.read_file(previous)
+
+
+@_needs_fd_traversal
+class TestDescriptorBindingWrites:
+    """Write-side authorization is bound to the object written (#632)."""
+
+    async def test_write_swap_to_outside_symlink_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'data.txt').write_text('inside\n')
+        outside = tmp_path / 'outside.txt'
+        outside.write_text('untouched\n')
+        ts = _plain_toolset(root)
+
+        original_check = FileSystemToolset._check_access
+        swapped = False
+
+        def swapping_check(
+            self: FileSystemToolset[Any], rel: str, *, write: bool = False, check_allowed: bool = True
+        ) -> None:
+            nonlocal swapped
+            original_check(self, rel, write=write, check_allowed=check_allowed)
+            if rel == 'data.txt' and not swapped:
+                swapped = True
+                (root / 'data.txt').unlink()
+                (root / 'data.txt').symlink_to(outside)
+
+        monkeypatch.setattr(FileSystemToolset, '_check_access', swapping_check)
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await ts.write_file('data.txt', 'HACKED\n')
+        assert swapped
+        assert outside.read_text() == 'untouched\n'
+
+    async def test_edit_swap_to_outside_symlink_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'data.txt').write_text('untouched\n')
+        outside = tmp_path / 'outside.txt'
+        outside.write_text('untouched\n')
+        ts = _plain_toolset(root)
+
+        original_check = FileSystemToolset._check_access
+        swapped = False
+
+        def swapping_check(
+            self: FileSystemToolset[Any], rel: str, *, write: bool = False, check_allowed: bool = True
+        ) -> None:
+            nonlocal swapped
+            original_check(self, rel, write=write, check_allowed=check_allowed)
+            if rel == 'data.txt' and not swapped:
+                swapped = True
+                (root / 'data.txt').unlink()
+                (root / 'data.txt').symlink_to(outside)
+
+        monkeypatch.setattr(FileSystemToolset, '_check_access', swapping_check)
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await ts.edit_file('data.txt', 'untouched', 'HACKED')
+        assert swapped
+        assert outside.read_text() == 'untouched\n'
+
+    async def test_intermediate_kept_swapping_reports_too_many_levels(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        (root / 'sub').mkdir(parents=True)
+        (root / 'sub' / 'inner.txt').write_text('content\n')
+        ts = _plain_toolset(root)
+
+        real_open = os.open
+
+        def always_swapped_open(path: str | Path, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+            if path == 'sub' and dir_fd is not None:
+                raise OSError(errno.ELOOP, 'simulated swap')
+            return real_open(path, flags, mode, dir_fd=dir_fd)
+
+        monkeypatch.setattr(os, 'open', always_swapped_open)
+        with pytest.raises(ModelRetry, match='too many levels of symbolic links'):
+            await ts.read_file('sub/inner.txt')
+
+    async def test_create_directory_tolerates_concurrent_mkdir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        ts = _plain_toolset(root)
+
+        real_mkdir = os.mkdir
+        raced = False
+
+        def racing_mkdir(path: str | Path, mode: int = 0o777, *, dir_fd: int | None = None) -> None:
+            nonlocal raced
+            real_mkdir(path, mode, dir_fd=dir_fd)
+            if path == 'ghost' and not raced:
+                raced = True
+                raise OSError(errno.EEXIST, 'simulated concurrent mkdir')
+
+        monkeypatch.setattr(os, 'mkdir', racing_mkdir)
+        await ts.create_directory('ghost/sub')
+        assert raced
+        assert (root / 'ghost' / 'sub').is_dir()
+
+
+@_needs_fd_traversal
+class TestSocketEntries:
+    """Sockets are reported as unopenable files, never a run abort."""
+
+    @pytest.fixture
+    def socket_root(self) -> Iterator[Path]:
+        import socket as socket_module
+
+        # A short base path: AF_UNIX socket paths are capped near 104 bytes,
+        # which pytest's tmp_path can exceed on macOS.
+        root = Path(tempfile.mkdtemp(prefix='fs-sock-'))
+        try:
+            server = socket_module.socket(socket_module.AF_UNIX, socket_module.SOCK_STREAM)
+            try:
+                server.bind(str(root / 'srv.sock'))
+            except OSError:
+                pytest.skip('cannot bind an AF_UNIX socket at this path')
+            finally:
+                server.close()
+            yield root
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    async def test_read_socket_reports_file_not_found(self, socket_root: Path) -> None:
+        ts = _plain_toolset(socket_root)
+        with pytest.raises(ModelRetry, match='File not found: srv.sock'):
+            await ts.read_file('srv.sock')
+
+    async def test_edit_socket_reports_file_not_found(self, socket_root: Path) -> None:
+        ts = _plain_toolset(socket_root)
+        with pytest.raises(ModelRetry, match='File not found: srv.sock'):
+            await ts.edit_file('srv.sock', 'a', 'b')
+
+    async def test_write_socket_reports_not_regular(self, socket_root: Path) -> None:
+        ts = _plain_toolset(socket_root)
+        with pytest.raises(ModelRetry, match='not a regular file'):
+            await ts.write_file('srv.sock', 'x\n')
+
+    async def test_file_info_socket_reports_metadata(self, socket_root: Path) -> None:
+        ts = _plain_toolset(socket_root)
+        result = await ts.file_info('srv.sock')
+        assert 'type: file' in result
+        assert 'binary:' not in result
+
+    async def test_list_directory_shows_socket(self, socket_root: Path) -> None:
+        ts = _plain_toolset(socket_root)
+        assert 'srv.sock' in await ts.list_directory('.')

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import errno
+import os
 from pathlib import Path
+from typing import Any
 
 import pytest
 from pydantic_ai import Agent
@@ -12,6 +15,7 @@ from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness.filesystem import READ_ONLY_TOOL_NAMES, FileSystem
+from pydantic_ai_harness.filesystem import _toolset as toolset_module
 from pydantic_ai_harness.filesystem._toolset import FileSystemToolset, _content_hash, _format_lines, _is_binary
 
 
@@ -80,8 +84,14 @@ class TestContentHash:
         assert len(_content_hash('test')) == 12
 
 
-@pytest.fixture
-def fs_root(tmp_path: Path) -> Path:
+# Every test that goes through `fs_root` runs twice: once with descriptor
+# (openat-style) traversal and once with the pathname fallback used on
+# platforms without `dir_fd` support, so both implementations keep identical
+# observable behavior.
+@pytest.fixture(params=['descriptor', 'pathname'])
+def fs_root(request: pytest.FixtureRequest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    if request.param == 'pathname':
+        monkeypatch.setattr(toolset_module, '_HAS_FD_TRAVERSAL', False)
     (tmp_path / 'hello.txt').write_text('Hello, world!\n')
     (tmp_path / 'multi.txt').write_text('line1\nline2\nline3\nline4\nline5\n')
     (tmp_path / 'subdir').mkdir()
@@ -1195,17 +1205,17 @@ class TestMutationKillers:
         # Exact match: no trailing double newline
         assert result == '     1\thello\n'
 
-    def test_safe_resolve_write_default_is_false(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
-        """Protected files should be readable via _safe_resolve's default (write=False)."""
+    def test_resolve_for_write_default_is_false(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        """Protected files should be readable via _resolve_for's default (write=False)."""
         (fs_root / '.env.local').write_text('SECRET=x\n')
-        # _safe_resolve without write= uses default write=False → read is allowed
-        resolved = toolset._safe_resolve('.env.local')
-        assert resolved.name == '.env.local'
-        # But with write=True, it should raise. `_safe_resolve` is an internal
+        # _resolve_for without write= uses default write=False → read is allowed
+        with toolset._resolve_for('.env.local', missing='File not found: .env.local') as resolved:
+            assert resolved.canonical == '.env.local'
+        # But with write=True, it should raise. `_resolve_for` is an internal
         # helper, so it raises the native PermissionError; the `ModelRetry`
         # conversion happens in the public tool methods that wrap it.
         with pytest.raises(PermissionError, match='protected'):
-            toolset._safe_resolve('.env.local', write=True)
+            toolset._resolve_for('.env.local', write=True, missing='File not found: .env.local')
 
     async def test_list_directory_exact_size(self, toolset: FileSystemToolset[None]) -> None:
         result = await toolset.list_directory('.')
@@ -1387,3 +1397,454 @@ class TestPatternCanonicalization:
         assert 'secrets.yaml:1:api: PRIVATE KEY material' in await ts.search_files('PRIVATE KEY')
         with pytest.raises(ModelRetry, match='protected'):
             await ts.write_file('secrets.yaml', 'changed\n')
+
+
+def _plain_toolset(root: Path) -> FileSystemToolset[None]:
+    return FileSystemToolset(
+        root_dir=root,
+        allowed_patterns=[],
+        denied_patterns=[],
+        protected_patterns=[],
+        max_read_lines=2000,
+        max_list_results=1000,
+        max_search_results=1000,
+        max_find_results=1000,
+    )
+
+
+class TestSymlinkResolution:
+    """Symlink and traversal semantics hold in both traversal modes."""
+
+    async def test_relative_dotdot_symlink_escape_rejected(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root.parent / 'rel-escape-target').write_text('outside secret\n')
+        (fs_root / 'up.txt').symlink_to('../rel-escape-target')
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await toolset.read_file('up.txt')
+
+    async def test_symlinked_directory_escape_rejected(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        outdir = fs_root.parent / 'outdir'
+        outdir.mkdir(exist_ok=True)
+        (outdir / 'f.txt').write_text('outside secret\n')
+        (fs_root / 'linkdir').symlink_to(outdir)
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await toolset.read_file('linkdir/f.txt')
+
+    async def test_absolute_symlinked_directory_inside_root_traverses(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'dirlink').symlink_to(fs_root / 'subdir')
+        result = await toolset.read_file('dirlink/nested.py')
+        assert 'nested' in result
+
+    async def test_relative_symlinked_directory_inside_root_traverses(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'dirlink').symlink_to('subdir')
+        result = await toolset.read_file('dirlink/nested.py')
+        assert 'nested' in result
+
+    async def test_write_through_in_root_alias_updates_target(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'alias.txt').symlink_to(fs_root / 'hello.txt')
+        await toolset.write_file('alias.txt', 'replaced\n')
+        assert (fs_root / 'hello.txt').read_text() == 'replaced\n'
+        assert (fs_root / 'alias.txt').is_symlink()
+
+    async def test_write_through_escape_symlink_rejected(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        target = fs_root.parent / 'write-escape-target'
+        target.write_text('untouched\n')
+        (fs_root / 'out.txt').symlink_to(target)
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await toolset.write_file('out.txt', 'HACKED\n')
+        assert target.read_text() == 'untouched\n'
+
+    async def test_write_through_dangling_in_root_symlink_creates_target(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'dangling.txt').symlink_to(fs_root / 'made.txt')
+        await toolset.write_file('dangling.txt', 'content\n')
+        assert (fs_root / 'made.txt').read_text() == 'content\n'
+
+    async def test_dotdot_within_root_resolves(self, toolset: FileSystemToolset[None]) -> None:
+        result = await toolset.read_file('subdir/../hello.txt')
+        assert 'Hello, world!' in result
+
+    async def test_absolute_path_inside_root_allowed(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        result = await toolset.read_file(str(fs_root / 'hello.txt'))
+        assert 'Hello, world!' in result
+
+    async def test_absolute_path_outside_root_rejected(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await toolset.read_file('/etc/passwd')
+
+    async def test_missing_path_with_dotdot_escape_rejected(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await toolset.read_file('ghost/../../etc/passwd')
+
+    async def test_denied_pattern_wins_over_missing_file(self, fs_root: Path) -> None:
+        ts = FileSystemToolset(
+            root_dir=fs_root,
+            allowed_patterns=[],
+            denied_patterns=['secret*'],
+            protected_patterns=[],
+            max_read_lines=2000,
+            max_list_results=1000,
+            max_search_results=1000,
+            max_find_results=1000,
+        )
+        with pytest.raises(ModelRetry, match='denied by pattern'):
+            await ts.read_file('secret.txt')
+        with pytest.raises(ModelRetry, match='denied by pattern'):
+            await ts.read_file('secretdir/inner.txt')
+
+    async def test_write_deep_missing_parent_names_full_parent(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match="Parent directory 'missing/sub' does not exist"):
+            await toolset.write_file('missing/sub/f.txt', 'x\n')
+
+    async def test_create_directory_collapses_dotdot_through_missing(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        result = await toolset.create_directory('ghost/../made')
+        assert result == 'Created directory: ghost/../made'
+        assert (fs_root / 'made').is_dir()
+        assert not (fs_root / 'ghost').exists()
+
+    async def test_create_directory_missing_then_dotdot_is_noop(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        result = await toolset.create_directory('ghost/..')
+        assert result == 'Created directory: ghost/..'
+        assert not (fs_root / 'ghost').exists()
+
+
+class TestDirectoryIntentEdges:
+    """Directory-shaped inputs to file tools behave the same in both modes."""
+
+    async def test_read_root_dot_is_reported_as_directory(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match='is a directory'):
+            await toolset.read_file('.')
+
+    async def test_write_to_root_dot_rejected(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match='[Ii]s a directory'):
+            await toolset.write_file('.', 'x\n')
+
+    async def test_write_to_directory_rejected(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match='[Ii]s a directory'):
+            await toolset.write_file('subdir', 'x\n')
+
+    async def test_edit_directory_reports_missing_file(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match='File not found: subdir'):
+            await toolset.edit_file('subdir', 'a', 'b')
+
+    async def test_edit_root_dot_reports_missing_file(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match='File not found: .'):
+            await toolset.edit_file('.', 'a', 'b')
+
+    async def test_create_directory_dot_is_noop(self, toolset: FileSystemToolset[None]) -> None:
+        assert await toolset.create_directory('.') == 'Created directory: .'
+
+    async def test_create_directory_over_file_aborts(self, toolset: FileSystemToolset[None]) -> None:
+        # Parity with `Path.mkdir`: an existing file aborts the run today; the
+        # recoverable conversion is tracked separately (#602, #612).
+        with pytest.raises(FileExistsError):
+            await toolset.create_directory('hello.txt')
+
+    async def test_write_empty_content(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        result = await toolset.write_file('empty.txt', '')
+        assert 'Wrote 0 chars' in result
+        assert (fs_root / 'empty.txt').read_text() == ''
+
+    async def test_file_info_on_root_dot(self, toolset: FileSystemToolset[None]) -> None:
+        result = await toolset.file_info('.')
+        assert 'type: directory' in result
+
+
+@pytest.mark.skipif(not hasattr(os, 'mkfifo'), reason='needs FIFO support')
+class TestSpecialFileReads:
+    """Non-regular files are reported, not read, in both modes."""
+
+    async def test_read_fifo_reports_file_not_found(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        os.mkfifo(fs_root / 'pipe')
+        with pytest.raises(ModelRetry, match='File not found: pipe'):
+            await toolset.read_file('pipe')
+
+    async def test_file_info_fifo_skips_content(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        os.mkfifo(fs_root / 'pipe')
+        result = await toolset.file_info('pipe')
+        assert 'type: file' in result
+        assert 'binary:' not in result
+
+    async def test_search_rooted_at_fifo_finds_nothing(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        os.mkfifo(fs_root / 'pipe')
+        assert await toolset.search_files('anything', path='pipe') == 'No matches found.'
+
+
+_needs_fd_traversal = pytest.mark.skipif(
+    not toolset_module._HAS_FD_TRAVERSAL, reason='needs openat-style descriptor traversal'
+)
+
+
+@_needs_fd_traversal
+class TestDescriptorBinding:
+    """Authorization is bound to the object the I/O touches (#632).
+
+    These tests mutate the workspace at the exact seam where the legacy
+    pathname implementation had authorized one object and would go on to open
+    another.
+    """
+
+    async def test_final_component_swapped_for_outside_symlink_is_rejected(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'data.txt').write_text('inside\n')
+        (tmp_path / 'outside.txt').write_text('outside secret\n')
+        ts = _plain_toolset(root)
+
+        original_check = FileSystemToolset._check_access
+
+        def swapping_check(
+            self: FileSystemToolset[Any], rel: str, *, write: bool = False, check_allowed: bool = True
+        ) -> None:
+            original_check(self, rel, write=write, check_allowed=check_allowed)
+            if rel == 'data.txt' and not (root / 'data.txt').is_symlink():
+                (root / 'data.txt').unlink()
+                (root / 'data.txt').symlink_to(tmp_path / 'outside.txt')
+
+        monkeypatch.setattr(FileSystemToolset, '_check_access', swapping_check)
+        with pytest.raises(ModelRetry, match='outside the root'):
+            await ts.read_file('data.txt')
+
+    async def test_intermediate_directory_swap_still_reads_authorized_object(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        (root / 'sub').mkdir(parents=True)
+        (root / 'sub' / 'inner.txt').write_text('original content\n')
+        outside = tmp_path / 'outside-dir'
+        outside.mkdir()
+        (outside / 'inner.txt').write_text('outside secret\n')
+        ts = _plain_toolset(root)
+
+        original_check = FileSystemToolset._check_access
+        swapped = False
+
+        def swapping_check(
+            self: FileSystemToolset[Any], rel: str, *, write: bool = False, check_allowed: bool = True
+        ) -> None:
+            nonlocal swapped
+            original_check(self, rel, write=write, check_allowed=check_allowed)
+            if rel == 'sub/inner.txt' and not swapped:
+                swapped = True
+                (root / 'sub').rename(root / 'sub-moved')
+                (root / 'sub').symlink_to(outside)
+
+        monkeypatch.setattr(FileSystemToolset, '_check_access', swapping_check)
+        # The walk already holds the original directory's descriptor, so the
+        # read lands on the object that was authorized, not the swapped-in one.
+        result = await ts.read_file('sub/inner.txt')
+        assert 'original content' in result
+        assert 'outside secret' not in result
+
+    async def test_symlink_loop_reported_as_loop(self, tmp_path: Path) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'a').symlink_to(root / 'b')
+        (root / 'b').symlink_to(root / 'a')
+        ts = _plain_toolset(root)
+        with pytest.raises(ModelRetry, match='symlink loop'):
+            await ts.read_file('a')
+
+    async def test_symlink_loop_skipped_by_search(self, tmp_path: Path) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'real.txt').write_text('cycle needle\n')
+        (root / 'loop').symlink_to(root / 'loop2')
+        (root / 'loop2').symlink_to(root / 'loop')
+        ts = _plain_toolset(root)
+        assert await ts.search_files('cycle needle') == 'real.txt:1:cycle needle'
+
+    async def test_read_through_file_reports_not_a_directory(self, tmp_path: Path) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'file.txt').write_text('x\n')
+        ts = _plain_toolset(root)
+        with pytest.raises(ModelRetry, match='Not a directory: file.txt'):
+            await ts.read_file('file.txt/impossible')
+
+    async def test_unreadable_intermediate_reports_permission(self, tmp_path: Path) -> None:
+        root = tmp_path / 'root'
+        (root / 'locked').mkdir(parents=True)
+        (root / 'locked' / 'f.txt').write_text('x\n')
+        ts = _plain_toolset(root)
+        os.chmod(root / 'locked', 0o000)
+        try:
+            with pytest.raises(ModelRetry, match='[Pp]ermission denied'):
+                await ts.read_file('locked/f.txt')
+        finally:
+            os.chmod(root / 'locked', 0o755)
+
+
+@_needs_fd_traversal
+class TestWalkRaces:
+    """Retry paths for components that change while the walk runs."""
+
+    async def test_final_component_became_symlink_retries_and_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'data.txt').write_text('content\n')
+        ts = _plain_toolset(root)
+
+        real_open = os.open
+        failures = [OSError(errno.ELOOP, 'simulated swap')]
+
+        def flaky_open(path: str | Path, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+            if path == 'data.txt' and dir_fd is not None and failures:
+                raise failures.pop()
+            return real_open(path, flags, mode, dir_fd=dir_fd)
+
+        monkeypatch.setattr(os, 'open', flaky_open)
+        result = await ts.read_file('data.txt')
+        assert 'content' in result
+
+    async def test_final_component_kept_swapping_reports_loop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        (root / 'data.txt').write_text('content\n')
+        ts = _plain_toolset(root)
+
+        real_open = os.open
+
+        def always_swapped_open(path: str | Path, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+            if path == 'data.txt' and dir_fd is not None:
+                raise OSError(errno.ELOOP, 'simulated swap')
+            return real_open(path, flags, mode, dir_fd=dir_fd)
+
+        monkeypatch.setattr(os, 'open', always_swapped_open)
+        with pytest.raises(ModelRetry, match='symlink loop'):
+            await ts.read_file('data.txt')
+
+    async def test_intermediate_became_symlink_retries_and_succeeds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        (root / 'sub').mkdir(parents=True)
+        (root / 'sub' / 'inner.txt').write_text('content\n')
+        ts = _plain_toolset(root)
+
+        real_open = os.open
+        failures = [OSError(errno.ELOOP, 'simulated swap')]
+
+        def flaky_open(path: str | Path, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+            if path == 'sub' and dir_fd is not None and failures:
+                raise failures.pop()
+            return real_open(path, flags, mode, dir_fd=dir_fd)
+
+        monkeypatch.setattr(os, 'open', flaky_open)
+        result = await ts.read_file('sub/inner.txt')
+        assert 'content' in result
+
+    async def test_write_target_vanishing_between_opens_retries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        ts = _plain_toolset(root)
+
+        real_open = os.open
+        failures = [OSError(errno.ENOENT, 'simulated delete'), OSError(errno.EEXIST, 'simulated create')]
+
+        def flaky_open(path: str | Path, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+            if path == 'v.txt' and dir_fd is not None and failures:
+                raise failures.pop()
+            return real_open(path, flags, mode, dir_fd=dir_fd)
+
+        monkeypatch.setattr(os, 'open', flaky_open)
+        result = await ts.write_file('v.txt', 'content\n')
+        assert 'Wrote' in result
+        assert (root / 'v.txt').read_text() == 'content\n'
+
+
+@_needs_fd_traversal
+@pytest.mark.skipif(not hasattr(os, 'mkfifo'), reason='needs FIFO support')
+class TestFifoWrites:
+    """Write-path tools refuse non-regular files instead of blocking on them."""
+
+    async def test_write_to_fifo_reports_not_regular(self, tmp_path: Path) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        os.mkfifo(root / 'pipe')
+        ts = _plain_toolset(root)
+        with pytest.raises(ModelRetry, match='not a regular file'):
+            await ts.write_file('pipe', 'x\n')
+
+    async def test_write_to_fifo_with_expected_hash_reports_not_regular(self, tmp_path: Path) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        os.mkfifo(root / 'pipe')
+        ts = _plain_toolset(root)
+        with pytest.raises(ModelRetry, match='not a regular file'):
+            await ts.write_file('pipe', 'x\n', expected_hash='abc123abc123')
+
+    async def test_edit_fifo_reports_file_not_found(self, tmp_path: Path) -> None:
+        root = tmp_path / 'root'
+        root.mkdir()
+        os.mkfifo(root / 'pipe')
+        ts = _plain_toolset(root)
+        with pytest.raises(ModelRetry, match='File not found: pipe'):
+            await ts.edit_file('pipe', 'a', 'b')
+
+
+class TestWalkCoverageEdges:
+    """Remaining walk paths behave identically in both modes."""
+
+    async def test_absolute_in_root_symlink_inside_subdir(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'subdir' / 'abs_link.txt').symlink_to(fs_root / 'hello.txt')
+        result = await toolset.read_file('subdir/abs_link.txt')
+        assert 'Hello, world!' in result
+
+    async def test_create_directory_collapses_dotdot_inside_subdir(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        await toolset.create_directory('subdir/ghost/../made')
+        assert (fs_root / 'subdir' / 'made').is_dir()
+        assert not (fs_root / 'subdir' / 'ghost').exists()
+
+    async def test_read_through_missing_directory(self, toolset: FileSystemToolset[None]) -> None:
+        with pytest.raises(ModelRetry, match='File not found: ghost-dir/f.txt'):
+            await toolset.read_file('ghost-dir/f.txt')
+
+    async def test_read_unreadable_file_reports_permission(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'noread.txt').write_text('x\n')
+        os.chmod(fs_root / 'noread.txt', 0o000)
+        try:
+            with pytest.raises(ModelRetry, match='[Pp]ermission denied'):
+                await toolset.read_file('noread.txt')
+        finally:
+            os.chmod(fs_root / 'noread.txt', 0o644)
+
+    async def test_write_unwritable_file_reports_permission(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'readonly.txt').write_text('x\n')
+        os.chmod(fs_root / 'readonly.txt', 0o444)
+        try:
+            with pytest.raises(ModelRetry, match='[Pp]ermission denied'):
+                await toolset.write_file('readonly.txt', 'y\n')
+        finally:
+            os.chmod(fs_root / 'readonly.txt', 0o644)
+
+    async def test_search_missing_directory_finds_nothing(self, toolset: FileSystemToolset[None]) -> None:
+        assert await toolset.search_files('anything', path='ghost-dir') == 'No matches found.'


### PR DESCRIPTION
## Summary

`FileSystemToolset` authorized a pathname with `os.path.realpath` and then did
I/O on that pathname. The check was never bound to the object opened: a
component swapped for a symlink between the check and the open redirected the
I/O outside the sandbox root. That held for direct access and for the walkers
(`list_directory`, `search_files`, `find_files`), and `search_files` could
disclose an out-of-root file's contents under a swap race. PR #364 documented
this honestly and #632 tracked the fix.

This binds authorization to the object read. On Linux and macOS every path is
walked component by component with `os.open(..., O_NOFOLLOW, dir_fd=parent)`
from a pinned root descriptor: symlinks are resolved through the same walk and
re-checked for containment, `..` pops the descriptor stack so it can never
climb past the root, and every tool does its reads, writes, edits, and stats
on the descriptor the checks authorized. Platforms without `dir_fd` support
(Windows) keep the pathname-based `realpath` fallback, now documented as
best-effort under concurrent mutation.

### Boundary notes

The change crosses the filesystem-syscall boundary. Downstream contract: I/O
now happens through `openat`-style descriptors, so the object authorized is
the object touched. Focused reproduction: `TestDescriptorBinding` and
`TestDescriptorBindingWrites` swap a component for an out-of-root symlink at
the exact seam (the containment check) where the old code would then open the
swapped-in target, and assert the read/write/edit is refused and the outside
file is untouched. Non-regular files (FIFOs, sockets, device nodes) are
reported as recoverable errors or metadata rather than hanging or aborting the
run. Descriptors from the walk stack are always closed in a `finally`; the
returned handle is context-managed at every call site.

Observable behavior is preserved across both traversal modes: the `fs_root`
test fixture runs the whole suite twice, once with descriptor traversal and
once forcing the pathname fallback. Deliberate deviations: symlink loops now
report "too many levels of symbolic links" uniformly (previously version- and
operation-dependent); write/edit on a FIFO error instead of hanging; unreadable
entries (`EACCES`) are skipped by walkers; error messages no longer embed the
absolute host path.

## Linked Issue

Closes #632.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)
