### PR TITLE
Annotate public string collections as `list[str]` and reject bare strings on security lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,15 @@ solves.
 - docstrings use single backticks (markdown), not RST double backticks
 - no typecasting (`as` in TypeScript, `cast()` in Python) -- use type narrowing instead
 - prefer the most generic input types possible (reduce dependency chains)
+- exception to the above: public parameters that take a collection of strings
+  are annotated `list[str]`, not `Sequence[str]` or `Iterable[str]` -- `str`
+  satisfies both, so a bare `'name'` type-checks and then splats into
+  one-character items. When the parameter configures a security control (an
+  allow/deny/protect list over commands, services, env vars, or file paths),
+  also reject a bare `str` at runtime via `reject_bare_str` in
+  `pydantic_ai_harness/_validate.py`; a string denylist would otherwise stop
+  matching anything while looking configured. Content filters such as search
+  domain lists rely on the annotation alone.
 - don't add comments that restate what the code does
 
 ## Writing style

--- a/docs/guardrails.md
+++ b/docs/guardrails.md
@@ -471,8 +471,8 @@ OutputGuardrail(
 ToolGuardrail(
     guard=None,         # inspects a ToolCallInfo before the tool runs
     result_guard=None,  # inspects a ToolResultInfo after it runs
-    tools=None,         # Sequence[str] | None -- restrict both guards to these tool names
-    hidden=(),          # Sequence[str] -- withhold these tools from the model entirely
+    tools=None,         # list[str] | None -- restrict both guards to these tool names
+    hidden=[],          # list[str] -- withhold these tools from the model entirely
 )
 ```
 

--- a/docs/repo-context.md
+++ b/docs/repo-context.md
@@ -86,7 +86,7 @@ Injecting file contents into the system prompt costs prompt-cache stability: a c
 RepoContext(
     workspace_dir,                  # Path -- the deepest dir the agent works in (required)
     home_dir=None,                  # Path | None -- shallowest dir to stop walk-up at, inclusive
-    filenames=('CLAUDE.md', 'AGENTS.md'),
+    filenames=['CLAUDE.md', 'AGENTS.md'],
     autoload_instructions=True,     # Strategy 1
     expose_inventory_tool=True,     # Strategy 2
     inventory_tool_name='inventory_agent_context',
@@ -94,7 +94,7 @@ RepoContext(
     nested_inject='pointer',        # 'pointer' | 'contents'
     traversal_tool_names=frozenset({'list_directory', 'read_file'}),
     traversal_path_arg='path',
-    asset_roots=('.claude', '.agents', '.codex', '.grok'),
+    asset_roots=['.claude', '.agents', '.codex', '.grok'],
 )
 ```
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -253,8 +253,8 @@ for code-defined capabilities.
 Skills(
     directories: str | Path | Sequence[str | Path],
     *,
-    include: Collection[str] | None = None,
-    exclude: Collection[str] | None = None,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
 )
 ```
 

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -241,7 +241,7 @@ SubAgent(
     agent,                 # AbstractAgent[AgentDepsT, Any] -- the child agent to run
     name=None,             # delegate name; defaults to the agent's own `name`
     description=None,      # prompt-listing description; defaults to the agent's own `description`
-    models=None,           # Sequence[str] -- menu keys this delegate may run on; the first is its default
+    models=None,           # list[str] -- menu keys this delegate may run on; the first is its default
     usage_limits=None,     # per-delegation request/token budget (isolated accounting)
     timeout_seconds=None,  # per-delegation wall-clock budget
     max_calls=None,        # max delegations to this sub-agent per parent run

--- a/examples/coding_agent.py
+++ b/examples/coding_agent.py
@@ -28,7 +28,7 @@ DEFAULT_MODEL = os.environ.get('PYDANTIC_AI_MODEL', 'anthropic:claude-fable-5')
 
 # Keep this blown-out composition in sync across docs/coder.md, docs/index.md, README.md,
 # pydantic_ai_harness/coder/README.md, and examples/coding_agent.py.
-ALLOWED_COMMANDS = (
+ALLOWED_COMMANDS = [
     'git',
     'rg',
     'grep',
@@ -43,7 +43,7 @@ ALLOWED_COMMANDS = (
     'pytest',
     'ruff',
     'make',
-)
+]
 
 
 def build_agent(model: Model | str = DEFAULT_MODEL, workspace: Path | None = None) -> Agent:

--- a/pydantic_ai_harness/_validate.py
+++ b/pydantic_ai_harness/_validate.py
@@ -1,0 +1,23 @@
+"""Runtime validation shared by capability packages."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from pydantic_ai.exceptions import UserError
+
+
+def reject_bare_str(class_name: str, fields: Sequence[tuple[str, Sequence[str], str]]) -> None:
+    """Reject a bare string where a collection of names is meant.
+
+    `str` satisfies `Sequence[str]`, so `denied_commands='rm'` type-checks and
+    then splats into `['r', 'm']`: a denylist that stops matching `rm` while
+    reading as configured. Each entry is `(field_name, value, noun)`, where the
+    noun names what the collection holds in the error message.
+    """
+    for field_name, value, noun in fields:
+        if isinstance(value, str):
+            raise UserError(
+                f'{class_name}.{field_name} takes a collection of {noun}, not a single string. '
+                f'Pass [{value!r}] rather than {value!r}.'
+            )

--- a/pydantic_ai_harness/coder/_capability.py
+++ b/pydantic_ai_harness/coder/_capability.py
@@ -9,6 +9,7 @@ from pydantic_ai import Agent
 from pydantic_ai.capabilities import AbstractCapability, Capability, CombinedCapability
 from pydantic_ai.tools import AgentDepsT
 
+from pydantic_ai_harness._validate import reject_bare_str
 from pydantic_ai_harness.compaction import ClearToolResults, WarnNearLimits
 from pydantic_ai_harness.filesystem import FileSystem
 from pydantic_ai_harness.planning import Planning
@@ -17,7 +18,7 @@ from pydantic_ai_harness.shell import LLM_API_KEY_ENV_PATTERNS, Shell
 from pydantic_ai_harness.subagents import SubAgent, SubAgents
 from pydantic_ai_harness.tool_output_limits import ToolOutputLimits
 
-DEFAULT_ALLOWED_COMMANDS: tuple[str, ...] = (
+DEFAULT_ALLOWED_COMMANDS: list[str] = [
     'git',
     'rg',
     'grep',
@@ -32,7 +33,7 @@ DEFAULT_ALLOWED_COMMANDS: tuple[str, ...] = (
     'pytest',
     'ruff',
     'make',
-)
+]
 """Commands available to `Coder` unless an explicit allowlist is supplied."""
 
 
@@ -66,10 +67,12 @@ class Coder(CombinedCapability[AgentDepsT]):
         self,
         workspace: str | Path = '.',
         *,
-        allowed_commands: Sequence[str] | None = None,
+        allowed_commands: list[str] | None = None,
         subagents: Sequence[SubAgent[AgentDepsT]] | None = None,
         instructions: str | None = None,
     ) -> None:
+        if allowed_commands is not None:
+            reject_bare_str('Coder', (('allowed_commands', allowed_commands, 'command names'),))
         delegates = [_explorer(workspace)] if subagents is None else subagents
         capabilities: list[AbstractCapability[AgentDepsT]] = []
         if instructions is not None:
@@ -79,8 +82,8 @@ class Coder(CombinedCapability[AgentDepsT]):
                 FileSystem[AgentDepsT](workspace),
                 Shell[AgentDepsT](
                     cwd=workspace,
-                    allowed_commands=DEFAULT_ALLOWED_COMMANDS if allowed_commands is None else allowed_commands,
-                    denied_env_patterns=LLM_API_KEY_ENV_PATTERNS,
+                    allowed_commands=list(DEFAULT_ALLOWED_COMMANDS if allowed_commands is None else allowed_commands),
+                    denied_env_patterns=list(LLM_API_KEY_ENV_PATTERNS),
                 ),
                 RepoContext[AgentDepsT](workspace_dir=Path(workspace)),
                 Planning[AgentDepsT](),

--- a/pydantic_ai_harness/exa/_capability.py
+++ b/pydantic_ai_harness/exa/_capability.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -86,14 +85,14 @@ class ExaSearch(AbstractCapability[AgentDepsT]):
     than the default.
     """
 
-    include_domains: Sequence[str] = field(default_factory=list[str])
+    include_domains: list[str] = field(default_factory=list[str])
     """If non-empty, search results only come from these domains (allowlist).
 
     Applies to `web_search` and `deep_search`. Mutually exclusive with
     `exclude_domains`.
     """
 
-    exclude_domains: Sequence[str] = field(default_factory=list[str])
+    exclude_domains: list[str] = field(default_factory=list[str])
     """Search results never come from these domains (denylist).
 
     Applies to `web_search` and `deep_search`. Mutually exclusive with
@@ -159,8 +158,8 @@ class ExaSearch(AbstractCapability[AgentDepsT]):
         max_text_chars: int = 10_000,
         text_summary: bool | str = False,
         include_deep_search: bool = False,
-        include_domains: Sequence[str] = (),
-        exclude_domains: Sequence[str] = (),
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
         guidance: str | None = None,
     ) -> ExaSearch[AgentDepsT]:
         """Construct the capability from serializable spec options.
@@ -173,7 +172,7 @@ class ExaSearch(AbstractCapability[AgentDepsT]):
             max_text_chars=max_text_chars,
             text_summary=text_summary,
             include_deep_search=include_deep_search,
-            include_domains=list(include_domains),
-            exclude_domains=list(exclude_domains),
+            include_domains=list(include_domains or []),
+            exclude_domains=list(exclude_domains or []),
             guidance=guidance,
         )

--- a/pydantic_ai_harness/exa/_toolset.py
+++ b/pydantic_ai_harness/exa/_toolset.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import json
 import re
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Concatenate, Literal, ParamSpec, Protocol, TypedDict, TypeVar
 
 import httpx
@@ -159,8 +159,8 @@ class ExaSearchToolset(FunctionToolset[AgentDepsT]):
         num_results: int,
         max_text_chars: int,
         include_deep_search: bool,
-        include_domains: Sequence[str] = (),
-        exclude_domains: Sequence[str] = (),
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
         text_summary: bool | str = False,
     ) -> None:
         super().__init__()

--- a/pydantic_ai_harness/filesystem/_capability.py
+++ b/pydantic_ai_harness/filesystem/_capability.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -11,6 +10,7 @@ from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import FilteredToolset
 
+from pydantic_ai_harness._validate import reject_bare_str
 from pydantic_ai_harness.filesystem._toolset import READ_ONLY_TOOL_NAMES, FileSystemToolset
 
 _DEFAULT_PROTECTED: list[str] = [
@@ -34,13 +34,13 @@ class FileSystem(AbstractCapability[AgentDepsT]):
     root_dir: str | Path = '.'
     """Root directory for all file operations. Defaults to the current directory."""
 
-    allowed_patterns: Sequence[str] = field(default_factory=list[str])
+    allowed_patterns: list[str] = field(default_factory=list[str])
     """If non-empty, only paths matching at least one glob pattern are accessible."""
 
-    denied_patterns: Sequence[str] = field(default_factory=list[str])
+    denied_patterns: list[str] = field(default_factory=list[str])
     """Paths matching any of these glob patterns are rejected."""
 
-    protected_patterns: Sequence[str] = field(default_factory=lambda: list(_DEFAULT_PROTECTED))
+    protected_patterns: list[str] = field(default_factory=lambda: list(_DEFAULT_PROTECTED))
     """Paths matching these patterns are read-only (writes are rejected).
 
     Defaults to protecting `.git/`, `.env`, key files, and secrets.
@@ -65,6 +65,15 @@ class FileSystem(AbstractCapability[AgentDepsT]):
     def __post_init__(self) -> None:
         # Runtime validation: dataclass field annotations are advisory, not enforced.
         # A config-driven caller could pass a string that would otherwise propagate.
+        reject_bare_str(
+            'FileSystem',
+            (
+                ('allowed_patterns', self.allowed_patterns, 'glob patterns'),
+                ('denied_patterns', self.denied_patterns, 'glob patterns'),
+                ('protected_patterns', self.protected_patterns, 'glob patterns'),
+            ),
+        )
+
         values: dict[str, Any] = {
             'max_read_lines': self.max_read_lines,
             'max_list_results': self.max_list_results,

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -15,6 +15,8 @@ from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import FunctionToolset
 
+from pydantic_ai_harness._validate import reject_bare_str
+
 _P = ParamSpec('_P')
 
 READ_ONLY_TOOL_NAMES: frozenset[str] = frozenset(
@@ -109,14 +111,23 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         self,
         *,
         root_dir: Path,
-        allowed_patterns: Sequence[str],
-        denied_patterns: Sequence[str],
-        protected_patterns: Sequence[str],
+        allowed_patterns: list[str],
+        denied_patterns: list[str],
+        protected_patterns: list[str],
         max_read_lines: int,
         max_list_results: int,
         max_search_results: int,
         max_find_results: int,
     ) -> None:
+        reject_bare_str(
+            'FileSystemToolset',
+            (
+                ('allowed_patterns', allowed_patterns, 'glob patterns'),
+                ('denied_patterns', denied_patterns, 'glob patterns'),
+                ('protected_patterns', protected_patterns, 'glob patterns'),
+            ),
+        )
+
         super().__init__()
         self._root = root_dir.resolve()
         self._real_root = Path(os.path.realpath(self._root))

--- a/pydantic_ai_harness/guardrails/README.md
+++ b/pydantic_ai_harness/guardrails/README.md
@@ -475,8 +475,8 @@ OutputGuardrail(
 ToolGuardrail(
     guard: Callable[..., bool | GuardrailResult | Awaitable[bool | GuardrailResult]] | None = None,
     result_guard: Callable[..., bool | GuardrailResult | Awaitable[bool | GuardrailResult]] | None = None,
-    tools: Sequence[str] | None = None,
-    hidden: Sequence[str] = (),
+    tools: list[str] | None = None,
+    hidden: list[str] = [],
 )
 
 

--- a/pydantic_ai_harness/guardrails/_tool_guardrail.py
+++ b/pydantic_ai_harness/guardrails/_tool_guardrail.py
@@ -25,7 +25,7 @@ the run's deferred approval flow.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from types import MappingProxyType
@@ -206,10 +206,10 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
     result_guard: ToolResultGuardrailFunc[AgentDepsT] | None = None
     """Callable that decides what to do with a tool result before the model sees it."""
 
-    tools: Sequence[str] | None = None
+    tools: list[str] | None = None
     """Restrict both guards to these tool names. `None` guards every tool.
 
-    An empty sequence guards nothing, which is the same as configuring no guard at all --
+    An empty list guards nothing, which is the same as configuring no guard at all --
     write `None` when you mean every tool.
 
     A configured name that no offered tool matches warns after a successful run when
@@ -217,7 +217,7 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
     from one step is not enough to diagnose a typo.
     """
 
-    hidden: Sequence[str] = field(default_factory=tuple)
+    hidden: list[str] = field(default_factory=list[str])
     """Tool names to withhold from the model entirely.
 
     Hiding differs from blocking: a hidden tool is dropped from the tool
@@ -243,11 +243,11 @@ class ToolGuardrail(AbstractCapability[AgentDepsT]):
     def __post_init__(self) -> None:
         """Reject a bare string where a collection of tool names is meant.
 
-        `str` satisfies `Sequence[str]`, so pyright accepts `hidden='danger'`
-        and the set built from it holds the six letters of the word. The tool
-        stays on the wire and nothing reports it -- a safety control failing
-        open. `tools='delete_all'` fails the other way, matching any tool whose
-        name is a substring of it.
+        The `list[str]` annotations cover typed call sites; untyped and
+        config-driven ones reach here unchecked. `hidden='danger'` builds a set
+        holding the six letters of the word, so the tool stays on the wire and
+        nothing reports it -- a safety control failing open. `tools='delete_all'`
+        fails the other way, matching any tool whose name is a substring of it.
         """
         for field_name, value in (('tools', self.tools), ('hidden', self.hidden)):
             if isinstance(value, str):

--- a/pydantic_ai_harness/guardrails/detectors.py
+++ b/pydantic_ai_harness/guardrails/detectors.py
@@ -44,7 +44,7 @@ not as the answer.
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import replace
 from typing import Literal, TypeGuard
 
@@ -205,7 +205,7 @@ _VALIDATORS: Mapping[str, Callable[[str], bool]] = {'credit_card': _luhn, 'iban'
 
 
 def _compile(
-    patterns: Mapping[str, str], only: Iterable[str] | None, extra: Mapping[str, str] | None
+    patterns: Mapping[str, str], only: list[str] | None, extra: Mapping[str, str] | None
 ) -> tuple[tuple[str, re.Pattern[str], Callable[[str], bool] | None], ...]:
     """The patterns a detector will run, as `(name, compiled, validator)` triples.
 
@@ -285,7 +285,7 @@ def _redactor(
 
 def secret_data(
     *,
-    only: Iterable[str] | None = None,
+    only: list[str] | None = None,
     extra: Mapping[str, str] | None = None,
     placeholder: str = _REDACTED,
 ) -> TextDetector:
@@ -306,7 +306,7 @@ def secret_data(
 
 def personal_data(
     *,
-    only: Iterable[str] | None = None,
+    only: list[str] | None = None,
     extra: Mapping[str, str] | None = None,
     placeholder: str = _REDACTED,
 ) -> TextDetector:
@@ -331,7 +331,7 @@ redact_personal_data = personal_data()
 
 
 def blocked_keywords(
-    keywords: Iterable[str],
+    keywords: list[str],
     *,
     case_sensitive: bool = False,
     whole_words: bool = False,

--- a/pydantic_ai_harness/localstack/_capability.py
+++ b/pydantic_ai_harness/localstack/_capability.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AgentToolset
 
+from pydantic_ai_harness._validate import reject_bare_str
 from pydantic_ai_harness.localstack._toolset import LocalStackToolset
 
 _INSTRUCTIONS = (
@@ -56,10 +57,10 @@ class LocalStack(AbstractCapability[AgentDepsT]):
     secret_access_key: str = 'test'
     """AWS secret access key. LocalStack accepts any value; defaults to its `test` convention."""
 
-    allowed_services: Sequence[str] = field(default_factory=list[str])
+    allowed_services: list[str] = field(default_factory=list[str])
     """If non-empty, only these AWS services may be used (allowlist), e.g. `['s3', 'dynamodb']`."""
 
-    denied_services: Sequence[str] = field(default_factory=list[str])
+    denied_services: list[str] = field(default_factory=list[str])
     """These AWS services are always rejected (denylist)."""
 
     default_timeout: float = 60.0
@@ -104,6 +105,16 @@ class LocalStack(AbstractCapability[AgentDepsT]):
 
     include_instructions: bool = True
     """If True, add instructions telling the model how to use the emulated environment."""
+
+    def __post_init__(self) -> None:
+        """Reject a bare string where a collection of service names is meant."""
+        reject_bare_str(
+            'LocalStack',
+            (
+                ('allowed_services', self.allowed_services, 'AWS service names'),
+                ('denied_services', self.denied_services, 'AWS service names'),
+            ),
+        )
 
     def get_instructions(self) -> str | None:
         """Explain the emulated environment to the model, unless disabled."""

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -19,6 +19,7 @@ from pydantic_ai.toolsets import AbstractToolset, FunctionToolset, ToolsetTool
 from typing_extensions import Self
 
 from pydantic_ai_harness._output import truncate_tail
+from pydantic_ai_harness._validate import reject_bare_str
 from pydantic_ai_harness.localstack._container import LocalStackContainer
 
 _HEALTH_PATH = '/_localstack/health'
@@ -61,8 +62,8 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         region: str,
         access_key_id: str,
         secret_access_key: str,
-        allowed_services: Sequence[str],
-        denied_services: Sequence[str],
+        allowed_services: list[str],
+        denied_services: list[str],
         default_timeout: float,
         max_output_chars: int,
         aws_cli_path: str,
@@ -77,6 +78,13 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         startup_timeout: float = 120.0,
     ) -> None:
         super().__init__()
+        reject_bare_str(
+            'LocalStackToolset',
+            (
+                ('allowed_services', allowed_services, 'AWS service names'),
+                ('denied_services', denied_services, 'AWS service names'),
+            ),
+        )
         if allowed_services and denied_services:
             raise ValueError('Specify allowed_services or denied_services, not both.')
         if max_output_chars <= 0:

--- a/pydantic_ai_harness/macroscope/_toolset.py
+++ b/pydantic_ai_harness/macroscope/_toolset.py
@@ -6,7 +6,6 @@ import os
 import shutil
 import signal
 import subprocess
-from collections.abc import Iterable
 from pathlib import Path
 
 import anyio
@@ -82,7 +81,7 @@ def _parse_issue(payload: str) -> MacroscopeIssue | None:
         return None
 
 
-def parse_macroscope_stream(lines: Iterable[str]) -> MacroscopeReview:
+def parse_macroscope_stream(lines: list[str]) -> MacroscopeReview:
     """Parse `macroscope codereview` output lines into a `MacroscopeReview`.
 
     The CLI interleaves a `review_id=` line, one `issue_event=<json>` line per

--- a/pydantic_ai_harness/modal_sandbox/_session.py
+++ b/pydantic_ai_harness/modal_sandbox/_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import math
 import posixpath
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -428,7 +428,7 @@ class ModalSandboxSession:
         return posixpath.join(self._cwd, path)
 
     async def exec(
-        self, argv: Sequence[str], *, timeout: float | None = None, max_output_bytes: int | None = None
+        self, argv: list[str], *, timeout: float | None = None, max_output_bytes: int | None = None
     ) -> ModalSandboxExecResult:
         """Run an argument vector in the sandbox (without a shell) and return its result.
 
@@ -453,9 +453,9 @@ class ModalSandboxSession:
         import modal
 
         if isinstance(argv, str):
-            # A str is a Sequence[str] of characters, so 'ls -la' would splat into
-            # one-character arguments; catch the mistake instead of running garbage.
-            raise TypeError(f'argv must be a sequence of arguments, not a string; got {argv!r}.')
+            # The annotation rules a string out, but an untyped caller can still pass one, and
+            # 'ls -la' iterates into one-character arguments; catch it instead of running garbage.
+            raise TypeError(f'argv must be a list of arguments, not a string; got {argv!r}.')
         if timeout is not None and (not math.isfinite(timeout) or timeout <= 0):
             raise ValueError(f'timeout must be a positive finite number or None, got {timeout!r}.')
         if max_output_bytes is not None and (type(max_output_bytes) is not int or max_output_bytes <= 0):

--- a/pydantic_ai_harness/planning/_capability.py
+++ b/pydantic_ai_harness/planning/_capability.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Literal
 
@@ -100,7 +100,7 @@ class Planning(AbstractCapability[AgentDepsT]):
     inject: bool = True
     """Surface the current plan as a cache-safe tail reminder each turn."""
 
-    tools: Sequence[str] | None = None
+    tools: list[str] | None = None
     """Optional allowlist of tool names to register; `None` registers all of them.
 
     The full surface is `write_plan`, `read_plan`, `add_task`, `update_task_status`,

--- a/pydantic_ai_harness/repo_context/README.md
+++ b/pydantic_ai_harness/repo_context/README.md
@@ -99,7 +99,7 @@ cache-relevant paths separate:
 RepoContext(
     workspace_dir,                  # Path -- the deepest dir the agent works in (required)
     home_dir=None,                  # Path | None -- shallowest dir to stop walk-up at, inclusive
-    filenames=('CLAUDE.md', 'AGENTS.md'),
+    filenames=['CLAUDE.md', 'AGENTS.md'],
     autoload_instructions=True,     # Strategy 1
     expose_inventory_tool=True,     # Strategy 2
     inventory_tool_name='inventory_agent_context',
@@ -107,7 +107,7 @@ RepoContext(
     nested_inject='pointer',        # 'pointer' | 'contents'
     traversal_tool_names=frozenset({'list_directory', 'read_file'}),
     traversal_path_arg='path',
-    asset_roots=('.claude', '.agents', '.codex', '.grok'),
+    asset_roots=['.claude', '.agents', '.codex', '.grok'],
 )
 ```
 

--- a/pydantic_ai_harness/repo_context/_capability.py
+++ b/pydantic_ai_harness/repo_context/_capability.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -79,7 +78,7 @@ class RepoContext(AbstractCapability[AgentDepsT]):
     """The shallowest directory to stop the walk-up at, inclusive. `None` (the
     default) scans only `workspace_dir` -- no walk-up."""
 
-    filenames: Sequence[str] = ('CLAUDE.md', 'AGENTS.md')
+    filenames: list[str] = field(default_factory=lambda: ['CLAUDE.md', 'AGENTS.md'])
     """Instruction filenames to look for, in within-directory precedence order."""
 
     autoload_instructions: bool = True
@@ -105,7 +104,7 @@ class RepoContext(AbstractCapability[AgentDepsT]):
     traversal_path_arg: str = 'path'
     """The tool argument key holding the listed/read path."""
 
-    asset_roots: Sequence[str] = ('.claude', '.agents', '.codex', '.grok')
+    asset_roots: list[str] = field(default_factory=lambda: ['.claude', '.agents', '.codex', '.grok'])
     """Root directories the inventory tool scans, relative to `workspace_dir`."""
 
     _context_files: list[ContextFile] | None = field(default=None, init=False, repr=False, compare=False)

--- a/pydantic_ai_harness/repo_context/_inventory.py
+++ b/pydantic_ai_harness/repo_context/_inventory.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -37,7 +36,7 @@ def _relposix(path: Path, workspace: Path) -> str:
         return path.as_posix()
 
 
-def scan_assets(workspace_dir: Path, asset_roots: Sequence[str]) -> AgentContextInventory:
+def scan_assets(workspace_dir: Path, asset_roots: list[str]) -> AgentContextInventory:
     """Scan `asset_roots` under `workspace_dir`, locating skills, agents, and hooks.
 
     This locates assets only; it does not open or parse SKILL.md, agent `.md`, or

--- a/pydantic_ai_harness/repo_context/_loader.py
+++ b/pydantic_ai_harness/repo_context/_loader.py
@@ -47,7 +47,7 @@ def _walk_dirs(workspace_dir: Path, home_dir: Path | None) -> list[Path]:
 def discover_instruction_files(
     workspace_dir: Path,
     home_dir: Path | None,
-    filenames: Sequence[str],
+    filenames: list[str],
 ) -> list[ContextFile]:
     """Collect instruction files from `home_dir` down to `workspace_dir`.
 
@@ -80,7 +80,7 @@ def discover_instruction_files(
     return found
 
 
-def find_dir_context_file(directory: Path, filenames: Sequence[str]) -> ContextFile | None:
+def find_dir_context_file(directory: Path, filenames: list[str]) -> ContextFile | None:
     """Return the first existing instruction file in `directory`, or `None`."""
     for filename in filenames:
         candidate = directory / filename

--- a/pydantic_ai_harness/repo_context/_toolset.py
+++ b/pydantic_ai_harness/repo_context/_toolset.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from pathlib import Path
 
 from pydantic_ai.tools import AgentDepsT
@@ -14,7 +13,7 @@ from pydantic_ai_harness.repo_context._inventory import AgentContextInventory, s
 class RepoContextToolset(FunctionToolset[AgentDepsT]):
     """Exposes a single tool that reports where the repo's CE assets live."""
 
-    def __init__(self, workspace_dir: Path, asset_roots: Sequence[str], tool_name: str) -> None:
+    def __init__(self, workspace_dir: Path, asset_roots: list[str], tool_name: str) -> None:
         super().__init__()
         self._workspace_dir = workspace_dir
         self._asset_roots = asset_roots

--- a/pydantic_ai_harness/shell/_capability.py
+++ b/pydantic_ai_harness/shell/_capability.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.tools import AgentDepsT
 
+from pydantic_ai_harness._validate import reject_bare_str
 from pydantic_ai_harness.shell._toolset import ShellToolset
 
-_DEFAULT_DENIED_COMMANDS: tuple[str, ...] = (
+_DEFAULT_DENIED_COMMANDS: list[str] = [
     'rm',
     'rmdir',
     'mkfs',
@@ -22,10 +23,10 @@ _DEFAULT_DENIED_COMMANDS: tuple[str, ...] = (
     'halt',
     'poweroff',
     'init',
-)
+]
 
 
-LLM_API_KEY_ENV_PATTERNS: tuple[str, ...] = (
+LLM_API_KEY_ENV_PATTERNS: list[str] = [
     'ANTHROPIC_*',
     'GATEWAY_*',
     'GEMINI_*',
@@ -33,7 +34,7 @@ LLM_API_KEY_ENV_PATTERNS: tuple[str, ...] = (
     'OPENAI_*',
     'OPENROUTER_*',
     'PYDANTIC_AI_GATEWAY_API_KEY',
-)
+]
 """Glob patterns for common LLM provider credentials, for `denied_env_patterns`.
 
 Pass these when an agent runs untrusted commands that must not read the host's
@@ -55,17 +56,17 @@ class Shell(AbstractCapability[AgentDepsT]):
     cwd: str | Path = '.'
     """Working directory for command execution."""
 
-    allowed_commands: Sequence[str] = field(default_factory=list[str])
+    allowed_commands: list[str] = field(default_factory=list[str])
     """If non-empty, only these command names may be executed (allowlist)."""
 
-    denied_commands: Sequence[str] = _DEFAULT_DENIED_COMMANDS
+    denied_commands: list[str] = field(default_factory=lambda: _DEFAULT_DENIED_COMMANDS)
     """These command names are always rejected (denylist).
 
     Defaults to blocking destructive commands (rm, dd, shutdown, etc.).
     Set to an empty list to disable.
     """
 
-    denied_operators: Sequence[str] = field(default_factory=list[str])
+    denied_operators: list[str] = field(default_factory=list[str])
     """Shell operators that are blocked (e.g. '>', '>>', '|' for restrictive mode)."""
 
     default_timeout: float = 30.0
@@ -89,7 +90,7 @@ class Shell(AbstractCapability[AgentDepsT]):
     tokens) out of commands the agent runs.
     """
 
-    denied_env_patterns: Sequence[str] = field(default_factory=list[str])
+    denied_env_patterns: list[str] = field(default_factory=list[str])
     """Glob patterns for environment variable names to strip before spawning.
 
     Follows the `denied_*` naming convention but matches by glob (`fnmatch`,
@@ -101,7 +102,16 @@ class Shell(AbstractCapability[AgentDepsT]):
     """
 
     def __post_init__(self) -> None:
-        """Resolve the built-in denylist according to the selected policy."""
+        """Reject bare strings, then resolve the built-in denylist according to the selected policy."""
+        reject_bare_str(
+            'Shell',
+            (
+                ('allowed_commands', self.allowed_commands, 'command names'),
+                ('denied_commands', self.denied_commands, 'command names'),
+                ('denied_operators', self.denied_operators, 'shell operators'),
+                ('denied_env_patterns', self.denied_env_patterns, 'glob patterns'),
+            ),
+        )
         if self.denied_commands is _DEFAULT_DENIED_COMMANDS:
             self.denied_commands = [] if self.allowed_commands else list(_DEFAULT_DENIED_COMMANDS)
 

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -11,7 +11,7 @@ import signal
 import subprocess
 import tempfile
 import uuid
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping
 from pathlib import Path
 from typing import Any, Concatenate, ParamSpec
 
@@ -23,6 +23,7 @@ from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset, ToolsetTool
 
 from pydantic_ai_harness._output import truncate_tail
+from pydantic_ai_harness._validate import reject_bare_str
 
 _IO_DRAIN_TIMEOUT: float = 2.0
 _KILL_GRACE_PERIOD: float = 2.0
@@ -96,17 +97,27 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         self,
         *,
         cwd: Path,
-        allowed_commands: Sequence[str],
-        denied_commands: Sequence[str],
-        denied_operators: Sequence[str],
+        allowed_commands: list[str],
+        denied_commands: list[str],
+        denied_operators: list[str],
         default_timeout: float,
         max_output_chars: int,
         persist_cwd: bool,
         allow_interactive: bool,
         env: Mapping[str, str] | None = None,
-        denied_env_patterns: Sequence[str] = (),
+        denied_env_patterns: list[str] | None = None,
     ) -> None:
         super().__init__()
+        denied_env_patterns = denied_env_patterns if denied_env_patterns is not None else []
+        reject_bare_str(
+            'ShellToolset',
+            (
+                ('allowed_commands', allowed_commands, 'command names'),
+                ('denied_commands', denied_commands, 'command names'),
+                ('denied_operators', denied_operators, 'shell operators'),
+                ('denied_env_patterns', denied_env_patterns, 'glob patterns'),
+            ),
+        )
         self._cwd = cwd.resolve()
         # The configured starting directory, never mutated by persist_cwd, so
         # `for_run` can hand each run a fresh instance rooted back here.

--- a/pydantic_ai_harness/skills/README.md
+++ b/pydantic_ai_harness/skills/README.md
@@ -248,8 +248,8 @@ for code-defined capabilities.
 Skills(
     directories: str | Path | Sequence[str | Path],
     *,
-    include: Collection[str] | None = None,
-    exclude: Collection[str] | None = None,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
 )
 ```
 

--- a/pydantic_ai_harness/skills/_capability.py
+++ b/pydantic_ai_harness/skills/_capability.py
@@ -44,7 +44,7 @@ class Skills(AbstractCapability[AgentDepsT]):
         self,
         directories: str | Path | Sequence[str | Path],
         *,
-        include: Collection[str],
+        include: list[str],
         exclude: None = None,
     ) -> None: ...
 
@@ -54,15 +54,15 @@ class Skills(AbstractCapability[AgentDepsT]):
         directories: str | Path | Sequence[str | Path],
         *,
         include: None = None,
-        exclude: Collection[str] | None = None,
+        exclude: list[str] | None = None,
     ) -> None: ...
 
     def __init__(
         self,
         directories: str | Path | Sequence[str | Path],
         *,
-        include: Collection[str] | None = None,
-        exclude: Collection[str] | None = None,
+        include: list[str] | None = None,
+        exclude: list[str] | None = None,
     ) -> None:
         """Build a snapshot of the selected Agent Skills.
 

--- a/pydantic_ai_harness/subagents/README.md
+++ b/pydantic_ai_harness/subagents/README.md
@@ -234,7 +234,7 @@ SubAgent(
     agent,                 # AbstractAgent[AgentDepsT, Any] -- the child agent to run
     name=None,             # delegate name; defaults to the agent's own `name`
     description=None,      # prompt-listing description; defaults to the agent's own `description`
-    models=None,           # Sequence[str] -- menu keys this delegate may run on; the first is its default
+    models=None,           # list[str] -- menu keys this delegate may run on; the first is its default
     usage_limits=None,     # per-delegation request/token budget (isolated accounting)
     timeout_seconds=None,  # per-delegation wall-clock budget
     max_calls=None,        # max delegations to this sub-agent per parent run

--- a/pydantic_ai_harness/subagents/_models.py
+++ b/pydantic_ai_harness/subagents/_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from pydantic_ai.models import KnownModelName, Model
@@ -62,7 +62,7 @@ def model_label(model: Model | KnownModelName | str) -> str:
     return model
 
 
-def validate_restriction(agent_name: str, allowed: Sequence[str] | None, menu: Mapping[str, ModelOption]) -> None:
+def validate_restriction(agent_name: str, allowed: list[str] | None, menu: Mapping[str, ModelOption]) -> None:
     """Check one delegate's `SubAgent.models` restriction against the configured menu.
 
     Raises:

--- a/pydantic_ai_harness/subagents/_toolset.py
+++ b/pydantic_ai_harness/subagents/_toolset.py
@@ -79,7 +79,7 @@ class SubAgent(Generic[AgentDepsT]):
     """Description for the system-prompt listing. Defaults to the agent's own
     `description` when unset; a delegate with neither is listed by name alone."""
 
-    models: Sequence[str] | None = None
+    models: list[str] | None = None
     """Which of `SubAgents.models` this delegate may run on, as menu keys, and
     which one it runs on by default: the first key listed. Leave it unset to let
     the parent pick any configured option and to fall back to the delegate's own

--- a/tests/exa/test_exa.py
+++ b/tests/exa/test_exa.py
@@ -148,16 +148,16 @@ def _toolset(
     max_text_chars: int = 10_000,
     text_summary: bool | str = False,
     include_deep_search: bool = False,
-    include_domains: Sequence[str] = (),
-    exclude_domains: Sequence[str] = (),
+    include_domains: list[str] | None = None,
+    exclude_domains: list[str] | None = None,
 ) -> ExaSearchToolset[None]:
     return ExaSearch[None](
         num_results=num_results,
         max_text_chars=max_text_chars,
         text_summary=text_summary,
         include_deep_search=include_deep_search,
-        include_domains=include_domains,
-        exclude_domains=exclude_domains,
+        include_domains=include_domains or [],
+        exclude_domains=exclude_domains or [],
         client=client,
     ).get_toolset()
 

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 from pydantic_ai import Agent
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
@@ -1340,6 +1340,19 @@ class TestFileSystemCapability:
         with pytest.raises(ValueError, match='max_read_lines must be a positive integer'):
             FileSystem(max_read_lines='1000')  # type: ignore[arg-type]
 
+    @pytest.mark.parametrize('field_name', ['allowed_patterns', 'denied_patterns', 'protected_patterns'])
+    def test_bare_string_pattern_rejected(self, field_name: str) -> None:
+        # A bare string is a collection of one-character patterns, which would
+        # leave the allow/deny/protect gate looking configured but not matching.
+        patterns: dict[str, object] = {field_name: '.env'}
+        with pytest.raises(UserError) as exc_info:
+            FileSystem(**patterns)  # type: ignore[arg-type]
+
+        assert str(exc_info.value) == (
+            f'FileSystem.{field_name} takes a collection of glob patterns, not a single string. '
+            "Pass ['.env'] rather than '.env'."
+        )
+
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration(self, tmp_path: Path, anyio_backend: object) -> None:
         if str(anyio_backend) != 'asyncio':
@@ -1349,6 +1362,31 @@ class TestFileSystemCapability:
         agent: Agent[None, str] = Agent(model, capabilities=[FileSystem(root_dir=tmp_path)])
         result = await agent.run('read test.txt')
         assert result.output == 'done'
+
+
+class TestToolsetPatternValidation:
+    @pytest.mark.parametrize('field_name', ['allowed_patterns', 'denied_patterns', 'protected_patterns'])
+    def test_bare_string_pattern_rejected(self, fs_root: Path, field_name: str) -> None:
+        patterns: dict[str, object] = {
+            'allowed_patterns': [],
+            'denied_patterns': [],
+            'protected_patterns': [],
+            field_name: '.env',
+        }
+        with pytest.raises(UserError) as exc_info:
+            FileSystemToolset(
+                root_dir=fs_root,
+                max_read_lines=2000,
+                max_list_results=1000,
+                max_search_results=1000,
+                max_find_results=1000,
+                **patterns,  # type: ignore[arg-type]
+            )
+
+        assert str(exc_info.value) == (
+            f'FileSystemToolset.{field_name} takes a collection of glob patterns, not a single string. '
+            "Pass ['.env'] rather than '.env'."
+        )
 
 
 class TestPatternCanonicalization:

--- a/tests/guardrails/test_detectors.py
+++ b/tests/guardrails/test_detectors.py
@@ -413,9 +413,9 @@ class TestBlockedKeywords:
         assert detector(f'{keyword}x').action == 'allow'
 
     def test_a_bare_string_is_refused(self):
-        """`str` is an `Iterable[str]`, so it would be one keyword per character."""
+        """An untyped caller reaching the runtime guard gets one keyword per character."""
         with pytest.raises(UserError, match='single string'):
-            blocked_keywords('internal-only')
+            blocked_keywords('internal-only')  # pyright: ignore[reportArgumentType]
 
     def test_an_empty_keyword_is_refused(self):
         """An empty pattern matches at position 0 of anything, so it would block every input."""

--- a/tests/guardrails/test_tool_guardrail.py
+++ b/tests/guardrails/test_tool_guardrail.py
@@ -569,7 +569,7 @@ class TestResultGuardOnAFailedTool:
 
 
 class TestConfigurationShape:
-    """A bare string satisfies `Sequence[str]`, and both fields misbehave on one."""
+    """A bare string reaches the runtime guard from untyped callers, and both fields misbehave on one."""
 
     def test_a_bare_string_for_hidden_is_refused(self):
         """`set('danger')` holds six letters, so the tool it names would stay on the wire."""

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -13,7 +13,7 @@ from typing import Any
 
 import pytest
 from pydantic_ai import Agent, RunContext
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
@@ -94,6 +94,40 @@ class TestConstruction:
     def test_non_positive_max_output_chars_rejected(self) -> None:
         with pytest.raises(ValueError, match='max_output_chars must be a positive integer.'):
             _toolset(max_output_chars=0)
+
+
+class TestBareStringRejected:
+    """A bare string is a collection of one-character service names, so the gate would stop matching."""
+
+    @pytest.mark.parametrize('field_name', ['allowed_services', 'denied_services'])
+    def test_capability_rejects_bare_string(self, field_name: str) -> None:
+        with pytest.raises(UserError) as exc_info:
+            LocalStack(**{field_name: 's3'})  # type: ignore[arg-type]
+
+        assert str(exc_info.value) == (
+            f'LocalStack.{field_name} takes a collection of AWS service names, not a single string. '
+            "Pass ['s3'] rather than 's3'."
+        )
+
+    @pytest.mark.parametrize('field_name', ['allowed_services', 'denied_services'])
+    def test_toolset_rejects_bare_string(self, field_name: str) -> None:
+        services: dict[str, object] = {'allowed_services': [], 'denied_services': [], field_name: 's3'}
+        with pytest.raises(UserError) as exc_info:
+            LocalStackToolset[None](
+                endpoint_url='http://localhost:4566',
+                region='us-east-1',
+                access_key_id='test',
+                secret_access_key='test',
+                default_timeout=10.0,
+                max_output_chars=50_000,
+                aws_cli_path='aws',
+                **services,  # type: ignore[arg-type]
+            )
+
+        assert str(exc_info.value) == (
+            f'LocalStackToolset.{field_name} takes a collection of AWS service names, not a single string. '
+            "Pass ['s3'] rather than 's3'."
+        )
 
 
 class TestOutputCap:

--- a/tests/modal_sandbox/test_session.py
+++ b/tests/modal_sandbox/test_session.py
@@ -346,11 +346,11 @@ class TestExec:
         assert result.timed_out is False
 
     async def test_string_argv_rejected(self, fake_modal: FakeModal) -> None:
-        # A str is a Sequence[str] of characters; 'ls -la' would splat into one-character
-        # arguments, so the mistake is caught up front.
+        # An untyped caller can still reach `exec` with a string; 'ls -la' would iterate
+        # into one-character arguments, so the mistake is caught up front.
         async with ModalSandboxSession() as session:
-            with pytest.raises(TypeError, match='argv must be a sequence of arguments'):
-                await session.exec('ls -la')
+            with pytest.raises(TypeError, match='argv must be a list of arguments'):
+                await session.exec('ls -la')  # type: ignore[arg-type]
 
     async def test_non_modal_stream_error_becomes_sandbox_error(self, fake_modal: FakeModal) -> None:
         # Transport failures during stream iteration are not modal.exception.Error; they

--- a/tests/repo_context/test_repo_context.py
+++ b/tests/repo_context/test_repo_context.py
@@ -59,19 +59,19 @@ class TestDiscoverInstructionFiles:
         _write(tmp_path / 'CLAUDE.md', 'root')
         workspace = tmp_path / 'a' / 'b'
         _write(workspace / 'CLAUDE.md', 'leaf')
-        files = discover_instruction_files(workspace, tmp_path, ('CLAUDE.md',))
+        files = discover_instruction_files(workspace, tmp_path, ['CLAUDE.md'])
         assert [f.content for f in files] == ['root', 'leaf']
 
     def test_home_none_only_workspace(self, tmp_path: Path) -> None:
         _write(tmp_path / 'CLAUDE.md', 'root')
         workspace = tmp_path / 'a'
         _write(workspace / 'CLAUDE.md', 'leaf')
-        files = discover_instruction_files(workspace, None, ('CLAUDE.md',))
+        files = discover_instruction_files(workspace, None, ['CLAUDE.md'])
         assert [f.content for f in files] == ['leaf']
 
     def test_home_equals_workspace(self, tmp_path: Path) -> None:
         _write(tmp_path / 'CLAUDE.md', 'only')
-        files = discover_instruction_files(tmp_path, tmp_path, ('CLAUDE.md',))
+        files = discover_instruction_files(tmp_path, tmp_path, ['CLAUDE.md'])
         assert [f.content for f in files] == ['only']
 
     def test_home_not_ancestor_falls_back_to_workspace(self, tmp_path: Path) -> None:
@@ -79,36 +79,36 @@ class TestDiscoverInstructionFiles:
         _write(workspace / 'CLAUDE.md', 'leaf')
         unrelated = tmp_path / 'other'
         unrelated.mkdir()
-        files = discover_instruction_files(workspace, unrelated, ('CLAUDE.md',))
+        files = discover_instruction_files(workspace, unrelated, ['CLAUDE.md'])
         assert [f.content for f in files] == ['leaf']
 
     def test_both_filenames_within_dir_order(self, tmp_path: Path) -> None:
         _write(tmp_path / 'CLAUDE.md', 'claude')
         _write(tmp_path / 'AGENTS.md', 'agents')
-        files = discover_instruction_files(tmp_path, None, ('CLAUDE.md', 'AGENTS.md'))
+        files = discover_instruction_files(tmp_path, None, ['CLAUDE.md', 'AGENTS.md'])
         assert [f.content for f in files] == ['claude', 'agents']
 
     @pytest.mark.skipif(sys.platform == 'win32', reason='symlinks need privileges on Windows')
     def test_symlink_deduped_by_realpath(self, tmp_path: Path) -> None:
         _write(tmp_path / 'CLAUDE.md', 'shared')
         (tmp_path / 'AGENTS.md').symlink_to(tmp_path / 'CLAUDE.md')
-        files = discover_instruction_files(tmp_path, None, ('CLAUDE.md', 'AGENTS.md'))
+        files = discover_instruction_files(tmp_path, None, ['CLAUDE.md', 'AGENTS.md'])
         assert len(files) == 1
 
     def test_identical_content_deduped_by_hash(self, tmp_path: Path) -> None:
         _write(tmp_path / 'CLAUDE.md', 'same')
         workspace = tmp_path / 'a'
         _write(workspace / 'CLAUDE.md', 'same')
-        files = discover_instruction_files(workspace, tmp_path, ('CLAUDE.md',))
+        files = discover_instruction_files(workspace, tmp_path, ['CLAUDE.md'])
         assert [f.content for f in files] == ['same']
 
     def test_missing_files_skipped(self, tmp_path: Path) -> None:
-        files = discover_instruction_files(tmp_path, None, ('CLAUDE.md',))
+        files = discover_instruction_files(tmp_path, None, ['CLAUDE.md'])
         assert files == []
 
     def test_non_utf8_file_does_not_crash(self, tmp_path: Path) -> None:
         (tmp_path / 'CLAUDE.md').write_bytes(b'caf\xe9 instructions')
-        files = discover_instruction_files(tmp_path, None, ('CLAUDE.md',))
+        files = discover_instruction_files(tmp_path, None, ['CLAUDE.md'])
         assert len(files) == 1
         assert 'instructions' in files[0].content
 
@@ -116,16 +116,16 @@ class TestDiscoverInstructionFiles:
 class TestFindDirContextFile:
     def test_first_existing_wins(self, tmp_path: Path) -> None:
         _write(tmp_path / 'AGENTS.md', 'agents')
-        found = find_dir_context_file(tmp_path, ('CLAUDE.md', 'AGENTS.md'))
+        found = find_dir_context_file(tmp_path, ['CLAUDE.md', 'AGENTS.md'])
         assert found is not None
         assert found.content == 'agents'
 
     def test_none_when_absent(self, tmp_path: Path) -> None:
-        assert find_dir_context_file(tmp_path, ('CLAUDE.md',)) is None
+        assert find_dir_context_file(tmp_path, ['CLAUDE.md']) is None
 
     def test_non_utf8_file_does_not_crash(self, tmp_path: Path) -> None:
         (tmp_path / 'CLAUDE.md').write_bytes(b'caf\xe9 instructions')
-        found = find_dir_context_file(tmp_path, ('CLAUDE.md',))
+        found = find_dir_context_file(tmp_path, ['CLAUDE.md'])
         assert found is not None
         assert 'instructions' in found.content
 
@@ -194,7 +194,7 @@ class TestScanAssets:
         _write(tmp_path / '.claude' / 'skills' / 'foo' / 'SKILL.md', 's')
         _write(tmp_path / '.claude' / 'agents' / 'bar.md', 'a')
         _write(tmp_path / '.claude' / 'settings.json', '{}')
-        inv = scan_assets(tmp_path, ('.claude', '.agents', '.codex', '.grok'))
+        inv = scan_assets(tmp_path, ['.claude', '.agents', '.codex', '.grok'])
         by_root = {r.root: r for r in inv.roots}
         claude = by_root['.claude']
         assert claude.exists
@@ -207,12 +207,12 @@ class TestScanAssets:
 
     def test_existing_root_without_settings(self, tmp_path: Path) -> None:
         _write(tmp_path / '.claude' / 'skills' / 'foo' / 'SKILL.md', 's')
-        inv = scan_assets(tmp_path, ('.claude',))
+        inv = scan_assets(tmp_path, ['.claude'])
         assert inv.roots[0].settings is None
         assert inv.roots[0].notes is None
 
     def test_returns_model(self, tmp_path: Path) -> None:
-        assert isinstance(scan_assets(tmp_path, ()), AgentContextInventory)
+        assert isinstance(scan_assets(tmp_path, []), AgentContextInventory)
 
     @pytest.mark.skipif(sys.platform == 'win32', reason='symlinks need privileges on Windows')
     def test_symlinked_asset_escaping_workspace(self, tmp_path: Path) -> None:
@@ -221,7 +221,7 @@ class TestScanAssets:
         link = workspace / '.claude' / 'skills' / 'foo' / 'SKILL.md'
         link.parent.mkdir(parents=True)
         link.symlink_to(outside)
-        inv = scan_assets(workspace, ('.claude',))
+        inv = scan_assets(workspace, ['.claude'])
         claude = inv.roots[0]
         assert claude.exists
         assert len(claude.skills) == 1

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import shlex
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -14,7 +14,7 @@ import anyio
 import pytest
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
@@ -32,7 +32,7 @@ def _env_toolset(
     shell_dir: Path,
     *,
     env: Mapping[str, str] | None = None,
-    denied_env_patterns: Sequence[str] = (),
+    denied_env_patterns: list[str] | None = None,
 ) -> ShellToolset[None]:
     """Build a ShellToolset wired for env-control tests, with safe defaults."""
     return ShellToolset(
@@ -1174,6 +1174,52 @@ class TestShellCapability:
         agent: Agent[None, str] = Agent(model, capabilities=[Shell(cwd=tmp_path)])
         result = await agent.run('run echo hello')
         assert result.output == 'done'
+
+
+_BARE_STRING_FIELDS = [
+    ('allowed_commands', 'rm', 'command names'),
+    ('denied_commands', 'rm', 'command names'),
+    ('denied_operators', '|', 'shell operators'),
+    ('denied_env_patterns', 'OPENAI_*', 'glob patterns'),
+]
+
+
+class TestBareStringRejected:
+    """A bare string is a collection of one-character entries, so each list would stop matching."""
+
+    @pytest.mark.parametrize(('field_name', 'value', 'noun'), _BARE_STRING_FIELDS)
+    def test_capability_rejects_bare_string(self, field_name: str, value: str, noun: str) -> None:
+        with pytest.raises(UserError) as exc_info:
+            Shell(**{field_name: value})  # type: ignore[arg-type]
+
+        assert str(exc_info.value) == (
+            f'Shell.{field_name} takes a collection of {noun}, not a single string. '
+            f'Pass [{value!r}] rather than {value!r}.'
+        )
+
+    @pytest.mark.parametrize(('field_name', 'value', 'noun'), _BARE_STRING_FIELDS)
+    def test_toolset_rejects_bare_string(self, tmp_path: Path, field_name: str, value: str, noun: str) -> None:
+        lists: dict[str, object] = {
+            'allowed_commands': [],
+            'denied_commands': [],
+            'denied_operators': [],
+            'denied_env_patterns': [],
+            field_name: value,
+        }
+        with pytest.raises(UserError) as exc_info:
+            ShellToolset(
+                cwd=tmp_path,
+                default_timeout=10.0,
+                max_output_chars=50_000,
+                persist_cwd=False,
+                allow_interactive=False,
+                **lists,  # type: ignore[arg-type]
+            )
+
+        assert str(exc_info.value) == (
+            f'ShellToolset.{field_name} takes a collection of {noun}, not a single string. '
+            f'Pass [{value!r}] rather than {value!r}.'
+        )
 
 
 async def _tools_offered_to_model(cwd: Path, *, shell_first: bool) -> dict[str, str | None]:

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import Capability
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.models.test import TestModel
 
 from pydantic_ai_harness.coder import DEFAULT_ALLOWED_COMMANDS, Coder, coder_agent
@@ -117,6 +118,18 @@ def test_coder_default_commands_and_empty_allowlist() -> None:
 
     assert default_shell.allowed_commands == DEFAULT_ALLOWED_COMMANDS
     assert empty_shell.allowed_commands == []
+
+
+def test_coder_rejects_bare_string_allowlist() -> None:
+    # A bare string is a collection of one-character command names, so the
+    # allowlist would refuse everything the model tries.
+    with pytest.raises(UserError) as exc_info:
+        Coder(allowed_commands='git')  # type: ignore[arg-type]
+
+    assert str(exc_info.value) == (
+        'Coder.allowed_commands takes a collection of command names, not a single string. '
+        "Pass ['git'] rather than 'git'."
+    )
 
 
 def test_coder_for_agent_preserves_subclass(tmp_path: Path) -> None:

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -66,7 +66,7 @@ def test_lazy_import_presets():
 def test_lazy_import_llm_api_key_env_patterns():
     from pydantic_ai_harness import LLM_API_KEY_ENV_PATTERNS
 
-    assert isinstance(LLM_API_KEY_ENV_PATTERNS, tuple)
+    assert isinstance(LLM_API_KEY_ENV_PATTERNS, list)
     assert 'OPENAI_*' in LLM_API_KEY_ENV_PATTERNS
 
 


### PR DESCRIPTION
`str` satisfies `Sequence[str]`, so a bare string in these public parameters type-checked and then splatted into one-character items. For allow/deny/protect lists that turned a configured policy into one that matches nothing: `Shell(denied_commands='rm')` let `rm` run, `denied_env_patterns='OPENAI_*'` produced a lone `*` pattern that stripped the whole environment, and `FileSystem(denied_patterns='.env')` enforced nothing.

- Annotate public string-collection parameters as `list[str]` across `shell`, `filesystem`, `localstack`, `coder`, `exa`, `repo_context`, and `macroscope`.
- Reject a bare `str` at runtime on the security lists via a shared `reject_bare_str` helper in `pydantic_ai_harness/_validate.py`, extending the `ToolGuardrail.__post_init__` precedent. Ergonomic filters rely on the annotation alone.
- Also narrow the surfaces that already had runtime guards (`ToolGuardrail`, `Skills`, `Planning`, `SubAgent.models`, modal `exec` argv, detector factories): no caller anywhere passes a non-list sequence, so the broad annotations bought nothing except letting the bare-string mistake type-check. Guards stay for untyped callers.
- Record the convention in `AGENTS.md`.
- `DEFAULT_ALLOWED_COMMANDS` and `LLM_API_KEY_ENV_PATTERNS` become lists (were tuples) so the documented `denied_env_patterns=LLM_API_KEY_ENV_PATTERNS` idiom still type-checks.

No behavior change for correct callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)