### PR TITLE
Allow release gates to pin `harness-ref`

### DIFF
--- a/.github/workflows/compat-test.yml
+++ b/.github/workflows/compat-test.yml
@@ -28,6 +28,11 @@ on:
         type: string
         required: false
         default: pydantic/pydantic-ai
+      harness-ref:
+        description: 'SHA, branch, or tag of pydantic-ai-harness to test. Release gates pass the latest published tag.'
+        type: string
+        required: false
+        default: main
 
 permissions:
   contents: read
@@ -38,11 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Checkout harness (main)
+      - name: Checkout harness @ ${{ inputs.harness-ref }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: pydantic/pydantic-ai-harness
-          ref: main
+          ref: ${{ inputs.harness-ref }}
           persist-credentials: false
 
       # Check out pydantic-ai into a workspace subdir, then move it OUTSIDE the


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Summary

Add an optional `harness-ref` input to the reusable compatibility workflow. It defaults to `main`, preserving existing callers while allowing a Pydantic AI release gate to test a published Harness tag.

### Boundary notes

- Event/ref: callers provide the Pydantic AI candidate; `harness-ref` selects the Harness revision.
- Checked-out code: the candidate Pydantic AI ref and selected Harness ref.
- Credentials: public repositories only, no secrets, `contents: read`.
- Executable steps: Harness lint, type checking, and tests.
- Conditional jobs and path inputs: unchanged.

## Linked Issue

Closes #651

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior (workflow validation only; no runtime code changes)
- [x] Workflow YAML, formatting, lint, and security validation pass locally
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)
