### PR TITLE
Add usage_update notification support to ACP adapter

### DIFF
--- a/pydantic_ai_harness/experimental/acp/_adapter.py
+++ b/pydantic_ai_harness/experimental/acp/_adapter.py
@@ -743,8 +743,7 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         conn = self._conn
         if conn is None:
             return
-        # Total tokens = input + output (ignoring cache tokens for the usage percentage, since
-        # they don't contribute to the context window size that matters for model limits).
+        # Total tokens = input + output; input_tokens already includes cache read/write tokens.
         total_tokens = request_usage.input_tokens + request_usage.output_tokens
         with contextlib.suppress(asyncio.CancelledError, Exception):
             await conn.session_update(

--- a/pydantic_ai_harness/experimental/acp/_adapter.py
+++ b/pydantic_ai_harness/experimental/acp/_adapter.py
@@ -48,6 +48,7 @@ from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 from pydantic_ai.usage import RunUsage, UsageLimits
 
+from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW, resolve_context_window
 from pydantic_ai_harness.experimental.acp._content import PromptContentBlock, prompt_blocks_to_user_content
 from pydantic_ai_harness.experimental.acp._permission import (
     PermissionPolicy,
@@ -683,6 +684,10 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
                     'persisting ACP session %s was cancelled; durable state is now behind', state.session_id
                 )
                 stop_reason = 'cancelled'
+
+        # Send usage_update notification to inform the client about context usage
+        await self._send_usage_update(turn.session_id, usage)
+
         return schema.PromptResponse(stop_reason=stop_reason, usage=_to_acp_usage(usage))
 
     async def _fail_outstanding_tool_calls(self, turn: _TurnState) -> None:
@@ -703,6 +708,37 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         """Send one `session/update` to the client, recording it for the transcript."""
         turn.updates.append(update)
         await turn.conn.session_update(session_id=turn.session_id, update=update)
+
+    async def _send_usage_update(self, session_id: str, usage: RunUsage) -> None:
+        """Send a `usage_update` session notification with current context usage.
+
+        Informs ACP clients (Zed, etc.) of the context token count and maximum window size so they can
+        render a usage percentage. Skipped when no connection is available. The notification is not
+        recorded in the transcript (fire-and-forget).
+        """
+        conn = self._conn
+        if conn is None:
+            return
+        with contextlib.suppress(Exception):
+            await conn.session_update(
+                session_id=session_id,
+                update=schema.UsageUpdate(
+                    session_update='usage_update',
+                    used=usage.total_tokens or 0,
+                    size=self._get_max_context_tokens(),
+                ),
+            )
+
+    def _get_max_context_tokens(self) -> int:
+        """Return the maximum context window size for the current model.
+
+        Uses DEFAULT_CONTEXT_WINDOW (200k) as fallback when the model cannot be resolved.
+        """
+        model = self._agent.model
+        if model is None:
+            return DEFAULT_CONTEXT_WINDOW
+        window = resolve_context_window(model)
+        return window if window is not None else DEFAULT_CONTEXT_WINDOW
 
     async def _emit_text(self, turn: _TurnState, text: str, *, thought: bool) -> None:
         """Stream text to the client as one or more chunked `session/update` notifications."""

--- a/pydantic_ai_harness/experimental/acp/_adapter.py
+++ b/pydantic_ai_harness/experimental/acp/_adapter.py
@@ -685,8 +685,11 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
                 )
                 stop_reason = 'cancelled'
 
-        # Send usage_update notification to inform the client about context usage
-        await self._send_usage_update(turn.session_id, usage)
+        # Send usage_update notification to inform the client about context usage.
+        # Use the resolved run model (state.model via model_resolver) rather than the agent's
+        # default model, since set_config_option can switch to a different model per session.
+        run_model = self._resolve_run_model(state.model)
+        await self._send_usage_update(turn.session_id, usage, run_model)
 
         return schema.PromptResponse(stop_reason=stop_reason, usage=_to_acp_usage(usage))
 
@@ -709,12 +712,18 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         turn.updates.append(update)
         await turn.conn.session_update(session_id=turn.session_id, update=update)
 
-    async def _send_usage_update(self, session_id: str, usage: RunUsage) -> None:
+    async def _send_usage_update(self, session_id: str, usage: RunUsage, run_model: Model | str | None) -> None:
         """Send a `usage_update` session notification with current context usage.
 
         Informs ACP clients (Zed, etc.) of the context token count and maximum window size so they can
         render a usage percentage. Skipped when no connection is available. The notification is not
         recorded in the transcript (fire-and-forget).
+
+        Args:
+            session_id: The session identifier.
+            usage: Token usage from the completed run.
+            run_model: The actual model used for this run (from state.model via model_resolver),
+                which may differ from self._agent.model when set_config_option switches models.
         """
         conn = self._conn
         if conn is None:
@@ -725,16 +734,19 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
                 update=schema.UsageUpdate(
                     session_update='usage_update',
                     used=usage.total_tokens or 0,
-                    size=self._get_max_context_tokens(),
+                    size=self._get_max_context_tokens(run_model),
                 ),
             )
 
-    def _get_max_context_tokens(self) -> int:
-        """Return the maximum context window size for the current model.
+    def _get_max_context_tokens(self, run_model: Model | str | None) -> int:
+        """Return the maximum context window size for the given model.
 
         Uses DEFAULT_CONTEXT_WINDOW (200k) as fallback when the model cannot be resolved.
+
+        Args:
+            run_model: The model used for the run. None falls back to the agent's default model.
         """
-        model = self._agent.model
+        model = run_model if run_model is not None else self._agent.model
         if model is None:
             return DEFAULT_CONTEXT_WINDOW
         window = resolve_context_window(model)

--- a/pydantic_ai_harness/experimental/acp/_adapter.py
+++ b/pydantic_ai_harness/experimental/acp/_adapter.py
@@ -698,7 +698,8 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         # model_resolver may be impure and return different results across calls).
         # Use final_result.response.usage (the final request's token counts) rather than result.usage
         # (which aggregates all model requests in the run, including tool-call passes that re-send context).
-        if final_result is not None and final_resolved_model is not None:
+        # final_resolved_model may be None when using the agent's default model, which _get_max_context_tokens handles.
+        if final_result is not None:
             await self._send_usage_update(turn.session_id, final_result.response.usage, final_resolved_model)
 
         return schema.PromptResponse(stop_reason=stop_reason, usage=_to_acp_usage(usage))

--- a/pydantic_ai_harness/experimental/acp/_adapter.py
+++ b/pydantic_ai_harness/experimental/acp/_adapter.py
@@ -597,6 +597,7 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         deferred_results: DeferredToolResults | None = None
         run_input: list[UserContent] | None = user_content
         output_type = [self._agent.output_type, DeferredToolRequests]
+        final_result = None  # Track the final run result for context usage reporting
         turn = _TurnState(
             conn=conn, session_id=state.session_id, cwd=state.cwd, approval_names=self._approval_tool_names(config)
         )
@@ -631,6 +632,7 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
                             await self._emit_event(turn, event)
 
                 assert result is not None, 'run_stream_events always yields a final result event'
+                final_result = result  # Save the final result for context usage reporting
                 history = result.all_messages()
                 usage += result.usage  # pydantic-ai 2.0: `usage` is a property, not a method
                 output = result.output
@@ -688,8 +690,11 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         # Send usage_update notification to inform the client about context usage.
         # Use the resolved run model (state.model via model_resolver) rather than the agent's
         # default model, since set_config_option can switch to a different model per session.
+        # Use final_result.usage (the last run's context usage) rather than the turn-wide billing
+        # total, which double-counts repeated context across approval/resume passes.
         run_model = self._resolve_run_model(state.model)
-        await self._send_usage_update(turn.session_id, usage, run_model)
+        if final_result is not None:
+            await self._send_usage_update(turn.session_id, final_result.usage, run_model)
 
         return schema.PromptResponse(stop_reason=stop_reason, usage=_to_acp_usage(usage))
 

--- a/pydantic_ai_harness/experimental/acp/_adapter.py
+++ b/pydantic_ai_harness/experimental/acp/_adapter.py
@@ -730,7 +730,8 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
 
         Informs ACP clients (Zed, etc.) of the context token count and maximum window size so they can
         render a usage percentage. Skipped when no connection is available. The notification is not
-        recorded in the transcript (fire-and-forget).
+        recorded in the transcript (fire-and-forget). Failures, including cancellation after the
+        turn has committed, are ignored.
 
         Args:
             session_id: The session identifier.
@@ -745,7 +746,7 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         # Total tokens = input + output (ignoring cache tokens for the usage percentage, since
         # they don't contribute to the context window size that matters for model limits).
         total_tokens = request_usage.input_tokens + request_usage.output_tokens
-        with contextlib.suppress(Exception):
+        with contextlib.suppress(asyncio.CancelledError, Exception):
             await conn.session_update(
                 session_id=session_id,
                 update=schema.UsageUpdate(

--- a/pydantic_ai_harness/experimental/acp/_adapter.py
+++ b/pydantic_ai_harness/experimental/acp/_adapter.py
@@ -46,7 +46,7 @@ from pydantic_ai.output import OutputDataT
 from pydantic_ai.run import AgentRunResultEvent
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
-from pydantic_ai.usage import RunUsage, UsageLimits
+from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
 from pydantic_ai_harness.compaction._context_window import DEFAULT_CONTEXT_WINDOW, resolve_context_window
 from pydantic_ai_harness.experimental.acp._content import PromptContentBlock, prompt_blocks_to_user_content
@@ -598,6 +598,7 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         run_input: list[UserContent] | None = user_content
         output_type = [self._agent.output_type, DeferredToolRequests]
         final_result = None  # Track the final run result for context usage reporting
+        final_resolved_model = None  # Track the resolved model used in the final run pass
         turn = _TurnState(
             conn=conn, session_id=state.session_id, cwd=state.cwd, approval_names=self._approval_tool_names(config)
         )
@@ -610,6 +611,10 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         try:
             while True:
                 result = None
+                # Resolve the model once per run pass to ensure consistency between the run and usage reporting.
+                # model_resolver is caller-supplied and not required to be pure (may rotate endpoints/models),
+                # so we must use the exact same resolved model for both run_stream_events and _get_max_context_tokens.
+                resolved_model = self._resolve_run_model(state.model)
                 async with self._agent.run_stream_events(
                     run_input,
                     message_history=history,
@@ -621,7 +626,7 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
                     # agent's own model, never mutating the shared agent. A `model_resolver` (if
                     # given) maps the advertised id to a pre-built `Model` for ids `infer_model`
                     # can't parse.
-                    model=self._resolve_run_model(state.model),
+                    model=resolved_model,
                     usage_limits=self._usage_limits,
                 ) as stream:
                     event: AgentStreamEvent | AgentRunResultEvent[object]
@@ -633,6 +638,7 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
 
                 assert result is not None, 'run_stream_events always yields a final result event'
                 final_result = result  # Save the final result for context usage reporting
+                final_resolved_model = resolved_model  # Save the model used in the final run pass
                 history = result.all_messages()
                 usage += result.usage  # pydantic-ai 2.0: `usage` is a property, not a method
                 output = result.output
@@ -688,13 +694,12 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
                 stop_reason = 'cancelled'
 
         # Send usage_update notification to inform the client about context usage.
-        # Use the resolved run model (state.model via model_resolver) rather than the agent's
-        # default model, since set_config_option can switch to a different model per session.
-        # Use final_result.usage (the last run's context usage) rather than the turn-wide billing
-        # total, which double-counts repeated context across approval/resume passes.
-        run_model = self._resolve_run_model(state.model)
-        if final_result is not None:
-            await self._send_usage_update(turn.session_id, final_result.usage, run_model)
+        # Use the exact resolved model from the final run pass (not re-resolving state.model, since
+        # model_resolver may be impure and return different results across calls).
+        # Use final_result.response.usage (the final request's token counts) rather than result.usage
+        # (which aggregates all model requests in the run, including tool-call passes that re-send context).
+        if final_result is not None and final_resolved_model is not None:
+            await self._send_usage_update(turn.session_id, final_result.response.usage, final_resolved_model)
 
         return schema.PromptResponse(stop_reason=stop_reason, usage=_to_acp_usage(usage))
 
@@ -717,7 +722,9 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
         turn.updates.append(update)
         await turn.conn.session_update(session_id=turn.session_id, update=update)
 
-    async def _send_usage_update(self, session_id: str, usage: RunUsage, run_model: Model | str | None) -> None:
+    async def _send_usage_update(
+        self, session_id: str, request_usage: RequestUsage, run_model: Model | str | None
+    ) -> None:
         """Send a `usage_update` session notification with current context usage.
 
         Informs ACP clients (Zed, etc.) of the context token count and maximum window size so they can
@@ -726,19 +733,23 @@ class PydanticAIACPAgent(acp.Agent, Generic[AgentDepsT, OutputDataT]):
 
         Args:
             session_id: The session identifier.
-            usage: Token usage from the completed run.
-            run_model: The actual model used for this run (from state.model via model_resolver),
-                which may differ from self._agent.model when set_config_option switches models.
+            request_usage: Token usage from the final model request (result.response.usage), not the
+                run-wide aggregate which double-counts context across multiple requests.
+            run_model: The actual model used for the final run pass (pre-resolved to avoid impure
+                model_resolver returning different results across calls).
         """
         conn = self._conn
         if conn is None:
             return
+        # Total tokens = input + output (ignoring cache tokens for the usage percentage, since
+        # they don't contribute to the context window size that matters for model limits).
+        total_tokens = request_usage.input_tokens + request_usage.output_tokens
         with contextlib.suppress(Exception):
             await conn.session_update(
                 session_id=session_id,
                 update=schema.UsageUpdate(
                     session_update='usage_update',
-                    used=usage.total_tokens or 0,
+                    used=total_tokens,
                     size=self._get_max_context_tokens(run_model),
                 ),
             )

--- a/tests/experimental/acp/test_acp.py
+++ b/tests/experimental/acp/test_acp.py
@@ -46,7 +46,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import FunctionToolset
-from pydantic_ai.usage import UsageLimits
+from pydantic_ai.usage import RequestUsage, UsageLimits
 
 from pydantic_ai_harness import FileSystem, Shell
 from pydantic_ai_harness.experimental import HarnessExperimentalWarning
@@ -131,6 +131,8 @@ class FakeClient(RecordingClientBase):
                 out.append((kind, getattr(update, 'title', '')))
             elif kind == 'tool_call_update':
                 out.append((kind, getattr(update, 'status', '')))
+            elif kind == 'usage_update':
+                continue
             else:  # pragma: no cover - guards against schema drift, not exercised
                 raise AssertionError(f'unexpected session/update kind: {kind!r}')
         return out
@@ -571,6 +573,17 @@ class TestStreaming:
         assert response.usage.input_tokens > 0 and response.usage.output_tokens > 0
         assert response.usage.total_tokens == response.usage.input_tokens + response.usage.output_tokens
 
+    async def test_usage_update_uses_inclusive_input_token_count(self) -> None:
+        adapter: PydanticAIACPAgent[None, str] = PydanticAIACPAgent(Agent(TestModel()))
+        client = FakeClient()
+        adapter.on_connect(client)
+        request_usage = RequestUsage(input_tokens=100, cache_read_tokens=30, cache_write_tokens=40, output_tokens=20)
+
+        await adapter._send_usage_update('sid', request_usage, None)  # pyright: ignore[reportPrivateUsage]
+
+        [update] = [item for item in client.updates if isinstance(item, schema.UsageUpdate)]
+        assert update.used == request_usage.total_tokens == 120
+
     async def test_usage_sums_across_approval_passes(self) -> None:
         # An approval pause splits the turn into two model passes; the reported usage must cover
         # both, not just the resume.
@@ -892,7 +905,8 @@ class TestPermission:
 
         stored = await store.load(session_id)
         assert stored is not None
-        assert stored.updates == [acp.update_user_message_text('delete'), *client.updates]
+        persisted_updates = [update for update in client.updates if not isinstance(update, schema.UsageUpdate)]
+        assert stored.updates == [acp.update_user_message_text('delete'), *persisted_updates]
 
     async def test_allow_always_skips_the_prompt_on_later_turns(self) -> None:
         executed: list[str] = []


### PR DESCRIPTION
## Summary

Implements `usage_update` session notifications in the ACP adapter to inform clients (like Zed) about context token usage and maximum window size, enabling them to render usage percentages.

Fixes #671 

## Changes

- Added `_send_usage_update()` method to send `schema.UsageUpdate` notifications after each turn
- Added `_get_max_context_tokens()` helper that uses `resolve_context_window()` with `DEFAULT_CONTEXT_WINDOW` (200k) as fallback for unknown models
- Integrated usage notification call into `_run_turn()` after the turn completes
- Handles `None` models and unknown models gracefully by falling back to 200k tokens

## Behavior

- For known models (gpt-4o, claude-3-5-sonnet, etc.): uses the resolved context window from `genai-prices`
- For unknown models (qwen-plus, custom endpoints, etc.): uses `DEFAULT_CONTEXT_WINDOW` (200,000 tokens)
- Notification is fire-and-forget (wrapped in `contextlib.suppress(Exception)`)
- Skipped only when no connection is available

## Testing

- [x] Code passes `ruff check` and `ruff format`
- [x] Verified `resolve_context_window()` correctly resolves known models
- [x] Verified fallback to `DEFAULT_CONTEXT_WINDOW` for unknown models
- [x] Manually tested with Zed editor - context usage now displays correctly

## Example

After this change, Zed editor displays context usage like:
<img width="289" height="174" alt="image" src="https://github.com/user-attachments/assets/0cd01d23-b98b-446f-add6-b5378de50f2f" />
