### PR TITLE
Expose the summarizer agent's `instructions` on `SummarizingCompaction`

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -341,6 +341,8 @@ agent = Agent(
 
 `model` accepts a model name or a `Model`; when left `None` it inherits the running agent's model. Its nested summary run inherits the parent usage limits and reserves one request from a finite request limit for the pending parent request. By default `incremental=True` updates the newest existing summary as an anchor. This changes the summary-call prompt from earlier releases; set `incremental=False` to retain the prior regeneration behavior.
 
+Both prompt surfaces of the summary request are fields: `summary_prompt` is the user-turn template (it must contain a `{messages}` placeholder) and `instructions` is the summarizer agent's system prompt. Override `instructions` when the summarizer endpoint constrains the system prompt, e.g. Claude Code OAuth endpoints require requests to open with a fixed instruction string.
+
 ### Usage accounting
 
 The summary call is a real request to the model, so its full usage -- tokens **and** the request itself -- is folded into the run's `ctx.usage`. This is deliberate: it keeps cost honest, keeps the request count consistent (a model request that did not count as one would be the surprise), and lets a `UsageLimits` request limit catch a runaway compaction. The nested run receives the other parent limits unchanged; the finite request limit is reduced by one so it cannot spend the slot already approved for the parent request. A run-request or iteration limiter will therefore see compaction calls among its requests.

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -341,7 +341,7 @@ agent = Agent(
 
 `model` accepts a model name or a `Model`; when left `None` it inherits the running agent's model. Its nested summary run inherits the parent usage limits and reserves one request from a finite request limit for the pending parent request. By default `incremental=True` updates the newest existing summary as an anchor. This changes the summary-call prompt from earlier releases; set `incremental=False` to retain the prior regeneration behavior.
 
-Both prompt surfaces of the summary request are fields: `summary_prompt` is the user-turn template (it must contain a `{messages}` placeholder) and `instructions` is the summarizer agent's system prompt. Override `instructions` when the summarizer endpoint constrains the system prompt, e.g. Claude Code OAuth endpoints require requests to open with a fixed instruction string.
+Both prompt surfaces of the summary request are fields: `summary_prompt` is the user-turn template (it must contain a `{messages}` placeholder), and `instructions` sets the internal agent's static instructions, which Pydantic AI sends in the request's system prompt. Override `instructions` when the summarizer endpoint requires a fixed leading instruction.
 
 ### Usage accounting
 

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -386,6 +386,11 @@ releases; set `incremental=False` to retain the prior regeneration behavior. `pr
 when it falls outside the window. Pass `keep_tokens` to trim the retained tail to a token budget instead
 of `keep_messages`.
 
+Both prompt surfaces of the summary request are fields: `summary_prompt` is the user-turn template (it
+must contain a `{messages}` placeholder) and `instructions` is the summarizer agent's system prompt.
+Override `instructions` when the summarizer endpoint constrains the system prompt, e.g. Claude Code
+OAuth endpoints require requests to open with a fixed instruction string.
+
 ## Usage accounting
 
 The summary call is a real request to the model, so its full usage -- tokens **and** the request

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -387,9 +387,9 @@ when it falls outside the window. Pass `keep_tokens` to trim the retained tail t
 of `keep_messages`.
 
 Both prompt surfaces of the summary request are fields: `summary_prompt` is the user-turn template (it
-must contain a `{messages}` placeholder) and `instructions` is the summarizer agent's system prompt.
-Override `instructions` when the summarizer endpoint constrains the system prompt, e.g. Claude Code
-OAuth endpoints require requests to open with a fixed instruction string.
+must contain a `{messages}` placeholder), and `instructions` sets the internal agent's static instructions,
+which Pydantic AI sends in the request's system prompt. Override `instructions` when the summarizer
+endpoint requires a fixed leading instruction.
 
 ## Usage accounting
 

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -86,6 +86,10 @@ preamble, no markdown fences.
 </messages>\
 """
 
+_DEFAULT_INSTRUCTIONS = (
+    'You are a context summarization assistant. Extract the most important information from conversations.'
+)
+
 _SUMMARY_PREFIX = 'Summary of previous conversation:\n\n'
 
 # Anchored-incremental update instruction (opencode mechanism): the previous summary is fed
@@ -310,6 +314,14 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
     """Prompt template for generating summaries.
 
     Must contain a ``{messages}`` placeholder.
+    """
+
+    instructions: str = _DEFAULT_INSTRUCTIONS
+    """Instructions for the internal agent that writes the summary.
+
+    `summary_prompt` shapes the user turn of the summary request; this shapes its system
+    prompt. Override it when the summarizer endpoint constrains the system prompt, e.g.
+    Claude Code OAuth endpoints require requests to open with a fixed instruction string.
     """
 
     tokenizer: Callable[[str], int] | None = None
@@ -624,7 +636,7 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
         # `Model[Any]`, mirroring core's own `reinject_system_prompt` idiom.
         agent: Agent[None, str] = Agent(
             cast('Model[Any] | str', model),
-            instructions='You are a context summarization assistant. Extract the most important information from conversations.',
+            instructions=self.instructions,
         )
         result = await agent.run(prompt, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
         return result.output.strip()

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -316,12 +316,12 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
     Must contain a ``{messages}`` placeholder.
     """
 
-    instructions: str = _DEFAULT_INSTRUCTIONS
+    instructions: str = field(default=_DEFAULT_INSTRUCTIONS, kw_only=True)
     """Instructions for the internal agent that writes the summary.
 
-    `summary_prompt` shapes the user turn of the summary request; this shapes its system
-    prompt. Override it when the summarizer endpoint constrains the system prompt, e.g.
-    Claude Code OAuth endpoints require requests to open with a fixed instruction string.
+    `summary_prompt` shapes the user turn of the summary request; this sets the internal
+    agent's static instructions, which Pydantic AI sends in the request's system prompt.
+    Override it when the summarizer endpoint requires a fixed leading instruction.
     """
 
     tokenizer: Callable[[str], int] | None = None

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -2141,6 +2141,45 @@ class TestSummarizingCompactionModel:
             request_limit=4, tool_calls_limit=2
         )
 
+    @pytest.mark.anyio
+    async def test_summarizer_agent_gets_the_default_instructions(self):
+        comp = SummarizingCompaction(max_messages=3, keep_messages=1, preserve_first_user_message=False)
+        messages: list[ModelMessage] = [_user('a'), _assistant('b'), _user('c'), _assistant('d')]
+
+        mock_result = AsyncMock()
+        mock_result.output = 'Default-instructions summary.'
+        with patch('pydantic_ai.Agent') as MockAgent:
+            mock_agent_instance = AsyncMock()
+            mock_agent_instance.run.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+            await comp.before_model_request(_make_ctx(), _make_request_context(messages))
+
+        assert MockAgent.call_args.kwargs['instructions'] == comp.instructions
+        assert 'context summarization assistant' in MockAgent.call_args.kwargs['instructions']
+
+    @pytest.mark.anyio
+    async def test_instructions_override_reaches_the_summarizer_agent(self):
+        # The motivating case: Claude Code OAuth endpoints require requests to open with a fixed
+        # instruction string, so the summarizer's system prompt must be configurable (#668).
+        required = "You are Claude Code, Anthropic's official CLI for Claude."
+        comp = SummarizingCompaction(
+            max_messages=3,
+            keep_messages=1,
+            preserve_first_user_message=False,
+            instructions=required,
+        )
+        messages: list[ModelMessage] = [_user('a'), _assistant('b'), _user('c'), _assistant('d')]
+
+        mock_result = AsyncMock()
+        mock_result.output = 'Overridden-instructions summary.'
+        with patch('pydantic_ai.Agent') as MockAgent:
+            mock_agent_instance = AsyncMock()
+            mock_agent_instance.run.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+            await comp.before_model_request(_make_ctx(), _make_request_context(messages))
+
+        assert MockAgent.call_args.kwargs['instructions'] == required
+
     def test_default_prompt_has_structured_sections(self):
         from pydantic_ai_harness.compaction._summarizing_compaction import _DEFAULT_SUMMARY_PROMPT
 

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -2159,9 +2159,7 @@ class TestSummarizingCompactionModel:
 
     @pytest.mark.anyio
     async def test_instructions_override_reaches_the_summarizer_agent(self):
-        # The motivating case: Claude Code OAuth endpoints require requests to open with a fixed
-        # instruction string, so the summarizer's system prompt must be configurable (#668).
-        required = "You are Claude Code, Anthropic's official CLI for Claude."
+        required = 'Required endpoint instruction.'
         comp = SummarizingCompaction(
             max_messages=3,
             keep_messages=1,

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -1247,7 +1247,9 @@ class TestPositionalCompatibility:
         assert SlidingWindowCompaction(None, 1_000, 40).keep_messages == 40
 
     def test_summarizing_compaction(self):
-        assert SummarizingCompaction('openai:gpt-4o', None, 1_000, 15).keep_messages == 15
+        strategy = SummarizingCompaction('openai:gpt-4o', None, 1_000, 15, None, '{messages}', len)
+        assert strategy.keep_messages == 15
+        assert strategy.tokenizer is len
 
     def test_clear_tool_results(self):
         assert ClearToolResults(None, 1_000, 5).keep_pairs == 5
@@ -1269,6 +1271,7 @@ class TestPositionalCompatibility:
         cases = [
             (SlidingWindowCompaction, 'max_fraction'),
             (SummarizingCompaction, 'max_fraction'),
+            (SummarizingCompaction, 'instructions'),
             (ClearToolResults, 'max_fraction'),
             (DeduplicateFileReads, 'max_fraction'),
             (TieredCompaction, 'target_fraction'),


### PR DESCRIPTION
Fixes #668.

`SummarizingCompaction` runs its nested summary request through an internal `Agent` whose `instructions` were hardcoded. `summary_prompt` customizes the user turn of the summary request, but the system prompt was out of reach.

That matters when the summarizer endpoint constrains the system prompt: Claude Code OAuth endpoints reject requests whose first system block is not a fixed instruction string, so pointing `model=` at one made every summary call fail (and with it, compaction for the run, modulo `FallbackCompaction`).

## Changes

- New `instructions: str` field on `SummarizingCompaction`, defaulting to the previous hardcoded string (`_DEFAULT_INSTRUCTIONS`), mirroring the `summary_prompt` / `_DEFAULT_SUMMARY_PROMPT` pattern. Behavior is unchanged unless the field is set.
- `_summarize` passes `instructions=self.instructions` to the internal agent.
- Docs parity: `pydantic_ai_harness/compaction/README.md` and `docs/compaction.md` both document the two prompt surfaces of the summary request.
- Tests: the default reaches the internal agent; an override reaches the internal agent (asserted through the same `patch('pydantic_ai.Agent')` seam the surrounding `TestSummarizingCompactionModel` tests use).

No new branches; a plain string field, spec-expressible as-is.

`make lint`, `pyright` (0 errors), and the full test suite (4460 passed) are green locally.
