### PR TITLE
Add a `Further reading` section to the `PlaywrightBrowser` docs and README

### DIFF
--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -490,6 +490,17 @@ egress firewall, or front it with a proxy, and pair it with the harness's
 tool-approval hooks for consequential actions. Treat these as defense in depth,
 not a guarantee.
 
+## Further reading
+
+- [Browser automation with Pydantic-AI + Playwright](https://techcommunity.microsoft.com/blog/azuredevcommunityblog/browser-automation-with-pydantic-ai--playwright/4547971) (Microsoft) -- this
+  capability driving a manual QA pass over a live site, wired to Microsoft
+  Foundry models, with the run's OpenTelemetry traces.
+- [Browser Use](browser-use.md) -- the other browser capability. Each runs its
+  own browser, so give an agent one or the other.
+- [Playwright for Python](https://playwright.dev/python/) -- the automation
+  library underneath, and the reference for selector syntax.
+- [Capabilities](/ai/capabilities/overview/)
+
 ## API reference
 
 ::: pydantic_ai_harness.playwright.PlaywrightBrowser

--- a/pydantic_ai_harness/playwright/README.md
+++ b/pydantic_ai_harness/playwright/README.md
@@ -480,3 +480,14 @@ For untrusted-input scenarios, run the browser in a container or VM with an
 egress firewall, or front it with a proxy, and pair it with the harness's
 tool-approval hooks for consequential actions. Treat these as defense in depth,
 not a guarantee.
+
+## Further reading
+
+- [Browser automation with Pydantic-AI + Playwright](https://techcommunity.microsoft.com/blog/azuredevcommunityblog/browser-automation-with-pydantic-ai--playwright/4547971) (Microsoft) -- this
+  capability driving a manual QA pass over a live site, wired to Microsoft
+  Foundry models, with the run's OpenTelemetry traces.
+- [Browser Use](../browser_use/README.md) -- the other browser capability. Each
+  runs its own browser, so give an agent one or the other.
+- [Playwright for Python](https://playwright.dev/python/) -- the automation
+  library underneath, and the reference for selector syntax.
+- [Pydantic AI capabilities](https://ai.pydantic.dev/capabilities/)


### PR DESCRIPTION
Closes #649.

`docs/playwright.md` and `pydantic_ai_harness/playwright/README.md` ran to the API reference and stopped. Other capability pages close with **Further reading** (`code_mode`, `dynamic_workflow`), so this gives `PlaywrightBrowser` the same ending.

The external link is Pamela Fox's write-up, published today, of [pamelafox/pydanticai-playwright-agent](https://github.com/pamelafox/pydanticai-playwright-agent): the capability driving a manual QA pass over a live site against Microsoft Foundry models, with the run's OpenTelemetry traces. It is the worked example the docs did not have.

The other three entries point at what a reader hits next: `BrowserUse` (with the pick-one framing both pages already carry), the Playwright Python docs for selector syntax, and the capabilities overview.

Link forms follow each surface: the docs page uses `browser-use.md` and `/ai/capabilities/overview/`, the README uses `../browser_use/README.md` and the absolute docs URL, matching `code_mode` and `dynamic_workflow`.

Docs only. `tests/test_docs_parity.py` passes.
