### PR TITLE
Keep local verification focused and sandbox-safe

### DIFF
--- a/.agents/skills/branch-context/append-pr-decision.sh
+++ b/.agents/skills/branch-context/append-pr-decision.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Append one decision entry to .claude/skills/branch-context/pr-decisions.md
+# Append one decision entry to the adjacent pr-decisions.md.
 #
 # Preferred (named flags -- resistant to arg-order mistakes):
 #   append-pr-decision.sh \
@@ -97,22 +97,30 @@ case "$SOURCE" in
         ;;
 esac
 
-# Must run from a worktree root -- locate the file relative to cwd.
-FILE=".claude/skills/branch-context/pr-decisions.md"
+# Static helpers can be reached through any harness skill root. Live state stays
+# beside the invoked helper, so resolve the directory rather than assuming cwd.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+FILE="$DIR/pr-decisions.md"
 if [ ! -f "$FILE" ]; then
-    echo "error: $FILE not found. Are you at the worktree root? Instantiate it from pr-decisions.template.md first." >&2
+    echo "error: $FILE not found. Initialize branch context before appending a decision." >&2
     exit 1
 fi
 
 DATE="$(date -u +%Y-%m-%d)"
 
-{
-    echo ""
-    echo "## $DATE · $TITLE · iter $ITER"
-    echo "- Decision: $DECISION"
-    echo "- Why: $WHY"
-    echo "- Source: $SOURCE"
-    [ -n "$SUPERSEDES" ] && echo "- Supersedes: $SUPERSEDES"
-} >> "$FILE"
+ENTRY="
+## $DATE · $TITLE · iter $ITER
+- Decision: $DECISION
+- Why: $WHY
+- Source: $SOURCE"
+if [ -n "$SUPERSEDES" ]; then
+    ENTRY="$ENTRY
+- Supersedes: $SUPERSEDES"
+fi
+
+if ! printf '%s\n' "$ENTRY" >> "$FILE"; then
+    echo "error: could not append decision to $FILE" >&2
+    exit 1
+fi
 
 echo "Appended decision to $FILE"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,13 +44,13 @@ repos:
     hooks:
       - id: lint
         name: Ruff Lint
-        entry: uv run ruff check
+        entry: uv run --no-sync ruff check
         types: [python]
         language: system
         pass_filenames: true
       - id: format
         name: Ruff Format
-        entry: uv run ruff format
+        entry: uv run --no-sync ruff format
         types: [python]
         language: system
         pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,22 +44,19 @@ repos:
     hooks:
       - id: lint
         name: Ruff Lint
-        entry: make
-        args: [lint]
+        entry: uv run ruff check
         types: [python]
         language: system
-        pass_filenames: false
+        pass_filenames: true
       - id: format
         name: Ruff Format
-        entry: make
-        args: [format]
+        entry: uv run ruff format
         types: [python]
         language: system
-        pass_filenames: false
+        pass_filenames: true
       - id: typecheck
         name: Pyright
-        entry: make
-        args: [typecheck]
+        entry: env PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright
         types: [python]
         language: system
-        pass_filenames: false
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,16 +44,16 @@ repos:
     hooks:
       - id: lint
         name: Ruff Lint
-        entry: uv run --no-sync ruff check
+        entry: uv run --no-sync ruff check .
         types: [python]
         language: system
-        pass_filenames: true
+        pass_filenames: false
       - id: format
         name: Ruff Format
-        entry: uv run --no-sync ruff format
+        entry: uv run --no-sync ruff format .
         types: [python]
         language: system
-        pass_filenames: true
+        pass_filenames: false
       - id: typecheck
         name: Pyright
         entry: env PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,10 +127,10 @@ Applies to docs, READMEs, docstrings, comments, commit messages, and PR text.
 Run focused checks for the paths that you modify before you commit.
 
 ```bash
-uv run ruff format --check pydantic_ai_harness/<module>.py tests/<module>.py
-uv run ruff check pydantic_ai_harness/<module>.py tests/<module>.py
-PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_harness/<module>.py tests/<module>.py
-uv run pytest tests/<capability>
+uv run --no-sync ruff format --check pydantic_ai_harness/<module>.py tests/<module>.py
+uv run --no-sync ruff check pydantic_ai_harness/<module>.py tests/<module>.py
+PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/<module>.py tests/<module>.py
+uv run --no-sync pytest -p no:cacheprovider tests/<capability>
 ```
 
 CI runs the repository-wide format, lint, typecheck, test, and combined coverage gates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@ solves.
 - Python 3.10+ (target version for pyright and ruff)
 - **pyright strict** mode -- no `Any` types, full type annotations
 - **ruff**: line-length=120, single quotes, max-complexity=15
-- **100% branch coverage** required (enforced by `make testcov`)
+- CI requires 100% branch coverage from combined matrix data. A local `make testcov`
+  result covers one environment only.
 - docstrings use single backticks (markdown), not RST double backticks
 - no typecasting (`as` in TypeScript, `cast()` in Python) -- use type narrowing instead
 - prefer the most generic input types possible (reduce dependency chains)
@@ -121,17 +122,19 @@ Applies to docs, READMEs, docstrings, comments, commit messages, and PR text.
 - PRs touching `pyproject.toml` or `uv.lock` require the
   `dependencies:approved` label; pushes clear approval.
 
-## Commands
+## Local verification
+
+Run focused checks for the paths that you modify before you commit.
 
 ```bash
-make format     # ruff format
-make lint       # ruff check
-make typecheck  # pyright strict
-make test       # pytest
-make testcov    # pytest with branch coverage
+uv run ruff format --check pydantic_ai_harness/<module>.py tests/<module>.py
+uv run ruff check pydantic_ai_harness/<module>.py tests/<module>.py
+PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_harness/<module>.py tests/<module>.py
+uv run pytest tests/<capability>
 ```
 
-Always run `make lint && make typecheck && make test` before committing.
+CI runs the repository-wide format, lint, typecheck, test, and combined coverage gates.
+Do not run repository-wide commands for local verification.
 
 ## File structure
 
@@ -154,7 +157,8 @@ need.
 
 ## Testing patterns
 
-- Use `pydantic_ai.models.TestModel` for all tests (no real API calls)
+- Import `TestModel` from `pydantic_ai.models.test` for model behavior.
+- Keep real provider calls out of tests.
 - `ALLOW_MODEL_REQUESTS = False` is set globally in `conftest.py`
 - Tests use `pytest-anyio` for async support
 - Each capability test class follows: `TestCapabilityName` with methods `test_<scenario>`
@@ -173,7 +177,6 @@ need.
 ## Contributing rules for AICAs
 
 - Always link sources for any claims made during research
-- Run `make lint && make typecheck && make test` before every commit
 - Commit messages should summarize the "why", not the "what"
 - PR titles feed the release notes verbatim -- GitHub builds "What's Changed" from them. Write an
   imperative sentence naming the change, and wrap every code identifier (class names, keyword

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,9 @@ solves.
 - Python 3.10+ (target version for pyright and ruff)
 - **pyright strict** mode -- no `Any` types, full type annotations
 - **ruff**: line-length=120, single quotes, max-complexity=15
-- CI requires 100% branch coverage from combined matrix data. A local `make testcov`
-  result covers one environment only.
+- CI enforces 100% branch coverage from combined matrix data.
+- Do not run coverage locally unless CI reports a specific coverage gap.
+- Investigate a reported gap with focused coverage for the flagged file or test.
 - docstrings use single backticks (markdown), not RST double backticks
 - no typecasting (`as` in TypeScript, `cast()` in Python) -- use type narrowing instead
 - prefer the most generic input types possible (reduce dependency chains)
@@ -124,17 +125,18 @@ Applies to docs, READMEs, docstrings, comments, commit messages, and PR text.
 
 ## Local verification
 
-Run focused checks for the paths that you modify before you commit.
+Run Ruff across the repository. Run Pyright and pytest for the paths that you modify.
 
 ```bash
-uv run --no-sync ruff format --check pydantic_ai_harness/<module>.py tests/<module>.py
-uv run --no-sync ruff check pydantic_ai_harness/<module>.py tests/<module>.py
+uv run --no-sync ruff format --check .
+uv run --no-sync ruff check .
 PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/<module>.py tests/<module>.py
 uv run --no-sync pytest -p no:cacheprovider tests/<capability>
 ```
 
-CI runs the repository-wide format, lint, typecheck, test, and combined coverage gates.
-Do not run repository-wide commands for local verification.
+CI runs the repository-wide typecheck, test, and combined coverage gates.
+Do not run repository-wide Pyright, pytest, or coverage locally.
+If CI reports a coverage gap, run coverage only for the flagged file or focused test.
 
 ## File structure
 

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,8 @@ test:
 	uv run pytest
 
 testcov:
-	@coverage_file="$$(mktemp "$${TMPDIR:-/tmp}/pydantic-ai-harness-coverage.XXXXXX")" || { echo 'Could not create a coverage data file.' >&2; exit 1; }; \
-	trap 'rm -f "$$coverage_file"' EXIT; \
-	COVERAGE_FILE="$$coverage_file" uv run coverage run -m pytest; \
-	status=$$?; \
-	if [ "$$status" -eq 0 ]; then \
-		COVERAGE_FILE="$$coverage_file" uv run coverage report; \
-		status=$$?; \
-	fi; \
-	exit "$$status"
+	uv run coverage run -m pytest
+	uv run coverage report
 
 integration-localstack:
 	uv run pytest integration_tests/localstack/test_live_localstack.py

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,15 @@ test:
 	uv run pytest
 
 testcov:
-	uv run coverage run -m pytest
-	uv run coverage report
+	@coverage_file="$$(mktemp "$${TMPDIR:-/tmp}/pydantic-ai-harness-coverage.XXXXXX")" || { echo 'Could not create a coverage data file.' >&2; exit 1; }; \
+	trap 'rm -f "$$coverage_file"' EXIT; \
+	COVERAGE_FILE="$$coverage_file" uv run coverage run -m pytest; \
+	status=$$?; \
+	if [ "$$status" -eq 0 ]; then \
+		COVERAGE_FILE="$$coverage_file" uv run coverage report; \
+		status=$$?; \
+	fi; \
+	exit "$$status"
 
 integration-localstack:
 	uv run pytest integration_tests/localstack/test_live_localstack.py

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -109,7 +109,7 @@ README, or source code.
   `tests/coder/test_coder_integration.py`) that runs it against a real task.
   Any change to that harness's composition, defaults, or instructions
   re-records the cassette in the same PR
-  (`uv run --env-file .env --no-sync pytest <test> --record-mode=rewrite`) —
+  (`uv run --env-file .env --no-sync pytest -p no:cacheprovider <test> --record-mode=rewrite`) —
   a green replay of a stale cassette proves nothing about the new definition.
 - `make lint`, `make typecheck`, and `make test` pass before handoff.
 

--- a/agent_docs/testing-capabilities.md
+++ b/agent_docs/testing-capabilities.md
@@ -42,8 +42,9 @@ focused tests for each applicable contract:
 
 ## Coverage
 
-CI enforces 100% branch coverage after combining matrix artifacts. `make testcov`
-runs one environment, so it cannot establish the CI combined-coverage result.
+CI enforces 100% branch coverage after combining matrix artifacts. Do not run
+coverage locally unless CI reports a specific coverage gap. To investigate a
+reported gap, run coverage only for the flagged file or focused test.
 
 Tests for a new capability should cover:
 
@@ -58,13 +59,13 @@ schemas, telemetry spans, or structured tool metadata.
 
 ## Commands
 
-Run focused checks for the changed paths:
+Run Ruff across the repository. Run pytest and Pyright for the changed paths:
 
 ```bash
+uv run --no-sync ruff format --check .
+uv run --no-sync ruff check .
 uv run --no-sync pytest -p no:cacheprovider tests/<capability>
-uv run --no-sync ruff format --check pydantic_ai_harness/<module>.py tests/<module>.py
-uv run --no-sync ruff check pydantic_ai_harness/<module>.py tests/<module>.py
 PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/<module>.py tests/<module>.py
 ```
 
-CI runs repository-wide checks and the combined coverage gate.
+CI runs the repository-wide typecheck, test, and combined coverage gates.

--- a/agent_docs/testing-capabilities.md
+++ b/agent_docs/testing-capabilities.md
@@ -5,7 +5,7 @@ helpers.
 
 ## Default Shape
 
-- Use `pydantic_ai.models.TestModel` for model behavior.
+- Import `TestModel` from `pydantic_ai.models.test` for model behavior.
 - Keep real provider calls out of tests.
 - Prefer `Agent(..., capabilities=[...])` tests for public behavior.
 - Mirror source packages under `tests/<capability>/`.
@@ -42,8 +42,10 @@ focused tests for each applicable contract:
 
 ## Coverage
 
-The project enforces 100% branch coverage with `make testcov`. Tests for a new
-capability should cover:
+CI enforces 100% branch coverage after combining matrix artifacts. `make testcov`
+runs one environment, so it cannot establish the CI combined-coverage result.
+
+Tests for a new capability should cover:
 
 - default configuration
 - important option combinations
@@ -56,12 +58,13 @@ schemas, telemetry spans, or structured tool metadata.
 
 ## Commands
 
-Run focused checks first, then broaden:
+Run focused checks for the changed paths:
 
 ```bash
 uv run pytest tests/<capability>
-make lint
-make typecheck
-make test
-make testcov
+uv run ruff format --check pydantic_ai_harness/<module>.py tests/<module>.py
+uv run ruff check pydantic_ai_harness/<module>.py tests/<module>.py
+PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_harness/<module>.py tests/<module>.py
 ```
+
+CI runs repository-wide checks and the combined coverage gate.

--- a/agent_docs/testing-capabilities.md
+++ b/agent_docs/testing-capabilities.md
@@ -61,10 +61,10 @@ schemas, telemetry spans, or structured tool metadata.
 Run focused checks for the changed paths:
 
 ```bash
-uv run pytest tests/<capability>
-uv run ruff format --check pydantic_ai_harness/<module>.py tests/<module>.py
-uv run ruff check pydantic_ai_harness/<module>.py tests/<module>.py
-PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run pyright pydantic_ai_harness/<module>.py tests/<module>.py
+uv run --no-sync pytest -p no:cacheprovider tests/<capability>
+uv run --no-sync ruff format --check pydantic_ai_harness/<module>.py tests/<module>.py
+uv run --no-sync ruff check pydantic_ai_harness/<module>.py tests/<module>.py
+PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/<module>.py tests/<module>.py
 ```
 
 CI runs repository-wide checks and the combined coverage gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,7 @@ quote-style = 'single'
 [tool.pyright]
 pythonVersion = '3.10'
 typeCheckingMode = 'strict'
-exclude = ['template', '.venv', 'mutants', '.agents', '.claude']
+exclude = ['template', '.venv', '.venv*', 'local-notes', 'mutants', '.agents', '.claude']
 # `reportUnusedFunction` is disabled for tests because fixtures and `@agent.tool_plain`
 # helpers are registered via decorators and never referenced by name (matches pydantic-ai).
 executionEnvironments = [

--- a/tests/coder/test_coder_integration.py
+++ b/tests/coder/test_coder_integration.py
@@ -31,16 +31,30 @@ else:
 
 pytestmark = pytest.mark.anyio
 
+_SNAPSHOT_OUTPUT_ENVIRONMENT_VARIABLES = (
+    'BUILD_ID',
+    'BUILD_NUMBER',
+    'CI',
+    'CLICOLOR_FORCE',
+    'FORCE_COLOR',
+    'GITHUB_ACTIONS',
+    'PY_COLORS',
+)
+
 
 @pytest.mark.vcr
 async def test_coder_completes_task(
     tmp_path: Path, allow_model_requests: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv('ANTHROPIC_API_KEY', os.environ.get('ANTHROPIC_API_KEY', 'replay-key'))
-    # The agent's `run_command` runs the workspace test suite in a subprocess whose stdout is snapshotted;
-    # CI-detection env vars would make inline-snapshot print a banner into it that isn't there locally.
-    for ci_env_var in ('CI', 'BUILD_ID', 'BUILD_NUMBER', 'GITHUB_ACTIONS'):
-        monkeypatch.delenv(ci_env_var, raising=False)
+    for environment_variable in ('CLICOLOR_FORCE', 'FORCE_COLOR', 'PY_COLORS'):
+        monkeypatch.setenv(environment_variable, '1')
+    # The agent's `run_command` snapshots subprocess output. These environment variables alter that output.
+    for environment_variable in _SNAPSHOT_OUTPUT_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(environment_variable, raising=False)
+    assert all(
+        environment_variable not in os.environ for environment_variable in _SNAPSHOT_OUTPUT_ENVIRONMENT_VARIABLES
+    )
     workspace = tmp_path / 'workspace'
     workspace.mkdir()
     (workspace / 'AGENTS.md').write_text(


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

## Summary

- make local verification target changed paths and leave repository-wide gates to CI
- prevent pre-commit and documented focused checks from syncing dependencies or writing pytest cache state
- keep coverage data out of the worktree and describe the combined CI coverage contract accurately
- exclude supported scratch and alternate virtual-environment paths from Pyright
- make branch decision logging resolve adjacent live state and fail clearly when an append is denied
- stabilize the coder integration snapshot across CI color environments

## Verification

- focused pre-commit hooks pass
- coder integration replay passes
- `uv.lock` remains unchanged across both commands
- branch decision helper appends from an unrelated working directory
