### PR TITLE
Exclude `chore` PRs from release notes and remove verification drift

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - chore

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -111,7 +111,7 @@ README, or source code.
   re-records the cassette in the same PR
   (`uv run --env-file .env --no-sync pytest -p no:cacheprovider <test> --record-mode=rewrite`) —
   a green replay of a stale cassette proves nothing about the new definition.
-- `make lint`, `make typecheck`, and `make test` pass before handoff.
+- Run the local verification commands in `AGENTS.md` before handoff.
 
 ## Docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,7 +201,7 @@ quote-style = 'single'
 [tool.pyright]
 pythonVersion = '3.10'
 typeCheckingMode = 'strict'
-exclude = ['template', '.venv', '.venv*', 'local-notes', 'mutants', '.agents', '.claude']
+exclude = ['template', '.venv*', 'local-notes', 'mutants', '.agents', '.claude']
 # `reportUnusedFunction` is disabled for tests because fixtures and `@agent.tool_plain`
 # helpers are registered via decorators and never referenced by name (matches pydantic-ai).
 executionEnvironments = [


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-5.6-sol on behalf of David.

Follow-up to #667 after an independent post-merge review, plus generated release-note configuration.

- remove the redundant exact `.venv` Pyright exclusion because `.venv*` covers both the default and suffixed environments
- replace the stale full local gate requirement with the canonical verification contract in `AGENTS.md`
- exclude PRs labeled `chore` from generated release notes

Verification: repository-wide Ruff and focused pre-commit checks pass; `uv.lock` is unchanged.
