### PR TITLE
Propagate `UsageLimits` to nested summaries

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -9,7 +9,7 @@ Compaction is a menu of strategies for keeping an agent's conversation history w
 
 All strategies preserve tool-call / tool-return **pairing**. Core does not validate this, and a provider rejects an orphaned pair, so the pairing guarantee is what makes these safe to drop into an agent. The zero-LLM strategies never call a model; only `SummarizingCompaction` (and `TieredCompaction` when it escalates that far) spends tokens.
 
-On OpenAI and Anthropic, core also ships [provider-native compaction](https://pydantic.dev/docs/ai/capabilities/compaction/) — the provider summarizes history server-side. The strategies on this page are the model-agnostic alternative: they work with every model and keep the compaction logic (and its costs) under your control.
+On OpenAI and Anthropic, core also ships [provider-native compaction](https://pydantic.dev/docs/ai/capabilities/compaction/) -- the provider summarizes history server-side. The strategies on this page are the model-agnostic alternative: they work with every model and keep the compaction logic (and its costs) under your control.
 
 [Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/compaction/)
 
@@ -339,11 +339,11 @@ agent = Agent(
 )
 ```
 
-`model` accepts a model name or a `Model`; when left `None` it inherits the running agent's model. No token caps are imposed on the summary call. By default `incremental=True` updates the newest existing summary as an anchor. This changes the summary-call prompt from earlier releases; set `incremental=False` to retain the prior regeneration behavior.
+`model` accepts a model name or a `Model`; when left `None` it inherits the running agent's model. Its nested summary run inherits the parent usage limits and reserves one request from a finite request limit for the pending parent request. By default `incremental=True` updates the newest existing summary as an anchor. This changes the summary-call prompt from earlier releases; set `incremental=False` to retain the prior regeneration behavior.
 
 ### Usage accounting
 
-The summary call is a real request to the model, so its full usage -- tokens **and** the request itself -- is folded into the run's `ctx.usage`. This is deliberate: it keeps cost honest, keeps the request count consistent (a model request that did not count as one would be the surprise), and lets a `UsageLimits` request limit catch a runaway compaction. A run-request or iteration limiter will therefore see compaction calls among its requests.
+The summary call is a real request to the model, so its full usage -- tokens **and** the request itself -- is folded into the run's `ctx.usage`. This is deliberate: it keeps cost honest, keeps the request count consistent (a model request that did not count as one would be the surprise), and lets a `UsageLimits` request limit catch a runaway compaction. The nested run receives the other parent limits unchanged; the finite request limit is reduced by one so it cannot spend the slot already approved for the parent request. A run-request or iteration limiter will therefore see compaction calls among its requests.
 
 ## `WarnNearLimits`: warn instead of rewrite
 

--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -230,9 +230,10 @@ for path in root.rglob('*'):
 
 ## Usage accounting
 
-A `Summarize` call is a real request to the model, so its full usage -- tokens and the
-request itself -- folds into the run's `ctx.usage`, exactly like `SummarizingCompaction`. No
-token caps are imposed on the summary call. A `UsageLimits` request limit will see it.
+A built-in `Summarize` call is a real request to the model, so its full usage -- tokens and the
+request itself -- folds into the run's `ctx.usage`, exactly like `SummarizingCompaction`. Its nested
+run receives the parent limits unchanged except that a finite request limit reserves one request for
+the pending parent request.
 
 By default `Summarize` inherits the running agent's model (`ctx.model`). Pass a model id or
 instance to `Summarize(model=...)` to override, or a `summarize` callable to bypass the

--- a/pydantic_ai_harness/_usage.py
+++ b/pydantic_ai_harness/_usage.py
@@ -1,0 +1,18 @@
+"""Shared helpers for nested agent usage accounting."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from pydantic_ai.usage import UsageLimits
+
+
+def reserved_usage_limits(limits: UsageLimits | None) -> UsageLimits | None:
+    """Reserve the pending parent request before a nested model call made from a hook.
+
+    The hook may run after the parent request's limit check. Reducing a finite request limit
+    prevents the nested call from spending the request that was already approved for the parent.
+    """
+    if limits is None or limits.request_limit is None:
+        return limits
+    return replace(limits, request_limit=max(0, limits.request_limit - 1))

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -377,7 +377,8 @@ from the edit point onward -- the next request pays a cache-write. Use `ClearToo
 ## Model inheritance
 
 `SummarizingCompaction(model=...)` accepts a model name or `Model`; when left `None` it inherits the
-running agent's model. No token caps are imposed on the summary call.
+running agent's model. Its nested summary run inherits the parent usage limits and reserves one request from a
+finite request limit for the pending parent request.
 
 By default `incremental=True` updates the newest existing summary from a prior compaction as an
 anchor rather than regenerating it from scratch. This changes the summary-call prompt from earlier
@@ -390,8 +391,9 @@ of `keep_messages`.
 The summary call is a real request to the model, so its full usage -- tokens **and** the request
 itself -- is folded into the run's `ctx.usage`. This is deliberate: it keeps cost honest, keeps the
 request count consistent (a model request that didn't count as one would be the surprise), and lets a
-`UsageLimits` request limit catch a runaway compaction. A run-request / iteration limiter will
-therefore see compaction calls among its requests.
+`UsageLimits` request limit catch a runaway compaction. The nested run receives the other parent limits unchanged;
+the finite request limit is reduced by one so it cannot spend the slot already approved for the parent request.
+A run-request / iteration limiter will therefore see compaction calls among its requests.
 
 ## `DeduplicateFileReads.file_key`
 

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -24,6 +24,7 @@ from pydantic_ai.models import Model
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.tools import RunContext
 
+from pydantic_ai_harness._usage import reserved_usage_limits
 from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW
 from pydantic_ai_harness.compaction._pinning import is_pinned, reinject_pinned
 from pydantic_ai_harness.compaction._receipts import (
@@ -625,5 +626,5 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
             cast('Model[Any] | str', model),
             instructions='You are a context summarization assistant. Extract the most important information from conversations.',
         )
-        result = await agent.run(prompt, usage=ctx.usage)
+        result = await agent.run(prompt, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
         return result.output.strip()

--- a/pydantic_ai_harness/system_reminders/_capability.py
+++ b/pydantic_ai_harness/system_reminders/_capability.py
@@ -23,10 +23,11 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import KnownModelName, Model
 from pydantic_ai.tools import AgentDepsT, RunContext
 
+from pydantic_ai_harness._usage import reserved_usage_limits
+
 if TYPE_CHECKING:
     from pydantic_ai.capabilities.abstract import WrapModelRequestHandler
     from pydantic_ai.models import ModelRequestContext
-    from pydantic_ai.usage import UsageLimits
 
 
 @dataclass
@@ -292,24 +293,11 @@ class LLMReminder(Generic[AgentDepsT]):
                 agent = Agent(self.model, instructions=self.instructions, output_type=str)
                 self._agent = agent
             transcript = _build_compact_transcript(ctx.messages, self.max_context_messages)
-            result = await agent.run(transcript, usage=ctx.usage, usage_limits=_reserved_limits(ctx.usage_limits))
+            result = await agent.run(transcript, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
             text = result.output.strip()
             return text or None
         except Exception:
             return GoalReanchor[AgentDepsT]()(ctx)
-
-
-def _reserved_limits(limits: UsageLimits | None) -> UsageLimits | None:
-    """The parent run's limits with one request held back for the model call this reminder precedes.
-
-    `wrap_model_request` runs after the parent request already cleared `check_before_request`, so
-    a nested run spending the last slot would let that approved request push the run one past
-    `request_limit`. Holding the slot back makes the nested run raise `UsageLimitExceeded` first;
-    the caller falls back to `GoalReanchor`, which costs no request, and the budget holds.
-    """
-    if limits is None or limits.request_limit is None:
-        return limits
-    return replace(limits, request_limit=max(0, limits.request_limit - 1))
 
 
 def _should_fire(reminder: Reminder[AgentDepsT], count: int) -> bool:

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -197,9 +197,10 @@ for path in root.rglob('*'):
 
 ## Usage accounting
 
-A `Summarize` call is a real request to the model, so its full usage -- tokens and the
-request itself -- folds into the run's `ctx.usage`, exactly like `SummarizingCompaction`. No
-token caps are imposed on the summary call. A `UsageLimits` request limit will see it.
+A built-in `Summarize` call is a real request to the model, so its full usage -- tokens and the
+request itself -- folds into the run's `ctx.usage`, exactly like `SummarizingCompaction`. Its nested
+run receives the parent limits unchanged except that a finite request limit reserves one request for
+the pending parent request.
 
 By default `Summarize` inherits the running agent's model (`ctx.model`). Pass a model id or
 instance to `Summarize(model=...)` to override, or a `summarize` callable to bypass the

--- a/pydantic_ai_harness/tool_output_limits/_bands.py
+++ b/pydantic_ai_harness/tool_output_limits/_bands.py
@@ -66,7 +66,9 @@ class Summarize:
     `model=None` inherits the running agent's model (`ctx.model`), mirroring
     `SummarizingCompaction`. Pass a model id / instance to override, or a `summarize`
     callable to bypass the built-in prompt entirely. Summary usage folds into `ctx.usage`;
-    no token caps are imposed. Falls back to `then` on a binary payload or a failed call.
+    the built-in agent receives the parent usage limits and reserves one request from a finite
+    request limit for the pending parent request. Falls back to `then` on a binary payload or a
+    failed call.
     """
 
     model: str | Model | None = None

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -15,6 +15,7 @@ from pydantic_ai.models import AbstractModel, Model
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition, ToolSelector, matches_tool_selector
 from pydantic_ai.toolsets import AgentToolset
 
+from pydantic_ai_harness._usage import reserved_usage_limits
 from pydantic_ai_harness.tool_output_limits._bands import (
     Action,
     Band,
@@ -457,7 +458,7 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         agent: Agent[None, str] = Agent(
             cast('Model[Any] | str', model), instructions='You summarize oversized tool output.'
         )
-        run = await agent.run(prompt, usage=ctx.usage)
+        run = await agent.run(prompt, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
         return run.output.strip()
 
 

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -34,7 +34,7 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
-from pydantic_ai.usage import RequestUsage, RunUsage
+from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
 from pydantic_ai_harness.compaction import (
     ClampOversizedMessages,
@@ -89,6 +89,7 @@ def _make_ctx(
     requests: int = 0,
     input_tokens: int = 0,
     output_tokens: int = 0,
+    usage_limits: UsageLimits | None = None,
 ) -> Any:
     """Build a minimal RunContext-like object for testing hooks."""
 
@@ -97,6 +98,7 @@ def _make_ctx(
     @dataclasses.dataclass
     class _FakeCtx:
         usage: RunUsage
+        usage_limits: UsageLimits | None = None
         model: Model = dataclasses.field(default_factory=TestModel)
         deps: None = None
         tracer: Tracer = dataclasses.field(default_factory=NoOpTracer)
@@ -107,7 +109,7 @@ def _make_ctx(
             default_factory=dict[str, AbstractCapability[None]]
         )
 
-    return _FakeCtx(usage=usage)
+    return _FakeCtx(usage=usage, usage_limits=usage_limits)
 
 
 def _make_request_context(messages: list[ModelMessage], model: Model | None = None) -> ModelRequestContext:
@@ -2120,6 +2122,24 @@ class TestSummarizingCompactionModel:
         assert MockAgent.call_args.args[0] is rc.model
         # Its usage is threaded into the parent run for honest accounting.
         assert mock_agent_instance.run.call_args.kwargs['usage'] is ctx.usage
+
+    @pytest.mark.anyio
+    async def test_nested_summary_reserves_parent_usage_limits(self):
+        comp = SummarizingCompaction(max_messages=3, keep_messages=1, preserve_first_user_message=False)
+        messages: list[ModelMessage] = [_user('a'), _assistant('b'), _user('c'), _assistant('d')]
+        ctx = _make_ctx(usage_limits=UsageLimits(request_limit=5, tool_calls_limit=2))
+
+        mock_result = AsyncMock()
+        mock_result.output = 'Bounded summary.'
+        with patch('pydantic_ai.Agent') as MockAgent:
+            mock_agent_instance = AsyncMock()
+            mock_agent_instance.run.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+            await comp.before_model_request(ctx, _make_request_context(messages))
+
+        assert mock_agent_instance.run.call_args.kwargs['usage_limits'] == UsageLimits(
+            request_limit=4, tool_calls_limit=2
+        )
 
     def test_default_prompt_has_structured_sections(self):
         from pydantic_ai_harness.compaction._summarizing_compaction import _DEFAULT_SUMMARY_PROMPT

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -26,7 +26,7 @@ from pydantic_ai.models import AbstractModel, Model, ModelRequestContext, ModelR
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
-from pydantic_ai.usage import RequestUsage, RunUsage
+from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
 from pydantic_ai_harness.compaction import (
     DEFAULT_CONTEXT_WINDOW,
@@ -87,6 +87,7 @@ def _ctx(model: Any = None) -> Any:
     @dataclasses.dataclass
     class _FakeCtx:
         usage: RunUsage = dataclasses.field(default_factory=RunUsage)
+        usage_limits: UsageLimits | None = None
         model: Model = dataclasses.field(default_factory=TestModel)
         deps: None = None
         tracer: Tracer = dataclasses.field(default_factory=NoOpTracer)

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,37 @@
+"""Tests for shared nested-agent usage helpers."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from decimal import Decimal
+
+import pytest
+from pydantic_ai.usage import UsageLimits
+
+from pydantic_ai_harness._usage import reserved_usage_limits
+
+
+def test_reserved_usage_limits_reserves_one_request_and_preserves_other_limits() -> None:
+    limits = UsageLimits(
+        cost_limit=Decimal('0.01'),
+        request_limit=1,
+        tool_calls_limit=2,
+        input_tokens_limit=3,
+        output_tokens_limit=4,
+        total_tokens_limit=5,
+        per_request_input_tokens_limit=6,
+        count_tokens_before_request=True,
+    )
+
+    assert reserved_usage_limits(limits) == replace(limits, request_limit=0)
+
+
+def test_reserved_usage_limits_clamps_zero_request_limit() -> None:
+    limits = UsageLimits(request_limit=0)
+
+    assert reserved_usage_limits(limits) == limits
+
+
+@pytest.mark.parametrize('limits', [None, UsageLimits(request_limit=None)])
+def test_reserved_usage_limits_preserves_absent_or_unbounded_limits(limits: UsageLimits | None) -> None:
+    assert reserved_usage_limits(limits) is limits

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -8,6 +8,7 @@ import time
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pydantic_ai import Agent
@@ -25,7 +26,7 @@ from pydantic_ai.models import AbstractModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RunUsage, UsageLimits
 from pydantic_core import to_json
 
 from pydantic_ai_harness.tool_output_limits import (
@@ -66,7 +67,9 @@ from pydantic_ai_harness.tool_output_limits._store import _safe_segment
 # ---------------------------------------------------------------------------
 
 
-def _make_ctx(*, run_id: str | None = 'run-1', retry: int = 0, model: Any = None) -> Any:
+def _make_ctx(
+    *, run_id: str | None = 'run-1', retry: int = 0, model: Any = None, usage_limits: UsageLimits | None = None
+) -> Any:
     """Build a minimal RunContext-like object for testing the hook directly."""
 
     @dataclasses.dataclass
@@ -78,11 +81,12 @@ def _make_ctx(*, run_id: str | None = 'run-1', retry: int = 0, model: Any = None
         usage: RunUsage
         run_id: str | None
         retry: int
+        usage_limits: UsageLimits | None = None
         tool_call_id: str | None = 'call-1'
         model: Any = dataclasses.field(default_factory=_FakeModel)
         deps: None = None
 
-    ctx = _FakeCtx(usage=RunUsage(), run_id=run_id, retry=retry)
+    ctx = _FakeCtx(usage=RunUsage(), run_id=run_id, retry=retry, usage_limits=usage_limits)
     if model is not None:
         ctx.model = model
     return ctx
@@ -647,6 +651,22 @@ class TestSummarize:
         out = await _run(cap, 'x' * 100, ctx=ctx)
         assert out == 'THE SUMMARY'
         assert ctx.usage.requests == 1
+
+    async def test_inherited_model_reserves_parent_usage_limits(self):
+        ctx = _make_ctx(
+            model=_fixed_model('THE SUMMARY'), usage_limits=UsageLimits(request_limit=5, tool_calls_limit=2)
+        )
+        cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=5, action=Summarize())])
+        mock_result = AsyncMock()
+        mock_result.output = 'THE SUMMARY'
+        mock_agent = AsyncMock()
+        mock_agent.run.return_value = mock_result
+
+        with patch('pydantic_ai.Agent', return_value=mock_agent):
+            out = await _run(cap, 'x' * 100, ctx=ctx)
+
+        assert out == 'THE SUMMARY'
+        assert mock_agent.run.call_args.kwargs['usage_limits'] == UsageLimits(request_limit=4, tool_calls_limit=2)
 
     async def test_explicit_model_overrides_ctx(self):
         ctx = _make_ctx(model=_fixed_model('FROM CTX MODEL'))


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-terra on behalf of David.

## Summary

Nested summaries now receive the parent usage limits, reserving one request from a finite request limit for the pending parent request.

## Changes

- Share the reservation logic already used by LLMReminder.
- Apply it to SummarizingCompaction and the built-in ToolOutputLimits summary action.
- Cover finite, zero, absent, and unbounded request limits while preserving other limits.
- Update the matching README and docs pages.

## Verification

- formatting and linting: pass
- focused static analysis: pass
- focused regression and documentation snippets: pass
- targeted coverage: pass; the new helper is 100% covered
- CI will run the full repository gates.

Closes #528

Prior art: closed PR #535.