### PR TITLE
Add a `serializer` seam and `indented_json`/`json_lines` presets so `ToolOutputLimits` spills page by line

### DIFF
--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -155,17 +155,19 @@ ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
 ```
 
 `indented_json` renders indent-2 JSON, so fields land on separate lines and
-`read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a top-level list
-as one compact JSON object per line (JSON Lines), so line offsets map directly to records; a
-value that is not a list falls back to `indented_json`.
+`read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a sequence
+(other than a string or a byte payload) as one compact JSON object per line (JSON Lines), so
+line offsets map directly to items; other values fall back to `indented_json`. Both presets
+escape the Unicode line separators that `str.splitlines` breaks on, so a line read back is
+always a whole item or field.
 
-Any `(value) -> str` callable works; `Serializer` is the exported alias. The capability
-serializes each structured return once: measurement, band selection, previews, stored bytes,
-and read-back all use the same text, which means an indented layout measures larger than
-compact JSON and can reach a band the compact form would not. The callable must be
-deterministic, so an identical return reduces to identical bytes and keeps the prompt prefix
-stable. Strings and binary payloads never pass through the serializer, and a structured
-return below the smallest band threshold passes through as the original object.
+Any `(value) -> str` callable can be supplied; `Serializer` is the exported alias. The
+capability serializes each structured return once: measurement, band selection, previews,
+stored bytes, and read-back all use the same text, which means an indented layout measures
+larger than compact JSON and can reach a band the compact form would not. If the callable
+raises, the capability warns and falls back to compact JSON for that return. Strings and
+binary payloads never pass through the serializer, and a structured return below the
+smallest band threshold passes through as the original object.
 
 ## Spill store
 

--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -142,34 +142,28 @@ escape sequences from text returns before measuring and reducing.
 
 ## Pageable structured spills
 
-Structured returns serialize as compact JSON, which puts the whole value on one line, so the
-line-based `read_tool_result` tool cannot page through a large spilled list. The `serializer`
-setting replaces that rendering for structured (non-string, non-binary) returns. Two presets
-cover the common layouts:
+A spilled structured return is stored as compact JSON: one long line. `read_tool_result`
+pages by line, so page 1 returns the whole payload and page 2 is empty. Setting `serializer`
+stores the value in a layout with real lines instead:
 
 ```python
 from pydantic_ai_harness.tool_output_limits import ToolOutputLimits, indented_json, json_lines
 
-ToolOutputLimits(serializer=indented_json)  # indented JSON: one field per line
-ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
+ToolOutputLimits(serializer=indented_json)  # one field per line
+ToolOutputLimits(serializer=json_lines)  # one record per line
 ```
 
-`indented_json` renders indent-2 JSON, so fields land on separate lines and
-`read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a sequence
-(other than a string or a byte payload) as one compact JSON value per line (JSON Lines), so
-line offsets map directly to items; other values fall back to `indented_json`. Both presets
-escape the Unicode line separators that `str.splitlines` breaks on, so a line read back is
-always a whole item or field. A tool that wraps its records in a mapping (say
-`{'items': [...]}`) gets the `indented_json` fallback; return the list directly, or supply
-a serializer that unwraps it, to get line-per-record paging.
+Use `json_lines` for tools that return lists of records: line N is record N, so page offsets
+and `pattern` matches line up with whole records. Anything that is not a list-like sequence
+falls back to `indented_json` -- including a list wrapped in a dict, so return the list
+directly for per-record paging. Use `indented_json` for everything else.
 
-Any `(value) -> str` callable can be supplied; `Serializer` is the exported alias. The
-capability serializes each structured return once: measurement, band selection, previews,
-stored bytes, and read-back all use the same text, which means an indented layout measures
-larger than compact JSON and can reach a band the compact form would not. If the callable
-raises or returns non-text, the capability warns and falls back to compact JSON for that
-return. Strings and binary payloads never pass through the serializer, and a structured
-return below the smallest band threshold passes through as the original object.
+Any `(value) -> str` callable works too, but prefer the presets: they escape the Unicode
+line separators (U+0085/U+2028/U+2029) that would otherwise knock read-back offsets off the
+line grid. The serialized text is also what gets measured, so an indented layout can cross
+a size band that compact JSON would not. Strings and binary returns are never serialized,
+returns below the smallest band pass through untouched, and a serializer that raises or
+returns non-text warns and falls back to compact JSON rather than losing the tool output.
 
 ## Spill store
 

--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -159,16 +159,17 @@ ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
 (other than a string or a byte payload) as one compact JSON value per line (JSON Lines), so
 line offsets map directly to items; other values fall back to `indented_json`. Both presets
 escape the Unicode line separators that `str.splitlines` breaks on, so a line read back is
-always a whole item or field.
+always a whole item or field. A tool that wraps its records in a mapping (say
+`{'items': [...]}`) gets the `indented_json` fallback; return the list directly, or supply
+a serializer that unwraps it, to get line-per-record paging.
 
 Any `(value) -> str` callable can be supplied; `Serializer` is the exported alias. The
 capability serializes each structured return once: measurement, band selection, previews,
 stored bytes, and read-back all use the same text, which means an indented layout measures
 larger than compact JSON and can reach a band the compact form would not. If the callable
 raises or returns non-text, the capability warns and falls back to compact JSON for that
-return. Strings and
-binary payloads never pass through the serializer, and a structured return below the
-smallest band threshold passes through as the original object.
+return. Strings and binary payloads never pass through the serializer, and a structured
+return below the smallest band threshold passes through as the original object.
 
 ## Spill store
 

--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -140,6 +140,33 @@ estimated tokens (the same ~4-chars-per-token heuristic as [compaction](compacti
 character operation regardless of the threshold unit. Set `strip_ansi=True` to strip ANSI
 escape sequences from text returns before measuring and reducing.
 
+## Pageable structured spills
+
+Structured returns serialize as compact JSON, which puts the whole value on one line, so the
+line-based `read_tool_result` tool cannot page through a large spilled list. The `serializer`
+setting replaces that rendering for structured (non-string, non-binary) returns. Two presets
+cover the common layouts:
+
+```python
+from pydantic_ai_harness.tool_output_limits import ToolOutputLimits, indented_json, json_lines
+
+ToolOutputLimits(serializer=indented_json)  # indented JSON: one field per line
+ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
+```
+
+`indented_json` renders indent-2 JSON, so fields land on separate lines and
+`read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a top-level list
+as one compact JSON object per line (JSON Lines), so line offsets map directly to records; a
+value that is not a list falls back to `indented_json`.
+
+Any `(value) -> str` callable works; `Serializer` is the exported alias. The capability
+serializes each structured return once: measurement, band selection, previews, stored bytes,
+and read-back all use the same text, which means an indented layout measures larger than
+compact JSON and can reach a band the compact form would not. The callable must be
+deterministic, so an identical return reduces to identical bytes and keeps the prompt prefix
+stable. Strings and binary payloads never pass through the serializer, and a structured
+return below the smallest band threshold passes through as the original object.
+
 ## Spill store
 
 Spilled payloads go through the narrow `OverflowStore` protocol. The default `LocalFileStore`

--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -156,7 +156,7 @@ ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
 
 `indented_json` renders indent-2 JSON, so fields land on separate lines and
 `read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a sequence
-(other than a string or a byte payload) as one compact JSON object per line (JSON Lines), so
+(other than a string or a byte payload) as one compact JSON value per line (JSON Lines), so
 line offsets map directly to items; other values fall back to `indented_json`. Both presets
 escape the Unicode line separators that `str.splitlines` breaks on, so a line read back is
 always a whole item or field.
@@ -165,7 +165,8 @@ Any `(value) -> str` callable can be supplied; `Serializer` is the exported alia
 capability serializes each structured return once: measurement, band selection, previews,
 stored bytes, and read-back all use the same text, which means an indented layout measures
 larger than compact JSON and can reach a band the compact form would not. If the callable
-raises, the capability warns and falls back to compact JSON for that return. Strings and
+raises or returns non-text, the capability warns and falls back to compact JSON for that
+return. Strings and
 binary payloads never pass through the serializer, and a structured return below the
 smallest band threshold passes through as the original object.
 

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -123,7 +123,7 @@ ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
 
 `indented_json` renders indent-2 JSON, so fields land on separate lines and
 `read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a sequence
-(other than a string or a byte payload) as one compact JSON object per line (JSON Lines), so
+(other than a string or a byte payload) as one compact JSON value per line (JSON Lines), so
 line offsets map directly to items; other values fall back to `indented_json`. Both presets
 escape the Unicode line separators that `str.splitlines` breaks on, so a line read back is
 always a whole item or field.
@@ -132,7 +132,8 @@ Any `(value) -> str` callable can be supplied; `Serializer` is the exported alia
 capability serializes each structured return once: measurement, band selection, previews,
 stored bytes, and read-back all use the same text, which means an indented layout measures
 larger than compact JSON and can reach a band the compact form would not. If the callable
-raises, the capability warns and falls back to compact JSON for that return. Strings and
+raises or returns non-text, the capability warns and falls back to compact JSON for that
+return. Strings and
 binary payloads never pass through the serializer, and a structured return below the
 smallest band threshold passes through as the original object.
 

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -122,17 +122,19 @@ ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
 ```
 
 `indented_json` renders indent-2 JSON, so fields land on separate lines and
-`read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a top-level list
-as one compact JSON object per line (JSON Lines), so line offsets map directly to records; a
-value that is not a list falls back to `indented_json`.
+`read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a sequence
+(other than a string or a byte payload) as one compact JSON object per line (JSON Lines), so
+line offsets map directly to items; other values fall back to `indented_json`. Both presets
+escape the Unicode line separators that `str.splitlines` breaks on, so a line read back is
+always a whole item or field.
 
-Any `(value) -> str` callable works; `Serializer` is the exported alias. The capability
-serializes each structured return once: measurement, band selection, previews, stored bytes,
-and read-back all use the same text, which means an indented layout measures larger than
-compact JSON and can reach a band the compact form would not. The callable must be
-deterministic, so an identical return reduces to identical bytes and keeps the prompt prefix
-stable. Strings and binary payloads never pass through the serializer, and a structured
-return below the smallest band threshold passes through as the original object.
+Any `(value) -> str` callable can be supplied; `Serializer` is the exported alias. The
+capability serializes each structured return once: measurement, band selection, previews,
+stored bytes, and read-back all use the same text, which means an indented layout measures
+larger than compact JSON and can reach a band the compact form would not. If the callable
+raises, the capability warns and falls back to compact JSON for that return. Strings and
+binary payloads never pass through the serializer, and a structured return below the
+smallest band threshold passes through as the original object.
 
 ## Spill store
 

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -107,6 +107,33 @@ callable for accuracy. `Truncate.max_chars` is always characters -- truncation i
 character operation regardless of the threshold unit. Set `strip_ansi=True` to strip ANSI
 escape sequences from text returns before measuring and reducing.
 
+## Pageable structured spills
+
+Structured returns serialize as compact JSON, which puts the whole value on one line, so the
+line-based `read_tool_result` tool cannot page through a large spilled list. The `serializer`
+setting replaces that rendering for structured (non-string, non-binary) returns. Two presets
+cover the common layouts:
+
+```python
+from pydantic_ai_harness.tool_output_limits import ToolOutputLimits, indented_json, json_lines
+
+ToolOutputLimits(serializer=indented_json)  # indented JSON: one field per line
+ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
+```
+
+`indented_json` renders indent-2 JSON, so fields land on separate lines and
+`read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a top-level list
+as one compact JSON object per line (JSON Lines), so line offsets map directly to records; a
+value that is not a list falls back to `indented_json`.
+
+Any `(value) -> str` callable works; `Serializer` is the exported alias. The capability
+serializes each structured return once: measurement, band selection, previews, stored bytes,
+and read-back all use the same text, which means an indented layout measures larger than
+compact JSON and can reach a band the compact form would not. The callable must be
+deterministic, so an identical return reduces to identical bytes and keeps the prompt prefix
+stable. Strings and binary payloads never pass through the serializer, and a structured
+return below the smallest band threshold passes through as the original object.
+
 ## Spill store
 
 Spilled payloads go through the narrow `OverflowStore` protocol. The default `LocalFileStore`

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -126,16 +126,17 @@ ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
 (other than a string or a byte payload) as one compact JSON value per line (JSON Lines), so
 line offsets map directly to items; other values fall back to `indented_json`. Both presets
 escape the Unicode line separators that `str.splitlines` breaks on, so a line read back is
-always a whole item or field.
+always a whole item or field. A tool that wraps its records in a mapping (say
+`{'items': [...]}`) gets the `indented_json` fallback; return the list directly, or supply
+a serializer that unwraps it, to get line-per-record paging.
 
 Any `(value) -> str` callable can be supplied; `Serializer` is the exported alias. The
 capability serializes each structured return once: measurement, band selection, previews,
 stored bytes, and read-back all use the same text, which means an indented layout measures
 larger than compact JSON and can reach a band the compact form would not. If the callable
 raises or returns non-text, the capability warns and falls back to compact JSON for that
-return. Strings and
-binary payloads never pass through the serializer, and a structured return below the
-smallest band threshold passes through as the original object.
+return. Strings and binary payloads never pass through the serializer, and a structured
+return below the smallest band threshold passes through as the original object.
 
 ## Spill store
 

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -109,34 +109,28 @@ escape sequences from text returns before measuring and reducing.
 
 ## Pageable structured spills
 
-Structured returns serialize as compact JSON, which puts the whole value on one line, so the
-line-based `read_tool_result` tool cannot page through a large spilled list. The `serializer`
-setting replaces that rendering for structured (non-string, non-binary) returns. Two presets
-cover the common layouts:
+A spilled structured return is stored as compact JSON: one long line. `read_tool_result`
+pages by line, so page 1 returns the whole payload and page 2 is empty. Setting `serializer`
+stores the value in a layout with real lines instead:
 
 ```python
 from pydantic_ai_harness.tool_output_limits import ToolOutputLimits, indented_json, json_lines
 
-ToolOutputLimits(serializer=indented_json)  # indented JSON: one field per line
-ToolOutputLimits(serializer=json_lines)  # top-level list: one record per line
+ToolOutputLimits(serializer=indented_json)  # one field per line
+ToolOutputLimits(serializer=json_lines)  # one record per line
 ```
 
-`indented_json` renders indent-2 JSON, so fields land on separate lines and
-`read_tool_result` can slice and `pattern`-filter them. `json_lines` renders a sequence
-(other than a string or a byte payload) as one compact JSON value per line (JSON Lines), so
-line offsets map directly to items; other values fall back to `indented_json`. Both presets
-escape the Unicode line separators that `str.splitlines` breaks on, so a line read back is
-always a whole item or field. A tool that wraps its records in a mapping (say
-`{'items': [...]}`) gets the `indented_json` fallback; return the list directly, or supply
-a serializer that unwraps it, to get line-per-record paging.
+Use `json_lines` for tools that return lists of records: line N is record N, so page offsets
+and `pattern` matches line up with whole records. Anything that is not a list-like sequence
+falls back to `indented_json` -- including a list wrapped in a dict, so return the list
+directly for per-record paging. Use `indented_json` for everything else.
 
-Any `(value) -> str` callable can be supplied; `Serializer` is the exported alias. The
-capability serializes each structured return once: measurement, band selection, previews,
-stored bytes, and read-back all use the same text, which means an indented layout measures
-larger than compact JSON and can reach a band the compact form would not. If the callable
-raises or returns non-text, the capability warns and falls back to compact JSON for that
-return. Strings and binary payloads never pass through the serializer, and a structured
-return below the smallest band threshold passes through as the original object.
+Any `(value) -> str` callable works too, but prefer the presets: they escape the Unicode
+line separators (U+0085/U+2028/U+2029) that would otherwise knock read-back offsets off the
+line grid. The serialized text is also what gets measured, so an indented layout can cross
+a size band that compact JSON would not. Strings and binary returns are never serialized,
+returns below the smallest band pass through untouched, and a serializer that raises or
+returns non-text warns and falls back to compact JSON rather than losing the tool output.
 
 ## Spill store
 

--- a/pydantic_ai_harness/tool_output_limits/__init__.py
+++ b/pydantic_ai_harness/tool_output_limits/__init__.py
@@ -20,7 +20,12 @@ from pydantic_ai_harness.tool_output_limits._bands import (
     Truncate,
 )
 from pydantic_ai_harness.tool_output_limits._capability import READ_TOOL_NAME, ToolOutputLimits
-from pydantic_ai_harness.tool_output_limits._payload import TruncationStrategy
+from pydantic_ai_harness.tool_output_limits._payload import (
+    Serializer,
+    TruncationStrategy,
+    indented_json,
+    json_lines,
+)
 from pydantic_ai_harness.tool_output_limits._store import LocalFileStore, OverflowStore
 
 __all__ = [
@@ -29,6 +34,7 @@ __all__ = [
     'Band',
     'LocalFileStore',
     'OverflowStore',
+    'Serializer',
     'ToolOutputLimits',
     'Passthrough',
     'Spill',
@@ -36,4 +42,6 @@ __all__ = [
     'SummarizeFunc',
     'Truncate',
     'TruncationStrategy',
+    'indented_json',
+    'json_lines',
 ]

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -149,8 +149,7 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
     """Render a structured (non-string, non-binary) return to the text that is measured,
     previewed, spilled, and read back. Defaults to compact JSON, which puts the whole value
     on one line; the `indented_json` and `json_lines` presets make large spills pageable by
-    line through `read_tool_result`. The callable must be deterministic, so an identical
-    return reduces to identical bytes and keeps the prompt prefix stable."""
+    line through `read_tool_result`."""
 
     _store: OverflowStore = field(init=False, repr=False)
     _bands: list[Band] = field(init=False, repr=False)
@@ -288,7 +287,16 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         if is_binary(value):
             return _Unit(binary=True, text=None, data=to_bytes(value), value=value, suffix=suffix)
         if self.serializer is not None and not isinstance(value, str):
-            text = self.serializer(value)
+            try:
+                text = self.serializer(value)
+            except Exception:
+                # An after-hook exception would abort the run and lose the tool's output,
+                # so a broken serializer degrades to the default rendering instead.
+                warnings.warn(
+                    'ToolOutputLimits: serializer raised; falling back to compact JSON.',
+                    stacklevel=2,
+                )
+                text = to_text(value)
         else:
             text = to_text(value)
         if self.strip_ansi:

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -147,9 +147,11 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
 
     serializer: Serializer | None = None
     """Render a structured (non-string, non-binary) return to the text that is measured,
-    previewed, spilled, and read back. Defaults to compact JSON, which puts the whole value
-    on one line; the `indented_json` and `json_lines` presets make large spills pageable by
-    line through `read_tool_result`."""
+    previewed, spilled, and read back. When unset, structured returns render as compact
+    JSON, which puts the whole value on one line; the `indented_json` and `json_lines`
+    presets make large spills pageable by line through `read_tool_result`. A return that
+    stays under every band threshold passes through as the original object, so the
+    serialized text is only model-visible once a band triggers."""
 
     _store: OverflowStore = field(init=False, repr=False)
     _bands: list[Band] = field(init=False, repr=False)
@@ -230,7 +232,7 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
             return original
 
         bands = self._per_tool.get(call.tool_name, self._bands)
-        value_unit = self._make_unit(return_value, suffix='')
+        value_unit = self._make_unit(return_value, tool_name=call.tool_name, suffix='')
         value_text, value_handle = await self._reduce(ctx, call, bands, value_unit)
         content_text, content_handle = await self._reduce_content(ctx, call, bands, content)
 
@@ -282,7 +284,7 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
             return spilled_out
         return value_text
 
-    def _make_unit(self, value: ToolReturnContent, *, suffix: str) -> _Unit:
+    def _make_unit(self, value: ToolReturnContent, *, tool_name: str, suffix: str) -> _Unit:
         """Pre-render a value into the text / bytes the reduction pipeline needs."""
         if is_binary(value):
             return _Unit(binary=True, text=None, data=to_bytes(value), value=value, suffix=suffix)
@@ -293,7 +295,8 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
                 # An after-hook exception would abort the run and lose the tool's output,
                 # so a broken serializer degrades to the default rendering instead.
                 warnings.warn(
-                    'ToolOutputLimits: serializer raised or returned non-text; falling back to compact JSON.',
+                    f'ToolOutputLimits: tool {tool_name!r} serializer raised or returned non-text; '
+                    f'falling back to compact JSON.',
                     stacklevel=2,
                 )
                 text = to_text(value)
@@ -336,7 +339,9 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         if content is None:
             return None, None
         if isinstance(content, str):
-            return await self._reduce(ctx, call, bands, self._make_unit(content, suffix='.content'))
+            return await self._reduce(
+                ctx, call, bands, self._make_unit(content, tool_name=call.tool_name, suffix='.content')
+            )
 
         text = ''.join(part for part in content if isinstance(part, str))
         size = measure(text, over_tokens=self.over_tokens, tokenizer=self.tokenizer)

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -24,6 +24,7 @@ from pydantic_ai_harness.tool_output_limits._bands import (
     Truncate,
 )
 from pydantic_ai_harness.tool_output_limits._payload import (
+    Serializer,
     is_binary,
     json_sketch,
     measure,
@@ -143,6 +144,13 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
 
     summary_prompt: str = _DEFAULT_SUMMARY_PROMPT
     """Prompt template for `Summarize`. Must contain `{tool_name}` and `{output}`."""
+
+    serializer: Serializer | None = None
+    """Render a structured (non-string, non-binary) return to the text that is measured,
+    previewed, spilled, and read back. Defaults to compact JSON, which puts the whole value
+    on one line; the `indented_json` and `json_lines` presets make large spills pageable by
+    line through `read_tool_result`. The callable must be deterministic, so an identical
+    return reduces to identical bytes and keeps the prompt prefix stable."""
 
     _store: OverflowStore = field(init=False, repr=False)
     _bands: list[Band] = field(init=False, repr=False)
@@ -279,7 +287,10 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         """Pre-render a value into the text / bytes the reduction pipeline needs."""
         if is_binary(value):
             return _Unit(binary=True, text=None, data=to_bytes(value), value=value, suffix=suffix)
-        text = to_text(value)
+        if self.serializer is not None and not isinstance(value, str):
+            text = self.serializer(value)
+        else:
+            text = to_text(value)
         if self.strip_ansi:
             text = strip_ansi(text)
         return _Unit(binary=False, text=text, data=text.encode('utf-8'), value=value, suffix=suffix)

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -288,12 +288,12 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
             return _Unit(binary=True, text=None, data=to_bytes(value), value=value, suffix=suffix)
         if self.serializer is not None and not isinstance(value, str):
             try:
-                text = self.serializer(value)
+                text = _ensure_text(self.serializer(value))
             except Exception:
                 # An after-hook exception would abort the run and lose the tool's output,
                 # so a broken serializer degrades to the default rendering instead.
                 warnings.warn(
-                    'ToolOutputLimits: serializer raised; falling back to compact JSON.',
+                    'ToolOutputLimits: serializer raised or returned non-text; falling back to compact JSON.',
                     stacklevel=2,
                 )
                 text = to_text(value)
@@ -454,6 +454,13 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         )
         run = await agent.run(prompt, usage=ctx.usage)
         return run.output.strip()
+
+
+def _ensure_text(rendered: object) -> str:
+    """Reject non-`str` serializer output (e.g. `to_json` bytes without `.decode()`)."""
+    if not isinstance(rendered, str):
+        raise TypeError(f'serializer returned {type(rendered).__name__}')
+    return rendered
 
 
 def _select_action(bands: Sequence[Band], size: int) -> Action | None:

--- a/pydantic_ai_harness/tool_output_limits/_payload.py
+++ b/pydantic_ai_harness/tool_output_limits/_payload.py
@@ -72,6 +72,31 @@ def to_text(value: object) -> str:
     return to_json(value).decode('utf-8', errors='replace')
 
 
+# A serializer callable for structured (non-string, non-binary) tool returns:
+# `(value) -> text`, where the text is what gets measured, previewed, spilled, and read back.
+Serializer = Callable[[object], str]
+
+
+def indented_json(value: object) -> str:
+    """Serializer preset: render `value` as indented JSON, one field per line.
+
+    A spilled payload rendered this way can be paged and `pattern`-filtered by line
+    through `read_tool_result`; compact JSON puts the whole value on one line.
+    """
+    return to_json(value, indent=2).decode('utf-8', errors='replace')
+
+
+def json_lines(value: object) -> str:
+    """Serializer preset: render a top-level list as JSON Lines, one compact object per line.
+
+    Line N is item N, so `read_tool_result` offsets and limits map directly to items and a
+    `pattern` match returns whole items. Values that are not lists fall back to `indented_json`.
+    """
+    if _is_text_sequence(value):
+        return '\n'.join(to_json(item).decode('utf-8', errors='replace') for item in value)
+    return indented_json(value)
+
+
 def measure(text: str, *, over_tokens: bool, tokenizer: Callable[[str], int] | None) -> int:
     """Measure `text` in characters (default) or estimated tokens (`over_tokens=True`)."""
     if not over_tokens:

--- a/pydantic_ai_harness/tool_output_limits/_payload.py
+++ b/pydantic_ai_harness/tool_output_limits/_payload.py
@@ -76,6 +76,11 @@ def to_text(value: object) -> str:
 # `(value) -> text`, where the text is what gets measured, previewed, spilled, and read back.
 Serializer = Callable[[object], str]
 
+# `str.splitlines` treats these as line breaks, but JSON only requires escaping control
+# characters below 0x20, so `to_json` emits them raw inside string values. Escaping them
+# keeps read-back line slicing aligned with the lines the presets rendered.
+_LINE_SEPARATOR_ESCAPES = {0x85: '\\u0085', 0x2028: '\\u2028', 0x2029: '\\u2029'}
+
 
 def indented_json(value: object) -> str:
     """Serializer preset: render `value` as indented JSON, one field per line.
@@ -83,17 +88,20 @@ def indented_json(value: object) -> str:
     A spilled payload rendered this way can be paged and `pattern`-filtered by line
     through `read_tool_result`; compact JSON puts the whole value on one line.
     """
-    return to_json(value, indent=2).decode('utf-8', errors='replace')
+    return to_json(value, indent=2).decode('utf-8', errors='replace').translate(_LINE_SEPARATOR_ESCAPES)
 
 
 def json_lines(value: object) -> str:
-    """Serializer preset: render a top-level list as JSON Lines, one compact object per line.
+    """Serializer preset: render a sequence as JSON Lines, one compact object per line.
 
     Line N is item N, so `read_tool_result` offsets and limits map directly to items and a
-    `pattern` match returns whole items. Values that are not lists fall back to `indented_json`.
+    `pattern` match returns whole items; an empty sequence renders as an empty string.
+    Values that are not sequences (or that are strings or byte payloads) fall back to
+    `indented_json`.
     """
     if _is_text_sequence(value):
-        return '\n'.join(to_json(item).decode('utf-8', errors='replace') for item in value)
+        rendered = '\n'.join(to_json(item).decode('utf-8', errors='replace') for item in value)
+        return rendered.translate(_LINE_SEPARATOR_ESCAPES)
     return indented_json(value)
 
 
@@ -123,7 +131,7 @@ def _is_mapping(value: object) -> TypeGuard[Mapping[object, object]]:
 
 
 def _is_text_sequence(value: object) -> TypeGuard[Sequence[object]]:
-    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray))
+    return isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray, memoryview))
 
 
 def _sketch_mapping(mapping: Mapping[object, object]) -> str:

--- a/pydantic_ai_harness/tool_output_limits/_payload.py
+++ b/pydantic_ai_harness/tool_output_limits/_payload.py
@@ -92,7 +92,7 @@ def indented_json(value: object) -> str:
 
 
 def json_lines(value: object) -> str:
-    """Serializer preset: render a sequence as JSON Lines, one compact object per line.
+    """Serializer preset: render a sequence as JSON Lines, one compact JSON value per line.
 
     Line N is item N, so `read_tool_result` offsets and limits map directly to items and a
     `pattern` match returns whole items; an empty sequence renders as an empty string.

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -149,11 +149,20 @@ class TestPayloadHelpers:
     def test_json_lines_list(self):
         assert json_lines([{'a': 1}, {'b': 2}]) == '{"a":1}\n{"b":2}'
 
-    def test_json_lines_non_list_falls_back_to_indented(self):
+    def test_json_lines_non_sequence_falls_back_to_indented(self):
         assert json_lines({'a': 1}) == '{\n  "a": 1\n}'
+
+    def test_json_lines_tuple_is_a_sequence(self):
+        assert json_lines(({'a': 1}, {'b': 2})) == '{"a":1}\n{"b":2}'
 
     def test_json_lines_empty_list(self):
         assert json_lines([]) == ''
+
+    def test_presets_escape_line_separator_chars(self):
+        rendered = json_lines([{'text': 'a\N{LINE SEPARATOR}b'}, {'ok': True}])
+        assert rendered.splitlines() == ['{"text":"a\\u2028b"}', '{"ok":true}']
+        indented = indented_json({'text': 'a\N{PARAGRAPH SEPARATOR}b\x85c'})
+        assert indented.splitlines() == ['{', '  "text": "a\\u2029b\\u0085c"', '}']
 
     def test_measure_chars_and_tokens(self):
         assert measure('x' * 100, over_tokens=False, tokenizer=None) == 100
@@ -459,10 +468,44 @@ class TestSpill:
         assert isinstance(out, ToolReturn)
         handle = out.metadata['overflow_handle']
         assert await store.read(handle) == json_lines(records).encode('utf-8')
-        page_1 = await _read_slice(store, handle, 0, 1, False, None)
-        page_2 = await _read_slice(store, handle, 1, 1, False, None)
-        assert '"record_id":0' in page_1
-        assert '"record_id":1' in page_2
+        toolset = cap.get_toolset()
+        assert toolset is not None
+        read = toolset.tools[READ_TOOL_NAME].function  # type: ignore[union-attr]
+        page_1 = await read(_make_ctx(), handle, offset=0, limit=1)  # type: ignore[attr-defined]
+        page_2 = await read(_make_ctx(), handle, offset=1, limit=1)  # type: ignore[attr-defined]
+        assert '"record_id":0' in page_1 and '"record_id":1' not in page_1
+        assert '"record_id":1' in page_2 and '"record_id":0' not in page_2
+
+    async def test_spill_serializer_inside_tool_return_envelope(self, tmp_path: Path):
+        store = LocalFileStore(base_dir=tmp_path)
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=5, action=Spill())], serializer=json_lines, store=store
+        )
+        out = await _run(cap, ToolReturn(return_value=[{'record_id': 1}, {'record_id': 2}], metadata={'orig': True}))
+        assert isinstance(out, ToolReturn)
+        assert out.metadata['orig'] is True
+        assert await store.read(out.metadata['overflow_handle']) == b'{"record_id":1}\n{"record_id":2}'
+
+    async def test_serializer_layout_reaches_band_compact_would_not(self):
+        value = {'a': 1, 'b': 2, 'c': 3}
+        bands = [Band(over=25, action=Truncate(max_chars=10, strategy=TruncationStrategy.head))]
+        plain: ToolOutputLimits[object] = ToolOutputLimits(bands=bands)
+        assert await _run(plain, value) is value
+        cap: ToolOutputLimits[object] = ToolOutputLimits(bands=bands, serializer=indented_json)
+        out = await _run(cap, value)
+        assert isinstance(out, str) and out.startswith('{\n  "a": 1')
+
+    async def test_serializer_error_warns_and_falls_back_to_compact(self):
+        def broken(value: object) -> str:
+            raise RuntimeError('boom')
+
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=10, action=Truncate(max_chars=20, strategy=TruncationStrategy.head))],
+            serializer=broken,
+        )
+        with pytest.warns(UserWarning, match='serializer raised'):
+            out = await _run(cap, {'rows': list(range(100))})
+        assert isinstance(out, str) and out.startswith('{"rows":[0,1,')
 
     async def test_spill_serializer_skips_strings(self, tmp_path: Path):
         store = LocalFileStore(base_dir=tmp_path)

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -26,6 +26,7 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RunUsage
+from pydantic_core import to_json
 
 from pydantic_ai_harness.tool_output_limits import (
     Band,
@@ -504,6 +505,15 @@ class TestSpill:
             serializer=broken,
         )
         with pytest.warns(UserWarning, match='serializer raised'):
+            out = await _run(cap, {'rows': list(range(100))})
+        assert isinstance(out, str) and out.startswith('{"rows":[0,1,')
+
+    async def test_serializer_non_text_return_warns_and_falls_back_to_compact(self):
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=10, action=Truncate(max_chars=20, strategy=TruncationStrategy.head))],
+            serializer=lambda value: to_json(value, indent=2),  # type: ignore[arg-type,return-value]
+        )
+        with pytest.warns(UserWarning, match='non-text'):
             out = await _run(cap, {'rows': list(range(100))})
         assert isinstance(out, str) and out.startswith('{"rows":[0,1,')
 

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -36,6 +36,8 @@ from pydantic_ai_harness.tool_output_limits import (
     ToolOutputLimits,
     Truncate,
     TruncationStrategy,
+    indented_json,
+    json_lines,
 )
 from pydantic_ai_harness.tool_output_limits._capability import (
     READ_TOOL_NAME,
@@ -140,6 +142,18 @@ class TestPayloadHelpers:
     def test_to_text_variants(self):
         assert to_text('hi') == 'hi'
         assert to_text({'a': 1}) == '{"a":1}'
+
+    def test_indented_json(self):
+        assert indented_json({'a': 1}) == '{\n  "a": 1\n}'
+
+    def test_json_lines_list(self):
+        assert json_lines([{'a': 1}, {'b': 2}]) == '{"a":1}\n{"b":2}'
+
+    def test_json_lines_non_list_falls_back_to_indented(self):
+        assert json_lines({'a': 1}) == '{\n  "a": 1\n}'
+
+    def test_json_lines_empty_list(self):
+        assert json_lines([]) == ''
 
     def test_measure_chars_and_tokens(self):
         assert measure('x' * 100, over_tokens=False, tokenizer=None) == 100
@@ -354,6 +368,13 @@ class TestPassthrough:
         out = await _run(cap, 'small')
         assert out == 'small'
 
+    async def test_below_threshold_structured_passthrough_with_serializer(self):
+        records = [{'record_id': 1}]
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=1000, action=Truncate())], serializer=indented_json
+        )
+        assert await _run(cap, records) is records
+
     async def test_exception_result_passthrough(self):
         cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=1, action=Truncate(max_chars=2))])
         err = ValueError('boom')
@@ -427,6 +448,31 @@ class TestSpill:
         out = await _run(cap, {'rows': list(range(1000)), 'ok': True})
         assert isinstance(out, ToolReturn)
         assert 'shape:' in out.return_value  # type: ignore[operator]
+
+    async def test_spill_serializer_json_lines_is_pageable(self, tmp_path: Path):
+        store = LocalFileStore(base_dir=tmp_path)
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=5, action=Spill(preview_chars=80))], serializer=json_lines, store=store
+        )
+        records = [{'record_id': record_id, 'item': f'item-{record_id}'} for record_id in range(10)]
+        out = await _run(cap, records)
+        assert isinstance(out, ToolReturn)
+        handle = out.metadata['overflow_handle']
+        assert await store.read(handle) == json_lines(records).encode('utf-8')
+        page_1 = await _read_slice(store, handle, 0, 1, False, None)
+        page_2 = await _read_slice(store, handle, 1, 1, False, None)
+        assert '"record_id":0' in page_1
+        assert '"record_id":1' in page_2
+
+    async def test_spill_serializer_skips_strings(self, tmp_path: Path):
+        store = LocalFileStore(base_dir=tmp_path)
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=5, action=Spill())], serializer=indented_json, store=store
+        )
+        text = 'line\n' * 100
+        out = await _run(cap, text)
+        assert isinstance(out, ToolReturn)
+        assert await store.read(out.metadata['overflow_handle']) == text.encode('utf-8')
 
     async def test_spill_failure_falls_back_to_truncate(self):
         cap: ToolOutputLimits[object] = ToolOutputLimits(


### PR DESCRIPTION
## Summary

Thanks to @andranik-sahakyan-mx for reporting #614 and the first fix in #615 — this PR takes that work forward (credited as co-author on the branch).

Spilled structured results are stored as compact JSON, all on one line, so the line-based `read_tool_result` tool can't page them. This adds a `serializer` field to `ToolOutputLimits` with two presets:

```python
ToolOutputLimits(serializer=indented_json)  # one field per line
ToolOutputLimits(serializer=json_lines)  # one record per line
```

Any `(value) -> str` callable works — same pattern as `tokenizer`, so we don't bake a format knob like `json_indent` into the API. The serialized text is the single representation that gets measured, previewed, spilled, and read back.

Details worth knowing:

- A serializer that raises or returns non-text warns and falls back to compact JSON, so a broken one never loses tool output.
- Both presets escape U+0085/U+2028/U+2029 (raw in JSON strings, but line breaks to `str.splitlines`), so read-back offsets always land on whole items.
- Strings and binary payloads never pass through the serializer; below-threshold returns pass through untouched.

Complementary to #332: line-shaped payloads make `grep_tool_result` matches meaningful for structured data.

Fixes #614

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)
