### PR TITLE
Handle pydantic-ai's new `RetryFeedbackPart`

### DIFF
--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -23,6 +23,7 @@ from pydantic_ai.messages import (
     ModelResponsePart,
     NativeToolCallPart,
     NativeToolReturnPart,
+    RetryFeedbackPart,
     RetryPromptPart,
     SpeechPart,
     SystemPromptPart,
@@ -106,6 +107,16 @@ def _request_part_text(part: ModelRequestPart) -> list[str]:
         # Both are sent in full. The tool-search and capability-load returns subclass
         # `ToolReturnPart`, so they arrive here too.
         return [str(part.content)]
+    elif isinstance(part, RetryFeedbackPart):
+        # Retry feedback that answers no tool call. It is stored model-neutral and rendered at
+        # request time as a mid-conversation system message (or `<system>`-tagged user text where
+        # the provider takes none), so it occupies the window exactly like the `SystemPromptPart`
+        # above. `model_response()` rather than `str(part.content)`: the content is a list of
+        # `ErrorDetails` for a validation failure, and this renders it the way the model sees it.
+        # The per-cause sentence framing it as the harness speaking is chosen during rendering and
+        # so is not counted -- a small fixed undercount, in an estimator that already counts no
+        # tool definitions at all.
+        return [part.model_response()]
     # Control bookkeeping rather than message text: it records which tools became available, and
     # the schemas themselves travel in the request's tool definitions. Those schemas are not free
     # -- this estimator counts no tool definitions at all, so revealing tools mid-run costs

--- a/pydantic_ai_harness/conversation_search/_toolset.py
+++ b/pydantic_ai_harness/conversation_search/_toolset.py
@@ -22,6 +22,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelRequestPart,
+    RetryFeedbackPart,
     RetryPromptPart,
     SpeechPart,
     SystemPromptPart,
@@ -202,6 +203,14 @@ def _format_request_part(part: ModelRequestPart, *, truncate: bool) -> str | Non
     if isinstance(part, RetryPromptPart):
         # A retry or validation-error prompt is worth recalling, so index it in full.
         return f'Retry [{part.tool_name}]: {part.content}'
+    if isinstance(part, RetryFeedbackPart):
+        # The same feedback for a response that answered no particular call -- output validation
+        # failed, an output validator raised, or nothing usable came back. Recalling why a run
+        # changed course is the same want whether or not the retry named a tool, and indexing only
+        # the tool-bound half would make that depend on which part type pydantic-ai happened to
+        # use. Unlike the availability delta below this is prose the model read and acted on, not
+        # bookkeeping. No tool name: this part is never bound to a call.
+        return f'Retry: {part.model_response()}'
     if isinstance(part, SpeechPart):
         # A realtime user turn: index the spoken transcript so speech is searchable, not the
         # raw audio. `transcript` is optional, so an audio-only part contributes no text.

--- a/pydantic_ai_harness/conversation_search/_toolset.py
+++ b/pydantic_ai_harness/conversation_search/_toolset.py
@@ -179,8 +179,13 @@ def _user_prompt_text(part: UserPromptPart) -> str:
     return ' '.join(texts)
 
 
-def _format_request_part(part: ModelRequestPart, *, truncate: bool) -> str | None:
-    """Render one request part to a searchable line, or `None` for non-content parts."""
+def _format_request_part(part: ModelRequestPart, *, truncate: bool) -> str | None:  # noqa: C901
+    """Render one request part to a searchable line, or `None` for non-content parts.
+
+    The complexity waiver covers the exhaustive part-type chain itself, which grows by one branch
+    every time pydantic-ai adds a part; splitting it would separate the branches from the
+    `assert_never` that keeps them exhaustive.
+    """
     if isinstance(part, UserPromptPart):
         content = _user_prompt_text(part)
         if truncate and len(content) > 500:
@@ -205,12 +210,20 @@ def _format_request_part(part: ModelRequestPart, *, truncate: bool) -> str | Non
         return f'Retry [{part.tool_name}]: {part.content}'
     if isinstance(part, RetryFeedbackPart):
         # The same feedback for a response that answered no particular call -- output validation
-        # failed, an output validator raised, or nothing usable came back. Recalling why a run
-        # changed course is the same want whether or not the retry named a tool, and indexing only
-        # the tool-bound half would make that depend on which part type pydantic-ai happened to
-        # use. Unlike the availability delta below this is prose the model read and acted on, not
-        # bookkeeping. No tool name: this part is never bound to a call.
-        return f'Retry: {part.model_response()}'
+        # failed, an output validator raised, or nothing usable came back. Its tool-bound
+        # counterpart is a `ToolReturnPart` carrying `outcome='retried'`, already indexed above, so
+        # skipping this one would make "a retry happened, and here is why" searchable only when the
+        # retry named a tool. Unlike the availability delta below, this text was in the model's
+        # context and shaped what it did next. No tool name: it is never bound to a call.
+        #
+        # `model_response()` renders a validation failure's `ErrorDetails` the way the model was
+        # shown them; `str(part.content)` would put a Python repr in the index. That rendering is a
+        # fenced JSON block per error, so the display excerpt is capped like the branches above it
+        # while the index keeps the full text.
+        feedback = part.model_response()
+        if truncate and len(feedback) > 500:
+            feedback = feedback[:500] + '...'
+        return f'Retry: {feedback}'
     if isinstance(part, SpeechPart):
         # A realtime user turn: index the spoken transcript so speech is searchable, not the
         # raw audio. `transcript` is optional, so an audio-only part contributes no text.

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -2423,11 +2423,15 @@ class TestHelperBranchCoverage:
         # question from what the request costs; a retry and a thinking block stay out of it.
         assert _format_messages(msgs) == ''
 
-    def test_retry_feedback_costs_what_the_system_message_it_renders_into_costs(self):
+    def test_retry_feedback_costs_what_its_feedback_text_costs_as_a_system_prompt(self):
         """It reaches the model as a mid-conversation system message, so it occupies the window.
 
         `content` is a list of error details here, which is why the estimate follows
         `model_response()` rather than `str(content)`: the model is shown the rendered text.
+
+        The per-cause sentence framing it as the harness speaking is added when the model renders
+        the part, so it is outside this equivalence -- a fixed ~10-token undercount, in an
+        estimator that counts no tool definitions at all.
         """
         from pydantic_ai.messages import RetryFeedbackPart
 

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -2423,6 +2423,23 @@ class TestHelperBranchCoverage:
         # question from what the request costs; a retry and a thinking block stay out of it.
         assert _format_messages(msgs) == ''
 
+    def test_retry_feedback_costs_what_the_system_message_it_renders_into_costs(self):
+        """It reaches the model as a mid-conversation system message, so it occupies the window.
+
+        `content` is a list of error details here, which is why the estimate follows
+        `model_response()` rather than `str(content)`: the model is shown the rendered text.
+        """
+        from pydantic_ai.messages import RetryFeedbackPart
+
+        part = RetryFeedbackPart(
+            content=[{'type': 'missing', 'loc': ('name',), 'msg': 'Field required', 'input': {}}],
+            cause='validation_error',
+        )
+        feedback: list[ModelMessage] = [ModelRequest(parts=[part])]
+        rendered: list[ModelMessage] = [ModelRequest(parts=[SystemPromptPart(content=part.model_response())])]
+
+        assert estimate_token_count(feedback) == estimate_token_count(rendered) > 0
+
     def test_a_provider_side_tool_call_and_its_result_are_counted(self):
         """A web search runs on the provider's side and its result still lands in the context."""
         from pydantic_ai.messages import NativeToolCallPart, NativeToolReturnPart

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -24,6 +24,7 @@ from pydantic_ai.messages import (
     ModelResponse,
     NativeToolCallPart,
     NativeToolReturnPart,
+    RetryFeedbackPart,
     RetryPromptPart,
     SystemPromptPart,
     TextContent,
@@ -2523,8 +2524,6 @@ class TestHelperBranchCoverage:
         the part, so it is outside this equivalence -- a fixed ~10-token undercount, in an
         estimator that counts no tool definitions at all.
         """
-        from pydantic_ai.messages import RetryFeedbackPart
-
         part = RetryFeedbackPart(
             content=[{'type': 'missing', 'loc': ('name',), 'msg': 'Field required', 'input': {}}],
             cause='validation_error',

--- a/tests/conversation_search/test_conversation_search.py
+++ b/tests/conversation_search/test_conversation_search.py
@@ -20,6 +20,7 @@ from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
     ModelResponse,
+    RetryFeedbackPart,
     RetryPromptPart,
     SpeechPart,
     SystemPromptPart,
@@ -748,6 +749,28 @@ class TestSearchScope:
         assert 'Tool [readfile]' in rendered
         assert 'Retry [readfile]: please retry' in rendered  # RetryPromptPart is searchable
         assert '...' in rendered  # truncation applied to the long tool return / args
+
+    async def test_retry_feedback_is_indexed(self) -> None:
+        """A retry that named no tool is recalled like one that did.
+
+        Why a run changed course is the same thing worth finding whether or not the retry
+        answered a particular call, so indexing only the tool-bound half would make recall
+        depend on which part type pydantic-ai reached for.
+        """
+        messages: list[ModelMessage] = [
+            ModelRequest(
+                parts=[
+                    UserPromptPart(content='mango question'),
+                    RetryFeedbackPart(content='the mango field is required', cause='validation_error'),
+                ]
+            ),
+            ModelResponse(parts=[TextPart(content='mango answer')]),
+        ]
+        source = _StubSource({'r1': messages})
+
+        rendered = await _search(source, 'mango')
+
+        assert 'Retry: the mango field is required' in rendered
 
     async def test_tool_availability_delta_is_not_indexed(self) -> None:
         """Tool-list bookkeeping is not conversation content, so it contributes no line.

--- a/tests/conversation_search/test_conversation_search.py
+++ b/tests/conversation_search/test_conversation_search.py
@@ -36,6 +36,7 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
+from pydantic_core import ErrorDetails
 
 from pydantic_ai_harness import HarnessDeprecationWarning
 from pydantic_ai_harness.compaction import SlidingWindowCompaction, SummarizingCompaction
@@ -761,7 +762,10 @@ class TestSearchScope:
             ModelRequest(
                 parts=[
                     UserPromptPart(content='mango question'),
-                    RetryFeedbackPart(content='the mango field is required', cause='validation_error'),
+                    RetryFeedbackPart(
+                        content=[{'type': 'missing', 'loc': ('mango',), 'msg': 'Field required', 'input': {}}],
+                        cause='validation_error',
+                    ),
                 ]
             ),
             ModelResponse(parts=[TextPart(content='mango answer')]),
@@ -770,7 +774,31 @@ class TestSearchScope:
 
         rendered = await _search(source, 'mango')
 
-        assert 'Retry: the mango field is required' in rendered
+        # `model_response()`, not `str(part.content)`: the latter would index a Python repr of the
+        # error list rather than the rendering the model was shown.
+        assert 'Retry: ' in rendered
+        assert 'mango' in rendered
+        assert "{'type': 'missing'" not in rendered
+
+    async def test_retry_feedback_truncates_but_stays_searchable(self) -> None:
+        """A validation failure renders one fenced JSON block per error, so it can run long.
+
+        The display excerpt is capped like the other content branches while the index keeps the
+        full text, so a term past the cutoff still matches.
+        """
+        errors: list[ErrorDetails] = [
+            {'type': 'missing', 'loc': (f'field_{i}',), 'msg': 'Field required', 'input': {}} for i in range(40)
+        ]
+        errors.append({'type': 'missing', 'loc': ('rambutan',), 'msg': 'Field required', 'input': {}})
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[RetryFeedbackPart(content=errors, cause='validation_error')]),
+        ]
+        source = _StubSource({'r1': messages})
+
+        rendered = await _search(source, 'rambutan')
+
+        assert 'Retry: ' in rendered
+        assert '...' in rendered
 
     async def test_tool_availability_delta_is_not_indexed(self) -> None:
         """Tool-list bookkeeping is not conversation content, so it contributes no line.


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

David has not reviewed the code; the two decisions below are AI-made and are the thing worth reviewing.

Companion to **pydantic/pydantic-ai#7353**, which splits `RetryPromptPart` by what the retry answers: one against a tool call becomes `ToolReturnPart(outcome='retried')`, one that answers nothing becomes a new `RetryFeedbackPart`. The new part lands in two `assert_never` chains here — the signal they were written to give.

## The two chains got different answers

They ask different questions, so they were decided separately rather than one pattern-matched onto the other.

**`compaction/_shared.py` — count it.** The question is what text occupies the model's context window. `RetryFeedbackPart` is stored model-neutral and rendered at request time as a mid-conversation system message (or `<system>`-tagged user text where the provider takes none), so it costs the window exactly like the `SystemPromptPart` branch above it. Not counting it would under-estimate and compact late.

It counts `model_response()` rather than `str(part.content)`: a validation failure carries a list of `ErrorDetails`, and the model is shown them rendered. The per-cause sentence framing it as the harness speaking is chosen during rendering, so it isn't counted — a small fixed undercount, in an estimator that already counts no tool definitions at all.

**`conversation_search/_toolset.py` — index it.** The question is whether a part reads as conversation worth recalling. The neighbouring `RetryPromptPart` branch already answers yes for the tool-bound half ("worth recalling, so index it in full"). Why a run changed course is the same thing worth finding whether or not the retry named a tool, so indexing only one half would make recall depend on which part type pydantic-ai reached for — an artifact of the split, not a property of the text. And unlike `ToolAvailabilityDeltaPart` directly below, this is prose the model read and acted on, not tool-list bookkeeping.

Rendered as `Retry: {model_response()}`, with no tool name, since the part is never bound to a call. The display excerpt truncates at 500 like every other content-bearing branch while the index keeps the full text — a `validation_error` renders one fenced JSON block per error, so it is the branch most likely to run long.

## CI is red, and cannot be green yet

`RetryFeedbackPart` is imported at module scope in two runtime modules, and it exists only on pydantic-ai#7353. So this is not a typecheck-only artifact — `lint`, `test` (resolves the lock at `pydantic-ai-slim==2.28.0`), `test-floor` (`--resolution lowest-direct`, same 2.28.0), `test-latest` (latest published, still no such class) and `coverage` all fail on `ImportError`. Please don't re-triage it as a lint quirk.

This is the [#586](https://github.com/pydantic/pydantic-ai-harness/pull/586) shape — handling plus a floor bump to the release that introduced the part — except the release doesn't exist yet, so `uv.lock` can't name it.

**Owed once pydantic-ai ships the part:**

1. Bump the `pydantic-ai-slim` floor to that release and relock.
2. Fix the stale comment above the floor in `pyproject.toml`: it still justifies the pin entirely in terms of `ToolAvailabilityDeltaPart` landing in 2.23.0, while the value has read `>=2.28.0` since #586 bumped it without touching the comment.
3. Consider hoisting `test_compaction.py`'s function-local import to module scope, which is what #579's review did once its floor guaranteed the class.

Verified locally against the actual target instead, with pydantic-ai#7353 installed editable: the type checker reports no errors, `tests/compaction` + `tests/conversation_search` pass (645 tests), and both changed modules report 100% coverage with no partial branches.

## Ordering

pydantic-ai#7353's `harness compat` check runs this repo's `main`, so it stays red until this merges; this PR's own jobs stay red until pydantic-ai releases the part. One of the two has to land red — on the #586 precedent that is pydantic-ai first, then the floor bump here.
