### PR TITLE
Expose upstream `AbsurdDurability` through Harness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -241,12 +241,13 @@ jobs:
       # newer pydantic-ai exists this step would fail rather than test it.
       - run: |
           env -u UV_LOCKED uv lock \
+            --upgrade-package pydantic-ai \
             --upgrade-package pydantic-ai-slim \
             --upgrade-package pydantic-graph
       - run: uv sync --locked --group dev --all-extras
       - run: uv run --no-sync pytest
 
-  # Guard the pymongo-free import path. The `test` matrix's slim job installs the
+  # Guard the optional-dependency-free import path. The `test` matrix's slim job installs the
   # `dev` group, which carries `mongomock-motor` -- and that pulls Motor/PyMongo
   # in transitively, so even "slim" has pymongo present. This job installs the
   # base package alone (no groups, no extras), so a capability that imports
@@ -267,12 +268,13 @@ jobs:
 
       - run: uv sync --locked --no-default-groups
 
-      # `find_spec` assertion keeps the smoke test honest: if a base dependency
-      # ever pulls pymongo back in, this fails loudly rather than passing while
-      # testing nothing.
+      # `find_spec` assertions keep the smoke test honest: if a base dependency
+      # ever pulls an optional package back in, this fails loudly rather than
+      # passing while testing nothing.
       - run: >
           uv run --no-sync python -c "import importlib.util;
           assert importlib.util.find_spec('pymongo') is None, 'base install must not have pymongo, or this smoke test no longer guards the lazy-import path';
+          assert importlib.util.find_spec('pydantic_ai_absurd') is None, 'base install must not have pydantic-ai-absurd';
           import pydantic_ai_harness;
           import pydantic_ai_harness.step_persistence;
           import pydantic_ai_harness.media"

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Outside the loop: how runs persist, survive failures, and get observed and confi
 | Capability | Package | What it does |
 |---|---|---|
 | [Durable execution](https://ai.pydantic.dev/capabilities/durable_execution/overview/) | Core | Runs that survive restarts and failures on [Temporal](https://ai.pydantic.dev/capabilities/durable_execution/temporal/), [DBOS](https://ai.pydantic.dev/capabilities/durable_execution/dbos/), or [Prefect](https://ai.pydantic.dev/capabilities/durable_execution/prefect/), with [Restate](https://ai.pydantic.dev/capabilities/durable_execution/restate/), [Kitaru](https://ai.pydantic.dev/capabilities/durable_execution/kitaru/), and [Airflow](https://ai.pydantic.dev/capabilities/durable_execution/airflow/) integrations |
+| [Absurd Durability](pydantic_ai_harness/absurd/) | Harness | Re-export the `pydantic-ai-absurd` durability integration for checkpointed Pydantic AI agent runs |
 | [Step Persistence](pydantic_ai_harness/step_persistence/) | Harness | Save, restore, resume (`continue_run`), and fork (`fork_run`) runs; file/SQLite/Mongo backends |
 | [Instrumentation](https://ai.pydantic.dev/capabilities/instrumentation/) | Core | OpenTelemetry GenAI spans for every model and tool call; the raw material for [Logfire](https://pydantic.dev/logfire) traces |
 | [Managed Prompt](pydantic_ai_harness/logfire/) | Harness | Back instructions with a [Logfire](https://pydantic.dev/logfire)-managed prompt; version and roll out without redeploying |

--- a/docs/absurd.md
+++ b/docs/absurd.md
@@ -1,0 +1,41 @@
+---
+title: Absurd Durability
+description: Make Pydantic AI agents durable with the pydantic-ai-absurd integration.
+---
+
+# Absurd Durability
+
+`AbsurdDurability` makes a Pydantic AI agent durable when it runs inside an
+Absurd task. Install the optional dependency and add the capability to an
+agent when its model calls and tool calls should resume from Absurd
+checkpoints after a worker restart.
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/absurd/)
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
+
+## Installation
+
+```bash
+uv add "pydantic-ai-harness[absurd]"
+```
+
+## Usage
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import AbsurdDurability
+
+agent = Agent(
+    'openai:gpt-5.6-sol',
+    name='worker',
+    capabilities=[AbsurdDurability()],
+)
+```
+
+Import `AbsurdDurability` from either `pydantic_ai_harness` or
+`pydantic_ai_harness.absurd`. Import `AbsurdParallelExecutionMode` only from
+`pydantic_ai_harness.absurd`. Both are the exact objects from
+[`pydantic-ai-absurd`](https://pypi.org/project/pydantic-ai-absurd/).
+The implementation, task integration, and checkpoint semantics all come from
+that package. Harness does not wrap or duplicate the durability runtime.

--- a/docs/index.md
+++ b/docs/index.md
@@ -239,6 +239,7 @@ Outside the loop: how runs persist, survive failures, and get observed and confi
 | Capability | Package | What it does |
 |---|---|---|
 | [Durable execution](/ai/capabilities/durable_execution/overview/) | Core | Runs that survive restarts and failures on [Temporal](/ai/capabilities/durable_execution/temporal/), [DBOS](/ai/capabilities/durable_execution/dbos/), or [Prefect](/ai/capabilities/durable_execution/prefect/), with [Restate](/ai/capabilities/durable_execution/restate/), [Kitaru](/ai/capabilities/durable_execution/kitaru/), and [Airflow](/ai/capabilities/durable_execution/airflow/) integrations |
+| [Absurd Durability](absurd.md) | Harness | Re-export the `pydantic-ai-absurd` durability integration for checkpointed Pydantic AI agent runs |
 | [Step Persistence](step-persistence.md) | Harness | Save, restore, resume (`continue_run`), and fork (`fork_run`) runs; file/SQLite/Mongo backends |
 | [Instrumentation](/ai/capabilities/instrumentation/) | Core | OpenTelemetry GenAI spans for every model and tool call; the raw material for [Logfire](https://pydantic.dev/logfire) traces |
 | [Managed Prompt](managed-prompt.md) | Harness | Back instructions with a [Logfire](https://pydantic.dev/logfire)-managed prompt; version and roll out without redeploying |

--- a/pydantic_ai_harness/__init__.py
+++ b/pydantic_ai_harness/__init__.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from ._warn import HarnessDeprecationWarning
 
 if TYPE_CHECKING:
+    from .absurd import AbsurdDurability
     from .advisor import Advisor
     from .browser_use import BrowserUse
     from .capability_creation import CapabilityCreation
@@ -58,6 +59,7 @@ if TYPE_CHECKING:
     from .youdotcom import YouResearch, YouSearch
 
 __all__ = [
+    'AbsurdDurability',
     'Advisor',
     'BrowserUse',
     'CapabilityCreation',
@@ -116,6 +118,7 @@ __all__ = [
 ]
 
 _CAPABILITY_EXPORTS = {
+    'AbsurdDurability': 'absurd',
     'Advisor': 'advisor',
     'BrowserUse': 'browser_use',
     'CapabilityCreation': 'capability_creation',

--- a/pydantic_ai_harness/absurd/README.md
+++ b/pydantic_ai_harness/absurd/README.md
@@ -1,0 +1,32 @@
+# Absurd Durability
+
+`AbsurdDurability` makes a Pydantic AI agent durable when it runs inside an
+Absurd task. Install the optional dependency and add the capability to an
+agent when its model calls and tool calls should resume from Absurd
+checkpoints after a worker restart.
+
+```bash
+uv add "pydantic-ai-harness[absurd]"
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import AbsurdDurability
+
+agent = Agent(
+    'openai:gpt-5.6-sol',
+    name='worker',
+    capabilities=[AbsurdDurability()],
+)
+```
+
+Import `AbsurdDurability` from either `pydantic_ai_harness` or
+`pydantic_ai_harness.absurd`. Import `AbsurdParallelExecutionMode` only from
+`pydantic_ai_harness.absurd`. Both are the exact objects from
+[`pydantic-ai-absurd`](https://pypi.org/project/pydantic-ai-absurd/).
+The implementation, task integration, and checkpoint semantics all come from
+that package. Harness does not wrap or duplicate the durability runtime.
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](../../README.md#version-policy).
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/absurd/)

--- a/pydantic_ai_harness/absurd/__init__.py
+++ b/pydantic_ai_harness/absurd/__init__.py
@@ -1,0 +1,13 @@
+"""Expose the `pydantic-ai-absurd` durability capability through Harness."""
+
+from importlib.util import find_spec
+
+if find_spec('pydantic_ai_absurd') is None:
+    raise ImportError(
+        'pydantic-ai-absurd is required for AbsurdDurability. Install it with: '
+        'pip install "pydantic-ai-harness[absurd]"'
+    )
+
+from pydantic_ai_absurd import AbsurdDurability, AbsurdParallelExecutionMode
+
+__all__ = ['AbsurdDurability', 'AbsurdParallelExecutionMode']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ modal = [
 dynamic-workflow = [
     "pydantic-monty>=0.0.19",
 ]
+absurd = [
+    "pydantic-ai-absurd>=0.8.0,<0.9.0",
+]
 acp = [
     # The SDK breaks across minors, so cap per minor.
     "agent-client-protocol>=0.11,<0.12",
@@ -152,13 +155,17 @@ style = 'pep440'
 bump = true
 
 [tool.uv]
-# `browser-use` pins provider SDKs to exact versions far below the floors `pydantic-ai-slim`
-# declares (`anthropic==0.76.0`, `openai==2.16.0`), so they only resolve together under an
+# `browser-use` pins provider SDKs to exact versions far below the floors
+# `pydantic-ai-slim` declares (`anthropic==0.76.0`, `google-genai==1.65.0`,
+# `openai==2.16.0`). They only resolve together under an
 # override -- browser-use then runs against SDKs newer than it pins. That is deliberate and
 # one-way: keeping pydantic-ai's floors current outranks tracking browser-use, whose exact-pin
 # policy has open, unaddressed resolution conflicts upstream (browser-use/browser-use#4824 and
 # #4877). When a floor can no longer be overridden without breaking browser-use, the extra
 # yields, not the floor.
+# The `google-genai` and `google-auth` overrides are also required when the
+# optional Absurd integration pulls in full `pydantic-ai`, whose Google extra
+# conflicts with browser-use's exact pins.
 #
 # An override *replaces* every requirement on the package it names, so it erases upper bounds
 # too, and `lowest-direct` resolves `pydantic-ai-slim` to its floor while taking provider SDKs
@@ -166,7 +173,12 @@ bump = true
 # floor predates: `anthropic>=1` is built on HTTPX2, and slim hands it an `httpx2.AsyncClient`
 # only from the release that raises its own floor to match. Move this bound together with the
 # `pydantic-ai-slim` floor below.
-override-dependencies = ['anthropic>=0.108.0,<1', 'openai>=2.45.0']
+override-dependencies = [
+    'anthropic>=0.108.0,<1',
+    'google-auth>=2.56.0',
+    'google-genai>=2.18.0',
+    'openai>=2.45.0',
+]
 
 
 [tool.hatch.build.targets.wheel]

--- a/tests/absurd/__init__.py
+++ b/tests/absurd/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Absurd durability integration."""

--- a/tests/absurd/test_absurd.py
+++ b/tests/absurd/test_absurd.py
@@ -1,0 +1,37 @@
+"""Tests for the upstream `pydantic-ai-absurd` integration."""
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+pytest.importorskip('pydantic_ai_absurd')
+
+from pydantic_ai_absurd import AbsurdDurability as UpstreamAbsurdDurability
+from pydantic_ai_absurd import AbsurdParallelExecutionMode as UpstreamAbsurdParallelExecutionMode
+
+import pydantic_ai_harness
+from pydantic_ai_harness.absurd import AbsurdDurability, AbsurdParallelExecutionMode
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+class TestAbsurdIntegration:
+    def test_reexports_upstream_objects(self) -> None:
+        assert AbsurdDurability is UpstreamAbsurdDurability
+        assert AbsurdParallelExecutionMode is UpstreamAbsurdParallelExecutionMode
+
+    def test_root_lazy_export_is_the_upstream_object(self) -> None:
+        assert pydantic_ai_harness.AbsurdDurability is UpstreamAbsurdDurability
+
+    async def test_composes_with_named_test_model_agent(self) -> None:
+        agent = Agent(TestModel(), name='harness-test', capabilities=[AbsurdDurability()])
+
+        result = await agent.run('hello')
+
+        assert agent.name == 'harness-test'
+        assert result.output == 'success (no tool calls)'

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -140,6 +140,7 @@ _CAPABILITY_PAGE_META = {
     'tool-output-limits.md': ('tool_output_limits', 'Tool Output Limits'),
     'warn-on-cache-busts.md': ('warn_on_cache_busts', 'Warn On Cache Busts'),
     'step-persistence.md': ('step_persistence', 'Step Persistence'),
+    'absurd.md': ('absurd', 'Absurd Durability'),
     'conversation-search.md': ('conversation_search', 'Conversation Search'),
     'media.md': ('media', 'Media Externalization'),
     'subagents.md': ('subagents', 'Subagents'),

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,21 @@ pydantic-evals = false
 [manifest]
 overrides = [
     { name = "anthropic", specifier = ">=0.108.0,<1" },
+    { name = "google-auth", specifier = ">=2.56.0" },
+    { name = "google-genai", specifier = ">=2.18.0" },
     { name = "openai", specifier = ">=2.45.0" },
+]
+
+[[package]]
+name = "absurd-sdk"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "psycopg", extra = ["binary"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/6a/2d4199ddc3d846ba13c51aa9c8614b9ee42a5af5144ef456ef11f4f6aa20/absurd_sdk-0.5.0.tar.gz", hash = "sha256:b22fbe8d10f649d0ed427ba16d885a4a452e4240f412591e7f087fe8584a6f00", size = 14973, upload-time = "2026-08-04T13:06:40.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/12/0d1c4e23dc00069a4666fc25c165514657fc62eb723a7bee3ce22ef416ae/absurd_sdk-0.5.0-py3-none-any.whl", hash = "sha256:a21465deaf159ba29ab4d15d87f429ae5dcf6f0e3098bce11ae9bc3e267fd03a", size = 15407, upload-time = "2026-08-04T13:06:39.406Z" },
 ]
 
 [[package]]
@@ -1723,21 +1737,15 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.48.0"
+version = "2.56.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
-    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
-]
-
-[package.optional-dependencies]
-requests = [
-    { name = "requests", version = "2.33.0", source = { registry = "https://pypi.org/simple" } },
+    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
 ]
 
 [[package]]
@@ -1768,23 +1776,27 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.65.0"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "distro" },
-    { name = "google-auth", extra = ["requests"] },
+    { name = "google-auth" },
     { name = "httpx" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" } },
-    { name = "requests", version = "2.33.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "requests", version = "2.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sniffio" },
     { name = "tenacity" },
     { name = "typing-extensions" },
-    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/f9/cc1191c2540d6a4e24609a586c4ed45d2db57cfef47931c139ee70e5874a/google_genai-1.65.0.tar.gz", hash = "sha256:d470eb600af802d58a79c7f13342d9ea0d05d965007cae8f76c7adff3d7a4750", size = 497206, upload-time = "2026-02-26T00:20:33.824Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/1a/a834dfed90cf32dba900b533a1d14dcdefbda398bda5661d2a5a60fdc9fc/google_genai-2.19.0.tar.gz", hash = "sha256:d8f4126643793a7de230c396bcd142d21c948c8bb57507580e152549a7a41d9d", size = 659496, upload-time = "2026-08-19T23:05:43.276Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/3c/3fea4e7c91357c71782d7dcaad7a2577d636c90317e003386893c25bc62c/google_genai-1.65.0-py3-none-any.whl", hash = "sha256:68c025205856919bc03edb0155c11b4b833810b7ce17ad4b7a9eeba5158f6c44", size = 724429, upload-time = "2026-02-26T00:20:32.186Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e8/de0accd8cd004cf11252ca53fc5c3dda59bcf1856abfc7609842ceba7363/google_genai-2.19.0-py3-none-any.whl", hash = "sha256:36e0326dd886b52ef765be4c46042732b46b21f637abbe060e3db7c3de23974c", size = 1051056, upload-time = "2026-08-19T23:05:41.462Z" },
 ]
 
 [[package]]
@@ -3860,6 +3872,32 @@ email = [
 ]
 
 [[package]]
+name = "pydantic-ai"
+version = "2.31.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic-ai-slim", extra = ["anthropic", "cli", "evals", "google", "logfire", "mcp", "openai", "retries", "web"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/5c/cd8bc734394b671de56b4b5ef51b8b0c19a40f7e10c7597fea3b2952efb0/pydantic_ai-2.31.1.tar.gz", hash = "sha256:2d2ba6f71b2665e12cf59113f4a2dab684def3ff72a5ff12069dab9b13fb7c4d", size = 23062, upload-time = "2026-08-18T03:39:50.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/45/39ea151b0c611450ffab5922e8626deecf0d27af200d1834f2ca0760c01f/pydantic_ai-2.31.1-py3-none-any.whl", hash = "sha256:ff3428ee3837784f9602091acb92900b39b3499a1f19d89829cae17a331e5805", size = 9340, upload-time = "2026-08-18T03:39:43.416Z" },
+]
+
+[[package]]
+name = "pydantic-ai-absurd"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absurd-sdk" },
+    { name = "pydantic-ai" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/c1/cc45f268e9b6638c8ffd285578875bbae11b035f15e22179c6556103edb2/pydantic_ai_absurd-0.8.0.tar.gz", hash = "sha256:53057c3bb3db9815fcf2f0a97271a3ffa0054322edf3a93593796f0df9b18162", size = 12537, upload-time = "2026-08-20T06:38:52.82Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/f5/e2cca131ae20372a66c503f026d51f3d1d442878e60d0faf0ad3969fd589/pydantic_ai_absurd-0.8.0-py3-none-any.whl", hash = "sha256:91d643c6a260fc04df02271a25bfe700bd1d81460c437ac38a18fbd2e8474c58", size = 16251, upload-time = "2026-08-20T06:38:51.839Z" },
+]
+
+[[package]]
 name = "pydantic-ai-harness"
 source = { editable = "." }
 dependencies = [
@@ -3869,6 +3907,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+absurd = [
+    { name = "pydantic-ai-absurd" },
+]
 acp = [
     { name = "agent-client-protocol" },
 ]
@@ -3969,6 +4010,7 @@ requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=4.31.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.0" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.61.0" },
+    { name = "pydantic-ai-absurd", marker = "extra == 'absurd'", specifier = ">=0.8.0,<0.9.0" },
     { name = "pydantic-ai-slim", specifier = ">=2.28.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.28.0" },
     { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.28.0" },
@@ -3988,7 +4030,7 @@ requires-dist = [
     { name = "stackone-defender", extras = ["onnx"], marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender-ml'", specifier = ">=0.7.3,<0.8" },
     { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.1,<4" },
 ]
-provides-extras = ["acp", "anthropic", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
+provides-extras = ["absurd", "acp", "anthropic", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4015,7 +4057,7 @@ lint = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.28.0"
+version = "2.31.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4030,9 +4072,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/3b/617ef9610a181eb9fc8014c3c0569f0f6bb1fccc93b68a726b1632c5e7e2/pydantic_ai_slim-2.28.0.tar.gz", hash = "sha256:46e8606831efbff8cc153ea112242d5057efe0dc3de2f90363c3dec1b3af5844", size = 1184793, upload-time = "2026-08-12T02:16:47.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/9d/a100fed1873151d930c45ed4e394647ba4d0bad5794d24d384b20dad3bad/pydantic_ai_slim-2.31.1.tar.gz", hash = "sha256:f04611e65e9a619b077732651240753cfb058bd844bd3c4e1eea549a48d38376", size = 1214403, upload-time = "2026-08-18T03:39:52.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/96/6d6b896ed32ca4cce03d55ac8e576f232758cd7b3d5755f3ddb4ec2527c0/pydantic_ai_slim-2.28.0-py3-none-any.whl", hash = "sha256:a3e0a67b1f63860fdbb0fa28eba0202391917bbe15183f8fbefc42fe939adb79", size = 1401259, upload-time = "2026-08-12T02:16:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/76/90841be18ff357a39c27d5bee5246af6bb71f13399b55ab318c4c32cc4c8/pydantic_ai_slim-2.31.1-py3-none-any.whl", hash = "sha256:4647d801c5febbd150203d130ddff6db2c481675626b648653e832f419609702", size = 1432432, upload-time = "2026-08-18T03:39:45.947Z" },
 ]
 
 [package.optional-dependencies]
@@ -4053,6 +4095,15 @@ dbos = [
 duckduckgo = [
     { name = "ddgs" },
 ]
+evals = [
+    { name = "pydantic-evals" },
+]
+google = [
+    { name = "google-genai" },
+]
+logfire = [
+    { name = "logfire", extra = ["httpx"] },
+]
 mcp = [
     { name = "fastmcp-slim", extra = ["client"] },
 ]
@@ -4060,12 +4111,20 @@ openai = [
     { name = "openai" },
     { name = "tiktoken" },
 ]
+retries = [
+    { name = "tenacity" },
+]
 spec = [
     { name = "pydantic-handlebars" },
     { name = "pyyaml" },
 ]
 temporal = [
     { name = "temporalio" },
+]
+web = [
+    { name = "httpx" },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 web-fetch = [
     { name = "markdownify" },
@@ -4315,8 +4374,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-evals"
+version = "2.31.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "logfire-api" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pydantic-ai-slim" },
+    { name = "pyyaml" },
+    { name = "rich", version = "14.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "rich", version = "15.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/1e/785ebd3a275680f8c080994c47a4c28a8dd852c13e744499b52ca139a68c/pydantic_evals-2.31.1.tar.gz", hash = "sha256:38ade29acd3e204ce1c74d1490f2435bbe9ddfb415b685db563f2572345022a0", size = 86722, upload-time = "2026-08-18T03:39:53.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/68/deb3326ebf8700674ddda1f921f4492841a9b84abd5aab0024a1ff9fa271/pydantic_evals-2.31.1-py3-none-any.whl", hash = "sha256:0dcf1c1ea3bd4838bd2fe9f61c56b24baff5bb0e954045274ea6c965591839d2", size = 101914, upload-time = "2026-08-18T03:39:47.725Z" },
+]
+
+[[package]]
 name = "pydantic-graph"
-version = "2.28.0"
+version = "2.31.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4327,9 +4406,9 @@ dependencies = [
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/83/07dd2434495c5a9747b558a3a91ace8542bedd54501b98a0af735f645e29/pydantic_graph-2.28.0.tar.gz", hash = "sha256:1d664de0525b335cf2d6d258ad9707b4df16837b8c07af059418cca7c43a0bae", size = 45180, upload-time = "2026-08-12T02:16:50.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/40/da6b9b7ee8c77b5c5e910ecc49a7d4ed93422a9bddb1726ed876b6abbeea/pydantic_graph-2.31.1.tar.gz", hash = "sha256:ac5f34e7bbf518a18a9c22f1e33418c3343542a8ea269ee8ee58e637e3f4fd56", size = 45179, upload-time = "2026-08-18T03:39:54.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/a4/365dc149500b5d6677775618e194c4381f029ef819bf96b9d9ab6c0f8f2e/pydantic_graph-2.28.0-py3-none-any.whl", hash = "sha256:e5e2640f49bd0c3d0808efe69429f4b1ddb12fb7d8ba4ad093117c0bdc9d39ea", size = 52662, upload-time = "2026-08-12T02:16:43.913Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/40/ca98101077f17c1773c1aad617d03f6a0666936a8c6aeb4aac4c3e61eb54/pydantic_graph-2.31.1-py3-none-any.whl", hash = "sha256:7a5a9a8143d52f509a917263eeb49b4466eda6caf5131d1e71143fc6e9710157", size = 52662, upload-time = "2026-08-18T03:39:49.133Z" },
 ]
 
 [[package]]
@@ -8302,18 +8381,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
     { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
     { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `pydantic-ai-harness[absurd]`, depending on `pydantic-ai-absurd>=0.8.0,<0.9.0`.
- Re-export the exact upstream `AbsurdDurability` object from `pydantic_ai_harness` and `pydantic_ai_harness.absurd`.
- Re-export the upstream `AbsurdParallelExecutionMode` type from `pydantic_ai_harness.absurd`.
- Keep durability execution, checkpoint formats, PostgreSQL integration, and replay behavior in `pydantic-ai-absurd`; Harness adds no wrapper or runtime implementation.
- Verify that the base Harness install does not include `pydantic-ai-absurd`.

## Dependencies

`pydantic-ai-absurd==0.8.0` depends on the full `pydantic-ai` package. Its Google provider requirements conflict with the exact provider versions declared by `browser-use`. Repository dependency overrides allow the development matrix to exercise both integrations, but those overrides are not published in wheel metadata.

As a result, the published combination `pydantic-ai-harness[absurd,browser-use]` is not currently resolvable. This PR should not merge until an upstream `pydantic-ai-absurd` release depends on `pydantic-ai-slim` instead of the full meta-package, or the dependency graphs otherwise become compatible.

## Tests

- Exact identity for both upstream exports.
- Lazy root export identity.
- Agent composition with a named `TestModel`.
- Base-install CI guard for optional dependency isolation.
- Latest-version CI upgrades the full `pydantic-ai` package together with slim and graph.
- Documentation parity and static snippet validation.

## Linked Issue

Closes #662

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint` and `make typecheck` pass locally
- [x] A maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)
