### PR TITLE
Add stable IDs to one-off capabilities

### DIFF
--- a/pydantic_ai_harness/browser_use/_capability.py
+++ b/pydantic_ai_harness/browser_use/_capability.py
@@ -89,6 +89,9 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
     judgement about unknown pages, not for scripted flows.
     """
 
+    id: str | None = field(default='browser_use', kw_only=True)
+    """Stable capability and toolset ID."""
+
     llm: ChatModelInput | None = None
     """The chat model driving the sub-agent.
 
@@ -294,6 +297,7 @@ class BrowserUse(AbstractCapability[AgentDepsT]):
             if sensitive_data is not None and browser_profile is not None:
                 browser_profile = browser_profile.model_copy(deep=True)
             self._toolset = BrowserUseToolset[AgentDepsT](
+                id=self.id,
                 browser_agent=self.browser_agent if self.browser_agent is not None else default_browser_agent,
                 llm=resolve_chat_model(self.llm),
                 browser_profile=browser_profile,

--- a/pydantic_ai_harness/browser_use/_toolset.py
+++ b/pydantic_ai_harness/browser_use/_toolset.py
@@ -413,6 +413,7 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         browser_agent: BrowserAgentFactory,
         llm: BaseChatModel | None,
         browser_profile: BrowserProfile | None,
@@ -428,7 +429,7 @@ class BrowserUseToolset(FunctionToolset[AgentDepsT]):
         session_scope: Literal['call', 'agent'],
         cdp_url: str | None,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._browser_agent = browser_agent
         self._llm = llm
         self._browser_profile = browser_profile

--- a/pydantic_ai_harness/capability_creation/_capability.py
+++ b/pydantic_ai_harness/capability_creation/_capability.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -63,6 +63,9 @@ class CapabilityCreation(AbstractCapability[AgentDepsT]):
     directory: Path
     """Directory holding the authored `<name>.py` files and the `manifest.json` index."""
 
+    id: str | None = field(default='capability_creation', kw_only=True)
+    """Stable capability and toolset ID."""
+
     guidance: str | None = None
     """Static system-prompt guidance on authoring. Cache-stable. Leave `None` for the
     default, or set `''` to omit guidance entirely."""
@@ -79,7 +82,7 @@ class CapabilityCreation(AbstractCapability[AgentDepsT]):
 
     def get_toolset(self) -> AgentToolset[AgentDepsT] | None:
         """Toolset providing the authoring tools over this capability's store."""
-        return CapabilityCreationToolset[AgentDepsT](self.store)
+        return CapabilityCreationToolset[AgentDepsT](self.store, id=self.id)
 
     @classmethod
     def get_serialization_name(cls) -> str | None:

--- a/pydantic_ai_harness/capability_creation/_toolset.py
+++ b/pydantic_ai_harness/capability_creation/_toolset.py
@@ -12,8 +12,8 @@ from pydantic_ai_harness.capability_creation._store import CapabilityStore
 class CapabilityCreationToolset(FunctionToolset[AgentDepsT]):
     """Exposes `author_capability`, `list_authored_capabilities`, and `disable_authored_capability`."""
 
-    def __init__(self, store: CapabilityStore) -> None:
-        super().__init__()
+    def __init__(self, store: CapabilityStore, *, id: str | None = None) -> None:
+        super().__init__(id=id)
         self._store = store
         self.add_function(
             self.author_capability,

--- a/pydantic_ai_harness/dynamic_workflow/_capability.py
+++ b/pydantic_ai_harness/dynamic_workflow/_capability.py
@@ -48,6 +48,9 @@ class DynamicWorkflow(AbstractCapability[AgentDepsT]):
     until the model loads the capability.
     """
 
+    id: str | None = 'dynamic_workflow'
+    """Stable capability and toolset ID."""
+
     agents: Sequence[AbstractAgent[AgentDepsT, object] | WorkflowAgent[AgentDepsT]]
     """Sub-agents the orchestration script can call as async functions.
 

--- a/pydantic_ai_harness/exa/_agent.py
+++ b/pydantic_ai_harness/exa/_agent.py
@@ -147,13 +147,14 @@ class ExaAgentToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         runs: ExaAgentRuns,
         effort: AgentEffort | None,
         output_schema: type[BaseModel] | dict[str, object] | None,
         system_prompt: str | None,
         owner_id: str,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._runs = runs
         self._effort: AgentEffort | None = effort
         self._output_schema = output_schema
@@ -206,6 +207,9 @@ class ExaAgent(AbstractCapability[AgentDepsT]):
     Authentication comes from the `EXA_API_KEY` environment variable by
     default; pass `runs` to configure it explicitly.
     """
+
+    id: str | None = field(default='exa_agent', kw_only=True)
+    """Stable capability and toolset ID."""
 
     effort: AgentEffort | None = None
     """How much work the Exa agent invests per run; `None` uses the API default."""
@@ -268,6 +272,7 @@ class ExaAgent(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> ExaAgentToolset[AgentDepsT]:
         """Build the toolset providing the `exa_agent` tool."""
         return ExaAgentToolset[AgentDepsT](
+            id=self.id,
             runs=self._resolved_runs(),
             effort=self.effort,
             output_schema=self.output_schema,

--- a/pydantic_ai_harness/exa/_capability.py
+++ b/pydantic_ai_harness/exa/_capability.py
@@ -54,6 +54,9 @@ class ExaSearch(AbstractCapability[AgentDepsT]):
     default; pass `client` to configure it explicitly.
     """
 
+    id: str | None = field(default='exa_search', kw_only=True)
+    """Stable capability and toolset ID."""
+
     num_results: int = 5
     """Number of results `web_search` returns per query (1 to 100, the Exa API range)."""
 
@@ -142,6 +145,7 @@ class ExaSearch(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> ExaSearchToolset[AgentDepsT]:
         """Build the toolset providing `web_search`, `get_page`, and the optional `deep_search` tool."""
         return ExaSearchToolset[AgentDepsT](
+            id=self.id,
             client=self.client,
             num_results=self.num_results,
             max_text_chars=self.max_text_chars,

--- a/pydantic_ai_harness/exa/_toolset.py
+++ b/pydantic_ai_harness/exa/_toolset.py
@@ -155,6 +155,7 @@ class ExaSearchToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         client: ExaClient | None,
         num_results: int,
         max_text_chars: int,
@@ -163,7 +164,7 @@ class ExaSearchToolset(FunctionToolset[AgentDepsT]):
         exclude_domains: Sequence[str] = (),
         text_summary: bool | str = False,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._client = client if client is not None else _default_client()
         self._num_results = num_results
         self._max_text_chars = max_text_chars

--- a/pydantic_ai_harness/filesystem/_capability.py
+++ b/pydantic_ai_harness/filesystem/_capability.py
@@ -31,6 +31,9 @@ class FileSystem(AbstractCapability[AgentDepsT]):
     is rejected. Symlinks are resolved before authorization.
     """
 
+    id: str | None = field(default='file_system', kw_only=True)
+    """Stable capability and toolset ID."""
+
     root_dir: str | Path = '.'
     """Root directory for all file operations. Defaults to the current directory."""
 
@@ -78,6 +81,7 @@ class FileSystem(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> FileSystemToolset[AgentDepsT] | FilteredToolset[AgentDepsT]:
         """Build and return the filesystem toolset."""
         toolset = FileSystemToolset[AgentDepsT](
+            id=self.id,
             root_dir=Path(self.root_dir),
             allowed_patterns=self.allowed_patterns,
             denied_patterns=self.denied_patterns,

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -179,6 +179,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         root_dir: Path,
         allowed_patterns: Sequence[str],
         denied_patterns: Sequence[str],
@@ -188,7 +189,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         max_search_results: int,
         max_find_results: int,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._root = root_dir.resolve()
         self._real_root = Path(os.path.realpath(self._root))
         self._allowed_patterns = list(allowed_patterns)

--- a/pydantic_ai_harness/localstack/_capability.py
+++ b/pydantic_ai_harness/localstack/_capability.py
@@ -40,6 +40,9 @@ class LocalStack(AbstractCapability[AgentDepsT]):
     ```
     """
 
+    id: str | None = field(default='local_stack', kw_only=True)
+    """Stable capability and toolset ID."""
+
     endpoint_url: str = 'http://localhost.localstack.cloud:4566'
     """Base URL of the running LocalStack instance.
 
@@ -114,6 +117,7 @@ class LocalStack(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> AgentToolset[AgentDepsT]:
         """Build and return the LocalStack toolset."""
         return LocalStackToolset[AgentDepsT](
+            id=self.id,
             endpoint_url=self.endpoint_url,
             region=self.region,
             access_key_id=self.access_key_id,

--- a/pydantic_ai_harness/localstack/_toolset.py
+++ b/pydantic_ai_harness/localstack/_toolset.py
@@ -57,6 +57,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         endpoint_url: str,
         region: str,
         access_key_id: str,
@@ -76,7 +77,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         docker_path: str = 'docker',
         startup_timeout: float = 120.0,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         if allowed_services and denied_services:
             raise ValueError('Specify allowed_services or denied_services, not both.')
         if max_output_chars <= 0:
@@ -113,6 +114,7 @@ class LocalStackToolset(FunctionToolset[AgentDepsT]):
         run gets its own instance (and its own container) that `__aexit__` can stop.
         """
         return LocalStackToolset[AgentDepsT](
+            id=self.id,
             endpoint_url=self._endpoint_url,
             region=self._region,
             access_key_id=self._access_key_id,

--- a/pydantic_ai_harness/macroscope/_capability.py
+++ b/pydantic_ai_harness/macroscope/_capability.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from pydantic_ai.capabilities import AbstractCapability
@@ -40,6 +40,9 @@ class Macroscope(AbstractCapability[AgentDepsT]):
     never starts, the tool reports that the user needs to run `macroscope` once.
     """
 
+    id: str | None = field(default='macroscope', kw_only=True)
+    """Stable capability and toolset ID."""
+
     base: str | None = None
     """Git ref to diff against. When `None`, `--base` is omitted and the CLI
     auto-detects the base branch itself (and creates its own review worktree)."""
@@ -63,6 +66,7 @@ class Macroscope(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> MacroscopeToolset[AgentDepsT]:
         """Build the toolset that provides the `run_macroscope_review` tool."""
         return MacroscopeToolset[AgentDepsT](
+            id=self.id,
             command=self.command,
             cwd=Path(self.cwd),
             base=self.base,

--- a/pydantic_ai_harness/macroscope/_toolset.py
+++ b/pydantic_ai_harness/macroscope/_toolset.py
@@ -121,8 +121,8 @@ class MacroscopeToolset(FunctionToolset[AgentDepsT]):
     fixing the findings is left to the agent's other tools.
     """
 
-    def __init__(self, *, command: str, cwd: Path, base: str | None, timeout: float) -> None:
-        super().__init__()
+    def __init__(self, *, id: str | None = None, command: str, cwd: Path, base: str | None, timeout: float) -> None:
+        super().__init__(id=id)
         self._command = command
         self._cwd = cwd.resolve()
         self._base = base

--- a/pydantic_ai_harness/memory/_toolset.py
+++ b/pydantic_ai_harness/memory/_toolset.py
@@ -281,7 +281,9 @@ class MemoryToolset(FunctionToolset[AgentDepsT]):
     """
 
     def __init__(self, capability: Memory[AgentDepsT]) -> None:
-        super().__init__(id='memory')
+        # `Memory` keeps `id=None` because multiple scoped memories are a supported
+        # composition; a custom id still stamps the toolset when the caller supplies one.
+        super().__init__(id=capability.id or 'memory')
         self._capability = capability
         self.add_function(self.write_memory, name='write_memory')
         self.add_function(self.read_memory, name='read_memory')

--- a/pydantic_ai_harness/modal_sandbox/_capability.py
+++ b/pydantic_ai_harness/modal_sandbox/_capability.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.tools import AgentDepsT
@@ -75,6 +75,9 @@ class ModalSandbox(AbstractCapability[AgentDepsT]):
     print(result.output)
     ```
     """
+
+    id: str | None = field(default='modal_sandbox', kw_only=True)
+    """Stable capability and toolset ID."""
 
     image: str = _DEFAULT_IMAGE
     """Container image for owned sandboxes, as a registry tag (e.g. `python:3.12-slim`)."""
@@ -288,6 +291,7 @@ class ModalSandbox(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> AgentToolset[AgentDepsT]:
         """Build and return the Modal sandbox toolset."""
         return ModalSandboxToolset[AgentDepsT](
+            id=self.id,
             image=self.image,
             sandbox_id=self.sandbox_id,
             app_name=self.app_name,

--- a/pydantic_ai_harness/modal_sandbox/_toolset.py
+++ b/pydantic_ai_harness/modal_sandbox/_toolset.py
@@ -33,6 +33,7 @@ class ModalSandboxToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         image: str,
         sandbox_id: str | None,
         app_name: str,
@@ -48,7 +49,7 @@ class ModalSandboxToolset(FunctionToolset[AgentDepsT]):
         session: ModalSandboxSession | None = None,
         _run_scoped: bool = False,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._image = image
         self._sandbox_id = sandbox_id
         self._app_name = app_name
@@ -84,6 +85,7 @@ class ModalSandboxToolset(FunctionToolset[AgentDepsT]):
         whose `__aexit__` requests that sandbox's termination.
         """
         return ModalSandboxToolset[AgentDepsT](
+            id=self.id,
             image=self._image,
             sandbox_id=self._sandbox_id,
             app_name=self._app_name,

--- a/pydantic_ai_harness/planning/_capability.py
+++ b/pydantic_ai_harness/planning/_capability.py
@@ -68,6 +68,9 @@ class Planning(AbstractCapability[AgentDepsT]):
     ```
     """
 
+    id: str | None = field(default='planning', kw_only=True)
+    """Stable capability and toolset ID."""
+
     guidance: str | None = None
     """Static planning guidance for the system prompt. Cache-stable.
 

--- a/pydantic_ai_harness/planning/_toolset.py
+++ b/pydantic_ai_harness/planning/_toolset.py
@@ -301,7 +301,7 @@ class PlanningToolset(FunctionToolset[AgentDepsT]):
     """
 
     def __init__(self, capability: Planning[AgentDepsT]) -> None:
-        super().__init__(id='planning')
+        super().__init__(id=capability.id or 'planning')
         self._capability = capability
         self._subtasks = capability.enable_subtasks
         descriptions = capability.descriptions or {}

--- a/pydantic_ai_harness/playwright/_capability.py
+++ b/pydantic_ai_harness/playwright/_capability.py
@@ -135,6 +135,9 @@ class PlaywrightBrowser(AbstractCapability[AgentDepsT]):
     at agent construction.
     """
 
+    id: str | None = field(default='playwright', kw_only=True)
+    """Stable capability and toolset ID."""
+
     headless: bool = True
     """Run Chromium without a visible window. `True` suits servers and CI."""
 
@@ -266,6 +269,7 @@ class PlaywrightBrowser(AbstractCapability[AgentDepsT]):
             launch_timeout_ms=self.navigation_timeout_ms,
         )
         self._toolset = PlaywrightBrowserToolset[AgentDepsT](
+            id=self.id or 'playwright',
             session=self._session,
             screenshot_on_navigate=self.screenshot_on_navigate,
             max_content_tokens=self.max_content_tokens,

--- a/pydantic_ai_harness/playwright/_toolset.py
+++ b/pydantic_ai_harness/playwright/_toolset.py
@@ -1575,6 +1575,7 @@ class PlaywrightBrowserToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = 'playwright',
         session: PlaywrightBrowserSession,
         screenshot_on_navigate: bool = False,
         max_content_tokens: int = DEFAULT_MAX_CONTENT_TOKENS,
@@ -1587,7 +1588,7 @@ class PlaywrightBrowserToolset(FunctionToolset[AgentDepsT]):
             raise ValueError('action_timeout_ms must be greater than or equal to 0')
         if navigation_timeout_ms < 0:
             raise ValueError('navigation_timeout_ms must be greater than or equal to 0')
-        super().__init__(id='playwright')
+        super().__init__(id=id)
         self._session = session
         # The session's policy, never a separate one. These checks and the route
         # guard the session installs are two layers of one decision: a toolset

--- a/pydantic_ai_harness/pydantic_ai_docs/_capability.py
+++ b/pydantic_ai_harness/pydantic_ai_docs/_capability.py
@@ -55,6 +55,9 @@ class PydanticAIDocs(AbstractCapability[AgentDepsT]):
     ```
     """
 
+    id: str | None = field(default='pydantic_ai_docs', kw_only=True)
+    """Stable capability and toolset ID."""
+
     local_docs_path: Path | None = None
     """Local pyai docs checkout to read first. When `None`, falls back to the
     `PYDANTIC_AI_HARNESS_DOCS_PATH` env var, then to the remote source."""
@@ -87,6 +90,7 @@ class PydanticAIDocs(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> AgentToolset[AgentDepsT] | None:
         """Toolset providing `read_pyai_docs` over the resolved local path and shared cache."""
         return PydanticAIDocsToolset[AgentDepsT](
+            id=self.id,
             local_docs_path=self._resolved_local_path(),
             cache=self._cache if self.cache else None,
         )

--- a/pydantic_ai_harness/pydantic_ai_docs/_toolset.py
+++ b/pydantic_ai_harness/pydantic_ai_docs/_toolset.py
@@ -44,10 +44,11 @@ class PydanticAIDocsToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         local_docs_path: Path | None,
         cache: dict[PydanticAIDocsTopic, str] | None,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._local_docs_path = local_docs_path
         # Shared with the capability so memoized docs outlive a single get_toolset
         # call; `None` disables caching entirely.

--- a/pydantic_ai_harness/repo_context/_capability.py
+++ b/pydantic_ai_harness/repo_context/_capability.py
@@ -75,6 +75,9 @@ class RepoContext(AbstractCapability[AgentDepsT]):
     """The deepest directory the agent works in. The walk-up and asset scan are
     anchored here."""
 
+    id: str | None = field(default='repo_context', kw_only=True)
+    """Stable capability and toolset ID."""
+
     home_dir: Path | None = None
     """The shallowest directory to stop the walk-up at, inclusive. `None` (the
     default) scans only `workspace_dir` -- no walk-up."""
@@ -138,7 +141,9 @@ class RepoContext(AbstractCapability[AgentDepsT]):
         """The asset-inventory toolset, or `None` when the tool is disabled."""
         if not self.expose_inventory_tool:
             return None
-        return RepoContextToolset[AgentDepsT](self.workspace_dir, self.asset_roots, self.inventory_tool_name)
+        return RepoContextToolset[AgentDepsT](
+            self.workspace_dir, self.asset_roots, self.inventory_tool_name, id=self.id
+        )
 
     async def after_tool_execute(
         self,

--- a/pydantic_ai_harness/repo_context/_toolset.py
+++ b/pydantic_ai_harness/repo_context/_toolset.py
@@ -14,8 +14,10 @@ from pydantic_ai_harness.repo_context._inventory import AgentContextInventory, s
 class RepoContextToolset(FunctionToolset[AgentDepsT]):
     """Exposes a single tool that reports where the repo's CE assets live."""
 
-    def __init__(self, workspace_dir: Path, asset_roots: Sequence[str], tool_name: str) -> None:
-        super().__init__()
+    def __init__(
+        self, workspace_dir: Path, asset_roots: Sequence[str], tool_name: str, *, id: str | None = None
+    ) -> None:
+        super().__init__(id=id)
         self._workspace_dir = workspace_dir
         self._asset_roots = asset_roots
         self.add_function(self.inventory_agent_context, name=tool_name)

--- a/pydantic_ai_harness/shell/_capability.py
+++ b/pydantic_ai_harness/shell/_capability.py
@@ -55,6 +55,9 @@ class Shell(AbstractCapability[AgentDepsT]):
     or `denied_commands` to control what the agent can invoke.
     """
 
+    id: str | None = field(default='shell', kw_only=True)
+    """Stable capability and toolset ID."""
+
     cwd: str | Path = '.'
     """Working directory for command execution."""
 
@@ -112,6 +115,7 @@ class Shell(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> ShellToolset[AgentDepsT]:
         """Build and return the shell toolset."""
         return ShellToolset[AgentDepsT](
+            id=self.id,
             cwd=Path(self.cwd),
             allowed_commands=self.allowed_commands,
             denied_commands=self.denied_commands,

--- a/pydantic_ai_harness/shell/_toolset.py
+++ b/pydantic_ai_harness/shell/_toolset.py
@@ -95,6 +95,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         cwd: Path,
         allowed_commands: Sequence[str],
         denied_commands: Sequence[str],
@@ -106,7 +107,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         env: Mapping[str, str] | None = None,
         denied_env_patterns: Sequence[str] = (),
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._cwd = cwd.resolve()
         # The configured starting directory, never mutated by persist_cwd, so
         # `for_run` can hand each run a fresh instance rooted back here.
@@ -150,6 +151,7 @@ class ShellToolset(FunctionToolset[AgentDepsT]):
         each other's background processes.
         """
         return ShellToolset(
+            id=self.id,
             cwd=self._initial_cwd,
             allowed_commands=self._allowed_commands,
             denied_commands=self._denied_commands,

--- a/pydantic_ai_harness/spend/_capability.py
+++ b/pydantic_ai_harness/spend/_capability.py
@@ -87,6 +87,9 @@ class SpendLimits(AbstractCapability[AgentDepsT]):
     Tracked in <https://github.com/pydantic/pydantic-ai-harness/issues/531>.
     """
 
+    id: str | None = field(default='spend', kw_only=True)
+    """Stable capability and toolset ID."""
+
     budgets: Sequence[Budget[AgentDepsT]] = ()
     """Windows to accumulate against, and which of them can refuse a request."""
 

--- a/pydantic_ai_harness/spend/_toolset.py
+++ b/pydantic_ai_harness/spend/_toolset.py
@@ -27,4 +27,4 @@ def build_toolset(limits: SpendLimits[AgentDepsT]) -> FunctionToolset[AgentDepsT
             for s in statuses
         )
 
-    return FunctionToolset[AgentDepsT]([get_spend], id='spend')
+    return FunctionToolset[AgentDepsT]([get_spend], id=limits.id or 'spend')

--- a/pydantic_ai_harness/subagents/_capability.py
+++ b/pydantic_ai_harness/subagents/_capability.py
@@ -91,6 +91,9 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     ```
     """
 
+    id: str | None = field(default='sub_agents', kw_only=True)
+    """Stable capability and toolset ID."""
+
     agents: Sequence[SubAgent[AgentDepsT]] = ()
     """The sub-agents to expose, each a `SubAgent` pairing an agent with its
     per-delegate run controls. See `SubAgent`. These take precedence over any
@@ -322,6 +325,7 @@ class SubAgents(AbstractCapability[AgentDepsT]):
         if not self._by_name:
             return None
         return SubAgentToolset(
+            id=self.id,
             agents=self._by_name,
             forward_usage=self.forward_usage,
             inherit_tools=self.inherit_tools,

--- a/pydantic_ai_harness/subagents/_toolset.py
+++ b/pydantic_ai_harness/subagents/_toolset.py
@@ -162,6 +162,7 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         agents: Mapping[str, SubAgent[AgentDepsT]],
         forward_usage: bool,
         inherit_tools: bool,
@@ -173,7 +174,7 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
         call_counts: dict[str, dict[str, int]],
         models: Mapping[str, ModelOption] | None = None,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._agents: dict[str, SubAgent[AgentDepsT]] = dict(agents)
         self._forward_usage = forward_usage
         self._inherit_tools = inherit_tools

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -122,6 +122,9 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         ```
     """
 
+    id: str | None = field(default='tool_output_limits', kw_only=True)
+    """Stable capability and toolset ID."""
+
     bands: Sequence[Band] = field(default_factory=_default_bands)
     """Ordered size bands. The first band whose `over` threshold is met wins."""
 
@@ -197,7 +200,7 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
             """
             return await _read_slice(store, handle, offset, limit, from_end, pattern)
 
-        return FunctionToolset([read_tool_result])
+        return FunctionToolset([read_tool_result], id=self.id)
 
     # --- reduction ---
 

--- a/pydantic_ai_harness/youdotcom/_capability.py
+++ b/pydantic_ai_harness/youdotcom/_capability.py
@@ -51,6 +51,9 @@ class YouSearch(AbstractCapability[AgentDepsT]):
 
     _: KW_ONLY
 
+    id: str | None = 'you_search'
+    """Stable capability and toolset ID."""
+
     num_results: int = 10
     """Number of results `web_search` returns per query (1 to 20)."""
 
@@ -126,6 +129,7 @@ class YouSearch(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> YouSearchToolset[AgentDepsT]:
         """Build the toolset providing `web_search` and `get_page`."""
         return YouSearchToolset[AgentDepsT](
+            id=self.id,
             client=self.client,
             num_results=self.num_results,
             extraction_mode=self.extraction_mode,

--- a/pydantic_ai_harness/youdotcom/_research.py
+++ b/pydantic_ai_harness/youdotcom/_research.py
@@ -89,6 +89,7 @@ class YouResearchToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         client: YouClient | None,
         research_effort: ResearchEffortName,
         finance_effort: FinanceEffortName,
@@ -100,7 +101,7 @@ class YouResearchToolset(FunctionToolset[AgentDepsT]):
         output_schema: Mapping[str, object] | None = None,
         timeout_ms: int = DEFAULT_RESEARCH_TIMEOUT_MS,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._client = client if client is not None else default_client(timeout_ms)
         self._effort = models.ResearchEffort(research_effort)
         self._finance_effort = models.FinanceResearchEffort(finance_effort)
@@ -226,6 +227,9 @@ class YouResearch(AbstractCapability[AgentDepsT]):
 
     _: KW_ONLY
 
+    id: str | None = 'you_research'
+    """Stable capability and toolset ID."""
+
     research_effort: ResearchEffortName = 'standard'
     """How hard `research` works: `lite`, `standard`, `deep`, or `exhaustive`.
 
@@ -291,6 +295,7 @@ class YouResearch(AbstractCapability[AgentDepsT]):
     def get_toolset(self) -> YouResearchToolset[AgentDepsT]:
         """Build the toolset providing `answer`, `research`, and `finance_research`."""
         return YouResearchToolset[AgentDepsT](
+            id=self.id,
             client=self.client,
             research_effort=self.research_effort,
             finance_effort=self.finance_effort,

--- a/pydantic_ai_harness/youdotcom/_toolset.py
+++ b/pydantic_ai_harness/youdotcom/_toolset.py
@@ -260,6 +260,7 @@ class YouSearchToolset(FunctionToolset[AgentDepsT]):
     def __init__(
         self,
         *,
+        id: str | None = None,
         client: YouClient | None,
         num_results: int,
         extraction_mode: ExtractionModeName,
@@ -271,7 +272,7 @@ class YouSearchToolset(FunctionToolset[AgentDepsT]):
         country: str | None = None,
         timeout_ms: int = DEFAULT_SEARCH_TIMEOUT_MS,
     ) -> None:
-        super().__init__()
+        super().__init__(id=id)
         self._client = client if client is not None else default_client(timeout_ms)
         self._num_results = num_results
         self._extraction_mode: ExtractionModeName = extraction_mode

--- a/tests/test_default_capability_ids.py
+++ b/tests/test_default_capability_ids.py
@@ -1,0 +1,184 @@
+"""Regression tests for one-off capability and toolset IDs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+
+def _no_arguments() -> dict[str, Any]:
+    return {}
+
+
+def _path_argument(name: str) -> Callable[[], dict[str, Any]]:
+    return lambda: {name: Path('.')}
+
+
+def _browser_arguments() -> dict[str, Any]:
+    return {'browser_agent': lambda task: None}
+
+
+def _exa_search_arguments() -> dict[str, Any]:
+    return {'client': object()}
+
+
+def _exa_agent_arguments() -> dict[str, Any]:
+    return {'runs': object()}
+
+
+def _sub_agents_arguments() -> dict[str, Any]:
+    subagents = pytest.importorskip('pydantic_ai_harness.subagents')
+    return {
+        'agents': [subagents.SubAgent(Agent(TestModel(), name='worker'))],
+        'agent_folders': [],
+    }
+
+
+def _dynamic_workflow_arguments() -> dict[str, Any]:
+    return {'agents': [Agent(TestModel(), name='worker')]}
+
+
+def _spend_arguments() -> dict[str, Any]:
+    return {'expose_tools': True}
+
+
+def _you_arguments() -> dict[str, Any]:
+    return {'client': object()}
+
+
+CapabilityFactory = Callable[[], dict[str, Any]]
+
+
+def _leaf_ids(toolset: Any) -> list[str | None]:
+    ids: list[str | None] = []
+    toolset.apply(lambda leaf: ids.append(leaf.id))
+    return ids
+
+
+CAPABILITY_ID_CASES: tuple[tuple[str, str, str | None, str, CapabilityFactory], ...] = (
+    ('pydantic_ai_harness.shell', 'Shell', 'shell', 'shell', _no_arguments),
+    ('pydantic_ai_harness.filesystem', 'FileSystem', 'file_system', 'file_system', _no_arguments),
+    ('pydantic_ai_harness.subagents', 'SubAgents', 'sub_agents', 'sub_agents', _sub_agents_arguments),
+    ('pydantic_ai_harness.modal_sandbox', 'ModalSandbox', 'modal_sandbox', 'modal_sandbox', _no_arguments),
+    ('pydantic_ai_harness.exa', 'ExaSearch', 'exa_search', 'exa_search', _exa_search_arguments),
+    ('pydantic_ai_harness.exa', 'ExaAgent', 'exa_agent', 'exa_agent', _exa_agent_arguments),
+    (
+        'pydantic_ai_harness.capability_creation',
+        'CapabilityCreation',
+        'capability_creation',
+        'capability_creation',
+        _path_argument('directory'),
+    ),
+    ('pydantic_ai_harness.browser_use', 'BrowserUse', 'browser_use', 'browser_use', _browser_arguments),
+    (
+        'pydantic_ai_harness.repo_context',
+        'RepoContext',
+        'repo_context',
+        'repo_context',
+        _path_argument('workspace_dir'),
+    ),
+    ('pydantic_ai_harness.pydantic_ai_docs', 'PydanticAIDocs', 'pydantic_ai_docs', 'pydantic_ai_docs', _no_arguments),
+    ('pydantic_ai_harness.localstack', 'LocalStack', 'local_stack', 'local_stack', _no_arguments),
+    ('pydantic_ai_harness.macroscope', 'Macroscope', 'macroscope', 'macroscope', _no_arguments),
+    ('pydantic_ai_harness.playwright', 'PlaywrightBrowser', 'playwright', 'playwright', _no_arguments),
+    (
+        'pydantic_ai_harness.tool_output_limits',
+        'ToolOutputLimits',
+        'tool_output_limits',
+        'tool_output_limits',
+        _no_arguments,
+    ),
+    (
+        'pydantic_ai_harness.dynamic_workflow',
+        'DynamicWorkflow',
+        'dynamic_workflow',
+        'dynamic_workflow',
+        _dynamic_workflow_arguments,
+    ),
+    # Multiple memories are a supported composition, so the capability keeps its
+    # auto-suffixed id while its leaf toolset retains the established durable id.
+    ('pydantic_ai_harness.memory', 'Memory', None, 'memory', _no_arguments),
+    ('pydantic_ai_harness.planning', 'Planning', 'planning', 'planning', _no_arguments),
+    ('pydantic_ai_harness.spend', 'SpendLimits', 'spend', 'spend', _spend_arguments),
+    ('pydantic_ai_harness.youdotcom', 'YouSearch', 'you_search', 'you_search', _you_arguments),
+    ('pydantic_ai_harness.youdotcom', 'YouResearch', 'you_research', 'you_research', _you_arguments),
+)
+
+
+@pytest.mark.parametrize(
+    ('module_name', 'class_name', 'default_capability_id', 'default_toolset_id', 'arguments'), CAPABILITY_ID_CASES
+)
+def test_default_and_custom_ids_reach_toolsets(
+    module_name: str,
+    class_name: str,
+    default_capability_id: str | None,
+    default_toolset_id: str,
+    arguments: CapabilityFactory,
+) -> None:
+    module = pytest.importorskip(module_name)
+    capability_class: Any = getattr(module, class_name)
+    kwargs = arguments()
+
+    default_capability = capability_class(**kwargs)
+    assert default_capability.id == default_capability_id
+    assert _leaf_ids(default_capability.get_toolset()) == [default_toolset_id]
+
+    custom_id = f'custom_{default_toolset_id}'
+    custom_capability = capability_class(**kwargs, id=custom_id)
+    assert custom_capability.id == custom_id
+    assert _leaf_ids(custom_capability.get_toolset()) == [custom_id]
+
+
+@pytest.mark.parametrize(
+    ('module_name', 'class_name'),
+    (
+        ('pydantic_ai_harness.shell', 'Shell'),
+        ('pydantic_ai_harness.modal_sandbox', 'ModalSandbox'),
+        ('pydantic_ai_harness.localstack', 'LocalStack'),
+    ),
+)
+def test_run_scoped_toolsets_keep_custom_id(module_name: str, class_name: str) -> None:
+    module = pytest.importorskip(module_name)
+    capability_class: Any = getattr(module, class_name)
+    toolset = capability_class(id='custom').get_toolset()
+
+    run_toolset = asyncio.run(toolset.for_run(None))
+
+    assert run_toolset.id == 'custom'
+
+
+def test_filtered_filesystem_keeps_the_leaf_id() -> None:
+    filesystem = pytest.importorskip('pydantic_ai_harness.filesystem')
+
+    toolset = filesystem.FileSystem(id='custom', read_only=True).get_toolset()
+
+    assert _leaf_ids(toolset) == ['custom']
+
+
+@pytest.mark.parametrize(
+    ('module_name', 'class_name', 'toolset_id', 'arguments'),
+    (
+        ('pydantic_ai_harness.memory', 'Memory', 'memory', _no_arguments),
+        ('pydantic_ai_harness.planning', 'Planning', 'planning', _no_arguments),
+        ('pydantic_ai_harness.spend', 'SpendLimits', 'spend', _spend_arguments),
+        ('pydantic_ai_harness.playwright', 'PlaywrightBrowser', 'playwright', _no_arguments),
+    ),
+)
+def test_established_toolset_ids_survive_explicit_none(
+    module_name: str,
+    class_name: str,
+    toolset_id: str,
+    arguments: CapabilityFactory,
+) -> None:
+    module = pytest.importorskip(module_name)
+    capability_class: Any = getattr(module, class_name)
+    capability = capability_class(**arguments(), id=None)
+
+    assert capability.id is None
+    assert _leaf_ids(capability.get_toolset()) == [toolset_id]


### PR DESCRIPTION
## Summary
- assign stable default ids to fixed one-off capabilities and forward them to their leaf toolsets
- include `PlaywrightBrowser`, `YouSearch`, and `YouResearch`, which landed after the issue's starting inventory
- preserve custom ids across run-scoped toolset clones and established toolset ids when `id=None`
- keep `Memory` capability ids auto-suffixed because multiple scoped memories are a supported composition, while forwarding a custom id to its toolset

Fixes #564.

## Validation
- 28 focused capability/toolset id regression tests passed
- 866 selected affected tests passed, 2 skipped, 4 known Windows-only tests deselected
- BrowserUse: 159 passed
- Playwright and You.com: 417 passed
- Ruff formatting and lint checks passed
- Pyright on changed files: 0 new errors

## Checklist
- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks