### PR TITLE
Add the `DaytonaSandbox` capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The workspace the agent acts in: the files it edits and the commands it runs, lo
 |---|---|---|
 | [FileSystem](pydantic_ai_harness/filesystem/) | Harness | Read, write, edit, search files under a root; path-traversal and symlink safe, secrets read-only |
 | [Shell](pydantic_ai_harness/shell/) | Harness | Command execution with allowlists, denylists, timeouts, and credential-stripping |
+| [Daytona Sandbox](pydantic_ai_harness/daytona_sandbox/) | Harness | Commands and files in an isolated [Daytona](https://www.daytona.io) cloud sandbox |
 | [Modal Sandbox](pydantic_ai_harness/modal_sandbox/) | Harness | Commands and files in an isolated [Modal](https://modal.com) cloud sandbox |
 
 ### Tools & native abilities

--- a/docs/daytona-sandbox.md
+++ b/docs/daytona-sandbox.md
@@ -69,6 +69,45 @@ DaytonaSandbox(sandbox_id='sandbox-id')
 `workdir` applies to commands and relative file paths. `env` is passed when the
 sandbox is created and on every command.
 
+To reuse one sandbox across sequential runs while controlling its lifetime,
+open a `DaytonaSandboxSession` and pass it to the capability:
+
+```python
+import asyncio
+
+from pydantic_ai import Agent
+from pydantic_ai_harness import DaytonaSandbox
+from pydantic_ai_harness.daytona_sandbox import DaytonaSandboxSession
+
+
+async def main() -> None:
+    async with DaytonaSandboxSession() as session:
+        agent = Agent(
+            'openai:gpt-5.6-sol',
+            capabilities=[DaytonaSandbox(session=session)],
+        )
+        await agent.run('Install the project dependencies.')
+        await agent.run('Run the tests in the same sandbox.')
+
+
+asyncio.run(main())
+```
+
+The caller opens and closes an injected session. The capability does neither.
+An attached session (`DaytonaSandboxSession(sandbox_id=...)`) is also left
+running when the session closes. Do not share one session between overlapping
+runs that need isolated files or processes.
+
+`session=` cannot be combined with `sandbox_id`, `snapshot`, a non-default
+`auto_stop_minutes`, `workdir`, or `env` on the capability. Configure those on
+`DaytonaSandboxSession`, which owns the sandbox.
+
+`DaytonaSandboxSession.exec` returns a `DaytonaSandboxExecResult` for
+applications that need command access outside an agent run. Daytona's direct
+execution response exposes one result string and does not separate stderr. The
+caller must provide a positive whole-second timeout. This lower-level method
+returns raw SDK output without the capability's byte or line limits.
+
 ## Limits
 
 Commands default to `default_command_timeout=60` seconds. Model-requested
@@ -106,6 +145,10 @@ activity replay or worker restart.
 ## API reference
 
 ::: pydantic_ai_harness.daytona_sandbox.DaytonaSandbox
+
+::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxSession
+
+::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxExecResult
 
 ::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxError
 

--- a/docs/daytona-sandbox.md
+++ b/docs/daytona-sandbox.md
@@ -109,10 +109,30 @@ Configure those on `DaytonaSandboxSession`, which owns the sandbox. Attached
 sandboxes retain their existing network settings.
 
 `DaytonaSandboxSession.exec` returns a `DaytonaSandboxExecResult` for
-applications that need command access outside an agent run. Daytona's direct
-execution response exposes one result string and does not separate stderr. The
-caller must provide a positive whole-second timeout. This lower-level method
-returns raw SDK output without the capability's byte or line limits.
+applications that need command access outside an agent run. It streams command
+output from Daytona and retains only the last `max_output_bytes`. The caller
+must provide a positive whole-second timeout.
+
+Use `DaytonaSandboxSession.process` when an application needs to exchange input
+with a long-running command or handle stdout and stderr separately:
+
+```python
+async with DaytonaSandboxSession(network_block_all=True) as session:
+    async with session.process(
+        'worker',
+        'python worker.py',
+        on_stdout=print,
+        on_stderr=print,
+        max_input_bytes=64 * 1024,
+    ) as process:
+        await process.send('{"task":"run"}\n')
+        returncode = await process.wait(timeout=60)
+```
+
+The caller supplies the process identity, input bound, and every wait. Starting,
+input, output streaming, and deletion use Daytona's process-session API. Context
+exit terminates the remote process session, including after a timeout or
+cancellation. Input echo is disabled so protocol input cannot appear on stdout.
 
 ## Limits
 
@@ -154,6 +174,8 @@ activity replay or worker restart.
 ::: pydantic_ai_harness.daytona_sandbox.DaytonaSandbox
 
 ::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxSession
+
+::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxProcess
 
 ::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxExecResult
 

--- a/docs/daytona-sandbox.md
+++ b/docs/daytona-sandbox.md
@@ -67,7 +67,12 @@ DaytonaSandbox(sandbox_id='sandbox-id')
 ```
 
 `workdir` applies to commands and relative file paths. `env` is passed when the
-sandbox is created and on every command.
+sandbox is created and on every command. Set `network_block_all=True` on a fresh
+sandbox or session to block outbound traffic:
+
+```python
+DaytonaSandbox(network_block_all=True)
+```
 
 To reuse one sandbox across sequential runs while controlling its lifetime,
 open a `DaytonaSandboxSession` and pass it to the capability:
@@ -99,8 +104,9 @@ running when the session closes. Do not share one session between overlapping
 runs that need isolated files or processes.
 
 `session=` cannot be combined with `sandbox_id`, `snapshot`, a non-default
-`auto_stop_minutes`, `workdir`, or `env` on the capability. Configure those on
-`DaytonaSandboxSession`, which owns the sandbox.
+`auto_stop_minutes`, `workdir`, `env`, or `network_block_all` on the capability.
+Configure those on `DaytonaSandboxSession`, which owns the sandbox. Attached
+sandboxes retain their existing network settings.
 
 `DaytonaSandboxSession.exec` returns a `DaytonaSandboxExecResult` for
 applications that need command access outside an agent run. Daytona's direct
@@ -133,7 +139,8 @@ PrefixTools(wrapped=DaytonaSandbox(instructions=''), prefix='daytona')
 ```
 
 Daytona sandboxes isolate processes and files from the application host. Network
-access and credentials inside the sandbox remain separate trust boundaries.
+access and credentials inside the sandbox remain separate trust boundaries. Use
+`network_block_all=True` when tools do not require outbound access.
 The Daytona SDK is asyncio-native, so this capability does not support trio.
 Durable execution is rejected because a live sandbox session cannot survive
 activity replay or worker restart.

--- a/docs/daytona-sandbox.md
+++ b/docs/daytona-sandbox.md
@@ -1,0 +1,114 @@
+---
+title: Daytona Sandbox
+description: Give a Pydantic AI agent a per-run Daytona sandbox with command and file tools.
+---
+
+# Daytona Sandbox
+
+`DaytonaSandbox` gives an agent an isolated cloud computer for running commands
+and working with files. Use it when model-generated code should not run on the
+application host.
+
+Each agent run gets a fresh [Daytona sandbox](https://www.daytona.io/docs/en/)
+that is deleted when the run ends. You can instead attach a sandbox you manage.
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
+
+## Quick start
+
+Install the extra and set a Daytona API key:
+
+```bash
+uv add "pydantic-ai-harness[daytona]"
+export DAYTONA_API_KEY=...
+```
+
+Add the capability:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import DaytonaSandbox
+
+agent = Agent(
+    'openai:gpt-5.6-sol',
+    capabilities=[DaytonaSandbox()],
+)
+
+result = agent.run_sync('Create a Python script and run its tests.')
+print(result.output)
+```
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `run_command` | Run a shell command with a bounded timeout and output. |
+| `read_file` | Read UTF-8 text with line paging. |
+| `write_file` | Write UTF-8 text and create parent directories. |
+| `list_directory` | List entries, marking directories with `/`. |
+
+Non-zero command exits are returned to the model. File errors become retryable
+tool errors. Missing sandboxes and rejected credentials raise
+`DaytonaSandboxUnavailableError` and `DaytonaSandboxAuthError`.
+
+## Lifecycle
+
+The default creates one sandbox per run and deletes it on exit. Daytona also
+stops it after `auto_stop_minutes` of inactivity and deletes it immediately
+after stopping, which bounds an orphan if teardown cannot reach the control
+plane.
+
+Set `sandbox_id` to attach an existing sandbox. Attached sandboxes are not
+deleted. `snapshot` selects the snapshot for a fresh sandbox and cannot be used
+with `sandbox_id`.
+
+```python
+DaytonaSandbox(sandbox_id='sandbox-id')
+```
+
+`workdir` applies to commands and relative file paths. `env` is passed when the
+sandbox is created and on every command.
+
+## Limits
+
+Commands default to `default_command_timeout=60` seconds. Model-requested
+timeouts are capped by `max_command_timeout=300`. Tool output is bounded by
+`max_output_bytes` and `max_output_lines`; command output keeps the tail and
+directory output keeps the head. `read_file` refuses files larger than
+`max_read_bytes` before decoding them.
+
+The Daytona SDK is currently constrained to `>=0.198.0,<0.199.0`. Later SDKs
+require `typing-extensions>=4.16.0`, while another Harness extra currently pins
+4.15.0. Raise the ceiling after those extras resolve together.
+
+## Composition
+
+The tools use common names. Prefix them when another capability contributes the
+same names:
+
+```python
+from pydantic_ai.capabilities import PrefixTools
+from pydantic_ai_harness import DaytonaSandbox
+
+PrefixTools(wrapped=DaytonaSandbox(instructions=''), prefix='daytona')
+```
+
+Daytona sandboxes isolate processes and files from the application host. Network
+access and credentials inside the sandbox remain separate trust boundaries.
+The Daytona SDK is asyncio-native, so this capability does not support trio.
+Durable execution is rejected because a live sandbox session cannot survive
+activity replay or worker restart.
+
+## Source
+
+- [Daytona Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/daytona_sandbox/)
+
+## API reference
+
+::: pydantic_ai_harness.daytona_sandbox.DaytonaSandbox
+
+::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxError
+
+::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxAuthError
+
+::: pydantic_ai_harness.daytona_sandbox.DaytonaSandboxUnavailableError

--- a/docs/index.md
+++ b/docs/index.md
@@ -146,6 +146,7 @@ The workspace the agent acts in: the files it edits and the commands it runs, lo
 |---|---|---|
 | [FileSystem](filesystem.md) | Harness | Read, write, edit, search files under a root; path-traversal and symlink safe, secrets read-only |
 | [Shell](shell.md) | Harness | Command execution with allowlists, denylists, timeouts, and credential-stripping |
+| [Daytona Sandbox](daytona-sandbox.md) | Harness | Commands and files in an isolated [Daytona](https://www.daytona.io) cloud sandbox |
 | [Modal Sandbox](modal-sandbox.md) | Harness | Commands and files in an isolated [Modal](https://modal.com) cloud sandbox |
 
 ### Tools & native abilities

--- a/pydantic_ai_harness/__init__.py
+++ b/pydantic_ai_harness/__init__.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         WarnNearLimits,
     )
     from .conversation_search import ConversationSearch
+    from .daytona_sandbox import DaytonaSandbox
     from .dynamic_workflow import DynamicWorkflow
     from .exa import ExaAgent, ExaSearch
     from .filesystem import READ_ONLY_TOOL_NAMES, FileSystem
@@ -69,6 +70,7 @@ __all__ = [
     'DEFAULT_ALLOWED_COMMANDS',
     'DEFAULT_RESEARCHER_INSTRUCTIONS',
     'DeduplicateFileReads',
+    'DaytonaSandbox',
     'DynamicWorkflow',
     'ExaAgent',
     'ExaSearch',
@@ -125,6 +127,7 @@ _CAPABILITY_EXPORTS = {
     'Coder': 'coder',
     'ConversationSearch': 'conversation_search',
     'DeduplicateFileReads': 'compaction',
+    'DaytonaSandbox': 'daytona_sandbox',
     'DynamicWorkflow': 'dynamic_workflow',
     'ExaAgent': 'exa',
     'ExaSearch': 'exa',

--- a/pydantic_ai_harness/daytona_sandbox/README.md
+++ b/pydantic_ai_harness/daytona_sandbox/README.md
@@ -64,6 +64,45 @@ DaytonaSandbox(sandbox_id='sandbox-id')
 `workdir` applies to commands and relative file paths. `env` is passed when the
 sandbox is created and on every command.
 
+To reuse one sandbox across sequential runs while controlling its lifetime,
+open a `DaytonaSandboxSession` and pass it to the capability:
+
+```python
+import asyncio
+
+from pydantic_ai import Agent
+from pydantic_ai_harness import DaytonaSandbox
+from pydantic_ai_harness.daytona_sandbox import DaytonaSandboxSession
+
+
+async def main() -> None:
+    async with DaytonaSandboxSession() as session:
+        agent = Agent(
+            'openai:gpt-5.6-sol',
+            capabilities=[DaytonaSandbox(session=session)],
+        )
+        await agent.run('Install the project dependencies.')
+        await agent.run('Run the tests in the same sandbox.')
+
+
+asyncio.run(main())
+```
+
+The caller opens and closes an injected session. The capability does neither.
+An attached session (`DaytonaSandboxSession(sandbox_id=...)`) is also left
+running when the session closes. Do not share one session between overlapping
+runs that need isolated files or processes.
+
+`session=` cannot be combined with `sandbox_id`, `snapshot`, a non-default
+`auto_stop_minutes`, `workdir`, or `env` on the capability. Configure those on
+`DaytonaSandboxSession`, which owns the sandbox.
+
+`DaytonaSandboxSession.exec` returns a `DaytonaSandboxExecResult` for
+applications that need command access outside an agent run. Daytona's direct
+execution response exposes one result string and does not separate stderr. The
+caller must provide a positive whole-second timeout. This lower-level method
+returns raw SDK output without the capability's byte or line limits.
+
 ## Limits
 
 Commands default to `default_command_timeout=60` seconds. Model-requested

--- a/pydantic_ai_harness/daytona_sandbox/README.md
+++ b/pydantic_ai_harness/daytona_sandbox/README.md
@@ -62,7 +62,12 @@ DaytonaSandbox(sandbox_id='sandbox-id')
 ```
 
 `workdir` applies to commands and relative file paths. `env` is passed when the
-sandbox is created and on every command.
+sandbox is created and on every command. Set `network_block_all=True` on a fresh
+sandbox or session to block outbound traffic:
+
+```python
+DaytonaSandbox(network_block_all=True)
+```
 
 To reuse one sandbox across sequential runs while controlling its lifetime,
 open a `DaytonaSandboxSession` and pass it to the capability:
@@ -94,8 +99,9 @@ running when the session closes. Do not share one session between overlapping
 runs that need isolated files or processes.
 
 `session=` cannot be combined with `sandbox_id`, `snapshot`, a non-default
-`auto_stop_minutes`, `workdir`, or `env` on the capability. Configure those on
-`DaytonaSandboxSession`, which owns the sandbox.
+`auto_stop_minutes`, `workdir`, `env`, or `network_block_all` on the capability.
+Configure those on `DaytonaSandboxSession`, which owns the sandbox. Attached
+sandboxes retain their existing network settings.
 
 `DaytonaSandboxSession.exec` returns a `DaytonaSandboxExecResult` for
 applications that need command access outside an agent run. Daytona's direct
@@ -128,7 +134,8 @@ PrefixTools(wrapped=DaytonaSandbox(instructions=''), prefix='daytona')
 ```
 
 Daytona sandboxes isolate processes and files from the application host. Network
-access and credentials inside the sandbox remain separate trust boundaries.
+access and credentials inside the sandbox remain separate trust boundaries. Use
+`network_block_all=True` when tools do not require outbound access.
 The Daytona SDK is asyncio-native, so this capability does not support trio.
 Durable execution is rejected because a live sandbox session cannot survive
 activity replay or worker restart.

--- a/pydantic_ai_harness/daytona_sandbox/README.md
+++ b/pydantic_ai_harness/daytona_sandbox/README.md
@@ -1,0 +1,99 @@
+# Daytona Sandbox
+
+`DaytonaSandbox` gives an agent an isolated cloud computer for running commands
+and working with files. Use it when model-generated code should not run on the
+application host.
+
+Each agent run gets a fresh [Daytona sandbox](https://www.daytona.io/docs/en/)
+that is deleted when the run ends. You can instead attach a sandbox you manage.
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
+
+## Quick start
+
+Install the extra and set a Daytona API key:
+
+```bash
+uv add "pydantic-ai-harness[daytona]"
+export DAYTONA_API_KEY=...
+```
+
+Add the capability:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import DaytonaSandbox
+
+agent = Agent(
+    'openai:gpt-5.6-sol',
+    capabilities=[DaytonaSandbox()],
+)
+
+result = agent.run_sync('Create a Python script and run its tests.')
+print(result.output)
+```
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `run_command` | Run a shell command with a bounded timeout and output. |
+| `read_file` | Read UTF-8 text with line paging. |
+| `write_file` | Write UTF-8 text and create parent directories. |
+| `list_directory` | List entries, marking directories with `/`. |
+
+Non-zero command exits are returned to the model. File errors become retryable
+tool errors. Missing sandboxes and rejected credentials raise
+`DaytonaSandboxUnavailableError` and `DaytonaSandboxAuthError`.
+
+## Lifecycle
+
+The default creates one sandbox per run and deletes it on exit. Daytona also
+stops it after `auto_stop_minutes` of inactivity and deletes it immediately
+after stopping, which bounds an orphan if teardown cannot reach the control
+plane.
+
+Set `sandbox_id` to attach an existing sandbox. Attached sandboxes are not
+deleted. `snapshot` selects the snapshot for a fresh sandbox and cannot be used
+with `sandbox_id`.
+
+```python
+DaytonaSandbox(sandbox_id='sandbox-id')
+```
+
+`workdir` applies to commands and relative file paths. `env` is passed when the
+sandbox is created and on every command.
+
+## Limits
+
+Commands default to `default_command_timeout=60` seconds. Model-requested
+timeouts are capped by `max_command_timeout=300`. Tool output is bounded by
+`max_output_bytes` and `max_output_lines`; command output keeps the tail and
+directory output keeps the head. `read_file` refuses files larger than
+`max_read_bytes` before decoding them.
+
+The Daytona SDK is currently constrained to `>=0.198.0,<0.199.0`. Later SDKs
+require `typing-extensions>=4.16.0`, while another Harness extra currently pins
+4.15.0. Raise the ceiling after those extras resolve together.
+
+## Composition
+
+The tools use common names. Prefix them when another capability contributes the
+same names:
+
+```python
+from pydantic_ai.capabilities import PrefixTools
+from pydantic_ai_harness import DaytonaSandbox
+
+PrefixTools(wrapped=DaytonaSandbox(instructions=''), prefix='daytona')
+```
+
+Daytona sandboxes isolate processes and files from the application host. Network
+access and credentials inside the sandbox remain separate trust boundaries.
+The Daytona SDK is asyncio-native, so this capability does not support trio.
+Durable execution is rejected because a live sandbox session cannot survive
+activity replay or worker restart.
+
+## Source
+
+- [Daytona Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/daytona_sandbox/)

--- a/pydantic_ai_harness/daytona_sandbox/README.md
+++ b/pydantic_ai_harness/daytona_sandbox/README.md
@@ -104,10 +104,30 @@ Configure those on `DaytonaSandboxSession`, which owns the sandbox. Attached
 sandboxes retain their existing network settings.
 
 `DaytonaSandboxSession.exec` returns a `DaytonaSandboxExecResult` for
-applications that need command access outside an agent run. Daytona's direct
-execution response exposes one result string and does not separate stderr. The
-caller must provide a positive whole-second timeout. This lower-level method
-returns raw SDK output without the capability's byte or line limits.
+applications that need command access outside an agent run. It streams command
+output from Daytona and retains only the last `max_output_bytes`. The caller
+must provide a positive whole-second timeout.
+
+Use `DaytonaSandboxSession.process` when an application needs to exchange input
+with a long-running command or handle stdout and stderr separately:
+
+```python
+async with DaytonaSandboxSession(network_block_all=True) as session:
+    async with session.process(
+        'worker',
+        'python worker.py',
+        on_stdout=print,
+        on_stderr=print,
+        max_input_bytes=64 * 1024,
+    ) as process:
+        await process.send('{"task":"run"}\n')
+        returncode = await process.wait(timeout=60)
+```
+
+The caller supplies the process identity, input bound, and every wait. Starting,
+input, output streaming, and deletion use Daytona's process-session API. Context
+exit terminates the remote process session, including after a timeout or
+cancellation. Input echo is disabled so protocol input cannot appear on stdout.
 
 ## Limits
 

--- a/pydantic_ai_harness/daytona_sandbox/__init__.py
+++ b/pydantic_ai_harness/daytona_sandbox/__init__.py
@@ -5,6 +5,7 @@ from ._session import (
     DaytonaSandboxAuthError,
     DaytonaSandboxError,
     DaytonaSandboxExecResult,
+    DaytonaSandboxProcess,
     DaytonaSandboxSession,
     DaytonaSandboxUnavailableError,
 )
@@ -14,6 +15,7 @@ __all__ = (
     'DaytonaSandboxAuthError',
     'DaytonaSandboxError',
     'DaytonaSandboxExecResult',
+    'DaytonaSandboxProcess',
     'DaytonaSandboxSession',
     'DaytonaSandboxUnavailableError',
 )

--- a/pydantic_ai_harness/daytona_sandbox/__init__.py
+++ b/pydantic_ai_harness/daytona_sandbox/__init__.py
@@ -4,6 +4,8 @@ from ._capability import DaytonaSandbox
 from ._session import (
     DaytonaSandboxAuthError,
     DaytonaSandboxError,
+    DaytonaSandboxExecResult,
+    DaytonaSandboxSession,
     DaytonaSandboxUnavailableError,
 )
 
@@ -11,5 +13,7 @@ __all__ = (
     'DaytonaSandbox',
     'DaytonaSandboxAuthError',
     'DaytonaSandboxError',
+    'DaytonaSandboxExecResult',
+    'DaytonaSandboxSession',
     'DaytonaSandboxUnavailableError',
 )

--- a/pydantic_ai_harness/daytona_sandbox/__init__.py
+++ b/pydantic_ai_harness/daytona_sandbox/__init__.py
@@ -1,0 +1,15 @@
+"""Daytona-backed command and file tools for Pydantic AI agents."""
+
+from ._capability import DaytonaSandbox
+from ._session import (
+    DaytonaSandboxAuthError,
+    DaytonaSandboxError,
+    DaytonaSandboxUnavailableError,
+)
+
+__all__ = (
+    'DaytonaSandbox',
+    'DaytonaSandboxAuthError',
+    'DaytonaSandboxError',
+    'DaytonaSandboxUnavailableError',
+)

--- a/pydantic_ai_harness/daytona_sandbox/_capability.py
+++ b/pydantic_ai_harness/daytona_sandbox/_capability.py
@@ -1,0 +1,126 @@
+"""Daytona sandbox capability."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.durable_exec._base import BaseDurabilityCapability  # pyright: ignore[reportPrivateUsage]
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.toolsets import AgentToolset
+
+from pydantic_ai_harness.daytona_sandbox._toolset import DaytonaSandboxToolset
+from pydantic_ai_harness.modal_sandbox._tool_output import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
+
+if TYPE_CHECKING:
+    from pydantic_ai.agent import AbstractAgent
+
+_DEFAULT_ID = 'daytona_sandbox'
+_DEFAULT_MAX_READ_BYTES = 5 * 1024 * 1024
+
+
+@dataclass(kw_only=True)
+class DaytonaSandbox(AbstractCapability[AgentDepsT]):
+    """Commands and files in an isolated Daytona cloud sandbox.
+
+    Each run creates a fresh sandbox and deletes it on exit. Set `sandbox_id` to
+    attach to a sandbox you manage instead; attached sandboxes are left running.
+
+    Requires the `daytona` extra and `DAYTONA_API_KEY`.
+    """
+
+    id: str | None = _DEFAULT_ID
+    """Stable capability and toolset ID."""
+
+    sandbox_id: str | None = None
+    """Existing sandbox ID or name to attach to instead of creating one."""
+
+    snapshot: str | None = None
+    """Daytona snapshot used for a fresh sandbox. None uses Daytona's default."""
+
+    auto_stop_minutes: int = 60
+    """Idle minutes before Daytona stops a fresh sandbox; stopped sandboxes auto-delete."""
+
+    workdir: str | None = None
+    """Working directory used by commands and relative file paths."""
+
+    env: Mapping[str, str] | None = None
+    """Environment variables for a fresh sandbox and its commands."""
+
+    default_command_timeout: int = 60
+    """Default command timeout in seconds."""
+
+    max_command_timeout: int = 300
+    """Maximum command timeout the model may request, in seconds."""
+
+    max_output_bytes: int = DEFAULT_MAX_BYTES
+    """Maximum UTF-8 bytes returned by each tool."""
+
+    max_output_lines: int = DEFAULT_MAX_LINES
+    """Maximum lines returned by each tool."""
+
+    max_read_bytes: int = _DEFAULT_MAX_READ_BYTES
+    """Largest file `read_file` will load."""
+
+    instructions: str | None = None
+    """Override the default sandbox instructions. Set `''` to disable them."""
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ('auto_stop_minutes', self.auto_stop_minutes),
+            ('default_command_timeout', self.default_command_timeout),
+            ('max_command_timeout', self.max_command_timeout),
+            ('max_output_bytes', self.max_output_bytes),
+            ('max_output_lines', self.max_output_lines),
+            ('max_read_bytes', self.max_read_bytes),
+        ):
+            if type(value) is not int or value <= 0:
+                raise ValueError(f'{name} must be a positive integer, got {value!r}.')
+        if self.default_command_timeout > self.max_command_timeout:
+            raise ValueError('default_command_timeout cannot exceed max_command_timeout.')
+        if self.sandbox_id is not None and self.snapshot is not None:
+            raise ValueError('snapshot cannot be combined with sandbox_id.')
+        if self.instructions is not None and type(self.instructions) is not str:
+            raise ValueError(f'instructions must be a string or None, got {self.instructions!r}.')
+        if self.env is not None:
+            self.env = dict(self.env)
+
+    def get_instructions(self) -> str | None:
+        if self.instructions is not None:
+            return self.instructions or None
+        lifetime = 'persists after this run' if self.sandbox_id is not None else 'is deleted after this run'
+        return (
+            'You have an isolated Daytona cloud sandbox. Use `run_command` for shell commands and '
+            '`read_file`, `write_file`, and `list_directory` for files. '
+            f'The sandbox {lifetime}. Commands default to {self.default_command_timeout}s and are capped at '
+            f'{self.max_command_timeout}s.'
+        )
+
+    def for_agent(self, agent: AbstractAgent[AgentDepsT, object]) -> AbstractCapability[AgentDepsT]:
+        """Reject durable execution, which cannot replay a live sandbox session."""
+        siblings: list[AbstractCapability[AgentDepsT]] = []
+        agent.root_capability.apply(siblings.append)
+        if any(isinstance(sibling, BaseDurabilityCapability) for sibling in siblings):
+            raise UserError(
+                'DaytonaSandbox does not support durable execution: a live sandbox session cannot survive '
+                'activity replay or worker restart.'
+            )
+        return self
+
+    def get_toolset(self) -> AgentToolset[AgentDepsT]:
+        return DaytonaSandboxToolset[AgentDepsT](
+            id=self.id or _DEFAULT_ID,
+            sandbox_id=self.sandbox_id,
+            snapshot=self.snapshot,
+            auto_stop_minutes=self.auto_stop_minutes,
+            workdir=self.workdir,
+            env=self.env,
+            default_command_timeout=self.default_command_timeout,
+            max_command_timeout=self.max_command_timeout,
+            max_output_bytes=self.max_output_bytes,
+            max_output_lines=self.max_output_lines,
+            max_read_bytes=self.max_read_bytes,
+        )

--- a/pydantic_ai_harness/daytona_sandbox/_capability.py
+++ b/pydantic_ai_harness/daytona_sandbox/_capability.py
@@ -94,6 +94,8 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
             raise ValueError('default_command_timeout cannot exceed max_command_timeout.')
         if self.sandbox_id is not None and self.snapshot is not None:
             raise ValueError('snapshot cannot be combined with sandbox_id.')
+        if self.sandbox_id is not None and self.auto_stop_minutes != DEFAULT_AUTO_STOP_MINUTES:
+            raise ValueError('auto_stop_minutes cannot be combined with sandbox_id.')
         if type(self.network_block_all) is not bool:
             raise ValueError(f'network_block_all must be a boolean, got {self.network_block_all!r}.')
         if self.sandbox_id is not None and self.network_block_all:

--- a/pydantic_ai_harness/daytona_sandbox/_capability.py
+++ b/pydantic_ai_harness/daytona_sandbox/_capability.py
@@ -12,6 +12,7 @@ from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AgentToolset
 
+from pydantic_ai_harness.daytona_sandbox._session import DEFAULT_AUTO_STOP_MINUTES, DaytonaSandboxSession
 from pydantic_ai_harness.daytona_sandbox._toolset import DaytonaSandboxToolset
 from pydantic_ai_harness.modal_sandbox._tool_output import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
 
@@ -38,10 +39,17 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
     sandbox_id: str | None = None
     """Existing sandbox ID or name to attach to instead of creating one."""
 
+    session: DaytonaSandboxSession | None = None
+    """An open caller-owned session to reuse across runs.
+
+    The capability uses the session but does not open or close it. Cannot be
+    combined with `sandbox_id` or fresh-sandbox provisioning settings.
+    """
+
     snapshot: str | None = None
     """Daytona snapshot used for a fresh sandbox. None uses Daytona's default."""
 
-    auto_stop_minutes: int = 60
+    auto_stop_minutes: int = DEFAULT_AUTO_STOP_MINUTES
     """Idle minutes before Daytona stops a fresh sandbox; stopped sandboxes auto-delete."""
 
     workdir: str | None = None
@@ -83,6 +91,23 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
             raise ValueError('default_command_timeout cannot exceed max_command_timeout.')
         if self.sandbox_id is not None and self.snapshot is not None:
             raise ValueError('snapshot cannot be combined with sandbox_id.')
+        if self.session is not None:
+            conflicts = [
+                name
+                for name, value, default in (
+                    ('sandbox_id', self.sandbox_id, None),
+                    ('snapshot', self.snapshot, None),
+                    ('auto_stop_minutes', self.auto_stop_minutes, DEFAULT_AUTO_STOP_MINUTES),
+                    ('workdir', self.workdir, None),
+                    ('env', self.env, None),
+                )
+                if value != default
+            ]
+            if conflicts:
+                raise ValueError(
+                    f'{", ".join(conflicts)} cannot be combined with `session`, which already owns '
+                    'the sandbox and its configuration.'
+                )
         if self.instructions is not None and type(self.instructions) is not str:
             raise ValueError(f'instructions must be a string or None, got {self.instructions!r}.')
         if self.env is not None:
@@ -91,7 +116,8 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
     def get_instructions(self) -> str | None:
         if self.instructions is not None:
             return self.instructions or None
-        lifetime = 'persists after this run' if self.sandbox_id is not None else 'is deleted after this run'
+        reused = self.sandbox_id is not None or self.session is not None
+        lifetime = 'persists after this run' if reused else 'is deleted after this run'
         return (
             'You have an isolated Daytona cloud sandbox. Use `run_command` for shell commands and '
             '`read_file`, `write_file`, and `list_directory` for files. '
@@ -114,6 +140,7 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
         return DaytonaSandboxToolset[AgentDepsT](
             id=self.id or _DEFAULT_ID,
             sandbox_id=self.sandbox_id,
+            session=self.session,
             snapshot=self.snapshot,
             auto_stop_minutes=self.auto_stop_minutes,
             workdir=self.workdir,

--- a/pydantic_ai_harness/daytona_sandbox/_capability.py
+++ b/pydantic_ai_harness/daytona_sandbox/_capability.py
@@ -58,6 +58,9 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
     env: Mapping[str, str] | None = None
     """Environment variables for a fresh sandbox and its commands."""
 
+    network_block_all: bool = False
+    """Block outbound network traffic from a fresh sandbox."""
+
     default_command_timeout: int = 60
     """Default command timeout in seconds."""
 
@@ -91,6 +94,10 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
             raise ValueError('default_command_timeout cannot exceed max_command_timeout.')
         if self.sandbox_id is not None and self.snapshot is not None:
             raise ValueError('snapshot cannot be combined with sandbox_id.')
+        if type(self.network_block_all) is not bool:
+            raise ValueError(f'network_block_all must be a boolean, got {self.network_block_all!r}.')
+        if self.sandbox_id is not None and self.network_block_all:
+            raise ValueError('network_block_all cannot configure an attached sandbox.')
         if self.session is not None:
             conflicts = [
                 name
@@ -100,6 +107,7 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
                     ('auto_stop_minutes', self.auto_stop_minutes, DEFAULT_AUTO_STOP_MINUTES),
                     ('workdir', self.workdir, None),
                     ('env', self.env, None),
+                    ('network_block_all', self.network_block_all, False),
                 )
                 if value != default
             ]
@@ -145,6 +153,7 @@ class DaytonaSandbox(AbstractCapability[AgentDepsT]):
             auto_stop_minutes=self.auto_stop_minutes,
             workdir=self.workdir,
             env=self.env,
+            network_block_all=self.network_block_all,
             default_command_timeout=self.default_command_timeout,
             max_command_timeout=self.max_command_timeout,
             max_output_bytes=self.max_output_bytes,

--- a/pydantic_ai_harness/daytona_sandbox/_session.py
+++ b/pydantic_ai_harness/daytona_sandbox/_session.py
@@ -3,7 +3,8 @@
 External assumptions, verified 2026-08-23 against Daytona Python SDK 0.198.0:
 
 - `AsyncDaytona.create`, `get`, `delete(wait=True)`, and `close` own sandbox lifecycle.
-- `sandbox.process.exec` returns `exit_code` and text in `result`.
+- process sessions provide bounded waits, input without echo, streamed stdout
+  and stderr, exit status, and explicit deletion.
 - `sandbox.fs` provides metadata, byte upload/download, and directory listing.
 - `CreateSandboxFromSnapshotParams.network_block_all=True` blocks outbound traffic.
 
@@ -19,18 +20,26 @@ dependency ceiling.
 
 from __future__ import annotations
 
+import asyncio
 import posixpath
 import shlex
-from collections.abc import Mapping
+import uuid
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias, TypeVar
 
 if TYPE_CHECKING:
     from daytona import AsyncDaytona
+    from daytona._async.process import AsyncProcess
     from daytona._async.sandbox import AsyncSandbox
 
 
 DEFAULT_AUTO_STOP_MINUTES = 60
+_DEFAULT_PROCESS_IO_TIMEOUT = 30
+_DEFAULT_EXEC_OUTPUT_BYTES = 50 * 1024
+
+ProcessOutputHandler: TypeAlias = Callable[[str], None] | Callable[[str], Awaitable[None]]
+_T = TypeVar('_T')
 
 
 class DaytonaSandboxError(RuntimeError):
@@ -57,6 +66,145 @@ class DaytonaSandboxExecResult:
 
     timed_out: bool = False
     """Whether the Daytona SDK stopped waiting at the command deadline."""
+
+    output_truncated: bool = False
+    """Whether earlier command output was discarded to bound host memory."""
+
+
+class DaytonaSandboxProcess:
+    """One bounded, bidirectional command in an open Daytona sandbox session."""
+
+    def __init__(
+        self,
+        *,
+        process: AsyncProcess,
+        process_id: str,
+        command: str,
+        on_stdout: ProcessOutputHandler,
+        on_stderr: ProcessOutputHandler,
+        max_input_bytes: int,
+        io_timeout: int,
+    ) -> None:
+        if not process_id:
+            raise ValueError('process_id must not be empty.')
+        _positive_int('max_input_bytes', max_input_bytes)
+        _positive_int('io_timeout', io_timeout)
+        self._process = process
+        self._process_id = process_id
+        self._command = command
+        self._on_stdout = on_stdout
+        self._on_stderr = on_stderr
+        self._max_input_bytes = max_input_bytes
+        self._io_timeout = io_timeout
+        self._command_id: str | None = None
+        self._logs: asyncio.Task[None] | None = None
+
+    @property
+    def process_id(self) -> str:
+        """The caller-supplied identity used for the Daytona process session."""
+        return self._process_id
+
+    async def __aenter__(self) -> DaytonaSandboxProcess:
+        if self._command_id is not None:
+            raise DaytonaSandboxError('The Daytona process is already open.')
+        created = False
+        try:
+            await _finish_on_cancellation(
+                self._process.create_session(self._process_id, request_timeout=self._io_timeout),
+                on_cancel=lambda _: self._process.delete_session(self._process_id, request_timeout=self._io_timeout),
+            )
+            created = True
+            from daytona import SessionExecuteRequest
+
+            response = await self._process.execute_session_command(
+                self._process_id,
+                SessionExecuteRequest(
+                    command=self._command,
+                    run_async=True,
+                    suppress_input_echo=True,
+                ),
+                timeout=self._io_timeout,
+            )
+        except BaseException:
+            if created:
+                await _finish_cleanup(self._process.delete_session(self._process_id, request_timeout=self._io_timeout))
+            raise
+        self._command_id = response.cmd_id
+        self._logs = asyncio.create_task(
+            self._process.get_session_command_logs_async(
+                self._process_id,
+                response.cmd_id,
+                self._on_stdout,
+                self._on_stderr,
+            )
+        )
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.close()
+
+    async def send(self, data: str, *, timeout: int = _DEFAULT_PROCESS_IO_TIMEOUT) -> None:
+        """Send bounded text to the command's standard input."""
+        _positive_int('timeout', timeout)
+        size = len(data.encode('utf-8'))
+        if size > self._max_input_bytes:
+            raise ValueError(f'input is {size} bytes, over the {self._max_input_bytes}-byte limit.')
+        command_id = self._require_command_id()
+        try:
+            await self._process.send_session_command_input(
+                self._process_id,
+                command_id,
+                data,
+                request_timeout=timeout,
+            )
+        except Exception as error:
+            raise _translate_error(error, unavailable=True) from error
+
+    async def wait(self, *, timeout: int) -> int:
+        """Wait a bounded time for completion and return the command exit status."""
+        _positive_int('timeout', timeout)
+        command_id = self._require_command_id()
+        logs = self._logs
+        if logs is None:  # pragma: no cover - maintained with `_command_id`
+            raise DaytonaSandboxError('The Daytona process log stream is unavailable.')
+        try:
+            await asyncio.wait_for(asyncio.shield(logs), timeout)
+            command = await self._process.get_session_command(
+                self._process_id,
+                command_id,
+                request_timeout=self._io_timeout,
+            )
+        except TimeoutError:
+            raise
+        except Exception as error:
+            raise _translate_error(error, unavailable=True) from error
+        if command.exit_code is None:
+            raise DaytonaSandboxError('Daytona closed the process log stream before reporting an exit status.')
+        return command.exit_code
+
+    async def close(self) -> None:
+        """Terminate the remote process session and its local log stream."""
+        if self._command_id is None:
+            return
+        try:
+            await _finish_cleanup(
+                self._process.delete_session(self._process_id, request_timeout=self._io_timeout),
+                then=self._clear,
+            )
+        except Exception as error:
+            raise _translate_error(error, unavailable=True) from error
+
+    def _clear(self) -> None:
+        logs = self._logs
+        if logs is not None and not logs.done():
+            logs.cancel()
+        self._command_id = None
+        self._logs = None
+
+    def _require_command_id(self) -> str:
+        if self._command_id is None:
+            raise DaytonaSandboxError('The Daytona process is not open.')
+        return self._command_id
 
 
 class DaytonaSandboxSession:
@@ -98,6 +246,8 @@ class DaytonaSandboxSession:
             raise ValueError(f'auto_stop_minutes must be a positive integer, got {auto_stop_minutes!r}.')
         if sandbox_id is not None and snapshot is not None:
             raise ValueError('snapshot cannot be combined with sandbox_id.')
+        if sandbox_id is not None and auto_stop_minutes != DEFAULT_AUTO_STOP_MINUTES:
+            raise ValueError('auto_stop_minutes cannot be combined with sandbox_id.')
         if type(network_block_all) is not bool:
             raise ValueError(f'network_block_all must be a boolean, got {network_block_all!r}.')
         if sandbox_id is not None and network_block_all:
@@ -110,6 +260,7 @@ class DaytonaSandboxSession:
         self._network_block_all = network_block_all
         self._client: AsyncDaytona | None = None
         self._sandbox: AsyncSandbox | None = None
+        self._owned_sandbox_deleted = False
 
     @property
     def sandbox_id(self) -> str | None:
@@ -130,9 +281,10 @@ class DaytonaSandboxSession:
             ) from error
 
         client = AsyncDaytona()
+        self._client = client
         try:
             if self._requested_id is not None:
-                sandbox = await client.get(self._requested_id)
+                sandbox = await _finish_on_cancellation(client.get(self._requested_id))
             else:
                 params = CreateSandboxFromSnapshotParams(
                     snapshot=self._snapshot,
@@ -141,30 +293,56 @@ class DaytonaSandboxSession:
                     auto_delete_interval=0,
                     network_block_all=self._network_block_all,
                 )
-                sandbox = await client.create(params)
+                sandbox = await _finish_on_cancellation(
+                    client.create(params),
+                    on_cancel=lambda created: client.delete(created, timeout=60, wait=True),
+                )
+        except asyncio.CancelledError:
+            if self._sandbox is not None:
+                await _finish_cleanup(client.delete(self._sandbox, timeout=60, wait=True))
+            await _finish_cleanup(client.close(), then=self._clear)
+            raise
         except Exception as error:
             await client.close()
+            self._client = None
             raise _translate_error(error, unavailable=self._requested_id is not None) from error
 
-        self._client = client
         self._sandbox = sandbox
+        self._owned_sandbox_deleted = False
         return self
 
     async def __aexit__(self, *_: object) -> None:
         client = self._client
         sandbox = self._sandbox
-        if client is None or sandbox is None:
+        if client is None:
+            return
+        if sandbox is None:
+            try:
+                await _finish_cleanup(client.close(), then=self._clear)
+            except Exception as error:
+                raise _translate_error(error, unavailable=False) from error
             return
 
+        if self._requested_id is None and not self._owned_sandbox_deleted:
+            try:
+                await _finish_cleanup(
+                    client.delete(sandbox, timeout=60, wait=True),
+                    then=self._mark_owned_sandbox_deleted,
+                )
+            except Exception as error:
+                raise _translate_error(error, unavailable=False) from error
         try:
-            if self._requested_id is None:
-                await client.delete(sandbox, timeout=60, wait=True)
+            await _finish_cleanup(client.close(), then=self._clear)
         except Exception as error:
             raise _translate_error(error, unavailable=False) from error
-        finally:
-            await client.close()
-            self._client = None
-            self._sandbox = None
+
+    def _mark_owned_sandbox_deleted(self) -> None:
+        self._owned_sandbox_deleted = True
+
+    def _clear(self) -> None:
+        self._client = None
+        self._sandbox = None
+        self._owned_sandbox_deleted = False
 
     def _require_sandbox(self) -> AsyncSandbox:
         if self._sandbox is None:
@@ -176,30 +354,74 @@ class DaytonaSandboxSession:
             return path
         return posixpath.join(self._workdir, path)
 
-    async def exec(self, command: str, *, timeout: int) -> DaytonaSandboxExecResult:
-        """Run a command with a finite whole-second timeout and return the raw SDK result.
+    def _command(self, command: str) -> str:
+        if self._env:
+            assignments = ' '.join(shlex.quote(f'{name}={value}') for name, value in self._env.items())
+            command = f'env -- {assignments} sh -c {shlex.quote(command)}'
+        if self._workdir is not None:
+            command = f'cd -- {shlex.quote(self._workdir)} && {command}'
+        return command
 
-        This lower-level method does not apply the capability's output limits.
-        """
-        if type(timeout) is not int or timeout <= 0:
-            raise ValueError(f'timeout must be a positive integer, got {timeout!r}.')
-        sandbox = self._require_sandbox()
+    def process(
+        self,
+        process_id: str,
+        command: str,
+        *,
+        on_stdout: ProcessOutputHandler,
+        on_stderr: ProcessOutputHandler,
+        max_input_bytes: int,
+        io_timeout: int = _DEFAULT_PROCESS_IO_TIMEOUT,
+    ) -> DaytonaSandboxProcess:
+        """Prepare one managed long-running command inside this open session."""
+        process = self._require_sandbox().process
+        return DaytonaSandboxProcess(
+            process=process,
+            process_id=process_id,
+            command=self._command(command),
+            on_stdout=on_stdout,
+            on_stderr=on_stderr,
+            max_input_bytes=max_input_bytes,
+            io_timeout=io_timeout,
+        )
+
+    async def exec(
+        self,
+        command: str,
+        *,
+        timeout: int,
+        max_output_bytes: int = _DEFAULT_EXEC_OUTPUT_BYTES,
+    ) -> DaytonaSandboxExecResult:
+        """Run a command while retaining only a bounded tail of streamed output."""
+        _positive_int('timeout', timeout)
+        _positive_int('max_output_bytes', max_output_bytes)
+        output = _TailBuffer(max_output_bytes)
+        process_id = f'harness-{uuid.uuid4().hex}'
         try:
-            response = await sandbox.process.exec(
+            async with self.process(
+                process_id,
                 command,
-                cwd=self._workdir,
-                env=self._env,
-                timeout=timeout,
-            )
-        except Exception as error:
-            try:
-                from daytona import DaytonaTimeoutError
-            except ImportError:  # pragma: no cover - the session already imported Daytona
-                raise DaytonaSandboxError('The Daytona SDK became unavailable.') from error
-            if isinstance(error, DaytonaTimeoutError):
-                return DaytonaSandboxExecResult(output='', returncode=-1, timed_out=True)
+                on_stdout=output.append,
+                on_stderr=output.append,
+                max_input_bytes=1,
+            ) as process:
+                try:
+                    returncode = await process.wait(timeout=timeout)
+                except TimeoutError:
+                    return DaytonaSandboxExecResult(
+                        output=output.text,
+                        returncode=-1,
+                        timed_out=True,
+                        output_truncated=output.truncated,
+                    )
+        except DaytonaSandboxError:
+            raise
+        except Exception as error:  # pragma: no cover - SDK failures are translated by the process
             raise _translate_error(error, unavailable=True) from error
-        return DaytonaSandboxExecResult(output=response.result, returncode=response.exit_code)
+        return DaytonaSandboxExecResult(
+            output=output.text,
+            returncode=returncode,
+            output_truncated=output.truncated,
+        )
 
     async def file_size(self, path: str) -> int:
         try:
@@ -253,3 +475,63 @@ def _translate_error(error: Exception, *, unavailable: bool) -> DaytonaSandboxEr
     if unavailable and isinstance(error, DaytonaNotFoundError):
         return DaytonaSandboxUnavailableError('The Daytona sandbox does not exist or is no longer available.')
     return DaytonaSandboxError(str(error))
+
+
+async def _finish_on_cancellation(
+    operation: Awaitable[_T],
+    *,
+    on_cancel: Callable[[_T], Awaitable[object]] | None = None,
+) -> _T:
+    task = asyncio.ensure_future(operation)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        try:
+            result = await task
+        except Exception:
+            pass
+        else:
+            if on_cancel is not None:
+                await _finish_cleanup(on_cancel(result))
+        raise
+
+
+async def _finish_cleanup(operation: Awaitable[object], *, then: Callable[[], None] | None = None) -> None:
+    task = asyncio.ensure_future(operation)
+    try:
+        await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await task
+        if then is not None:
+            then()
+        raise
+    if then is not None:
+        then()
+
+
+def _positive_int(name: str, value: int) -> None:
+    if type(value) is not int or value <= 0:
+        raise ValueError(f'{name} must be a positive integer, got {value!r}.')
+
+
+class _TailBuffer:
+    def __init__(self, max_bytes: int) -> None:
+        self._max_bytes = max_bytes
+        self._data = bytearray()
+        self.truncated = False
+
+    @property
+    def text(self) -> str:
+        return bytes(self._data).decode('utf-8', errors='ignore')
+
+    def append(self, chunk: str) -> None:
+        data = chunk.encode('utf-8')
+        if len(data) >= self._max_bytes:
+            self.truncated = self.truncated or bool(self._data) or len(data) > self._max_bytes
+            self._data[:] = data[-self._max_bytes :]
+            return
+        overflow = len(self._data) + len(data) - self._max_bytes
+        if overflow > 0:
+            del self._data[:overflow]
+            self.truncated = True
+        self._data.extend(data)

--- a/pydantic_ai_harness/daytona_sandbox/_session.py
+++ b/pydantic_ai_harness/daytona_sandbox/_session.py
@@ -5,11 +5,13 @@ External assumptions, verified 2026-08-23 against Daytona Python SDK 0.198.0:
 - `AsyncDaytona.create`, `get`, `delete(wait=True)`, and `close` own sandbox lifecycle.
 - `sandbox.process.exec` returns `exit_code` and text in `result`.
 - `sandbox.fs` provides metadata, byte upload/download, and directory listing.
+- `CreateSandboxFromSnapshotParams.network_block_all=True` blocks outbound traffic.
 
 Sources:
 https://www.daytona.io/docs/en/python-sdk/async/async-daytona/
 https://www.daytona.io/docs/en/python-sdk/async/async-process/
 https://www.daytona.io/docs/en/python-sdk/async/async-file-system/
+https://www.daytona.io/docs/en/network-limits/
 
 Re-check those signatures against the lowest supported SDK before raising the
 dependency ceiling.
@@ -90,16 +92,22 @@ class DaytonaSandboxSession:
         auto_stop_minutes: int = DEFAULT_AUTO_STOP_MINUTES,
         workdir: str | None = None,
         env: Mapping[str, str] | None = None,
+        network_block_all: bool = False,
     ) -> None:
         if type(auto_stop_minutes) is not int or auto_stop_minutes <= 0:
             raise ValueError(f'auto_stop_minutes must be a positive integer, got {auto_stop_minutes!r}.')
         if sandbox_id is not None and snapshot is not None:
             raise ValueError('snapshot cannot be combined with sandbox_id.')
+        if type(network_block_all) is not bool:
+            raise ValueError(f'network_block_all must be a boolean, got {network_block_all!r}.')
+        if sandbox_id is not None and network_block_all:
+            raise ValueError('network_block_all cannot configure an attached sandbox.')
         self._requested_id = sandbox_id
         self._snapshot = snapshot
         self._auto_stop_minutes = auto_stop_minutes
         self._workdir = workdir
         self._env = dict(env) if env is not None else None
+        self._network_block_all = network_block_all
         self._client: AsyncDaytona | None = None
         self._sandbox: AsyncSandbox | None = None
 
@@ -131,6 +139,7 @@ class DaytonaSandboxSession:
                     env_vars=self._env,
                     auto_stop_interval=self._auto_stop_minutes,
                     auto_delete_interval=0,
+                    network_block_all=self._network_block_all,
                 )
                 sandbox = await client.create(params)
         except Exception as error:

--- a/pydantic_ai_harness/daytona_sandbox/_session.py
+++ b/pydantic_ai_harness/daytona_sandbox/_session.py
@@ -1,0 +1,196 @@
+"""Small Daytona SDK boundary used by `DaytonaSandbox`.
+
+External assumptions, verified 2026-08-23 against Daytona Python SDK 0.198.0:
+
+- `AsyncDaytona.create`, `get`, `delete(wait=True)`, and `close` own sandbox lifecycle.
+- `sandbox.process.exec` returns `exit_code` and text in `result`.
+- `sandbox.fs` provides metadata, byte upload/download, and directory listing.
+
+Sources:
+https://www.daytona.io/docs/en/python-sdk/async/async-daytona/
+https://www.daytona.io/docs/en/python-sdk/async/async-process/
+https://www.daytona.io/docs/en/python-sdk/async/async-file-system/
+
+Re-check those signatures against the lowest supported SDK before raising the
+dependency ceiling.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import shlex
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from daytona import AsyncDaytona
+    from daytona._async.sandbox import AsyncSandbox
+
+
+class DaytonaSandboxError(RuntimeError):
+    """A Daytona sandbox operation failed."""
+
+
+class DaytonaSandboxAuthError(DaytonaSandboxError):
+    """Daytona rejected the configured credentials."""
+
+
+class DaytonaSandboxUnavailableError(DaytonaSandboxError):
+    """The requested Daytona sandbox no longer exists."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class _ExecResult:
+    output: str
+    returncode: int
+    timed_out: bool = False
+
+
+class DaytonaSandboxSession:
+    """Own or attach to one Daytona sandbox for one agent run."""
+
+    def __init__(
+        self,
+        *,
+        sandbox_id: str | None,
+        snapshot: str | None,
+        auto_stop_minutes: int,
+        workdir: str | None,
+        env: Mapping[str, str] | None,
+    ) -> None:
+        self._requested_id = sandbox_id
+        self._snapshot = snapshot
+        self._auto_stop_minutes = auto_stop_minutes
+        self._workdir = workdir
+        self._env = dict(env) if env is not None else None
+        self._client: AsyncDaytona | None = None
+        self._sandbox: AsyncSandbox | None = None
+        self.sandbox_id: str | None = sandbox_id
+
+    async def __aenter__(self) -> DaytonaSandboxSession:
+        try:
+            from daytona import AsyncDaytona, CreateSandboxFromSnapshotParams
+        except ImportError as error:
+            raise DaytonaSandboxError(
+                'The `daytona` package is required. Install it with `uv add "pydantic-ai-harness[daytona]"`.'
+            ) from error
+
+        client = AsyncDaytona()
+        try:
+            if self._requested_id is not None:
+                sandbox = await client.get(self._requested_id)
+            else:
+                params = CreateSandboxFromSnapshotParams(
+                    snapshot=self._snapshot,
+                    env_vars=self._env,
+                    auto_stop_interval=self._auto_stop_minutes,
+                    auto_delete_interval=0,
+                )
+                sandbox = await client.create(params)
+        except Exception as error:
+            await client.close()
+            raise _translate_error(error, unavailable=self._requested_id is not None) from error
+
+        self._client = client
+        self._sandbox = sandbox
+        self.sandbox_id = sandbox.id
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        client = self._client
+        sandbox = self._sandbox
+        if client is None or sandbox is None:
+            return
+
+        try:
+            if self._requested_id is None:
+                await client.delete(sandbox, timeout=60, wait=True)
+        except Exception as error:
+            raise _translate_error(error, unavailable=False) from error
+        finally:
+            await client.close()
+            self._client = None
+            self._sandbox = None
+
+    def _require_sandbox(self) -> AsyncSandbox:
+        if self._sandbox is None:
+            raise DaytonaSandboxError('The Daytona sandbox session is not open.')
+        return self._sandbox
+
+    def _path(self, path: str) -> str:
+        if self._workdir is None or posixpath.isabs(path):
+            return path
+        return posixpath.join(self._workdir, path)
+
+    async def exec(self, command: str, *, timeout: int) -> _ExecResult:
+        sandbox = self._require_sandbox()
+        try:
+            response = await sandbox.process.exec(
+                command,
+                cwd=self._workdir,
+                env=self._env,
+                timeout=timeout,
+            )
+        except Exception as error:
+            try:
+                from daytona import DaytonaTimeoutError
+            except ImportError:  # pragma: no cover - the session already imported Daytona
+                raise DaytonaSandboxError('The Daytona SDK became unavailable.') from error
+            if isinstance(error, DaytonaTimeoutError):
+                return _ExecResult(output='', returncode=-1, timed_out=True)
+            raise _translate_error(error, unavailable=True) from error
+        return _ExecResult(output=response.result, returncode=response.exit_code)
+
+    async def file_size(self, path: str) -> int:
+        try:
+            return (await self._require_sandbox().fs.get_file_info(self._path(path))).size
+        except Exception as error:
+            raise _translate_error(error, unavailable=False) from error
+
+    async def read_bytes(self, path: str) -> bytes:
+        try:
+            data = await self._require_sandbox().fs.download_file(self._path(path))
+        except Exception as error:
+            raise _translate_error(error, unavailable=False) from error
+        return data
+
+    async def write_bytes(self, path: str, data: bytes) -> None:
+        sandbox = self._require_sandbox()
+        resolved = self._path(path)
+        parent = posixpath.dirname(resolved)
+        try:
+            if parent not in ('', '.', '/'):
+                mkdir = await sandbox.process.exec(f'mkdir -p -- {shlex.quote(parent)}', timeout=30)
+                if mkdir.exit_code != 0:
+                    raise DaytonaSandboxError(mkdir.result or f'Could not create {parent!r}.')
+            await sandbox.fs.upload_file(data, resolved)
+        except DaytonaSandboxError:
+            raise
+        except Exception as error:
+            raise _translate_error(error, unavailable=False) from error
+
+    async def list_files(self, path: str) -> list[tuple[str, bool]]:
+        try:
+            entries = await self._require_sandbox().fs.list_files(self._path(path))
+        except Exception as error:
+            raise _translate_error(error, unavailable=False) from error
+        return [(entry.name, entry.is_dir) for entry in entries]
+
+
+def _translate_error(error: Exception, *, unavailable: bool) -> DaytonaSandboxError:
+    """Map SDK failures without leaking SDK types through the public API."""
+    try:
+        from daytona import (
+            DaytonaAuthenticationError,
+            DaytonaAuthorizationError,
+            DaytonaNotFoundError,
+        )
+    except ImportError:  # pragma: no cover - the session already imported Daytona
+        return DaytonaSandboxError(str(error))
+
+    if isinstance(error, (DaytonaAuthenticationError, DaytonaAuthorizationError)):
+        return DaytonaSandboxAuthError('Daytona rejected the credentials. Set DAYTONA_API_KEY and try again.')
+    if unavailable and isinstance(error, DaytonaNotFoundError):
+        return DaytonaSandboxUnavailableError('The Daytona sandbox does not exist or is no longer available.')
+    return DaytonaSandboxError(str(error))

--- a/pydantic_ai_harness/daytona_sandbox/_session.py
+++ b/pydantic_ai_harness/daytona_sandbox/_session.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
     from daytona._async.sandbox import AsyncSandbox
 
 
+DEFAULT_AUTO_STOP_MINUTES = 60
+
+
 class DaytonaSandboxError(RuntimeError):
     """A Daytona sandbox operation failed."""
 
@@ -41,24 +44,57 @@ class DaytonaSandboxUnavailableError(DaytonaSandboxError):
 
 
 @dataclass(frozen=True, kw_only=True)
-class _ExecResult:
+class DaytonaSandboxExecResult:
+    """The outcome of running a command in a Daytona sandbox."""
+
     output: str
+    """The command result text returned by Daytona's direct execution API."""
+
     returncode: int
+    """The command exit status, or `-1` when the SDK reports a timeout."""
+
     timed_out: bool = False
+    """Whether the Daytona SDK stopped waiting at the command deadline."""
 
 
 class DaytonaSandboxSession:
-    """Own or attach to one Daytona sandbox for one agent run."""
+    """Async context manager that owns or attaches to one Daytona sandbox.
+
+    A session without `sandbox_id` creates a sandbox from `snapshot` and deletes
+    it on exit. A session with `sandbox_id` attaches to that sandbox and leaves it
+    running. Pass an already-open session to `DaytonaSandbox(session=...)` to
+    reuse one sandbox across several agent runs while retaining lifecycle
+    ownership in the caller.
+
+    ```python
+    import asyncio
+
+    from pydantic_ai_harness.daytona_sandbox import DaytonaSandboxSession
+
+
+    async def main() -> None:
+        async with DaytonaSandboxSession() as session:
+            result = await session.exec('python --version', timeout=30)
+            print(result.output)
+
+
+    asyncio.run(main())
+    ```
+    """
 
     def __init__(
         self,
         *,
-        sandbox_id: str | None,
-        snapshot: str | None,
-        auto_stop_minutes: int,
-        workdir: str | None,
-        env: Mapping[str, str] | None,
+        sandbox_id: str | None = None,
+        snapshot: str | None = None,
+        auto_stop_minutes: int = DEFAULT_AUTO_STOP_MINUTES,
+        workdir: str | None = None,
+        env: Mapping[str, str] | None = None,
     ) -> None:
+        if type(auto_stop_minutes) is not int or auto_stop_minutes <= 0:
+            raise ValueError(f'auto_stop_minutes must be a positive integer, got {auto_stop_minutes!r}.')
+        if sandbox_id is not None and snapshot is not None:
+            raise ValueError('snapshot cannot be combined with sandbox_id.')
         self._requested_id = sandbox_id
         self._snapshot = snapshot
         self._auto_stop_minutes = auto_stop_minutes
@@ -66,9 +102,18 @@ class DaytonaSandboxSession:
         self._env = dict(env) if env is not None else None
         self._client: AsyncDaytona | None = None
         self._sandbox: AsyncSandbox | None = None
-        self.sandbox_id: str | None = sandbox_id
+
+    @property
+    def sandbox_id(self) -> str | None:
+        """The ID of the open sandbox, or `None` outside the session context."""
+        return self._sandbox.id if self._sandbox is not None else None
 
     async def __aenter__(self) -> DaytonaSandboxSession:
+        if self._sandbox is not None:
+            raise DaytonaSandboxError(
+                'The session is already open; exit it before entering again. '
+                'Use a separate session per concurrent context.'
+            )
         try:
             from daytona import AsyncDaytona, CreateSandboxFromSnapshotParams
         except ImportError as error:
@@ -94,7 +139,6 @@ class DaytonaSandboxSession:
 
         self._client = client
         self._sandbox = sandbox
-        self.sandbox_id = sandbox.id
         return self
 
     async def __aexit__(self, *_: object) -> None:
@@ -123,7 +167,13 @@ class DaytonaSandboxSession:
             return path
         return posixpath.join(self._workdir, path)
 
-    async def exec(self, command: str, *, timeout: int) -> _ExecResult:
+    async def exec(self, command: str, *, timeout: int) -> DaytonaSandboxExecResult:
+        """Run a command with a finite whole-second timeout and return the raw SDK result.
+
+        This lower-level method does not apply the capability's output limits.
+        """
+        if type(timeout) is not int or timeout <= 0:
+            raise ValueError(f'timeout must be a positive integer, got {timeout!r}.')
         sandbox = self._require_sandbox()
         try:
             response = await sandbox.process.exec(
@@ -138,9 +188,9 @@ class DaytonaSandboxSession:
             except ImportError:  # pragma: no cover - the session already imported Daytona
                 raise DaytonaSandboxError('The Daytona SDK became unavailable.') from error
             if isinstance(error, DaytonaTimeoutError):
-                return _ExecResult(output='', returncode=-1, timed_out=True)
+                return DaytonaSandboxExecResult(output='', returncode=-1, timed_out=True)
             raise _translate_error(error, unavailable=True) from error
-        return _ExecResult(output=response.result, returncode=response.exit_code)
+        return DaytonaSandboxExecResult(output=response.result, returncode=response.exit_code)
 
     async def file_size(self, path: str) -> int:
         try:

--- a/pydantic_ai_harness/daytona_sandbox/_toolset.py
+++ b/pydantic_ai_harness/daytona_sandbox/_toolset.py
@@ -35,6 +35,7 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
         auto_stop_minutes: int,
         workdir: str | None,
         env: Mapping[str, str] | None,
+        network_block_all: bool,
         default_command_timeout: int,
         max_command_timeout: int,
         max_output_bytes: int,
@@ -49,6 +50,7 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
         self._auto_stop_minutes = auto_stop_minutes
         self._workdir = workdir
         self._env = dict(env) if env is not None else None
+        self._network_block_all = network_block_all
         self._default_command_timeout = default_command_timeout
         self._max_command_timeout = max_command_timeout
         self._max_output_bytes = max_output_bytes
@@ -75,6 +77,7 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
             auto_stop_minutes=self._auto_stop_minutes,
             workdir=self._workdir,
             env=self._env,
+            network_block_all=self._network_block_all,
             default_command_timeout=self._default_command_timeout,
             max_command_timeout=self._max_command_timeout,
             max_output_bytes=self._max_output_bytes,
@@ -101,6 +104,7 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
             auto_stop_minutes=self._auto_stop_minutes,
             workdir=self._workdir,
             env=self._env,
+            network_block_all=self._network_block_all,
         )
         await session.__aenter__()
         self._session = session

--- a/pydantic_ai_harness/daytona_sandbox/_toolset.py
+++ b/pydantic_ai_harness/daytona_sandbox/_toolset.py
@@ -30,6 +30,7 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
         *,
         id: str,
         sandbox_id: str | None,
+        session: DaytonaSandboxSession | None,
         snapshot: str | None,
         auto_stop_minutes: int,
         workdir: str | None,
@@ -43,6 +44,7 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
     ) -> None:
         super().__init__(id=id)
         self._sandbox_id = sandbox_id
+        self._external_session = session
         self._snapshot = snapshot
         self._auto_stop_minutes = auto_stop_minutes
         self._workdir = workdir
@@ -68,6 +70,7 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
         return DaytonaSandboxToolset[AgentDepsT](
             id=self.id or 'daytona_sandbox',
             sandbox_id=self._sandbox_id,
+            session=self._external_session,
             snapshot=self._snapshot,
             auto_stop_minutes=self._auto_stop_minutes,
             workdir=self._workdir,
@@ -85,6 +88,13 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
             return self
         if self._session is not None:
             raise DaytonaSandboxError('The Daytona sandbox session is already open.')
+        if self._external_session is not None:
+            if self._external_session.sandbox_id is None:
+                raise DaytonaSandboxError(
+                    'The injected session is not open. Enter it with `async with session:` before running the agent.'
+                )
+            self._session = self._external_session
+            return self
         session = DaytonaSandboxSession(
             sandbox_id=self._sandbox_id,
             snapshot=self._snapshot,
@@ -99,7 +109,7 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
     async def __aexit__(self, *args: object) -> None:
         session = self._session
         self._session = None
-        if session is not None:
+        if session is not None and self._external_session is None:
             await session.__aexit__(*args)
 
     def _require_session(self) -> DaytonaSandboxSession:

--- a/pydantic_ai_harness/daytona_sandbox/_toolset.py
+++ b/pydantic_ai_harness/daytona_sandbox/_toolset.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 from pydantic_ai import RunContext
@@ -112,9 +112,9 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
 
     async def __aexit__(self, *args: object) -> None:
         session = self._session
-        self._session = None
         if session is not None and self._external_session is None:
             await session.__aexit__(*args)
+        self._session = None
 
     def _require_session(self) -> DaytonaSandboxSession:
         if self._session is None:
@@ -134,26 +134,18 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
         timeout = min(math.ceil(requested), self._max_command_timeout)
         session = self._require_session()
         try:
-            result = await session.exec(command, timeout=timeout)
+            result = await session.exec(command, timeout=timeout, max_output_bytes=self._max_output_bytes)
         except (DaytonaSandboxAuthError, DaytonaSandboxUnavailableError):
             raise
         except DaytonaSandboxError as error:
             raise ModelRetry(str(error))
 
-        output = (
-            truncate_output(
-                result.output,
-                max_lines=self._max_output_lines,
-                max_bytes=self._max_output_bytes,
-                direction='tail',
-            )
-            or '(no output)'
-        )
+        output = result.output.rstrip('\n') or '(no output)'
         if result.timed_out:
-            return f'{output}\n[timed out after {timeout}s]'
-        if result.returncode:
-            return f'{output}\n[exit code: {result.returncode}]'
-        return output
+            output = f'{output}\n[timed out after {timeout}s]'
+        elif result.returncode:
+            output = f'{output}\n[exit code: {result.returncode}]'
+        return self._bound_output(output, direction='tail', already_truncated=result.output_truncated)
 
     async def read_file(
         self,
@@ -220,9 +212,49 @@ class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
         if not entries:
             return '(empty)'
         names = [f'{name}/' if is_dir else name for name, is_dir in sorted(entries)]
-        return truncate_output(
+        return self._bound_output(
             '\n'.join(names),
-            max_lines=self._max_output_lines,
-            max_bytes=self._max_output_bytes,
             direction='head',
         )
+
+    def _bound_output(
+        self,
+        text: str,
+        *,
+        direction: Literal['head', 'tail'],
+        already_truncated: bool = False,
+    ) -> str:
+        rendered = truncate_output(
+            text,
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+            direction=direction,
+            already_truncated=already_truncated,
+        )
+        lines = rendered.split('\n')
+        if len(lines) > self._max_output_lines:
+            if direction == 'tail' and lines[0].startswith('[... output truncated'):
+                kept = self._max_output_lines - 1
+                unit = 'line' if kept == 1 else 'lines'
+                marker = (
+                    f'[... output truncated to the last {kept} {unit} ...]'
+                    if kept
+                    else '[... output omitted by the 1-line limit ...]'
+                )
+                lines = [marker, *lines[-kept:]] if kept else [marker]
+            elif direction == 'head' and lines[-1].startswith('[... output truncated'):
+                kept = self._max_output_lines - 1
+                unit = 'line' if kept == 1 else 'lines'
+                marker = (
+                    f'[... output truncated to the first {kept} {unit} ...]'
+                    if kept
+                    else '[... output omitted by the 1-line limit ...]'
+                )
+                lines = [*lines[:kept], marker] if kept else [marker]
+            else:
+                lines = lines[-self._max_output_lines :] if direction == 'tail' else lines[: self._max_output_lines]
+        data = '\n'.join(lines).encode('utf-8')
+        if len(data) <= self._max_output_bytes:
+            return data.decode('utf-8')
+        data = data[-self._max_output_bytes :] if direction == 'tail' else data[: self._max_output_bytes]
+        return data.decode('utf-8', errors='ignore')

--- a/pydantic_ai_harness/daytona_sandbox/_toolset.py
+++ b/pydantic_ai_harness/daytona_sandbox/_toolset.py
@@ -1,0 +1,214 @@
+"""Agent tools backed by one run-scoped Daytona sandbox."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from typing import Annotated
+
+from pydantic import Field
+from pydantic_ai import RunContext
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
+from typing_extensions import Self
+
+from pydantic_ai_harness.daytona_sandbox._session import (
+    DaytonaSandboxAuthError,
+    DaytonaSandboxError,
+    DaytonaSandboxSession,
+    DaytonaSandboxUnavailableError,
+)
+from pydantic_ai_harness.modal_sandbox._tool_output import guard_read_size, render_file_window, truncate_output
+
+
+class DaytonaSandboxToolset(FunctionToolset[AgentDepsT]):
+    """Run-scoped Daytona command and file tools."""
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        sandbox_id: str | None,
+        snapshot: str | None,
+        auto_stop_minutes: int,
+        workdir: str | None,
+        env: Mapping[str, str] | None,
+        default_command_timeout: int,
+        max_command_timeout: int,
+        max_output_bytes: int,
+        max_output_lines: int,
+        max_read_bytes: int,
+        _run_scoped: bool = False,
+    ) -> None:
+        super().__init__(id=id)
+        self._sandbox_id = sandbox_id
+        self._snapshot = snapshot
+        self._auto_stop_minutes = auto_stop_minutes
+        self._workdir = workdir
+        self._env = dict(env) if env is not None else None
+        self._default_command_timeout = default_command_timeout
+        self._max_command_timeout = max_command_timeout
+        self._max_output_bytes = max_output_bytes
+        self._max_output_lines = max_output_lines
+        self._max_read_bytes = max_read_bytes
+        self._run_scoped = _run_scoped
+        self._session: DaytonaSandboxSession | None = None
+
+        self.add_function(
+            self.run_command,
+            name='run_command',
+            metadata={'code_arg_name': 'command', 'code_arg_language': 'shell'},
+        )
+        self.add_function(self.read_file, name='read_file')
+        self.add_function(self.write_file, name='write_file')
+        self.add_function(self.list_directory, name='list_directory')
+
+    async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
+        return DaytonaSandboxToolset[AgentDepsT](
+            id=self.id or 'daytona_sandbox',
+            sandbox_id=self._sandbox_id,
+            snapshot=self._snapshot,
+            auto_stop_minutes=self._auto_stop_minutes,
+            workdir=self._workdir,
+            env=self._env,
+            default_command_timeout=self._default_command_timeout,
+            max_command_timeout=self._max_command_timeout,
+            max_output_bytes=self._max_output_bytes,
+            max_output_lines=self._max_output_lines,
+            max_read_bytes=self._max_read_bytes,
+            _run_scoped=True,
+        )
+
+    async def __aenter__(self) -> Self:
+        if not self._run_scoped:
+            return self
+        if self._session is not None:
+            raise DaytonaSandboxError('The Daytona sandbox session is already open.')
+        session = DaytonaSandboxSession(
+            sandbox_id=self._sandbox_id,
+            snapshot=self._snapshot,
+            auto_stop_minutes=self._auto_stop_minutes,
+            workdir=self._workdir,
+            env=self._env,
+        )
+        await session.__aenter__()
+        self._session = session
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        session = self._session
+        self._session = None
+        if session is not None:
+            await session.__aexit__(*args)
+
+    def _require_session(self) -> DaytonaSandboxSession:
+        if self._session is None:
+            raise DaytonaSandboxError('The Daytona sandbox session is not open.')
+        return self._session
+
+    async def run_command(self, command: str, *, timeout_seconds: float | None = None) -> str:
+        """Run a shell command in the sandbox and return its output.
+
+        Args:
+            command: Shell command to run.
+            timeout_seconds: Maximum seconds to wait.
+        """
+        requested = self._default_command_timeout if timeout_seconds is None else timeout_seconds
+        if isinstance(requested, bool) or not math.isfinite(requested) or requested <= 0:
+            raise ModelRetry(f'timeout_seconds must be greater than 0, got {requested}.')
+        timeout = min(math.ceil(requested), self._max_command_timeout)
+        session = self._require_session()
+        try:
+            result = await session.exec(command, timeout=timeout)
+        except (DaytonaSandboxAuthError, DaytonaSandboxUnavailableError):
+            raise
+        except DaytonaSandboxError as error:
+            raise ModelRetry(str(error))
+
+        output = (
+            truncate_output(
+                result.output,
+                max_lines=self._max_output_lines,
+                max_bytes=self._max_output_bytes,
+                direction='tail',
+            )
+            or '(no output)'
+        )
+        if result.timed_out:
+            return f'{output}\n[timed out after {timeout}s]'
+        if result.returncode:
+            return f'{output}\n[exit code: {result.returncode}]'
+        return output
+
+    async def read_file(
+        self,
+        path: str,
+        *,
+        offset: Annotated[int | None, Field(description='Line number to start reading from (1-indexed)')] = None,
+        limit: Annotated[int | None, Field(description='Maximum number of lines to read')] = None,
+    ) -> str:
+        """Read a UTF-8 text file from the sandbox.
+
+        Args:
+            path: File path inside the sandbox.
+            offset: Line number to start reading from (1-indexed).
+            limit: Maximum number of lines to read.
+        """
+        session = self._require_session()
+        try:
+            guard_read_size(await session.file_size(path), max_bytes=self._max_read_bytes)
+            data = await session.read_bytes(path)
+        except (DaytonaSandboxAuthError, DaytonaSandboxUnavailableError):
+            raise
+        except DaytonaSandboxError as error:
+            raise ModelRetry(f'Could not read {path!r}: {error}')
+        guard_read_size(len(data), max_bytes=self._max_read_bytes)
+        return render_file_window(
+            data,
+            offset=offset,
+            limit=limit,
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+        )
+
+    async def write_file(self, path: str, content: str) -> str:
+        """Write UTF-8 text to a sandbox file, creating parent directories.
+
+        Args:
+            path: File path inside the sandbox.
+            content: Text to write.
+        """
+        try:
+            data = content.encode('utf-8')
+        except UnicodeEncodeError:
+            raise ModelRetry('content contains characters that cannot be encoded as UTF-8.')
+        try:
+            await self._require_session().write_bytes(path, data)
+        except (DaytonaSandboxAuthError, DaytonaSandboxUnavailableError):
+            raise
+        except DaytonaSandboxError as error:
+            raise ModelRetry(f'Could not write {path!r}: {error}')
+        return f'Wrote {len(data)} bytes to {path!r}.'
+
+    async def list_directory(self, path: str = '.') -> str:
+        """List a sandbox directory, marking directories with `/`.
+
+        Args:
+            path: Directory path inside the sandbox.
+        """
+        try:
+            entries = await self._require_session().list_files(path)
+        except (DaytonaSandboxAuthError, DaytonaSandboxUnavailableError):
+            raise
+        except DaytonaSandboxError as error:
+            raise ModelRetry(f'Could not list {path!r}: {error}')
+        if not entries:
+            return '(empty)'
+        names = [f'{name}/' if is_dir else name for name, is_dir in sorted(entries)]
+        return truncate_output(
+            '\n'.join(names),
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+            direction='head',
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,9 @@ prompt-injection-defender = [
 prompt-injection-defender-ml = [
     "stackone-defender[onnx]>=0.7.3,<0.8 ; python_full_version >= '3.11'",
 ]
+daytona = [
+    "daytona>=0.198.0,<0.199.0",
+]
 
 [project.urls]
 Homepage = 'https://github.com/pydantic/pydantic-ai-harness'

--- a/tests/daytona_sandbox/conftest.py
+++ b/tests/daytona_sandbox/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from .fake_daytona import FakeDaytona
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+@pytest.fixture
+def fake_daytona(monkeypatch: pytest.MonkeyPatch) -> FakeDaytona:
+    import daytona
+
+    fake = FakeDaytona()
+    monkeypatch.setattr(daytona, 'AsyncDaytona', fake.client)
+    return fake

--- a/tests/daytona_sandbox/fake_daytona.py
+++ b/tests/daytona_sandbox/fake_daytona.py
@@ -15,6 +15,7 @@ class CreateParams(Protocol):
     auto_stop_interval: int | None
     auto_delete_interval: int | None
     env_vars: dict[str, str] | None
+    network_block_all: bool | None
 
 
 @dataclass

--- a/tests/daytona_sandbox/fake_daytona.py
+++ b/tests/daytona_sandbox/fake_daytona.py
@@ -1,0 +1,152 @@
+"""Controllable fake for the Daytona SDK boundary."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Protocol
+
+from daytona import DaytonaNotFoundError
+
+
+class CreateParams(Protocol):
+    snapshot: str | None
+    auto_stop_interval: int | None
+    auto_delete_interval: int | None
+    env_vars: dict[str, str] | None
+
+
+@dataclass
+class ExecCall:
+    command: str
+    cwd: str | None
+    env: dict[str, str] | None
+    timeout: int | None
+
+
+class FakeProcess:
+    def __init__(self, owner: FakeSandbox) -> None:
+        self.owner = owner
+
+    async def exec(
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int | None = None,
+    ) -> SimpleNamespace:
+        self.owner.exec_calls.append(ExecCall(command, cwd, env, timeout))
+        if self.owner.exec_error is not None:
+            raise self.owner.exec_error
+        if command.startswith('mkdir -p -- '):
+            return SimpleNamespace(result='', exit_code=self.owner.mkdir_exit_code)
+        output, exit_code = self.owner.responder(command, timeout)
+        return SimpleNamespace(result=output, exit_code=exit_code)
+
+
+class FakeFileSystem:
+    def __init__(self, owner: FakeSandbox) -> None:
+        self.owner = owner
+
+    async def get_file_info(self, path: str) -> SimpleNamespace:
+        self._raise_if_needed()
+        data = self.owner.files.get(path)
+        if data is None:
+            raise DaytonaNotFoundError(f'no file: {path}')
+        size = self.owner.reported_sizes.get(path, len(data))
+        return SimpleNamespace(size=size)
+
+    async def download_file(self, path: str) -> bytes:
+        self._raise_if_needed()
+        data = self.owner.files.get(path)
+        if data is None:
+            raise DaytonaNotFoundError(f'no file: {path}')
+        return data
+
+    async def upload_file(self, data: bytes, path: str) -> None:
+        self._raise_if_needed()
+        self.owner.files[path] = data
+
+    async def list_files(self, path: str) -> list[SimpleNamespace]:
+        self._raise_if_needed()
+        prefix = '' if path in ('', '.') else path.rstrip('/') + '/'
+        entries: dict[str, bool] = {}
+        for candidate in self.owner.files:
+            if not candidate.startswith(prefix):
+                continue
+            relative = candidate[len(prefix) :]
+            name, separator, _ = relative.partition('/')
+            if name:
+                entries[name] = bool(separator) or entries.get(name, False)
+        return [SimpleNamespace(name=name, is_dir=is_dir) for name, is_dir in entries.items()]
+
+    def _raise_if_needed(self) -> None:
+        if self.owner.fs_error is not None:
+            raise self.owner.fs_error
+
+
+class FakeSandbox:
+    def __init__(self, sandbox_id: str) -> None:
+        self.id = sandbox_id
+        self.deleted = False
+        self.files: dict[str, bytes] = {}
+        self.reported_sizes: dict[str, int] = {}
+        self.exec_calls: list[ExecCall] = []
+        self.exec_error: Exception | None = None
+        self.fs_error: Exception | None = None
+        self.mkdir_exit_code = 0
+        self.responder: Callable[[str, int | None], tuple[str, int]] = lambda command, timeout: ('', 0)
+        self.process = FakeProcess(self)
+        self.fs = FakeFileSystem(self)
+
+
+class FakeClient:
+    def __init__(self, owner: FakeDaytona) -> None:
+        self.owner = owner
+        self.closed = False
+
+    async def create(self, params: CreateParams) -> FakeSandbox:
+        if self.owner.create_error is not None:
+            raise self.owner.create_error
+        sandbox = FakeSandbox(f'sb-{len(self.owner.sandboxes) + 1}')
+        self.owner.sandboxes.append(sandbox)
+        self.owner.create_params.append(params)
+        return sandbox
+
+    async def get(self, sandbox_id: str) -> FakeSandbox:
+        if self.owner.get_error is not None:
+            raise self.owner.get_error
+        for sandbox in self.owner.sandboxes:
+            if sandbox.id == sandbox_id:
+                return sandbox
+        raise DaytonaNotFoundError(f'no sandbox: {sandbox_id}')
+
+    async def delete(self, sandbox: FakeSandbox, timeout: float, wait: bool) -> None:
+        self.owner.delete_calls.append((sandbox.id, timeout, wait))
+        if self.owner.delete_error is not None:
+            raise self.owner.delete_error
+        sandbox.deleted = True
+
+    async def close(self) -> None:
+        self.closed = True
+        self.owner.closed_clients += 1
+
+
+class FakeDaytona:
+    def __init__(self) -> None:
+        self.sandboxes: list[FakeSandbox] = []
+        self.create_params: list[CreateParams] = []
+        self.delete_calls: list[tuple[str, float, bool]] = []
+        self.closed_clients = 0
+        self.create_error: Exception | None = None
+        self.get_error: Exception | None = None
+        self.delete_error: Exception | None = None
+
+    def client(self) -> FakeClient:
+        return FakeClient(self)
+
+    def sandbox(self, sandbox_id: str = 'sb-existing') -> FakeSandbox:
+        sandbox = FakeSandbox(sandbox_id)
+        self.sandboxes.append(sandbox)
+        return sandbox

--- a/tests/daytona_sandbox/fake_daytona.py
+++ b/tests/daytona_sandbox/fake_daytona.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Protocol
@@ -44,6 +46,83 @@ class FakeProcess:
             return SimpleNamespace(result='', exit_code=self.owner.mkdir_exit_code)
         output, exit_code = self.owner.responder(command, timeout)
         return SimpleNamespace(result=output, exit_code=exit_code)
+
+    async def create_session(self, session_id: str, request_timeout: float | None = None) -> None:
+        self.owner.process_calls.append(('create', session_id, request_timeout))
+        self.owner.process_create_started.set()
+        if self.owner.process_create_gate is not None:
+            await self.owner.process_create_gate.wait()
+        self.owner.process_sessions.add(session_id)
+
+    async def execute_session_command(
+        self,
+        session_id: str,
+        request: object,
+        timeout: int | None = None,
+    ) -> SimpleNamespace:
+        self.owner.process_calls.append(('execute', session_id, timeout))
+        if self.owner.exec_error is not None:
+            raise self.owner.exec_error
+        self.owner.process_command = getattr(request, 'command')
+        self.owner.process_run_async = getattr(request, 'run_async')
+        self.owner.process_suppress_input_echo = getattr(request, 'suppress_input_echo')
+        if not self.owner.process_stdout and not self.owner.process_stderr and not self.owner.process_waits_for_input:
+            output, self.owner.process_exit_code = self.owner.responder(self.owner.process_command, timeout)
+            self.owner.process_stdout = [output]
+        return SimpleNamespace(cmd_id='cmd-1')
+
+    async def get_session_command_logs_async(
+        self,
+        session_id: str,
+        command_id: str,
+        on_stdout: Callable[[str], Awaitable[None] | None],
+        on_stderr: Callable[[str], Awaitable[None] | None],
+    ) -> None:
+        self.owner.process_calls.append(('logs', session_id, command_id))
+        for handler, chunks in (
+            (on_stdout, self.owner.process_stdout),
+            (on_stderr, self.owner.process_stderr),
+        ):
+            for chunk in chunks:
+                result = handler(chunk)
+                if inspect.isawaitable(result):
+                    await result
+        if self.owner.process_waits_for_input:
+            await self.owner.process_input_event.wait()
+        for handler, chunks in (
+            (on_stdout, self.owner.process_stdout_after_input),
+            (on_stderr, self.owner.process_stderr_after_input),
+        ):
+            for chunk in chunks:
+                result = handler(chunk)
+                if inspect.isawaitable(result):
+                    await result
+
+    async def send_session_command_input(
+        self,
+        session_id: str,
+        command_id: str,
+        data: str,
+        request_timeout: float | None = None,
+    ) -> None:
+        self.owner.process_calls.append(('input', session_id, command_id, data, request_timeout))
+        self.owner.process_input_event.set()
+
+    async def get_session_command(
+        self,
+        session_id: str,
+        command_id: str,
+        request_timeout: float | None = None,
+    ) -> SimpleNamespace:
+        self.owner.process_calls.append(('status', session_id, command_id, request_timeout))
+        return SimpleNamespace(exit_code=self.owner.process_exit_code)
+
+    async def delete_session(self, session_id: str, request_timeout: float | None = None) -> None:
+        self.owner.process_calls.append(('delete', session_id, request_timeout))
+        if self.owner.process_delete_error is not None:
+            raise self.owner.process_delete_error
+        self.owner.process_sessions.discard(session_id)
+        self.owner.process_input_event.set()
 
 
 class FakeFileSystem:
@@ -98,6 +177,21 @@ class FakeSandbox:
         self.fs_error: Exception | None = None
         self.mkdir_exit_code = 0
         self.responder: Callable[[str, int | None], tuple[str, int]] = lambda command, timeout: ('', 0)
+        self.process_calls: list[tuple[object, ...]] = []
+        self.process_sessions: set[str] = set()
+        self.process_command = ''
+        self.process_run_async: bool | None = None
+        self.process_suppress_input_echo: bool | None = None
+        self.process_stdout: list[str] = []
+        self.process_stderr: list[str] = []
+        self.process_stdout_after_input: list[str] = []
+        self.process_stderr_after_input: list[str] = []
+        self.process_waits_for_input = False
+        self.process_input_event = asyncio.Event()
+        self.process_exit_code: int | None = 0
+        self.process_delete_error: Exception | None = None
+        self.process_create_gate: asyncio.Event | None = None
+        self.process_create_started = asyncio.Event()
         self.process = FakeProcess(self)
         self.fs = FakeFileSystem(self)
 
@@ -108,6 +202,9 @@ class FakeClient:
         self.closed = False
 
     async def create(self, params: CreateParams) -> FakeSandbox:
+        self.owner.create_started.set()
+        if self.owner.create_gate is not None:
+            await self.owner.create_gate.wait()
         if self.owner.create_error is not None:
             raise self.owner.create_error
         sandbox = FakeSandbox(f'sb-{len(self.owner.sandboxes) + 1}')
@@ -143,6 +240,8 @@ class FakeDaytona:
         self.create_error: Exception | None = None
         self.get_error: Exception | None = None
         self.delete_error: Exception | None = None
+        self.create_gate: asyncio.Event | None = None
+        self.create_started = asyncio.Event()
 
     def client(self) -> FakeClient:
         return FakeClient(self)

--- a/tests/daytona_sandbox/test_daytona_sandbox.py
+++ b/tests/daytona_sandbox/test_daytona_sandbox.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator, Mapping
 from contextlib import asynccontextmanager
 from typing import Protocol, TypeGuard, runtime_checkable
@@ -20,6 +21,7 @@ from pydantic_ai_harness.daytona_sandbox import (
     DaytonaSandboxAuthError,
     DaytonaSandboxError,
     DaytonaSandboxExecResult,
+    DaytonaSandboxProcess,
     DaytonaSandboxSession,
     DaytonaSandboxUnavailableError,
 )
@@ -146,6 +148,109 @@ async def test_session_exposes_command_result_and_open_sandbox_id(fake_daytona: 
     assert session.sandbox_id is None
 
 
+async def test_session_manages_bidirectional_process(fake_daytona: FakeDaytona) -> None:
+    stdout: list[str] = []
+    stderr: list[str] = []
+    async with DaytonaSandboxSession(workdir='/workspace', env={'A': 'b'}) as session:
+        sandbox = fake_daytona.sandboxes[0]
+        sandbox.process_stdout = ['ready\n']
+        sandbox.process_stderr = ['warning\n']
+        sandbox.process_stdout_after_input = ['done\n']
+        sandbox.process_waits_for_input = True
+        sandbox.process_exit_code = 3
+        async with session.process(
+            'broker',
+            'python -m child',
+            on_stdout=stdout.append,
+            on_stderr=stderr.append,
+            max_input_bytes=8,
+            io_timeout=7,
+        ) as process:
+            await process.send('go\n', timeout=5)
+            assert await process.wait(timeout=6) == 3
+        assert process.process_id == 'broker'
+        assert sandbox.process_command == "cd -- /workspace && env -- A=b sh -c 'python -m child'"
+        assert sandbox.process_run_async is True
+        assert sandbox.process_suppress_input_echo is True
+        assert sandbox.process_sessions == set()
+    assert stdout == ['ready\n', 'done\n']
+    assert stderr == ['warning\n']
+
+
+async def test_process_rejects_oversized_input_and_times_out(fake_daytona: FakeDaytona) -> None:
+    async with DaytonaSandboxSession() as session:
+        sandbox = fake_daytona.sandboxes[0]
+        sandbox.process_waits_for_input = True
+        async with session.process(
+            'broker',
+            'python -m child',
+            on_stdout=lambda chunk: None,
+            on_stderr=lambda chunk: None,
+            max_input_bytes=2,
+        ) as process:
+            with pytest.raises(ValueError, match='over the 2-byte limit'):
+                await process.send('abc')
+            with pytest.raises(TimeoutError):
+                await process.wait(timeout=1)
+        assert sandbox.process_sessions == set()
+
+
+async def test_cancelled_process_start_deletes_remote_session(fake_daytona: FakeDaytona) -> None:
+    async with DaytonaSandboxSession() as session:
+        sandbox = fake_daytona.sandboxes[0]
+        sandbox.process_create_gate = asyncio.Event()
+        process = session.process(
+            'broker',
+            'python -m child',
+            on_stdout=lambda chunk: None,
+            on_stderr=lambda chunk: None,
+            max_input_bytes=2,
+        )
+        entering = asyncio.create_task(process.__aenter__())
+        await sandbox.process_create_started.wait()
+        entering.cancel()
+        sandbox.process_create_gate.set()
+        with pytest.raises(asyncio.CancelledError):
+            await entering
+        assert sandbox.process_sessions == set()
+
+
+async def test_process_cleanup_can_be_retried(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaConnectionError
+
+    async with DaytonaSandboxSession() as session:
+        sandbox = fake_daytona.sandboxes[0]
+        process = session.process(
+            'broker',
+            'python -m child',
+            on_stdout=lambda chunk: None,
+            on_stderr=lambda chunk: None,
+            max_input_bytes=2,
+        )
+        await process.__aenter__()
+        sandbox.process_delete_error = DaytonaConnectionError('offline')
+        with pytest.raises(DaytonaSandboxError, match='offline'):
+            await process.__aexit__(None, None, None)
+        assert sandbox.process_sessions == {'broker'}
+        sandbox.process_delete_error = None
+        await process.__aexit__(None, None, None)
+        assert sandbox.process_sessions == set()
+
+
+async def test_cancelled_creation_deletes_created_sandbox(fake_daytona: FakeDaytona) -> None:
+    fake_daytona.create_gate = asyncio.Event()
+    session = DaytonaSandboxSession()
+    entering = asyncio.create_task(session.__aenter__())
+    await fake_daytona.create_started.wait()
+    entering.cancel()
+    fake_daytona.create_gate.set()
+    with pytest.raises(asyncio.CancelledError):
+        await entering
+    assert fake_daytona.sandboxes[0].deleted is True
+    assert fake_daytona.closed_clients == 1
+    assert session.sandbox_id is None
+
+
 async def test_attached_session_is_left_running(fake_daytona: FakeDaytona) -> None:
     sandbox = fake_daytona.sandbox()
     async with DaytonaSandboxSession(sandbox_id=sandbox.id) as session:
@@ -197,7 +302,7 @@ async def test_creation_configuration_reaches_daytona(fake_daytona: FakeDaytona)
     [
         ('', 0, '(no output)'),
         ('bad\n', 2, 'bad\n[exit code: 2]'),
-        ('one\ntwo\nthree', 0, '[... output truncated to the last 2 lines ...]\ntwo\nthree'),
+        ('one\ntwo\nthree', 0, '[... output truncated to the last 1 line ...]\nthree'),
     ],
 )
 async def test_command_output(fake_daytona: FakeDaytona, output: str, exit_code: int, expected: str) -> None:
@@ -206,18 +311,31 @@ async def test_command_output(fake_daytona: FakeDaytona, output: str, exit_code:
         assert await tools.run_command('example') == expected
 
 
-async def test_command_timeout_is_clamped(fake_daytona: FakeDaytona) -> None:
+async def test_complete_command_result_obeys_output_bounds(fake_daytona: FakeDaytona) -> None:
+    async with _tools(max_output_bytes=12, max_output_lines=1) as tools:
+        fake_daytona.sandboxes[0].responder = lambda command, timeout: ('x' * 100, 2)
+        result = await tools.run_command('example')
+    assert len(result.encode('utf-8')) <= 12
+    assert len(result.splitlines()) <= 1
+
+
+async def test_command_timeout_is_clamped(fake_daytona: FakeDaytona, monkeypatch: pytest.MonkeyPatch) -> None:
+    waits: list[int] = []
+
+    async def wait(process: DaytonaSandboxProcess, *, timeout: int) -> int:
+        waits.append(timeout)
+        return 0
+
+    monkeypatch.setattr(DaytonaSandboxProcess, 'wait', wait)
     async with _tools() as tools:
         await tools.run_command('slow', timeout_seconds=999)
-    assert fake_daytona.sandboxes[0].exec_calls[0].timeout == 300
+    assert waits == [300]
 
 
 async def test_command_timeout_is_reported(fake_daytona: FakeDaytona) -> None:
-    from daytona import DaytonaTimeoutError
-
     async with _tools() as tools:
-        fake_daytona.sandboxes[0].exec_error = DaytonaTimeoutError('late')
-        assert await tools.run_command('slow', timeout_seconds=2) == '(no output)\n[timed out after 2s]'
+        fake_daytona.sandboxes[0].process_waits_for_input = True
+        assert await tools.run_command('slow', timeout_seconds=1) == '(no output)\n[timed out after 1s]'
 
 
 async def test_command_sdk_failures(fake_daytona: FakeDaytona) -> None:
@@ -358,9 +476,15 @@ async def test_cleanup_failure_is_reported(fake_daytona: FakeDaytona) -> None:
     from daytona import DaytonaConnectionError
 
     fake_daytona.delete_error = DaytonaConnectionError('offline')
+    session = DaytonaSandboxSession()
+    await session.__aenter__()
     with pytest.raises(DaytonaSandboxError, match='offline'):
-        async with _tools():
-            pass
+        await session.__aexit__(None, None, None)
+    assert session.sandbox_id == 'sb-1'
+    assert fake_daytona.closed_clients == 0
+    fake_daytona.delete_error = None
+    await session.__aexit__(None, None, None)
+    assert session.sandbox_id is None
     assert fake_daytona.closed_clients == 1
 
 
@@ -385,6 +509,8 @@ def test_configuration_conflicts_and_instructions() -> None:
         DaytonaSandbox(default_command_timeout=2, max_command_timeout=1)
     with pytest.raises(ValueError, match='snapshot cannot'):
         DaytonaSandbox(sandbox_id='sb', snapshot='snap')
+    with pytest.raises(ValueError, match='auto_stop_minutes cannot'):
+        DaytonaSandbox(sandbox_id='sb', auto_stop_minutes=5)
     with pytest.raises(ValueError, match='instructions must'):
         DaytonaSandbox(instructions=1)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match='network_block_all must be a boolean'):
@@ -406,6 +532,8 @@ def test_configuration_conflicts_and_instructions() -> None:
             DaytonaSandboxSession(auto_stop_minutes=value)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match='snapshot cannot'):
         DaytonaSandboxSession(sandbox_id='sb', snapshot='snap')
+    with pytest.raises(ValueError, match='auto_stop_minutes cannot'):
+        DaytonaSandboxSession(sandbox_id='sb', auto_stop_minutes=5)
     with pytest.raises(ValueError, match='network_block_all must be a boolean'):
         DaytonaSandboxSession(network_block_all=1)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match='network_block_all cannot configure an attached'):
@@ -453,6 +581,7 @@ def test_public_exports() -> None:
         'DaytonaSandboxAuthError',
         'DaytonaSandboxError',
         'DaytonaSandboxExecResult',
+        'DaytonaSandboxProcess',
         'DaytonaSandboxSession',
         'DaytonaSandboxUnavailableError',
     )

--- a/tests/daytona_sandbox/test_daytona_sandbox.py
+++ b/tests/daytona_sandbox/test_daytona_sandbox.py
@@ -19,6 +19,8 @@ from pydantic_ai_harness.daytona_sandbox import (
     DaytonaSandbox,
     DaytonaSandboxAuthError,
     DaytonaSandboxError,
+    DaytonaSandboxExecResult,
+    DaytonaSandboxSession,
     DaytonaSandboxUnavailableError,
 )
 
@@ -63,6 +65,7 @@ def _context() -> RunContext[None]:
 async def _tools(
     *,
     sandbox_id: str | None = None,
+    session: DaytonaSandboxSession | None = None,
     snapshot: str | None = None,
     workdir: str | None = None,
     env: Mapping[str, str] | None = None,
@@ -72,6 +75,7 @@ async def _tools(
 ) -> AsyncGenerator[_Tools]:
     base = DaytonaSandbox[None](
         sandbox_id=sandbox_id,
+        session=session,
         snapshot=snapshot,
         workdir=workdir,
         env=env,
@@ -110,6 +114,66 @@ async def test_attached_sandbox_is_left_running(fake_daytona: FakeDaytona) -> No
         assert await tools.run_command('echo hello') == 'hello'
     assert sandbox.deleted is False
     assert fake_daytona.delete_calls == []
+
+
+async def test_caller_owned_session_is_reused_across_agent_runs(fake_daytona: FakeDaytona) -> None:
+    def call_then_finish(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if not any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            return ModelResponse(parts=[ToolCallPart('write_file', {'path': 'state.txt', 'content': 'ready'})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    async with DaytonaSandboxSession() as session:
+        agent: Agent[None, str] = Agent(FunctionModel(call_then_finish), capabilities=[DaytonaSandbox(session=session)])
+        assert (await agent.run('first')).output == 'done'
+        assert (await agent.run('second')).output == 'done'
+        assert len(fake_daytona.sandboxes) == 1
+        assert fake_daytona.sandboxes[0].files['state.txt'] == b'ready'
+        assert fake_daytona.sandboxes[0].deleted is False
+    assert fake_daytona.sandboxes[0].deleted is True
+    assert fake_daytona.delete_calls == [('sb-1', 60, True)]
+
+
+async def test_session_exposes_command_result_and_open_sandbox_id(fake_daytona: FakeDaytona) -> None:
+    session = DaytonaSandboxSession(workdir='/workspace', env={'A': 'b'})
+    assert session.sandbox_id is None
+    async with session:
+        fake_daytona.sandboxes[0].responder = lambda command, timeout: ('hello\n', 3)
+        result = await session.exec('example', timeout=7)
+        assert result == DaytonaSandboxExecResult(output='hello\n', returncode=3)
+        assert session.sandbox_id == 'sb-1'
+    assert session.sandbox_id is None
+
+
+async def test_attached_session_is_left_running(fake_daytona: FakeDaytona) -> None:
+    sandbox = fake_daytona.sandbox()
+    async with DaytonaSandboxSession(sandbox_id=sandbox.id) as session:
+        assert session.sandbox_id == sandbox.id
+    assert sandbox.deleted is False
+    assert fake_daytona.delete_calls == []
+
+
+async def test_session_exit_without_enter_is_safe() -> None:
+    await DaytonaSandboxSession().__aexit__(None, None, None)
+
+
+@pytest.mark.parametrize('timeout', [0, True, 1.5])
+async def test_session_rejects_invalid_exec_timeout(fake_daytona: FakeDaytona, timeout: object) -> None:
+    async with DaytonaSandboxSession() as session:
+        with pytest.raises(ValueError, match='timeout must be a positive integer'):
+            await session.exec('example', timeout=timeout)  # type: ignore[arg-type]
+
+
+async def test_injected_session_must_be_open(fake_daytona: FakeDaytona) -> None:
+    with pytest.raises(DaytonaSandboxError, match='injected session is not open'):
+        async with _tools(session=DaytonaSandboxSession()):
+            pass  # pragma: no cover
+
+
+async def test_session_cannot_be_entered_twice(fake_daytona: FakeDaytona) -> None:
+    async with DaytonaSandboxSession() as session:
+        with pytest.raises(DaytonaSandboxError, match='already open'):
+            await session.__aenter__()
+    assert len(fake_daytona.sandboxes) == 1
 
 
 async def test_creation_configuration_reaches_daytona(fake_daytona: FakeDaytona) -> None:
@@ -320,10 +384,24 @@ def test_configuration_conflicts_and_instructions() -> None:
         DaytonaSandbox(sandbox_id='sb', snapshot='snap')
     with pytest.raises(ValueError, match='instructions must'):
         DaytonaSandbox(instructions=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match='sandbox_id.*cannot be combined with `session`'):
+        DaytonaSandbox(sandbox_id='sb', session=DaytonaSandboxSession())
+    with pytest.raises(ValueError, match='snapshot.*cannot be combined with `session`'):
+        DaytonaSandbox(snapshot='snap', session=DaytonaSandboxSession())
+    with pytest.raises(ValueError, match='workdir.*env.*cannot be combined with `session`'):
+        DaytonaSandbox(workdir='/work', env={'A': 'b'}, session=DaytonaSandboxSession())
+    with pytest.raises(ValueError, match='auto_stop_minutes.*cannot be combined with `session`'):
+        DaytonaSandbox(auto_stop_minutes=30, session=DaytonaSandboxSession())
+    for value in (0, True, 1.5):
+        with pytest.raises(ValueError, match='auto_stop_minutes must be a positive integer'):
+            DaytonaSandboxSession(auto_stop_minutes=value)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match='snapshot cannot'):
+        DaytonaSandboxSession(sandbox_id='sb', snapshot='snap')
     assert DaytonaSandbox(instructions='').get_instructions() is None
     assert DaytonaSandbox(instructions='custom').get_instructions() == 'custom'
     assert 'is deleted after this run' in (DaytonaSandbox().get_instructions() or '')
     assert 'persists after this run' in (DaytonaSandbox(sandbox_id='sb').get_instructions() or '')
+    assert 'persists after this run' in (DaytonaSandbox(session=DaytonaSandboxSession()).get_instructions() or '')
     toolset = DaytonaSandbox[None](id=None).get_toolset()
     if not isinstance(toolset, _Tools):  # pragma: no cover - capability contract
         raise AssertionError('DaytonaSandbox is missing its tools')
@@ -361,6 +439,8 @@ def test_public_exports() -> None:
         'DaytonaSandbox',
         'DaytonaSandboxAuthError',
         'DaytonaSandboxError',
+        'DaytonaSandboxExecResult',
+        'DaytonaSandboxSession',
         'DaytonaSandboxUnavailableError',
     )
 

--- a/tests/daytona_sandbox/test_daytona_sandbox.py
+++ b/tests/daytona_sandbox/test_daytona_sandbox.py
@@ -1,0 +1,372 @@
+"""Tests for the public Daytona sandbox capability."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Mapping
+from contextlib import asynccontextmanager
+from typing import Protocol, TypeGuard, runtime_checkable
+
+import pytest
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.exceptions import ModelRetry, UserError
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import AbstractToolset
+from pydantic_ai.usage import RunUsage
+
+from pydantic_ai_harness.daytona_sandbox import (
+    DaytonaSandbox,
+    DaytonaSandboxAuthError,
+    DaytonaSandboxError,
+    DaytonaSandboxUnavailableError,
+)
+
+from .fake_daytona import FakeDaytona
+
+pytestmark = pytest.mark.anyio(backends=['asyncio'])
+
+
+@runtime_checkable
+class _Tools(Protocol):  # pragma: no cover - structural typing only
+    id: str | None
+
+    async def __aenter__(self) -> _Tools: ...
+
+    async def __aexit__(self, *args: object) -> None: ...
+
+    async def run_command(self, command: str, *, timeout_seconds: float | None = None) -> str: ...
+
+    async def read_file(self, path: str, *, offset: int | None = None, limit: int | None = None) -> str: ...
+
+    async def write_file(self, path: str, content: str) -> str: ...
+
+    async def list_directory(self, path: str = '.') -> str: ...
+
+
+def _is_toolset(value: object) -> TypeGuard[AbstractToolset[None]]:
+    return isinstance(value, AbstractToolset)
+
+
+def _context() -> RunContext[None]:
+    return RunContext(
+        deps=None,
+        model=TestModel(),
+        usage=RunUsage(),
+        prompt=None,
+        messages=[],
+        run_step=0,
+    )
+
+
+@asynccontextmanager
+async def _tools(
+    *,
+    sandbox_id: str | None = None,
+    snapshot: str | None = None,
+    workdir: str | None = None,
+    env: Mapping[str, str] | None = None,
+    max_output_bytes: int = 50 * 1024,
+    max_output_lines: int = 2000,
+    max_read_bytes: int = 5 * 1024 * 1024,
+) -> AsyncGenerator[_Tools]:
+    base = DaytonaSandbox[None](
+        sandbox_id=sandbox_id,
+        snapshot=snapshot,
+        workdir=workdir,
+        env=env,
+        max_output_bytes=max_output_bytes,
+        max_output_lines=max_output_lines,
+        max_read_bytes=max_read_bytes,
+    ).get_toolset()
+    if not _is_toolset(base):  # pragma: no cover - capability contract
+        raise AssertionError('DaytonaSandbox must return an AbstractToolset')
+    run = await base.for_run(_context())
+    if not isinstance(run, _Tools):  # pragma: no cover - capability contract
+        raise AssertionError('DaytonaSandbox is missing its tools')
+    async with run:
+        yield run
+
+
+async def test_agent_runs_command_and_deletes_owned_sandbox(fake_daytona: FakeDaytona) -> None:
+    def call_then_finish(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if not any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            return ModelResponse(parts=[ToolCallPart('run_command', {'command': 'echo hello'})])
+        return ModelResponse(parts=[TextPart('done')])
+
+    agent: Agent[None, str] = Agent(FunctionModel(call_then_finish), capabilities=[DaytonaSandbox()])
+    fake_daytona.sandbox().responder = lambda command, timeout: ('unused', 0)
+    result = await agent.run('run it')
+
+    assert result.output == 'done'
+    assert fake_daytona.sandboxes[-1].deleted is True
+    assert fake_daytona.delete_calls == [('sb-2', 60, True)]
+
+
+async def test_attached_sandbox_is_left_running(fake_daytona: FakeDaytona) -> None:
+    sandbox = fake_daytona.sandbox()
+    sandbox.responder = lambda command, timeout: ('hello\n', 0)
+    async with _tools(sandbox_id=sandbox.id) as tools:
+        assert await tools.run_command('echo hello') == 'hello'
+    assert sandbox.deleted is False
+    assert fake_daytona.delete_calls == []
+
+
+async def test_creation_configuration_reaches_daytona(fake_daytona: FakeDaytona) -> None:
+    async with _tools(snapshot='snap-python', workdir='/workspace', env={'A': 'b'}) as tools:
+        await tools.write_file('src/main.py', 'print(1)')
+    params = fake_daytona.create_params[0]
+    assert params.snapshot == 'snap-python'
+    assert params.auto_stop_interval == 60
+    assert params.auto_delete_interval == 0
+    assert params.env_vars == {'A': 'b'}
+    sandbox = fake_daytona.sandboxes[0]
+    assert sandbox.files['/workspace/src/main.py'] == b'print(1)'
+    assert sandbox.exec_calls[0].command == 'mkdir -p -- /workspace/src'
+
+
+@pytest.mark.parametrize(
+    ('output', 'exit_code', 'expected'),
+    [
+        ('', 0, '(no output)'),
+        ('bad\n', 2, 'bad\n[exit code: 2]'),
+        ('one\ntwo\nthree', 0, '[... output truncated to the last 2 lines ...]\ntwo\nthree'),
+    ],
+)
+async def test_command_output(fake_daytona: FakeDaytona, output: str, exit_code: int, expected: str) -> None:
+    async with _tools(max_output_lines=2) as tools:
+        fake_daytona.sandboxes[0].responder = lambda command, timeout: (output, exit_code)
+        assert await tools.run_command('example') == expected
+
+
+async def test_command_timeout_is_clamped(fake_daytona: FakeDaytona) -> None:
+    async with _tools() as tools:
+        await tools.run_command('slow', timeout_seconds=999)
+    assert fake_daytona.sandboxes[0].exec_calls[0].timeout == 300
+
+
+async def test_command_timeout_is_reported(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaTimeoutError
+
+    async with _tools() as tools:
+        fake_daytona.sandboxes[0].exec_error = DaytonaTimeoutError('late')
+        assert await tools.run_command('slow', timeout_seconds=2) == '(no output)\n[timed out after 2s]'
+
+
+async def test_command_sdk_failures(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaAuthenticationError, DaytonaConnectionError, DaytonaNotFoundError
+
+    async with _tools() as tools:
+        sandbox = fake_daytona.sandboxes[0]
+        sandbox.exec_error = DaytonaConnectionError('offline')
+        with pytest.raises(ModelRetry, match='offline'):
+            await tools.run_command('example')
+        sandbox.exec_error = DaytonaNotFoundError('gone')
+        with pytest.raises(DaytonaSandboxUnavailableError):
+            await tools.run_command('example')
+        sandbox.exec_error = DaytonaAuthenticationError('denied')
+        with pytest.raises(DaytonaSandboxAuthError):
+            await tools.run_command('example')
+
+
+@pytest.mark.parametrize('timeout', [0, -1, float('inf'), float('nan'), True])
+async def test_invalid_command_timeout_is_retryable(fake_daytona: FakeDaytona, timeout: float) -> None:
+    async with _tools() as tools:
+        with pytest.raises(ModelRetry, match='greater than 0'):
+            await tools.run_command('bad', timeout_seconds=timeout)
+
+
+async def test_file_tools(fake_daytona: FakeDaytona) -> None:
+    async with _tools() as tools:
+        sandbox = fake_daytona.sandboxes[0]
+        sandbox.files['notes.txt'] = b'one\ntwo\nthree\n'
+        sandbox.files['src/main.py'] = b'print(1)'
+        assert await tools.read_file('notes.txt', offset=2, limit=1) == (
+            'two\n\n[1 more lines in file. Use offset=3 to continue.]'
+        )
+        assert await tools.list_directory() == 'notes.txt\nsrc/'
+        assert await tools.write_file('out/result.txt', 'ok') == "Wrote 2 bytes to 'out/result.txt'."
+        assert sandbox.files['out/result.txt'] == b'ok'
+
+
+async def test_absolute_and_parentless_writes(fake_daytona: FakeDaytona) -> None:
+    async with _tools(workdir='/workspace') as tools:
+        await tools.write_file('/tmp/absolute.txt', 'a')
+        await tools.write_file('plain.txt', 'b')
+    sandbox = fake_daytona.sandboxes[0]
+    assert sandbox.files['/tmp/absolute.txt'] == b'a'
+    assert sandbox.files['/workspace/plain.txt'] == b'b'
+
+
+async def test_write_failures_are_retryable(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaConnectionError
+
+    async with _tools() as tools:
+        sandbox = fake_daytona.sandboxes[0]
+        sandbox.mkdir_exit_code = 1
+        with pytest.raises(ModelRetry, match='Could not create'):
+            await tools.write_file('dir/file', 'content')
+        sandbox.mkdir_exit_code = 0
+        sandbox.fs_error = DaytonaConnectionError('offline')
+        with pytest.raises(ModelRetry, match='Could not write'):
+            await tools.write_file('file', 'content')
+        with pytest.raises(ModelRetry, match='cannot be encoded'):
+            await tools.write_file('file', '\ud800')
+
+
+async def test_empty_directory(fake_daytona: FakeDaytona) -> None:
+    async with _tools() as tools:
+        assert await tools.list_directory() == '(empty)'
+
+
+async def test_file_auth_failures_are_terminal(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaAuthorizationError
+
+    async with _tools() as tools:
+        fake_daytona.sandboxes[0].fs_error = DaytonaAuthorizationError('denied')
+        with pytest.raises(DaytonaSandboxAuthError):
+            await tools.read_file('file')
+        with pytest.raises(DaytonaSandboxAuthError):
+            await tools.write_file('file', 'content')
+        with pytest.raises(DaytonaSandboxAuthError):
+            await tools.list_directory()
+
+
+async def test_list_failure_is_retryable(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaConnectionError
+
+    async with _tools() as tools:
+        fake_daytona.sandboxes[0].fs_error = DaytonaConnectionError('offline')
+        with pytest.raises(ModelRetry, match='Could not list'):
+            await tools.list_directory()
+
+
+async def test_missing_file_is_retryable(fake_daytona: FakeDaytona) -> None:
+    async with _tools() as tools:
+        with pytest.raises(ModelRetry, match='Could not read'):
+            await tools.read_file('missing')
+
+
+async def test_oversized_file_is_retryable(fake_daytona: FakeDaytona) -> None:
+    async with _tools(max_read_bytes=2) as tools:
+        fake_daytona.sandboxes[0].files['large'] = b'abc'
+        with pytest.raises(ModelRetry, match='over the 2B read limit'):
+            await tools.read_file('large')
+
+
+async def test_file_growth_is_checked_after_download(fake_daytona: FakeDaytona) -> None:
+    async with _tools(max_read_bytes=2) as tools:
+        sandbox = fake_daytona.sandboxes[0]
+        sandbox.files['growing'] = b'abc'
+        sandbox.reported_sizes['growing'] = 1
+        with pytest.raises(ModelRetry, match='over the 2B read limit'):
+            await tools.read_file('growing')
+
+
+async def test_unavailable_attached_sandbox_is_terminal(fake_daytona: FakeDaytona) -> None:
+    with pytest.raises(DaytonaSandboxUnavailableError, match='does not exist'):
+        async with _tools(sandbox_id='missing'):
+            pass
+
+
+async def test_sdk_auth_error_is_terminal(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaAuthenticationError
+
+    fake_daytona.create_error = DaytonaAuthenticationError('no')
+    with pytest.raises(DaytonaSandboxAuthError, match='DAYTONA_API_KEY'):
+        async with _tools():
+            pass
+
+
+async def test_generic_creation_failure_is_reported(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaConnectionError
+
+    fake_daytona.create_error = DaytonaConnectionError('offline')
+    with pytest.raises(DaytonaSandboxError, match='offline'):
+        async with _tools():
+            pass
+
+
+async def test_cleanup_failure_is_reported(fake_daytona: FakeDaytona) -> None:
+    from daytona import DaytonaConnectionError
+
+    fake_daytona.delete_error = DaytonaConnectionError('offline')
+    with pytest.raises(DaytonaSandboxError, match='offline'):
+        async with _tools():
+            pass
+    assert fake_daytona.closed_clients == 1
+
+
+@pytest.mark.parametrize(
+    ('name', 'value'),
+    [
+        ('auto_stop_minutes', 0),
+        ('default_command_timeout', True),
+        ('max_command_timeout', -1),
+        ('max_output_bytes', 0),
+        ('max_output_lines', 0),
+        ('max_read_bytes', 0),
+    ],
+)
+def test_positive_integer_configuration(name: str, value: object) -> None:
+    with pytest.raises(ValueError, match=f'{name} must be a positive integer'):
+        DaytonaSandbox(**{name: value})  # type: ignore[arg-type]
+
+
+def test_configuration_conflicts_and_instructions() -> None:
+    with pytest.raises(ValueError, match='cannot exceed'):
+        DaytonaSandbox(default_command_timeout=2, max_command_timeout=1)
+    with pytest.raises(ValueError, match='snapshot cannot'):
+        DaytonaSandbox(sandbox_id='sb', snapshot='snap')
+    with pytest.raises(ValueError, match='instructions must'):
+        DaytonaSandbox(instructions=1)  # type: ignore[arg-type]
+    assert DaytonaSandbox(instructions='').get_instructions() is None
+    assert DaytonaSandbox(instructions='custom').get_instructions() == 'custom'
+    assert 'is deleted after this run' in (DaytonaSandbox().get_instructions() or '')
+    assert 'persists after this run' in (DaytonaSandbox(sandbox_id='sb').get_instructions() or '')
+    toolset = DaytonaSandbox[None](id=None).get_toolset()
+    if not isinstance(toolset, _Tools):  # pragma: no cover - capability contract
+        raise AssertionError('DaytonaSandbox is missing its tools')
+    assert toolset.id == 'daytona_sandbox'
+
+
+async def test_toolset_requires_run_lifecycle() -> None:
+    base = DaytonaSandbox[None]().get_toolset()
+    if not isinstance(base, _Tools):  # pragma: no cover - capability contract
+        raise AssertionError('DaytonaSandbox is missing its tools')
+    async with base:
+        with pytest.raises(DaytonaSandboxError, match='session is not open'):
+            await base.run_command('echo hello')
+    await base.__aexit__(None, None, None)
+
+
+async def test_run_toolset_cannot_be_entered_twice(fake_daytona: FakeDaytona) -> None:
+    base = DaytonaSandbox[None]().get_toolset()
+    if not _is_toolset(base):  # pragma: no cover - capability contract
+        raise AssertionError('DaytonaSandbox must return an AbstractToolset')
+    run = await base.for_run(_context())
+    await run.__aenter__()
+    try:
+        with pytest.raises(DaytonaSandboxError, match='already open'):
+            await run.__aenter__()
+    finally:
+        await run.__aexit__(None, None, None)
+
+
+def test_public_exports() -> None:
+    import pydantic_ai_harness.daytona_sandbox as module
+
+    assert module.DaytonaSandbox is DaytonaSandbox
+    assert module.__all__ == (
+        'DaytonaSandbox',
+        'DaytonaSandboxAuthError',
+        'DaytonaSandboxError',
+        'DaytonaSandboxUnavailableError',
+    )
+
+
+def test_rejects_durable_execution() -> None:
+    from pydantic_ai.durable_exec.temporal import TemporalDurability
+
+    with pytest.raises(UserError, match='does not support durable execution'):
+        Agent(TestModel(), capabilities=[DaytonaSandbox(), TemporalDurability()])

--- a/tests/daytona_sandbox/test_daytona_sandbox.py
+++ b/tests/daytona_sandbox/test_daytona_sandbox.py
@@ -69,6 +69,7 @@ async def _tools(
     snapshot: str | None = None,
     workdir: str | None = None,
     env: Mapping[str, str] | None = None,
+    network_block_all: bool = False,
     max_output_bytes: int = 50 * 1024,
     max_output_lines: int = 2000,
     max_read_bytes: int = 5 * 1024 * 1024,
@@ -79,6 +80,7 @@ async def _tools(
         snapshot=snapshot,
         workdir=workdir,
         env=env,
+        network_block_all=network_block_all,
         max_output_bytes=max_output_bytes,
         max_output_lines=max_output_lines,
         max_read_bytes=max_read_bytes,
@@ -177,13 +179,14 @@ async def test_session_cannot_be_entered_twice(fake_daytona: FakeDaytona) -> Non
 
 
 async def test_creation_configuration_reaches_daytona(fake_daytona: FakeDaytona) -> None:
-    async with _tools(snapshot='snap-python', workdir='/workspace', env={'A': 'b'}) as tools:
+    async with _tools(snapshot='snap-python', workdir='/workspace', env={'A': 'b'}, network_block_all=True) as tools:
         await tools.write_file('src/main.py', 'print(1)')
     params = fake_daytona.create_params[0]
     assert params.snapshot == 'snap-python'
     assert params.auto_stop_interval == 60
     assert params.auto_delete_interval == 0
     assert params.env_vars == {'A': 'b'}
+    assert params.network_block_all is True
     sandbox = fake_daytona.sandboxes[0]
     assert sandbox.files['/workspace/src/main.py'] == b'print(1)'
     assert sandbox.exec_calls[0].command == 'mkdir -p -- /workspace/src'
@@ -384,6 +387,10 @@ def test_configuration_conflicts_and_instructions() -> None:
         DaytonaSandbox(sandbox_id='sb', snapshot='snap')
     with pytest.raises(ValueError, match='instructions must'):
         DaytonaSandbox(instructions=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match='network_block_all must be a boolean'):
+        DaytonaSandbox(network_block_all=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match='network_block_all cannot configure an attached'):
+        DaytonaSandbox(sandbox_id='sb', network_block_all=True)
     with pytest.raises(ValueError, match='sandbox_id.*cannot be combined with `session`'):
         DaytonaSandbox(sandbox_id='sb', session=DaytonaSandboxSession())
     with pytest.raises(ValueError, match='snapshot.*cannot be combined with `session`'):
@@ -392,11 +399,17 @@ def test_configuration_conflicts_and_instructions() -> None:
         DaytonaSandbox(workdir='/work', env={'A': 'b'}, session=DaytonaSandboxSession())
     with pytest.raises(ValueError, match='auto_stop_minutes.*cannot be combined with `session`'):
         DaytonaSandbox(auto_stop_minutes=30, session=DaytonaSandboxSession())
+    with pytest.raises(ValueError, match='network_block_all.*cannot be combined with `session`'):
+        DaytonaSandbox(network_block_all=True, session=DaytonaSandboxSession())
     for value in (0, True, 1.5):
         with pytest.raises(ValueError, match='auto_stop_minutes must be a positive integer'):
             DaytonaSandboxSession(auto_stop_minutes=value)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match='snapshot cannot'):
         DaytonaSandboxSession(sandbox_id='sb', snapshot='snap')
+    with pytest.raises(ValueError, match='network_block_all must be a boolean'):
+        DaytonaSandboxSession(network_block_all=1)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match='network_block_all cannot configure an attached'):
+        DaytonaSandboxSession(sandbox_id='sb', network_block_all=True)
     assert DaytonaSandbox(instructions='').get_instructions() is None
     assert DaytonaSandbox(instructions='custom').get_instructions() == 'custom'
     assert 'is deleted after this run' in (DaytonaSandbox().get_instructions() or '')

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -127,6 +127,7 @@ _CAPABILITY_PAGE_META = {
     'shell.md': ('shell', 'Shell'),
     'managed-prompt.md': ('logfire', 'Managed Prompt'),
     'memory.md': ('memory', 'Memory'),
+    'daytona-sandbox.md': ('daytona_sandbox', 'Daytona Sandbox'),
     'modal-sandbox.md': ('modal_sandbox', 'Modal Sandbox'),
     'repo-context.md': ('repo_context', 'Repo Context'),
     'researcher.md': ('researcher', 'Researcher'),

--- a/uv.lock
+++ b/uv.lock
@@ -71,11 +71,11 @@ wheels = [
 
 [[package]]
 name = "aiofiles"
-version = "25.1.0"
+version = "24.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
 ]
 
 [[package]]
@@ -353,6 +353,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-retry"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", version = "3.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp", version = "3.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608, upload-time = "2024-11-06T10:44:54.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981, upload-time = "2024-11-06T10:44:52.917Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -536,6 +549,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "bidict"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload-time = "2024-02-18T19:09:05.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload-time = "2024-02-18T19:09:04.156Z" },
 ]
 
 [[package]]
@@ -1317,6 +1339,144 @@ wheels = [
 ]
 
 [[package]]
+name = "daytona"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp", version = "3.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp", version = "3.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "daytona-analytics-api-client" },
+    { name = "daytona-analytics-api-client-async" },
+    { name = "daytona-api-client" },
+    { name = "daytona-api-client-async" },
+    { name = "daytona-toolbox-api-client" },
+    { name = "daytona-toolbox-api-client-async" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "httpx-ws" },
+    { name = "obstore" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-aiohttp-client" },
+    { name = "opentelemetry-sdk" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dotenv" },
+    { name = "python-multipart" },
+    { name = "python-socketio", extra = ["asyncio-client", "client"] },
+    { name = "toml" },
+    { name = "urllib3" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/1b/dd2ce6f1c0d708710d20465454227cd39b962d4766bc00c88e2818bdc161/daytona-0.198.0.tar.gz", hash = "sha256:b9513be515c742f683d9d4c2ceb2f9ca95413223656821547d63563ebbfe0b2e", size = 176071, upload-time = "2026-07-16T09:17:54.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/71/d8b27a4f6ef97f7bd1b13acf25b2c6fe66c85e23b2301bc89844f4bd3e4d/daytona-0.198.0-py3-none-any.whl", hash = "sha256:8eb19b74ed5b0bdadb35f592db59aadc86f00787dc8438d3d0a9e0e77fcd7981", size = 211796, upload-time = "2026-07-16T09:17:55.823Z" },
+]
+
+[[package]]
+name = "daytona-analytics-api-client"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/fc/92666cf4cfbd72b1ef866ce9e481114616d9435daa40d8644c620bc8ebb1/daytona_analytics_api_client-0.198.0.tar.gz", hash = "sha256:8c0d05f5711042ef7524a00696dd4d375274d005689d56823264b4099be4e75c", size = 30034, upload-time = "2026-07-16T09:17:10.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/58/1bc386dd3e617ed17596f0b98983c0d585722ffa39e59dde317fa04f5808/daytona_analytics_api_client-0.198.0-py3-none-any.whl", hash = "sha256:3fc92faf102f0affcbdd81157ea7f88bb7c92e3651d940f59ffd532ca22c40cd", size = 45004, upload-time = "2026-07-16T09:17:11.293Z" },
+]
+
+[[package]]
+name = "daytona-analytics-api-client-async"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", version = "3.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp", version = "3.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/28/ac54bc290aeea7cf434a998a6c55e92956a31c18ce7ffffadb81b5439a99/daytona_analytics_api_client_async-0.198.0.tar.gz", hash = "sha256:b7863766be03dda2d268d999d8fb02247b48f78803529d074067a983bc3c7308", size = 30046, upload-time = "2026-07-16T09:17:01.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/39/1bd663fd1f7f00f9a4ed7bc3fa7cebcd0c0d36cf87ce36ab9df31668fe97/daytona_analytics_api_client_async-0.198.0-py3-none-any.whl", hash = "sha256:e189c37406e1d8f9a9e5c11fb8c8ed27f8a5c6c27f40728975a014205691e329", size = 45276, upload-time = "2026-07-16T09:17:02.066Z" },
+]
+
+[[package]]
+name = "daytona-api-client"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/2f/9dbfdc70ccfe5de1a335c35dedf7b2714ca9fbf7aa7b4589a4db48d77c1f/daytona_api_client-0.198.0.tar.gz", hash = "sha256:0daf3dd33a21bbf3291bf2d93bb5c916afac7abeaa227012bf0f51b504b2f33b", size = 124346, upload-time = "2026-07-16T09:17:20.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/b0/7cf252e2d680c960f4915a0a66b7eb8027e5b8a02255db28346343b40853/daytona_api_client-0.198.0-py3-none-any.whl", hash = "sha256:1b30649218fe6e1307387de81d041c66e19a4947a88eec4caea6d9c518d15b00", size = 315467, upload-time = "2026-07-16T09:17:21.397Z" },
+]
+
+[[package]]
+name = "daytona-api-client-async"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", version = "3.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp", version = "3.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/53/27d056246593c552023c836ae5c2d8629100c328d78efea043b712a6a171/daytona_api_client_async-0.198.0.tar.gz", hash = "sha256:c76c42c08b350729eb938551df11f6e3193b5bb2d12a11488aea441fed865a1d", size = 124869, upload-time = "2026-07-16T09:17:01.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/0c/c6fd85b80561bb3fca5a9e706385544000e1eb6a8ed67dab0b8407c7bfae/daytona_api_client_async-0.198.0-py3-none-any.whl", hash = "sha256:522d0c2235c7125a02c45a55905fed6a6583d6fc0f2bd911f5fd62bfccb356f5", size = 318067, upload-time = "2026-07-16T09:17:03.751Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/f1/e933c40e1320b2bff173d4254c6757870f929ecd4f2447d1a09b9139361d/daytona_toolbox_api_client-0.198.0.tar.gz", hash = "sha256:75624bccda97346019453129c89d9fcc5979847ee249eec36aba8b7ce22d2a26", size = 86297, upload-time = "2026-07-16T09:17:11.745Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/4d/0ab80c2d97eb7e11129e9069729c56e216f3e979a4f889b788af07b2598d/daytona_toolbox_api_client-0.198.0-py3-none-any.whl", hash = "sha256:179d82ed726e2508e4833ef8605988400e521552df5195d9ca53e28422974dd3", size = 247056, upload-time = "2026-07-16T09:17:13.051Z" },
+]
+
+[[package]]
+name = "daytona-toolbox-api-client-async"
+version = "0.198.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", version = "3.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp", version = "3.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "aiohttp-retry" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/0d/5b4211851b5fc6467b5b73c25536d7575583aa511c093c5ccc774b235b47/daytona_toolbox_api_client_async-0.198.0.tar.gz", hash = "sha256:89a70ca15b6a1b6ec3bb3beec13488c05d30db1cf27f935ce732283bbc3c352c", size = 80151, upload-time = "2026-07-16T09:17:01.567Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/7b/d3dcf6a88fbb45bce0dbad570ff466d32d8b4431d3f8efc0da49626c7988/daytona_toolbox_api_client_async-0.198.0-py3-none-any.whl", hash = "sha256:2ce23b3c464e009b09f02c398a24aa8a558edd8ef02a77de2415c05905296b8b", size = 245525, upload-time = "2026-07-16T09:17:02.904Z" },
+]
+
+[[package]]
 name = "dbos"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1349,6 +1509,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/77/24/9d29eeb7dd4852c27c3673adcaf30c4dc55ced76b303c1fbb792ce7cae52/ddgs-9.14.4.tar.gz", hash = "sha256:f7b118a2b709a9e9c04a1dca6e96b98c25d4dfaca1a4b0a244d74454fcca48ef", size = 59742, upload-time = "2026-05-15T06:53:45.946Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/5f/32de4d99220eb559b7b1cd1c529a1856efa8097f7a3e10b6c207aa95e36c/ddgs-9.14.4-py3-none-any.whl", hash = "sha256:acb084c34bf1110c974caf7e5e5a2c1973beb4bd9e170bfd191fe5ed2d2b2d6c", size = 70638, upload-time = "2026-05-15T06:53:44.761Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -2031,6 +2203,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx-ws"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
 ]
 
 [[package]]
@@ -3034,6 +3222,93 @@ wheels = [
 ]
 
 [[package]]
+name = "obstore"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/8c/9ec984edd0f3b72226adfaa19b1c61b15823b35b52f311ca4af36d009d15/obstore-0.8.2.tar.gz", hash = "sha256:a467bc4e97169e2ba749981b4fd0936015428d9b8f3fb83a5528536b1b6f377f", size = 168852, upload-time = "2025-09-16T15:34:55.786Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e9/0a1e340ef262f225ad71f556ccba257896f85ca197f02cd228fe5e20b45a/obstore-0.8.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:49104c0d72688c180af015b02c691fbb6cf6a45b03a9d71b84059ed92dbec704", size = 3622821, upload-time = "2025-09-16T15:32:53.79Z" },
+    { url = "https://files.pythonhosted.org/packages/24/86/2b53e8b0a838dbbf89ef5dfddde888770bc1a993c691698dae411a407228/obstore-0.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c49776abd416e4d80d003213522d82ad48ed3517bee27a6cf8ce0f0cf4e6337e", size = 3356349, upload-time = "2025-09-16T15:32:55.715Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/79/1ba6dc854d7de7704a2c474d723ffeb01b6884f72eea7cbe128efc472f4a/obstore-0.8.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1636372b5e171a98369612d122ea20b955661daafa6519ed8322f4f0cb43ff74", size = 3454842, upload-time = "2025-09-16T15:32:57.072Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/03/ca67ccc9b9e63cfc0cd069b84437807fed4ef880be1e445b3f29d11518e0/obstore-0.8.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2efed0d86ad4ebffcbe3d0c4d84f26c2c6b20287484a0a748499c169a8e1f2c4", size = 3688363, upload-time = "2025-09-16T15:32:58.164Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/2f/c78eb4352d8be64a072934fe3ff2af79a1d06f4571af7c70d96f9741766b/obstore-0.8.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00c5542616dc5608de82ab6f6820633c9dbab6ff048e770fb8a5fcd1d30cd656", size = 3960133, upload-time = "2025-09-16T15:32:59.614Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/34/9e828d19194e227fd9f1d2dd70710da99c2bd2cd728686d59ea80be10b7c/obstore-0.8.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d9df46aaf25ce80fff48c53382572adc67b6410611660b798024450281a3129", size = 3925493, upload-time = "2025-09-16T15:33:00.923Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7d/9ec5967f3e2915fbc441f72c3892a7f0fb3618e3ae5c8a44181ce4aa641c/obstore-0.8.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ccf0f03a7fe453fb8640611c922bce19f021c6aaeee6ee44d6d8fb57db6be48", size = 3769401, upload-time = "2025-09-16T15:33:02.373Z" },
+    { url = "https://files.pythonhosted.org/packages/85/bf/00b65013068bde630a7369610a2dae4579315cd6ce82d30e3d23315cf308/obstore-0.8.2-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:ddfbfadc88c5e9740b687ef0833384329a56cea07b34f44e1c4b00a0e97d94a9", size = 3534383, upload-time = "2025-09-16T15:33:03.903Z" },
+    { url = "https://files.pythonhosted.org/packages/52/39/1b684fd96c9a33974fc52f417c52b42c1d50df40b44e588853c4a14d9ab1/obstore-0.8.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:53ad53bb16e64102f39559ec470efd78a5272b5e3b84c53aa0423993ac5575c1", size = 3697939, upload-time = "2025-09-16T15:33:05.355Z" },
+    { url = "https://files.pythonhosted.org/packages/85/58/93a2c78935f17fde7e22842598a6373e46a9c32d0243ec3b26b5da92df27/obstore-0.8.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:b0b905b46354db0961ab818cad762b9c1ac154333ae5d341934c90635a6bd7ab", size = 3681746, upload-time = "2025-09-16T15:33:09.344Z" },
+    { url = "https://files.pythonhosted.org/packages/38/90/225c2972338d18f92e7a56f71e34df6935b0b1bd7458bb6a0d2bd4d48f92/obstore-0.8.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fee235694406ebb2dc4178752cf5587f471d6662659b082e9786c716a0a9465c", size = 3765156, upload-time = "2025-09-16T15:33:10.457Z" },
+    { url = "https://files.pythonhosted.org/packages/79/eb/aca27e895bfcbbcd2bf05ea6a2538a94b718e6f6d72986e16ab158b753ec/obstore-0.8.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6c36faf7ace17dd0832aa454118a63ea21862e3d34f71b9297d0c788d00f4985", size = 3941190, upload-time = "2025-09-16T15:33:11.59Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ce/c8251a397e7507521768f05bc355b132a0daaff3739e861e51fa6abd821e/obstore-0.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:948a1db1d34f88cfc7ab7e0cccdcfd84cf3977365634599c95ba03b4ef80d1c4", size = 3970041, upload-time = "2025-09-16T15:33:13.035Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c4/018f90701f1e5ea3fbd57f61463f42e1ef5218e548d3adcf12b6be021c34/obstore-0.8.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2edaa97687c191c5324bb939d72f6fe86a7aa8191c410f1648c14e8296d05c1c", size = 3622568, upload-time = "2025-09-16T15:33:14.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/62/72dd1e7d52fc554bb1fdb1a9499bda219cf3facea5865a1d97fdc00b3a1b/obstore-0.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c4fb7ef8108f08d14edc8bec9e9a6a2e5c4d14eddb8819f5d0da498aff6e8888", size = 3356109, upload-time = "2025-09-16T15:33:15.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ae/089fe5b9207091252fe5ce352551214f04560f85eb8f2cc4f716a6a1a57e/obstore-0.8.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fda8f658c0edf799ab1e264f9b12c7c184cd09a5272dc645d42e987810ff2772", size = 3454588, upload-time = "2025-09-16T15:33:16.421Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/10/1865ae2d1ba45e8ae85fb0c1aada2dc9533baf60c4dfe74dab905348d74a/obstore-0.8.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87fe2bc15ce4051ecb56abd484feca323c2416628beb62c1c7b6712114564d6e", size = 3688627, upload-time = "2025-09-16T15:33:17.604Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/09/5d7ba6d0aeac563ea5f5586401c677bace4f782af83522b1fdf15430e152/obstore-0.8.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2482aa2562ab6a4ca40250b26bea33f8375b59898a9b5615fd412cab81098123", size = 3959896, upload-time = "2025-09-16T15:33:18.789Z" },
+    { url = "https://files.pythonhosted.org/packages/16/15/2b3eda59914761a9ff4d840e2daec5697fd29b293bd18d3dc11c593aed06/obstore-0.8.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4153b928f5d2e9c6cb645e83668a53e0b42253d1e8bcb4e16571fc0a1434599a", size = 3933162, upload-time = "2025-09-16T15:33:19.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7a/5fc63b41526587067537fb1498c59a210884664c65ccf0d1f8f823b0875a/obstore-0.8.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbfa9c38620cc191be98c8b5558c62071e495dc6b1cc724f38293ee439aa9f92", size = 3769605, upload-time = "2025-09-16T15:33:21.389Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4e/2208ab6e1fc021bf8b7e117249a10ab75d0ed24e0f2de1a8d7cd67d885b5/obstore-0.8.2-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:0822836eae8d52499f10daef17f26855b4c123119c6eb984aa4f2d525ec2678d", size = 3534396, upload-time = "2025-09-16T15:33:22.574Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/8f/a0e2882edd6bd285c82b8a5851c4ecf386c93fe75b6e340d5d9d30e809fc/obstore-0.8.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8ef6435dfd586d83b4f778e7927a5d5b0d8b771e9ba914bc809a13d7805410e6", size = 3697777, upload-time = "2025-09-16T15:33:23.723Z" },
+    { url = "https://files.pythonhosted.org/packages/94/78/ebf0c33bed5c9a8eed3b00eefafbcc0a687eeb1e05451c76fcf199d29ff8/obstore-0.8.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:0f2cba91f4271ca95a932a51aa8dda1537160342b33f7836c75e1eb9d40621a2", size = 3681546, upload-time = "2025-09-16T15:33:24.935Z" },
+    { url = "https://files.pythonhosted.org/packages/af/21/9bf4fb9e53fd5f01af580b6538de2eae857e31d24b0ebfc4d916c306a1e4/obstore-0.8.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:23c876d603af0627627808d19a58d43eb5d8bfd02eecd29460bc9a58030fed55", size = 3765336, upload-time = "2025-09-16T15:33:26.069Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3c/7f6895c23719482d231b2d6ed328e3223fdf99785f6850fba8d2fc5a86ee/obstore-0.8.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ff3c4b5d07629b70b9dee494cd6b94fff8465c3864752181a1cb81a77190fe42", size = 3941142, upload-time = "2025-09-16T15:33:27.275Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a4/56ccdb756161595680a28f4b0def2c04f7048ffacf128029be8394367b26/obstore-0.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:aadb2cb72de7227d07f4570f82729625ffc77522fadca5cf13c3a37fbe8c8de9", size = 3970172, upload-time = "2025-09-16T15:33:28.393Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/dc/60fefbb5736e69eab56657bca04ca64dc07fdeccb3814164a31b62ad066b/obstore-0.8.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bb70ce297a47392b1d9a3e310f18d59cd5ebbb9453428210fef02ed60e4d75d1", size = 3612955, upload-time = "2025-09-16T15:33:29.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/844e8f382e5a12b8a3796a05d76a03e12c7aedc13d6900419e39207d7868/obstore-0.8.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1619bf618428abf1f607e0b219b2e230a966dcf697b717deccfa0983dd91f646", size = 3346564, upload-time = "2025-09-16T15:33:30.698Z" },
+    { url = "https://files.pythonhosted.org/packages/89/73/8537f99e09a38a54a6a15ede907aa25d4da089f767a808f0b2edd9c03cec/obstore-0.8.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a4605c3ed7c9515aeb4c619b5f7f2c9986ed4a79fe6045e536b5e59b804b1476", size = 3460809, upload-time = "2025-09-16T15:33:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/99/7714dec721e43f521d6325a82303a002cddad089437640f92542b84e9cc8/obstore-0.8.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ce42670417876dd8668cbb8659e860e9725e5f26bbc86449fd259970e2dd9d18", size = 3692081, upload-time = "2025-09-16T15:33:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/4ac4175fe95a24c220a96021c25c432bcc0c0212f618be0737184eebbaad/obstore-0.8.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4a3e893b2a06585f651c541c1972fe1e3bf999ae2a5fda052ee55eb7e6516f5", size = 3957466, upload-time = "2025-09-16T15:33:34.528Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/04/caa288fb735484fc5cb019bdf3d896eaccfae0ac4622e520d05692c46790/obstore-0.8.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08462b32f95a9948ed56ed63e88406e2e5a4cae1fde198f9682e0fb8487100ed", size = 3951293, upload-time = "2025-09-16T15:33:35.733Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2f/d380239da2d6a1fda82e17df5dae600a404e8a93a065784518ff8325d5f6/obstore-0.8.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a0bf7763292a8fc47d01cd66e6f19002c5c6ad4b3ed4e6b2729f5e190fa8a0d", size = 3766199, upload-time = "2025-09-16T15:33:36.904Z" },
+    { url = "https://files.pythonhosted.org/packages/28/41/d391be069d3da82969b54266948b2582aeca5dd735abeda4d63dba36e07b/obstore-0.8.2-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:bcd47f8126cb192cbe86942b8f73b1c45a651ce7e14c9a82c5641dfbf8be7603", size = 3529678, upload-time = "2025-09-16T15:33:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/4c/4862fdd1a3abde459ee8eea699b1797df638a460af235b18ca82c8fffb72/obstore-0.8.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:57eda9fd8c757c3b4fe36cf3918d7e589cc1286591295cc10b34122fa36dd3fd", size = 3698079, upload-time = "2025-09-16T15:33:39.696Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ca/014e747bc53b570059c27e3565b2316fbe5c107d4134551f4cd3e24aa667/obstore-0.8.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ea44442aad8992166baa69f5069750979e4c5d9ffce772e61565945eea5774b9", size = 3687154, upload-time = "2025-09-16T15:33:40.92Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/6db5f8edd93028e5b8bfbeee15e6bd3e56f72106107d31cb208b57659de4/obstore-0.8.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:41496a3ab8527402db4142aaaf0d42df9d7d354b13ba10d9c33e0e48dd49dd96", size = 3773444, upload-time = "2025-09-16T15:33:42.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/e5/c9e2cc540689c873beb61246e1615d6e38301e6a34dec424f5a5c63c1afd/obstore-0.8.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:43da209803f052df96c7c3cbec512d310982efd2407e4a435632841a51143170", size = 3939315, upload-time = "2025-09-16T15:33:43.252Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c9/bb53280ca50103c1ffda373cdc9b0f835431060039c2897cbc87ddd92e42/obstore-0.8.2-cp312-cp312-win_amd64.whl", hash = "sha256:1836f5dcd49f9f2950c75889ab5c51fb290d3ea93cdc39a514541e0be3af016e", size = 3978234, upload-time = "2025-09-16T15:33:44.393Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/5d/8c3316cc958d386d5e6ab03e9db9ddc27f8e2141cee4a6777ae5b92f3aac/obstore-0.8.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:212f033e53fe6e53d64957923c5c88949a400e9027f7038c705ec2e9038be563", size = 3612027, upload-time = "2025-09-16T15:33:45.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/4d/699359774ce6330130536d008bfc32827fab0c25a00238d015a5974a3d1d/obstore-0.8.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bee21fa4ba148d08fa90e47a96df11161661ed31e09c056a373cb2154b0f2852", size = 3344686, upload-time = "2025-09-16T15:33:47.185Z" },
+    { url = "https://files.pythonhosted.org/packages/82/37/55437341f10512906e02fd9fa69a8a95ad3f2f6a916d3233fda01763d110/obstore-0.8.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4c66594b59832ff1ced4c72575d9beb8b5f9b4e404ac1150a42bfb226617fd50", size = 3459860, upload-time = "2025-09-16T15:33:48.382Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/51/4245a616c94ee4851965e33f7a563ab4090cc81f52cc73227ff9ceca2e46/obstore-0.8.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:089f33af5c2fe132d00214a0c1f40601b28f23a38e24ef9f79fb0576f2730b74", size = 3691648, upload-time = "2025-09-16T15:33:49.524Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f1/4e2fb24171e3ca3641a4653f006be826e7e17634b11688a5190553b00b83/obstore-0.8.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d87f658dfd340d5d9ea2d86a7c90d44da77a0db9e00c034367dca335735110cf", size = 3956867, upload-time = "2025-09-16T15:33:51.082Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f5/b703115361c798c9c1744e1e700d5908d904a8c2e2bd38bec759c9ffb469/obstore-0.8.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e2e4fa92828c4fbc2d487f3da2d3588701a1b67d9f6ca3c97cc2afc912e9c63", size = 3950599, upload-time = "2025-09-16T15:33:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/53/20/08c6dc0f20c1394e2324b9344838e4e7af770cdcb52c30757a475f50daeb/obstore-0.8.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab440e89c5c37a8ec230857dd65147d4b923e0cada33297135d05e0f937d696a", size = 3765865, upload-time = "2025-09-16T15:33:53.291Z" },
+    { url = "https://files.pythonhosted.org/packages/77/20/77907765e29b2eba6bd8821872284d91170d7084f670855b2dfcb249ea14/obstore-0.8.2-cp313-cp313-manylinux_2_24_aarch64.whl", hash = "sha256:b9beed107c5c9cd995d4a73263861fcfbc414d58773ed65c14f80eb18258a932", size = 3529807, upload-time = "2025-09-16T15:33:54.535Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f5/f629d39cc30d050f52b1bf927e4d65c1cc7d7ffbb8a635cd546b5c5219a0/obstore-0.8.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b75b4e7746292c785e31edcd5aadc8b758238372a19d4c5e394db5c305d7d175", size = 3693629, upload-time = "2025-09-16T15:33:56.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ff/106763fd10f2a1cb47f2ef1162293c78ad52f4e73223d8d43fc6b755445d/obstore-0.8.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:f33e6c366869d05ab0b7f12efe63269e631c5450d95d6b4ba4c5faf63f69de70", size = 3686176, upload-time = "2025-09-16T15:33:57.247Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/0c/d2ccb6f32feeca906d5a7c4255340df5262af8838441ca06c9e4e37b67d5/obstore-0.8.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:12c885a9ce5ceb09d13cc186586c0c10b62597eff21b985f6ce8ff9dab963ad3", size = 3773081, upload-time = "2025-09-16T15:33:58.475Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/79/40d1cc504cefc89c9b3dd8874287f3fddc7d963a8748d6dffc5880222013/obstore-0.8.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4accc883b93349a81c9931e15dd318cc703b02bbef2805d964724c73d006d00e", size = 3938589, upload-time = "2025-09-16T15:33:59.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/916c6777222db3271e9fb3cf9a97ed92b3a9b3e465bdeec96de9ab809d53/obstore-0.8.2-cp313-cp313-win_amd64.whl", hash = "sha256:ec850adf9980e5788a826ccfd5819989724e2a2f712bfa3258e85966c8d9981e", size = 3977768, upload-time = "2025-09-16T15:34:01.25Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/61/66f8dc98bbf5613bbfe5bf21747b4c8091442977f4bd897945895ab7325c/obstore-0.8.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1431e40e9bb4773a261e51b192ea6489d0799b9d4d7dbdf175cdf813eb8c0503", size = 3623364, upload-time = "2025-09-16T15:34:02.957Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/66/6d527b3027e42f625c8fc816ac7d19b0d6228f95bfe7666e4d6b081d2348/obstore-0.8.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ddb39d4da303f50b959da000aa42734f6da7ac0cc0be2d5a7838b62c97055bb9", size = 3347764, upload-time = "2025-09-16T15:34:04.236Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/79/c00103302b620192ea447a948921ad3fed031ce3d19e989f038e1183f607/obstore-0.8.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e01f4e13783db453e17e005a4a3ceff09c41c262e44649ba169d253098c775e8", size = 3460981, upload-time = "2025-09-16T15:34:05.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d9/bfe4ed4b1aebc45b56644dd5b943cf8e1673505cccb352e66878a457e807/obstore-0.8.2-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:df0fc2d0bc17caff9b538564ddc26d7616f7e8b7c65b1a3c90b5048a8ad2e797", size = 3692711, upload-time = "2025-09-16T15:34:06.796Z" },
+    { url = "https://files.pythonhosted.org/packages/13/47/cd6c2cbb18e1f40c77e7957a4a03d2d83f1859a2e876a408f1ece81cad4c/obstore-0.8.2-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e439d06c99a140348f046c9f598ee349cc2dcd9105c15540a4b231f9cc48bbae", size = 3958362, upload-time = "2025-09-16T15:34:08.277Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ea/5ee82bf23abd71c7d6a3f2d008197ae8f8f569d41314c26a8f75318245be/obstore-0.8.2-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0e37d9046669fcc59522d0faf1d105fcbfd09c84cccaaa1e809227d8e030f32c", size = 3957082, upload-time = "2025-09-16T15:34:09.477Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ee/46650405e50fdaa8d95f30375491f9c91fac9517980e8a28a4a6af66927f/obstore-0.8.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2646fdcc4bbe92dc2bb5bcdff15574da1211f5806c002b66d514cee2a23c7cb8", size = 3775539, upload-time = "2025-09-16T15:34:10.726Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d6/348a7ebebe2ca3d94dfc75344ea19675ae45472823e372c1852844078307/obstore-0.8.2-cp314-cp314-manylinux_2_24_aarch64.whl", hash = "sha256:e31a7d37675056d93dfc244605089dee67f5bba30f37c88436623c8c5ad9ba9d", size = 3535048, upload-time = "2025-09-16T15:34:12.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/b7a16cc0da91a4b902d47880ad24016abfe7880c63f7cdafda45d89a2f91/obstore-0.8.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:656313dd8170dde0f0cd471433283337a63912e8e790a121f7cc7639c83e3816", size = 3699035, upload-time = "2025-09-16T15:34:13.331Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/3269a3a58347e0b019742d888612c4b765293c9c75efa44e144b1e884c0d/obstore-0.8.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329038c9645d6d1741e77fe1a53e28a14b1a5c1461cfe4086082ad39ebabf981", size = 3687307, upload-time = "2025-09-16T15:34:14.501Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f9/4fd4819ad6a49d2f462a45be453561f4caebded0dc40112deeffc34b89b1/obstore-0.8.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1e4df99b369790c97c752d126b286dc86484ea49bff5782843a265221406566f", size = 3776076, upload-time = "2025-09-16T15:34:16.207Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/7c4f958fa0b9fc4778fb3d232e38b37db8c6b260f641022fbba48b049d7e/obstore-0.8.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9e1c65c65e20cc990414a8a9af88209b1bbc0dd9521b5f6b0293c60e19439bb7", size = 3947445, upload-time = "2025-09-16T15:34:17.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/37/14bae1f5bf4369027abc5315cdba2428ad4c16e2fd3bd5d35b7ee584aa0c/obstore-0.8.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6ea04118980a9c22fc8581225ff4507b6a161baf8949d728d96e68326ebaab59", size = 3624857, upload-time = "2025-09-16T15:34:35.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c4/8cba91629aa20479ba86a57c2c2b3bc0a54fc6a31a4594014213603efae6/obstore-0.8.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5f33a7570b6001b54252260fbec18c3f6d21e25d3ec57e9b6c5e7330e8290eb2", size = 3355999, upload-time = "2025-09-16T15:34:36.954Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/10/3e40557d6d9c38c5a0f7bac1508209b9dbb8c4da918ddfa9326ba9a1de3f/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:11fa78dfb749edcf5a041cd6db20eae95b3e8b09dfdd9b38d14939da40e7c115", size = 3457322, upload-time = "2025-09-16T15:34:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/dcf7988350c286683698cbdd8c15498aec43cbca72eaabad06fd77f0f34a/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:872bc0921ff88305884546ba05e258ccd95672a03d77db123f0d0563fd3c000b", size = 3689452, upload-time = "2025-09-16T15:34:39.638Z" },
+    { url = "https://files.pythonhosted.org/packages/97/02/643eb2ede58933e47bdbc92786058c83d9aa569826d5bf6e83362d24a27a/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:72556a2fbf018edd921286283e5c7eec9f69a21c6d12516d8a44108eceaa526a", size = 3961171, upload-time = "2025-09-16T15:34:41.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5d/c0b515df6089d0f54109de8031a6f6ed31271361948bee90ab8271d22f79/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75fa1abf21499dfcfb0328941a175f89a9aa58245bf00e3318fe928e4b10d297", size = 3935988, upload-time = "2025-09-16T15:34:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/97/114d7bc172bb846472181d6fa3e950172ee1b1ccd11291777303c499dbdd/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f54f72f30cd608c4399679781c884bf8a0e816c1977a2fac993bf5e1fb30609f", size = 3771781, upload-time = "2025-09-16T15:34:44.405Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/43/4aa6de6dc406ef5e109b21a5614c34999575de638254deb456703fae24aa/obstore-0.8.2-pp310-pypy310_pp73-manylinux_2_24_aarch64.whl", hash = "sha256:b044ebf1bf7b8f7b0ca309375c1cd9e140be79e072ae8c70bbd5d9b2ad1f7678", size = 3536689, upload-time = "2025-09-16T15:34:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/06/a5/870ce541aa1a9ee1d9c3e99c2187049bf5a4d278ee9678cc449aae0a4e68/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:b1326cd2288b64d6fe8857cc22d3a8003b802585fc0741eff2640a8dc35e8449", size = 3700560, upload-time = "2025-09-16T15:34:47.252Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/93/76a5fc3833aaa833b4152950d9cdfd328493a48316c24e32ddefe9b8870f/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:ba6863230648a9b0e11502d2745d881cf74262720238bc0093c3eabd22a3b24c", size = 3683450, upload-time = "2025-09-16T15:34:49.589Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/4c389362c187630c42f61ef9214e67fc336e44b8aafc47cf49ba9ab8007d/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:887615da9eeefeb2df849d87c380e04877487aa29dbeb367efc3f17f667470d3", size = 3766628, upload-time = "2025-09-16T15:34:51.937Z" },
+    { url = "https://files.pythonhosted.org/packages/03/12/08547e63edf2239ec6660af434602208ab6f394955ef660a6edda13a0bee/obstore-0.8.2-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:4eec1fb32ffa4fb9fe9ad584611ff031927a5c22732b56075ee7204f0e35ebdf", size = 3944069, upload-time = "2025-09-16T15:34:54.108Z" },
+]
+
+[[package]]
 name = "ollama"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3175,6 +3450,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-aiohttp-client"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/3b/3feb8c0ff2ce154a1633580269ba89f0f6a247a930761c6ef3419dc3a534/opentelemetry_instrumentation_aiohttp_client-0.62b1.tar.gz", hash = "sha256:602c52358fdf56841ded98025593298f93de5c98fc8ab7799f5282e227bd9487", size = 19313, upload-time = "2026-04-24T13:22:33.996Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/77/4518a02b266c9f97083c93b38865956cc99029e97ecad1e544bbabee9452/opentelemetry_instrumentation_aiohttp_client-0.62b1-py3-none-any.whl", hash = "sha256:e0fbf5489e4c5e08928de25ae9efcceb6f94c2a8e9f5e9529e3434a50aacfd01", size = 14533, upload-time = "2026-04-24T13:21:34.309Z" },
 ]
 
 [[package]]
@@ -3899,6 +4190,9 @@ codemode = [
     { name = "pydantic-ai-slim", extra = ["duckduckgo"] },
     { name = "pydantic-monty" },
 ]
+daytona = [
+    { name = "daytona" },
+]
 dbos = [
     { name = "pydantic-ai-slim", extra = ["dbos"] },
 ]
@@ -3971,6 +4265,7 @@ lint = [
 requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.11,<0.12" },
     { name = "browser-use", marker = "python_full_version >= '3.11' and extra == 'browser-use'", specifier = ">=0.13.6,<0.14" },
+    { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.198.0,<0.199.0" },
     { name = "exa-py", marker = "extra == 'exa'", specifier = ">=2.16.0" },
     { name = "fastmcp", marker = "extra == 'stackone'", specifier = ">=3.4.5,<4" },
     { name = "genai-prices", specifier = ">=0.0.71" },
@@ -3998,7 +4293,7 @@ requires-dist = [
     { name = "stackone-defender", extras = ["onnx"], marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender-ml'", specifier = ">=0.7.3,<0.8" },
     { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.1,<4" },
 ]
-provides-extras = ["acp", "anthropic", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
+provides-extras = ["acp", "anthropic", "browser-use", "cli", "code-mode", "codemode", "daytona", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -7643,12 +7938,48 @@ wheels = [
 ]
 
 [[package]]
+name = "python-engineio"
+version = "4.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simple-websocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/d8/65cc479ab697a2e7fdee83a9bd8a06b61ec68bf763a58a302cf161bf38bb/python_engineio-4.13.5.tar.gz", hash = "sha256:b5764d62243e3ffbc4c76dda3d7897c329dc52294c80c27105f9faa054e76897", size = 80035, upload-time = "2026-08-12T22:52:23.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/01/f804208061b504894546fddc479f6075e0f00dfe88cb1703dafaa8c3c67e/python_engineio-4.13.5-py3-none-any.whl", hash = "sha256:05c9f4951d242ad33d613b4245299562e5f64e4199f00e5390f9888505831704", size = 59963, upload-time = "2026-08-12T22:52:22.5Z" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "python-socketio"
+version = "5.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict" },
+    { name = "python-engineio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/5e/87d6b547c87c6d64f4a05f5bfaf6f42e9b786561216434290fdaa83f8667/python_socketio-5.16.4.tar.gz", hash = "sha256:f7fa4a43cc8e687930b5c6e44d6e2efc2071eca4bef49b8bb3dc0827f7f92235", size = 128140, upload-time = "2026-08-06T23:11:21.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/463feca73ec119a135d90c9f40c0172b4758150b5ed442f0ca1e8fed807a/python_socketio-5.16.4-py3-none-any.whl", hash = "sha256:0eb9c7687e7fbf59e60d714fd62afba77dfaf8ef8a06a0bff05a86c351accc2f", size = 82098, upload-time = "2026-08-06T23:11:19.851Z" },
+]
+
+[package.optional-dependencies]
+asyncio-client = [
+    { name = "aiohttp", version = "3.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "aiohttp", version = "3.14.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+client = [
+    { name = "requests", version = "2.33.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "requests", version = "2.34.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "websocket-client" },
 ]
 
 [[package]]
@@ -8395,6 +8726,18 @@ wheels = [
 ]
 
 [[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -9054,6 +9397,15 @@ wheels = [
 ]
 
 [[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -9273,6 +9625,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
     { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
     { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/pydantic/pydantic-ai-harness/issues/683

Adds a `DaytonaSandbox` capability with bounded command/file tools, explicit fresh or attached lifecycle, network blocking, reusable sessions, and a managed bidirectional process seam.

The process seam streams stdout and stderr separately, bounds stdin and waits, suppresses input echo, and keeps cleanup retryable. Command tools now use streamed output so the configured host-memory bound applies before materialization.

## Verification

- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/daytona_sandbox tests/daytona_sandbox`
- `uv run --no-sync pytest -p no:cacheprovider tests/daytona_sandbox tests/test_docs_parity.py tests/test_doc_snippets.py` (803 passed, 18 skipped)
- docs parity review: no findings
- live cloud proof pending a valid SDK API key; signed-in CLI access tokens are not SDK API keys

Authored with Codex assistance.