### PR TITLE
Allow compaction summaries to override model settings

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -339,7 +339,7 @@ agent = Agent(
 )
 ```
 
-`model` accepts a model name or a `Model`; when left `None` it inherits the running agent's model. No token caps are imposed on the summary call. By default `incremental=True` updates the newest existing summary as an anchor. This changes the summary-call prompt from earlier releases; set `incremental=False` to retain the prior regeneration behavior.
+`model` accepts a model name or a `Model`; when left `None` it inherits the running agent's model. No token caps are imposed on the summary call. Pass `model_settings` to give the dedicated summary call settings that differ from defaults carried by that model. The supplied settings merge over the model defaults without mutating the model or the settings dictionary. By default `incremental=True` updates the newest existing summary as an anchor. This changes the summary-call prompt from earlier releases; set `incremental=False` to retain the prior regeneration behavior.
 
 ### Usage accounting
 

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -377,7 +377,9 @@ from the edit point onward -- the next request pays a cache-write. Use `ClearToo
 ## Model inheritance
 
 `SummarizingCompaction(model=...)` accepts a model name or `Model`; when left `None` it inherits the
-running agent's model. No token caps are imposed on the summary call.
+running agent's model. No token caps are imposed on the summary call. Pass `model_settings` to give
+the dedicated summary call settings that differ from defaults carried by that model. The supplied
+settings merge over the model defaults without mutating the model or the settings dictionary.
 
 By default `incremental=True` updates the newest existing summary from a prior compaction as an
 anchor rather than regenerating it from scratch. This changes the summary-call prompt from earlier

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -22,6 +22,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import Model
 from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import RunContext
 
 from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW
@@ -268,6 +269,13 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
     When `None`, inherits the model the request being compacted is going to. Core starts
     that as the run's model, so the two differ only where a capability replaced
     `ModelRequestContext.model`; set this explicitly to pin the summarizer regardless.
+    """
+
+    model_settings: ModelSettings | None = field(default=None, kw_only=True)
+    """Settings for the dedicated summary model call.
+
+    These merge over defaults carried by `model`, allowing the summary call to use a
+    policy that differs from the running agent without mutating the model.
     """
 
     max_messages: int | None = None
@@ -624,6 +632,7 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
         agent: Agent[None, str] = Agent(
             cast('Model[Any] | str', model),
             instructions='You are a context summarization assistant. Extract the most important information from conversations.',
+            model_settings=self.model_settings,
         )
         result = await agent.run(prompt, usage=ctx.usage)
         return result.output.strip()

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -32,6 +32,7 @@ from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameter
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import RunContext
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
 from pydantic_ai.usage import RequestUsage, RunUsage
@@ -722,6 +723,37 @@ class TestCompaction:
         ctx = _make_ctx()
         result = await comp.before_model_request(ctx, rc)
         assert result.messages == messages
+
+    @pytest.mark.anyio
+    async def test_summary_model_settings_override_model_defaults_without_mutation(self, anyio_backend: str):
+        if anyio_backend != 'asyncio':
+            pytest.skip('pydantic-ai Agent execution uses asyncio')
+        observed_settings: list[ModelSettings | None] = []
+
+        def summarize(_messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            observed_settings.append(info.model_settings)
+            return ModelResponse(parts=[TextPart(content='A summary.')])
+
+        model_defaults = ModelSettings(temperature=1.0, max_tokens=4_096)
+        original_model_defaults = model_defaults.copy()
+        model = FunctionModel(summarize, settings=model_defaults)
+        summary_settings = ModelSettings(max_tokens=1_024)
+        original_summary_settings = summary_settings.copy()
+        comp = SummarizingCompaction(
+            model=model,
+            model_settings=summary_settings,
+            max_messages=1,
+            keep_messages=1,
+        )
+
+        await comp.compact(
+            [_user('first'), _assistant('response'), _user('latest')],
+            _make_ctx(),
+        )
+
+        assert observed_settings == [ModelSettings(temperature=1.0, max_tokens=1_024)]
+        assert summary_settings == original_summary_settings
+        assert model_defaults == original_model_defaults
 
     @pytest.mark.anyio
     async def test_compaction_replaces_old_messages(self):


### PR DESCRIPTION
## Summary

- add a keyword-only `model_settings` option to `SummarizingCompaction`
- pass those settings to the dedicated inner summarization `Agent`
- document that summary-call settings merge over model defaults without mutation
- add coverage for override and configuration-isolation behavior

## Why

Some model instances carry default request settings that are appropriate for the main agent but not for a one-shot compaction summary. Because `SummarizingCompaction` creates a dedicated inner `Agent`, callers currently cannot override those defaults for the summary request without mutating the model.

This adds a provider-agnostic public configuration seam while preserving existing behavior when `model_settings` is omitted. One use case is retaining a cache breakpoint for stable summarizer instructions while disabling message-level prompt caching for large, unique conversation history.

It also lets callers independently configure summary-call budgets and provider-specific settings, such as `max_tokens`, `openai_reasoning_effort`, or `anthropic_effort`, without mutating the underlying model.

## Testing

- `pytest tests/compaction -q` — 586 passed, 1 skipped
- `ruff check .`
- `ruff format --check .`
- `pyright pydantic_ai_harness/compaction/_summarizing_compaction.py tests/compaction/test_compaction.py`
