### PR TITLE
Expose base fields in capability `from_spec` schemas

### DIFF
--- a/pydantic_ai_harness/browser_use/_capability.py
+++ b/pydantic_ai_harness/browser_use/_capability.py
@@ -352,6 +352,9 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
         session_scope: Literal['call', 'agent'] = 'call',
         cdp_url: str | None = None,
         guidance: str | None = None,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
     ) -> BrowserUse[AgentDepsT]:
         """Construct the capability from serializable spec options.
 
@@ -371,4 +374,7 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
             session_scope=session_scope,
             cdp_url=cdp_url,
             guidance=guidance,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
         )

--- a/pydantic_ai_harness/exa/_agent.py
+++ b/pydantic_ai_harness/exa/_agent.py
@@ -351,6 +351,9 @@ class ExaAgent(AbstractCapability[AgentDepsT]):
         poll_interval: int = 1000,
         timeout_ms: int = 3_600_000,
         guidance: str | None = None,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
     ) -> ExaAgent[AgentDepsT]:
         """Construct the capability from serializable spec options.
 
@@ -367,4 +370,7 @@ class ExaAgent(AbstractCapability[AgentDepsT]):
             poll_interval=poll_interval,
             timeout_ms=timeout_ms,
             guidance=guidance,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
         )

--- a/pydantic_ai_harness/exa/_capability.py
+++ b/pydantic_ai_harness/exa/_capability.py
@@ -162,6 +162,9 @@ class ExaSearch(AbstractCapability[AgentDepsT]):
         include_domains: Sequence[str] = (),
         exclude_domains: Sequence[str] = (),
         guidance: str | None = None,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
     ) -> ExaSearch[AgentDepsT]:
         """Construct the capability from serializable spec options.
 
@@ -176,4 +179,7 @@ class ExaSearch(AbstractCapability[AgentDepsT]):
             include_domains=list(include_domains),
             exclude_domains=list(exclude_domains),
             guidance=guidance,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
         )

--- a/pydantic_ai_harness/memory/_capability.py
+++ b/pydantic_ai_harness/memory/_capability.py
@@ -286,6 +286,9 @@ class Memory(AbstractCapability[AgentDepsT]):
         max_search_files: int = 1_000,
         guidance: str | None = None,
         injection_errors: Literal['ignore', 'raise'] = 'ignore',
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
     ) -> Memory[AgentDepsT]:
         """Construct a memory capability from serializable options."""
         if backend != 'file' and directory != '.agent-memory':
@@ -319,6 +322,9 @@ class Memory(AbstractCapability[AgentDepsT]):
             max_search_files=max_search_files,
             guidance=guidance,
             injection_errors=injection_errors,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
         )
 
     @classmethod

--- a/pydantic_ai_harness/planning/_capability.py
+++ b/pydantic_ai_harness/planning/_capability.py
@@ -195,6 +195,9 @@ class Planning(AbstractCapability[AgentDepsT]):
         guidance: str | None = None,
         cache_ttl: Literal['5m', '1h'] = '5m',
         tools: list[str] | None = None,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
     ) -> Planning[AgentDepsT]:
         """Construct a `Planning` capability from serializable options."""
         if backend != 'sqlite' and database != '.agent-plan.db':
@@ -217,6 +220,9 @@ class Planning(AbstractCapability[AgentDepsT]):
             guidance=guidance,
             cache_ttl=cache_ttl,
             tools=tools,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
         )
 
     @classmethod

--- a/tests/browser_use/test_browser_use.py
+++ b/tests/browser_use/test_browser_use.py
@@ -1277,7 +1277,8 @@ class TestBrowserUse:
 class TestAgentSpec:
     def test_spec_schema_includes_browser_use(self) -> None:
         schema = AgentSpec.model_json_schema_with_capabilities([BrowserUse])
-        assert 'BrowserUse' in json.dumps(schema)
+        params = schema['$defs']['spec_params_BrowserUse']
+        assert {'id', 'description', 'defer_loading'} <= params['properties'].keys()
 
     def test_from_spec_builds_capability(self) -> None:
         capability = BrowserUse[None].from_spec(
@@ -1291,6 +1292,9 @@ class TestAgentSpec:
             session_scope='agent',
             cdp_url='http://localhost:9222',
             guidance='Delegate.',
+            id='browser',
+            description='Use for interactive web tasks.',
+            defer_loading=True,
         )
         assert capability.allowed_domains == ['http*://example.com', 'http*://www.example.com']
         assert capability.block_ip_addresses is False
@@ -1302,6 +1306,9 @@ class TestAgentSpec:
         assert capability.session_scope == 'agent'
         assert capability.cdp_url == 'http://localhost:9222'
         assert capability.guidance == 'Delegate.'
+        assert capability.id == 'browser'
+        assert capability.description == 'Use for interactive web tasks.'
+        assert capability.defer_loading is True
         assert capability.llm is None
         assert capability.browser_profile is None
         assert capability.output_schema is None

--- a/tests/exa/test_agent.py
+++ b/tests/exa/test_agent.py
@@ -1,6 +1,5 @@
 """Tests for the ExaAgent capability, ExaAgentToolset, and agent_run_result."""
 
-import json
 from pathlib import Path
 
 import httpx
@@ -430,7 +429,8 @@ class TestExaAgent:
 class TestAgentSpec:
     def test_spec_schema_includes_exa_agent(self) -> None:
         schema = AgentSpec.model_json_schema_with_capabilities([ExaAgent])
-        assert 'ExaAgent' in json.dumps(schema)
+        params = schema['$defs']['spec_params_ExaAgent']
+        assert {'id', 'description', 'defer_loading'} <= params['properties'].keys()
 
     def test_from_spec_builds_capability(self) -> None:
         schema: dict[str, object] = {'type': 'object', 'properties': {'name': {'type': 'string'}}}
@@ -442,6 +442,9 @@ class TestAgentSpec:
             poll_interval=500,
             timeout_ms=120_000,
             guidance='Delegate.',
+            id='research-agent',
+            description='Use for delegated research.',
+            defer_loading=True,
         )
         assert capability.effort == 'low'
         assert capability.execution == 'external'
@@ -450,6 +453,9 @@ class TestAgentSpec:
         assert capability.poll_interval == 500
         assert capability.timeout_ms == 120_000
         assert capability.guidance == 'Delegate.'
+        assert capability.id == 'research-agent'
+        assert capability.description == 'Use for delegated research.'
+        assert capability.defer_loading is True
         assert capability.runs is None
 
     def test_agent_loads_from_spec_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/exa/test_exa.py
+++ b/tests/exa/test_exa.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -500,7 +499,8 @@ class TestExaSearch:
 class TestAgentSpec:
     def test_spec_schema_includes_exa_search(self) -> None:
         schema = AgentSpec.model_json_schema_with_capabilities([ExaSearch])
-        assert 'ExaSearch' in json.dumps(schema)
+        params = schema['$defs']['spec_params_ExaSearch']
+        assert {'id', 'description', 'defer_loading'} <= params['properties'].keys()
 
     def test_from_spec_builds_capability(self) -> None:
         capability = ExaSearch[None].from_spec(
@@ -508,11 +508,17 @@ class TestAgentSpec:
             text_summary=True,
             include_deep_search=True,
             include_domains=['a.dev'],
+            id='web-research',
+            description='Use for cited web research.',
+            defer_loading=True,
         )
         assert capability.num_results == 3
         assert capability.text_summary is True
         assert capability.include_deep_search is True
         assert capability.include_domains == ['a.dev']
+        assert capability.id == 'web-research'
+        assert capability.description == 'Use for cited web research.'
+        assert capability.defer_loading is True
         assert capability.client is None
 
     def test_agent_loads_from_spec_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -1241,9 +1241,12 @@ class TestConfigurationAndSpecs:
             'agent_name',
             'backend',
             'database',
+            'defer_loading',
+            'description',
             'directory',
             'guidance',
             'heading',
+            'id',
             'inject_memory',
             'injection_errors',
             'max_lines',
@@ -1276,7 +1279,17 @@ class TestConfigurationAndSpecs:
         assert 'storage-id' not in instructions
 
     def test_from_spec_backends_and_cross_backend_validation(self, tmp_path: Path) -> None:
-        assert isinstance(Memory.from_spec().store, InMemoryStore)
+        capability = Memory.from_spec(
+            id='memory',
+            description='Use for durable notes.',
+            defer_loading=True,
+        )
+        assert isinstance(capability.store, InMemoryStore)
+        assert (capability.id, capability.description, capability.defer_loading) == (
+            'memory',
+            'Use for durable notes.',
+            True,
+        )
         assert isinstance(Memory.from_spec(backend='file', directory=str(tmp_path)).store, FileStore)
         assert isinstance(
             Memory.from_spec(backend='sqlite', database=str(tmp_path / 'memory.db')).store, SqliteMemoryStore

--- a/tests/planning/test_planning.py
+++ b/tests/planning/test_planning.py
@@ -6,7 +6,7 @@ from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic_ai import Agent
+from pydantic_ai import Agent, AgentSpec
 from pydantic_ai.messages import (
     CachePoint,
     ModelMessage,
@@ -836,11 +836,26 @@ class TestCapability:
         assert stores == [first.resolve_store(_ctx()), second.resolve_store(_ctx())]
 
     def test_from_spec(self, tmp_path: str) -> None:
-        assert Planning.from_spec().store is None
+        capability = Planning.from_spec(
+            id='planning',
+            description='Use for multi-step work.',
+            defer_loading=True,
+        )
+        assert capability.store is None
+        assert (capability.id, capability.description, capability.defer_loading) == (
+            'planning',
+            'Use for multi-step work.',
+            True,
+        )
         sqlite_cap = Planning.from_spec(backend='sqlite', database=str(tmp_path))
         assert isinstance(sqlite_cap.store, SqlitePlanStore)
         with pytest.raises(ValueError, match='database is only valid'):
             Planning.from_spec(backend='memory', database='custom.db')
+
+    def test_spec_schema_includes_base_fields(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([Planning])
+        params = schema['$defs']['spec_params_Planning']
+        assert {'id', 'description', 'defer_loading'} <= params['properties'].keys()
 
     def test_from_spec_rejects_an_unknown_backend(self) -> None:
         """`backend` is a `Literal`, but a spec is deserialized text; nothing has checked it yet."""


### PR DESCRIPTION
## Summary
- expose `id`, `description`, and `defer_loading` in generated `AgentSpec` schemas for `BrowserUse`, `ExaAgent`, `ExaSearch`, `Memory`, and `Planning`
- forward values through each `from_spec()` constructor
- add schema and round-trip regression coverage

Fixes #554.

## Boundary notes
- the default remains `defer_loading=false`, so existing specs keep the same visible tools, instructions, and runtime behavior
- an explicit `defer_loading=true` now reaches the existing `AbstractCapability` loading gate instead of being impossible to express through `AgentSpec`
- focused schema and round-trip tests cover both inherited field exposure and constructor forwarding for all five affected capabilities
- this change introduces no new command, parser, process, network, cleanup, resource-limit, dependency, or CI boundary

## Validation
- 13 focused spec tests passed
- affected module suites: 539 passed; two unrelated Windows-only environment failures (path length and symlink privilege)
- `ruff format --check .`
- `ruff check .`
- Pyright on changed source/tests: 0 errors

## Checklist
- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks