### PR TITLE
Add `TruncatingCompaction` for protected token tails

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -25,7 +25,7 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 |---|---|---|---|
 | `ClampOversizedMessages` | zero-LLM | Head/tail-truncates a single oversized part (response text, tool-call args) | One runaway generation blew past the context cap and no other strategy can reach it |
 | `SlidingWindowCompaction` | zero-LLM | Drops the oldest whole messages down to a tail | You only need the recent turns and can discard old context entirely |
-| `TruncatingCompaction` | zero-LLM | Always bounds history to a recent token tail | You want deterministic truncation without a separate trigger or model call |
+| `TruncatingCompaction` | zero-LLM | Bounds unprotected history to a recent token tail while preserving protected messages and required tool pairs | You want deterministic truncation without a separate trigger or model call |
 | `ClearToolResults` | zero-LLM | Blanks the content of old tool *results* in place, keeping the last `keep_pairs` | Tool outputs dominate context and can be re-fetched on demand (the cheap first tier) |
 | `DeduplicateFileReads` | zero-LLM | Blanks every file read superseded by a newer read of the same file | The agent re-reads files and only the latest version matters |
 | `SummarizingCompaction` | one LLM call | Summarizes older messages into a structured summary, keeping the recent tail | Old context still matters but must be compressed; use behind the cheap tiers |

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -25,6 +25,7 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 |---|---|---|---|
 | `ClampOversizedMessages` | zero-LLM | Head/tail-truncates a single oversized part (response text, tool-call args) | One runaway generation blew past the context cap and no other strategy can reach it |
 | `SlidingWindowCompaction` | zero-LLM | Drops the oldest whole messages down to a tail | You only need the recent turns and can discard old context entirely |
+| `TruncatingCompaction` | zero-LLM | Always bounds history to a recent token tail | You want deterministic truncation without a separate trigger or model call |
 | `ClearToolResults` | zero-LLM | Blanks the content of old tool *results* in place, keeping the last `keep_pairs` | Tool outputs dominate context and can be re-fetched on demand (the cheap first tier) |
 | `DeduplicateFileReads` | zero-LLM | Blanks every file read superseded by a newer read of the same file | The agent re-reads files and only the latest version matters |
 | `SummarizingCompaction` | one LLM call | Summarizes older messages into a structured summary, keeping the recent tail | Old context still matters but must be compressed; use behind the cheap tiers |
@@ -298,6 +299,16 @@ agent = Agent(
 ```
 
 By default `preserve_first_user_message=True` keeps the first user turn (in addition to system prompts) even when it falls outside the window, so the agent does not lose the original task. Pass `keep_tokens` instead of `keep_messages` to trim to a token budget rather than a message count.
+
+## `TruncatingCompaction`: bound history without a trigger
+
+`TruncatingCompaction` is the token-tail specialization of `SlidingWindowCompaction`. It has no separate trigger: when history exceeds `keep_tokens`, it drops the oldest whole messages while preserving tool pairs, pins, and the first user message by default. Use it for manual truncation or as a deterministic final `TieredCompaction` tier.
+
+```python
+from pydantic_ai_harness import TruncatingCompaction
+
+truncation = TruncatingCompaction(keep_tokens=50_000)
+```
 
 ## `SummarizingCompaction`: compress, do not discard
 

--- a/pydantic_ai_harness/__init__.py
+++ b/pydantic_ai_harness/__init__.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
         SlidingWindowCompaction,
         SummarizingCompaction,
         TieredCompaction,
+        TruncatingCompaction,
         WarnNearLimits,
     )
     from .conversation_search import ConversationSearch
@@ -105,6 +106,7 @@ __all__ = [
     'SystemReminders',
     'TieredCompaction',
     'ToolGuardrail',
+    'TruncatingCompaction',
     'ToolOutputLimits',
     'WarnNearLimits',
     'WarnOnCacheBusts',
@@ -146,6 +148,7 @@ _CAPABILITY_EXPORTS = {
     'SystemReminders': 'system_reminders',
     'TieredCompaction': 'compaction',
     'ToolGuardrail': 'guardrails',
+    'TruncatingCompaction': 'compaction',
     'ToolOutputLimits': 'tool_output_limits',
     'WarnNearLimits': 'compaction',
     'WarnOnCacheBusts': 'warn_on_cache_busts',

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -20,7 +20,7 @@ alternative: they work with every model and keep the compaction logic (and its c
 |---|---|---|---|
 | `ClampOversizedMessages` | zero-LLM | Head/tail-truncates a single oversized part (response text, tool-call args) | One runaway generation blew past the context cap and no other strategy can reach it |
 | `SlidingWindowCompaction` | zero-LLM | Drops the oldest whole messages down to a tail | You only need the recent turns and can discard old context entirely |
-| `TruncatingCompaction` | zero-LLM | Always bounds history to a recent token tail | You want deterministic truncation without a separate trigger or model call |
+| `TruncatingCompaction` | zero-LLM | Bounds unprotected history to a recent token tail while preserving protected messages and required tool pairs | You want deterministic truncation without a separate trigger or model call |
 | `ClearToolResults` | zero-LLM | Blanks the content of old tool *results* in place, keeping the last `keep_pairs` | Tool outputs dominate context and can be re-fetched on demand (the cheap first tier) |
 | `DeduplicateFileReads` | zero-LLM | Blanks every file read superseded by a newer read of the same file | The agent re-reads files and only the latest version matters |
 | `SummarizingCompaction` | one LLM call | Summarizes older messages into a structured summary, keeping the recent tail | Old context still matters but must be compressed; use behind the cheap tiers |

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -20,6 +20,7 @@ alternative: they work with every model and keep the compaction logic (and its c
 |---|---|---|---|
 | `ClampOversizedMessages` | zero-LLM | Head/tail-truncates a single oversized part (response text, tool-call args) | One runaway generation blew past the context cap and no other strategy can reach it |
 | `SlidingWindowCompaction` | zero-LLM | Drops the oldest whole messages down to a tail | You only need the recent turns and can discard old context entirely |
+| `TruncatingCompaction` | zero-LLM | Always bounds history to a recent token tail | You want deterministic truncation without a separate trigger or model call |
 | `ClearToolResults` | zero-LLM | Blanks the content of old tool *results* in place, keeping the last `keep_pairs` | Tool outputs dominate context and can be re-fetched on demand (the cheap first tier) |
 | `DeduplicateFileReads` | zero-LLM | Blanks every file read superseded by a newer read of the same file | The agent re-reads files and only the latest version matters |
 | `SummarizingCompaction` | one LLM call | Summarizes older messages into a structured summary, keeping the recent tail | Old context still matters but must be compressed; use behind the cheap tiers |
@@ -293,6 +294,18 @@ TieredCompaction(
 `SlidingWindowCompaction` keeps the last `keep_messages` down to a tail; pass `keep_tokens` instead for a token
 budget rather than a message count. By default `preserve_first_user_message=True` keeps the first user
 turn even when it falls outside the window, so the agent does not lose the original task.
+
+`TruncatingCompaction` is the token-tail specialization of `SlidingWindowCompaction`. It has no
+separate trigger: when history exceeds `keep_tokens`, it drops the oldest whole messages while
+preserving tool pairs, pins, and the first user message by default:
+
+```python
+from pydantic_ai_harness import TruncatingCompaction
+
+truncation = TruncatingCompaction(keep_tokens=50_000)
+```
+
+Use it for manual truncation or as a deterministic final `TieredCompaction` tier.
 
 `ClearToolResults` keeps the last `keep_pairs` intact. Set `clear_tool_inputs=True` to also blank the
 arguments of the cleared calls, and `exclude_tools` to a set of tool names whose results are never

--- a/pydantic_ai_harness/compaction/__init__.py
+++ b/pydantic_ai_harness/compaction/__init__.py
@@ -25,6 +25,7 @@ from pydantic_ai_harness.compaction._shared import (
 from pydantic_ai_harness.compaction._sliding_window_compaction import SlidingWindowCompaction
 from pydantic_ai_harness.compaction._summarizing_compaction import SummarizingCompaction
 from pydantic_ai_harness.compaction._tiered_compaction import TieredCompaction
+from pydantic_ai_harness.compaction._truncating_compaction import TruncatingCompaction
 from pydantic_ai_harness.compaction._warn_near_limits import WarningKind, WarnNearLimits
 
 __all__ = [
@@ -40,6 +41,7 @@ __all__ = [
     'SupportsFocus',
     'TieredCompaction',
     'TranscriptHandleProvider',
+    'TruncatingCompaction',
     'WarnNearLimits',
     'WarningKind',
     'compact_now',

--- a/pydantic_ai_harness/compaction/_sliding_window_compaction.py
+++ b/pydantic_ai_harness/compaction/_sliding_window_compaction.py
@@ -201,7 +201,7 @@ class SlidingWindowCompaction(AbstractCapability[AgentDepsT]):
         handle = discover_transcript_handle(ctx)
         record_receipt(
             ReceiptInfo(
-                strategy='SlidingWindowCompaction',
+                strategy=type(self).__name__,
                 dropped_messages=len(dropped),
                 dropped_tokens=dropped_tokens,
                 by='the harness',
@@ -238,7 +238,7 @@ class SlidingWindowCompaction(AbstractCapability[AgentDepsT]):
             return request_context
         compacted = await compact_with_span(
             request_ctx,
-            strategy='SlidingWindowCompaction',
+            strategy=type(self).__name__,
             messages=messages,
             compact=lambda: self.compact(messages, request_ctx),
             tokenizer=self.tokenizer,

--- a/pydantic_ai_harness/compaction/_truncating_compaction.py
+++ b/pydantic_ai_harness/compaction/_truncating_compaction.py
@@ -1,0 +1,34 @@
+"""`TruncatingCompaction` -- retain a recent token-bounded history tail."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from pydantic_ai._run_context import AgentDepsT
+
+from pydantic_ai_harness.compaction._sliding_window_compaction import SlidingWindowCompaction
+
+
+class TruncatingCompaction(SlidingWindowCompaction[AgentDepsT]):
+    """Drop old messages while retaining a tool-pair-safe recent token tail.
+
+    Unlike `SlidingWindowCompaction`, this strategy has no separate trigger:
+    every request is compacted to `keep_tokens` when needed. This also makes it
+    a deterministic zero-LLM final tier for `TieredCompaction`.
+    """
+
+    def __init__(
+        self,
+        keep_tokens: int,
+        *,
+        tokenizer: Callable[[str], int] | None = None,
+        preserve_first_user_message: bool = True,
+        receipts: bool = False,
+    ) -> None:
+        super().__init__(
+            max_tokens=1,
+            keep_tokens=keep_tokens,
+            tokenizer=tokenizer,
+            preserve_first_user_message=preserve_first_user_message,
+            receipts=receipts,
+        )

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -40,6 +40,7 @@ from pydantic_ai_harness.compaction import (
     SummarizingCompaction,
     TieredCompaction,
     TranscriptHandleProvider,
+    TruncatingCompaction,
     WarnNearLimits,
     estimate_context_tokens,
     estimate_token_count,
@@ -431,6 +432,23 @@ class TestSlidingWindowCompaction:
         assert len(result.messages) < 10
 
 
+class TestTruncatingCompaction:
+    def test_validation_negative_keep_tokens(self):
+        with pytest.raises(ValueError, match='keep_tokens must be non-negative'):
+            TruncatingCompaction(keep_tokens=-1)
+
+    @pytest.mark.anyio
+    async def test_keeps_recent_token_tail(self):
+        truncation = TruncatingCompaction(
+            keep_tokens=10,
+            tokenizer=len,
+            preserve_first_user_message=False,
+        )
+        messages: list[ModelMessage] = [_user('x' * 5) for _ in range(5)]
+        result = await truncation.before_model_request(_make_ctx(), _make_request_context(messages))
+        assert result.messages == messages[-2:]
+
+
 # ---------------------------------------------------------------------------
 # WarnNearLimits
 # ---------------------------------------------------------------------------
@@ -813,6 +831,7 @@ class TestExports:
             'WarnNearLimits',
             'SummarizingCompaction',
             'TieredCompaction',
+            'TruncatingCompaction',
         ]
         for name in names:
             assert hasattr(compaction, name)


### PR DESCRIPTION
## Summary

Add `TruncatingCompaction`, a very small token-tail specialization of `SlidingWindowCompaction`.

It has no separate public trigger. When history exceeds `keep_tokens`, it drops the oldest whole messages while reusing the existing tool-pair-safe cutoff, pin reinjection, first-user preservation, receipts, tracing, and capability hooks.

The implementation is intentionally seven executable lines. This does not duplicate the sliding-window cutoff algorithm.

## Why

This surfaced while migrating Code Puppy from bespoke compaction to Harness `TieredCompaction`. We initially conflated history truncation with `ClampOversizedMessages`, then considered `SlidingWindowCompaction` directly. Source inspection clarified three distinct user concepts:

- clamp one oversized message part;
- maintain a triggered moving history window;
- explicitly truncate history to a protected recent-token tail.

Code Puppy needs the third operation for deterministic zero-LLM compaction and currently retains a local `truncate()` compatibility path.

Design proposal and full discovery trail: pydantic/pydantic-ai-notes#10.

## Verification

- `make lint`: passed
- targeted strict Pyright on both truncation/sliding-window modules: passed
- compaction tests: 392 passed
- full `make test`: passed
- new and modified compaction modules: 100% branch coverage
- `make testcov`: repository aggregate reports 99% because pre-existing `tests/test_doc_snippets.py:86-89` has two uncovered statements
- full `make typecheck`: currently traverses `mikes-clanker/.venv` and reports third-party `pip`/`urllib3` errors; no errors are reported for the changed modules
