### PR TITLE
Preserve caller-owned media marker keys

### DIFF
--- a/docs/media.md
+++ b/docs/media.md
@@ -78,6 +78,8 @@ full = await restore_media(lean, media_store=store)
 
 The current reader restores binary markers written before text externalization. That compatibility is upgrade-only: a release that predates text externalization treats every marker as binary, so it cannot validate a snapshot containing an externalized text marker. Keep a current reader for persisted snapshots that contain those markers.
 
+If a payload uses the same namespaced keys as the marker format, the writer moves those values into a versioned reserved mapping and the current reader restores them. Readers remain compatible with markers written before this escaping format was added.
+
 ## Public URLs
 
 When a store is fronted by a CDN, a local HTTP server, or a signed-URL service, pass a `public_url=` resolver (or use `make_static_public_url`) to turn a stored `media+sha256://` URI into a URL the model can fetch directly. Without a resolver, `public_url(...)` returns `None`.
@@ -167,3 +169,4 @@ Source: [`pydantic_ai_harness/media/`](https://github.com/pydantic/pydantic-ai-h
 ## Related
 
 - [Step Persistence](step-persistence.md) -- the first consumer of these stores, externalizing large `BinaryContent` and text parts in run snapshots.
+

--- a/docs/media.md
+++ b/docs/media.md
@@ -169,4 +169,3 @@ Source: [`pydantic_ai_harness/media/`](https://github.com/pydantic/pydantic-ai-h
 ## Related
 
 - [Step Persistence](step-persistence.md) -- the first consumer of these stores, externalizing large `BinaryContent` and text parts in run snapshots.
-

--- a/pydantic_ai_harness/media/README.md
+++ b/pydantic_ai_harness/media/README.md
@@ -73,4 +73,3 @@ If a payload uses the same namespaced keys as the marker format, the writer move
 | `PublicUrlResolver`, `make_static_public_url` | Resolve a stored URI to a public URL |
 | `externalize_media`, `restore_media` | Walk a message node to externalize / rehydrate large binary and text payloads |
 | `media_uri_for`, `parse_media_uri` | Compute and parse a `media+sha256://` URI |
-

--- a/pydantic_ai_harness/media/README.md
+++ b/pydantic_ai_harness/media/README.md
@@ -60,6 +60,8 @@ full = await restore_media(lean, media_store=store)
 
 The current reader restores binary markers written before text externalization. That compatibility is upgrade-only: a release that predates text externalization treats every marker as binary, so it cannot validate a snapshot containing an externalized text marker. Keep a current reader for persisted snapshots that contain those markers.
 
+If a payload uses the same namespaced keys as the marker format, the writer moves those values into a versioned reserved mapping and the current reader restores them. Readers remain compatible with markers written before this escaping format was added.
+
 ## API
 
 | Symbol | Purpose |
@@ -71,3 +73,4 @@ The current reader restores binary markers written before text externalization. 
 | `PublicUrlResolver`, `make_static_public_url` | Resolve a stored URI to a public URL |
 | `externalize_media`, `restore_media` | Walk a message node to externalize / rehydrate large binary and text payloads |
 | `media_uri_for`, `parse_media_uri` | Compute and parse a `media+sha256://` URI |
+

--- a/pydantic_ai_harness/media/_walker.py
+++ b/pydantic_ai_harness/media/_walker.py
@@ -42,6 +42,19 @@ _TEXT_MARKER = '__harness_external_text__'
 # `part_kind`/`content`/`uri`, and a plain `uri` key alone would drop the
 # original. See `_write_reference` for the backward-compatible `uri` mirror.
 _URI_KEY = '__harness_external_uri__'
+# A marker can overwrite fields with the same names as its own metadata. New
+# markers move those caller-owned values into a versioned mapping before writing
+# the metadata, and the reader puts them back after rehydrating the payload.
+_ESCAPED_KEYS = '__harness_external_escaped_keys__'
+_MARKER_FORMAT = '__harness_external_marker_format__'
+_ESCAPED_KEYS_FORMAT = 'escaped-keys-v1'
+_MARKER_METADATA_KEYS = (
+    _EXTERNAL_MARKER,
+    _TEXT_MARKER,
+    _URI_KEY,
+    _ESCAPED_KEYS,
+    _MARKER_FORMAT,
+)
 # `TextContent.kind` (`pydantic_ai.messages.TextContent`). Unlike a message
 # part it carries no `part_kind`, so it needs its own discriminator match.
 _TEXT_CONTENT_KIND = 'text-content'
@@ -146,6 +159,7 @@ async def _maybe_externalize_binary(
     # survives new `BinaryContent` fields added by pydantic_ai upstream. Fields
     # are recursively walked so any nested externalizable payload still goes out.
     marker = await _preserve_fields(node, 'data', media_store, threshold_bytes)
+    _escape_marker_metadata(marker)
     marker[_EXTERNAL_MARKER] = True
     _write_reference(marker, node, uri)
     return marker
@@ -172,6 +186,7 @@ async def _maybe_externalize_text(
     # `_TEXT_MARKER` tells `restore_media` to decode UTF-8 back into `content`
     # rather than base64 into `data`.
     marker = await _preserve_fields(node, 'content', media_store, threshold_bytes)
+    _escape_marker_metadata(marker)
     marker[_EXTERNAL_MARKER] = True
     marker[_TEXT_MARKER] = True
     _write_reference(marker, node, uri)
@@ -195,6 +210,17 @@ def _write_reference(marker: dict[str, object], node: dict[str, object], uri: st
     marker[_URI_KEY] = uri
     if 'uri' not in node:
         marker['uri'] = uri
+
+
+def _escape_marker_metadata(marker: dict[str, object]) -> None:
+    """Move caller-owned marker metadata keys aside before writing our values."""
+    escaped: dict[str, object] = {}
+    for key in _MARKER_METADATA_KEYS:
+        if key in marker:
+            escaped[key] = marker.pop(key)
+    if escaped:
+        marker[_MARKER_FORMAT] = _ESCAPED_KEYS_FORMAT
+        marker[_ESCAPED_KEYS] = escaped
 
 
 async def _preserve_fields(
@@ -236,6 +262,13 @@ async def restore_media(node: object, *, media_store: MediaStore) -> object:
 
 async def _restore_external(node: dict[str, object], media_store: MediaStore) -> dict[str, object]:
     dropped = {_EXTERNAL_MARKER, _TEXT_MARKER}
+    escaped: dict[str, object] | None = None
+    if node.get(_MARKER_FORMAT) == _ESCAPED_KEYS_FORMAT:
+        escaped_value = node.get(_ESCAPED_KEYS)
+        if not _is_json_dict(escaped_value):
+            raise ValueError(f'externalized media marker has invalid escaped keys: {node!r}')
+        escaped = escaped_value
+        dropped.update({_MARKER_FORMAT, _ESCAPED_KEYS})
     if _URI_KEY in node:
         uri_value = node[_URI_KEY]
         dropped.add(_URI_KEY)
@@ -270,8 +303,12 @@ async def _restore_external(node: dict[str, object], media_store: MediaStore) ->
         if key in dropped:
             continue
         restored[key] = await restore_media(value, media_store=media_store)
+    if escaped is not None:
+        for key, value in escaped.items():
+            restored[key] = await restore_media(value, media_store=media_store)
     if is_text:
         restored['content'] = raw.decode('utf-8', errors='surrogatepass')
     else:
         restored['data'] = base64.b64encode(raw).decode('ascii')
     return restored
+

--- a/pydantic_ai_harness/media/_walker.py
+++ b/pydantic_ai_harness/media/_walker.py
@@ -311,4 +311,3 @@ async def _restore_external(node: dict[str, object], media_store: MediaStore) ->
     else:
         restored['data'] = base64.b64encode(raw).decode('ascii')
     return restored
-

--- a/tests/media/test_media.py
+++ b/tests/media/test_media.py
@@ -1269,4 +1269,3 @@ def test_concrete_stores_satisfy_protocol(tmp_path: Path) -> None:
             secret_access_key='s',
         )
     )
-

--- a/tests/media/test_media.py
+++ b/tests/media/test_media.py
@@ -525,6 +525,59 @@ class TestExternalizeRestoreWalker:
         restored = await restore_media(externalized, media_store=store)
         assert restored == node  # original uri survives, content re-inlined
 
+    async def test_namespaced_marker_fields_round_trip(self, tmp_path: Path) -> None:
+        """Caller-owned marker metadata is escaped before the marker writes its values."""
+        import base64
+
+        store = DiskMediaStore(tmp_path)
+        node = {
+            'kind': 'binary',
+            'data': base64.b64encode(b'\x01' * 70_000).decode('ascii'),
+            '__harness_external_media__': 'caller-media-marker',
+            '__harness_external_text__': True,
+            '__harness_external_uri__': 'caller-uri',
+            '__harness_external_escaped_keys__': {'caller': 'escaped-keys'},
+            '__harness_external_marker_format__': 'caller-format',
+            '__harness_external_field__': 'caller-field',
+        }
+
+        externalized = await externalize_media(node, media_store=store, threshold_bytes=64 * 1024)
+        assert _is_marker_dict(externalized)
+        assert externalized['__harness_external_media__'] is True
+        assert externalized['__harness_external_marker_format__'] == 'escaped-keys-v1'
+        assert externalized['__harness_external_uri__'] != 'caller-uri'
+
+        assert await restore_media(externalized, media_store=store) == node
+
+    async def test_text_marker_field_round_trips(self, tmp_path: Path) -> None:
+        """A text part can use the text marker key without losing its value."""
+        store = DiskMediaStore(tmp_path)
+        node = {
+            'part_kind': 'tool-return',
+            'content': 'x' * 70_000,
+            '__harness_external_text__': 'caller-text-marker',
+        }
+
+        externalized = await externalize_media(node, media_store=store, threshold_bytes=64 * 1024)
+        assert _is_marker_dict(externalized)
+        assert externalized['__harness_external_text__'] is True
+        assert await restore_media(externalized, media_store=store) == node
+
+    async def test_invalid_escaped_marker_fields_raise(self, tmp_path: Path) -> None:
+        """A versioned marker with a malformed escaped-key mapping fails loudly."""
+        store = DiskMediaStore(tmp_path)
+        uri = await store.put(b'payload')
+        marker = {
+            '__harness_external_media__': True,
+            '__harness_external_uri__': uri,
+            '__harness_external_marker_format__': 'escaped-keys-v1',
+            '__harness_external_escaped_keys__': ['not', 'a', 'mapping'],
+            'kind': 'binary',
+        }
+
+        with pytest.raises(ValueError, match='invalid escaped keys'):
+            await restore_media(marker, media_store=store)
+
     async def test_legacy_uri_marker_restores(self, tmp_path: Path) -> None:
         """A marker in the pre-`_URI_KEY` format (blob ref under plain `uri`) restores.
 
@@ -632,6 +685,8 @@ class TestExternalizeRestoreWalker:
         marker = await externalize_media(node, media_store=store, threshold_bytes=64 * 1024)
         assert _is_marker_dict(marker)
         assert marker['uri'] == marker['__harness_external_uri__']
+        assert '__harness_external_marker_format__' not in marker
+        assert '__harness_external_escaped_keys__' not in marker
 
         rolled_back = await _restore_as_pre_pr_reader(marker, store)
         # The old reader keeps keys it does not know; pydantic ignores the extra
@@ -1214,3 +1269,4 @@ def test_concrete_stores_satisfy_protocol(tmp_path: Path) -> None:
             secret_access_key='s',
         )
     )
+


### PR DESCRIPTION
## Summary

- preserve caller-owned values that collide with media marker metadata keys
- store collisions in a versioned escape mapping and restore nested values recursively
- keep the existing marker shape when no collision occurs and reject malformed versioned metadata
- add binary/text regression tests and keep both media documentation surfaces in sync

## Verification

- `uv run coverage run --branch -m pytest tests/media tests/test_docs_parity.py -q -k "not key_strategy_blocks_absolute_path"` — 391 passed, 1 skipped, 1 deselected
- `uv run coverage report --include="pydantic_ai_harness/media/_walker.py" --show-missing` — 100% statement and branch coverage
- `uv run ruff format --check` — 319 files already formatted
- `uv run ruff check` — all checks passed
- `uv run pyright pydantic_ai_harness/media/_walker.py tests/media/test_media.py` — 0 errors

Full-repository Pyright on this Windows host reports existing POSIX-only symbols such as `os.killpg`, `os.mkfifo`, and `signal.SIGALRM` in untouched files. The changed files pass strict Pyright.

## Linked Issue

Fixes #541

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (Windows platform limitations documented above; focused and repository-wide portable checks pass)
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)
