### PR TITLE
Give the `CodeMode` sandbox the value shape its own stubs declare

### DIFF
--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -382,6 +382,7 @@ Code runs inside [Monty](https://github.com/pydantic/monty), a sandboxed Python 
 - No `import *`.
 - Filesystem I/O needs an `os_access` handler or a `mount`; `os.getenv` / `os.environ` need an `os_access` handler.
 - Tools requiring approval or with deferred (`CallDeferred`) execution are sandboxed like any other tool; without a `HandleDeferredToolCalls` (or equivalent) capability on the agent to resolve them inline, calling one from `run_code` raises an error that surfaces to the model as a retry.
+- Tool results reach the sandbox in the JSON shape their generated stub declares, since the stub is derived from the tool's JSON schema. `Decimal`, `UUID` and `datetime` arrive as strings, and mapping keys are stringified, so a `dict[int, str]` of `{1: 'a'}` arrives as `{'1': 'a'}`. `bytes` and `bytearray` are the exception: Monty carries binary natively, so they cross unchanged even though the stub declares `str` for them.
 
 ## Agent spec (YAML/JSON)
 

--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -390,6 +390,7 @@ Code runs inside [Monty](https://github.com/pydantic/monty), a sandboxed Python 
 - No `import *`
 - Filesystem I/O needs an `os_access` handler or a `mount`; `os.getenv`/`os.environ` need an `os_access` handler
 - Tools requiring approval or with deferred (`CallDeferred`) execution are sandboxed like any other tool; without a `HandleDeferredToolCalls` (or equivalent) capability on the agent to resolve them inline, calling one from `run_code` raises an error that surfaces to the model as a retry
+- Tool results reach the sandbox in the JSON shape their generated stub declares, since the stub is derived from the tool's JSON schema: `Decimal`, `UUID` and `datetime` arrive as strings, and mapping keys are stringified, so a `dict[int, str]` of `{1: 'a'}` arrives as `{'1': 'a'}`. `bytes` and `bytearray` are the exception: Monty carries binary natively, so they cross unchanged even though the stub declares `str` for them
 
 ## API
 

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -319,6 +319,18 @@ _TOOL_RETURN_CONTENT_TA: TypeAdapter[Any] = TypeAdapter(ToolReturnContent)
 _SANDBOX_NATIVE_SCALARS = (str, bytes, bytearray, bool, int, float, type(None))
 
 
+def _jsonable_key(key: Any) -> Any:
+    """Render one mapping key the way `to_jsonable_python` renders JSON object keys.
+
+    JSON object keys are always strings, so `_build_type_check_stubs` declares every
+    mapping as `dict[str, ...]` whatever the Python key type is. Left alone, a `Decimal`
+    key is rejected by Monty and an `int` key silently contradicts that stub, so a
+    snippet indexing with the declared `str` raises `KeyError` at runtime.
+    """
+    (jsonable_key,) = to_jsonable_python({key: None})
+    return jsonable_key
+
+
 def _jsonable_for_sandbox(value: Any) -> Any:
     """Render the leaves Monty cannot hold as the JSON values the stubs describe.
 
@@ -327,11 +339,15 @@ def _jsonable_for_sandbox(value: Any) -> Any:
     keeps the original objects instead: Monty rejects `Decimal` and `UUID` outright,
     and a `datetime` arrives where the stub promised a `str`, so the type check passes
     and the snippet fails at runtime.
+
+    `bytes` and `bytearray` are the deliberate exception: they cross as themselves
+    rather than as the `str` their stub declares, because Monty carries binary natively
+    and encoding it would change what every binary payload looks like inside the sandbox.
     """
     if isinstance(value, _SANDBOX_NATIVE_SCALARS):
         return value
     if isinstance(value, Mapping):
-        return {key: _jsonable_for_sandbox(item) for key, item in value.items()}  # pyright: ignore[reportUnknownVariableType]
+        return {_jsonable_key(key): _jsonable_for_sandbox(item) for key, item in value.items()}  # pyright: ignore[reportUnknownVariableType]
     if isinstance(value, (list, tuple)):
         return [_jsonable_for_sandbox(item) for item in value]  # pyright: ignore[reportUnknownVariableType]
     return to_jsonable_python(value)

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -315,8 +315,9 @@ _RUN_CODE_ARGS_VALIDATOR: SchemaValidatorProt = _RUN_CODE_ADAPTER.validator  # p
 _TOOL_RETURN_CONTENT_TA: TypeAdapter[Any] = TypeAdapter(ToolReturnContent)
 
 # Values Monty holds as-is. `bytes` is here because Monty carries binary payloads
-# natively and JSON would utf-8 decode them, which arbitrary bytes fail.
-_SANDBOX_NATIVE_SCALARS = (str, bytes, bytearray, bool, int, float, type(None))
+# natively and JSON would utf-8 decode them, which arbitrary bytes fail. `Ellipsis`
+# is here because Monty holds it and JSON has no form for it at all.
+_SANDBOX_NATIVE_SCALARS = (str, bytes, bytearray, bool, int, float, type(None), type(Ellipsis))
 
 
 def _jsonable_key(key: Any) -> Any:
@@ -347,8 +348,18 @@ def _jsonable_for_sandbox(value: Any) -> Any:
     if isinstance(value, _SANDBOX_NATIVE_SCALARS):
         return value
     if isinstance(value, Mapping):
-        return {_jsonable_key(key): _jsonable_for_sandbox(item) for key, item in value.items()}  # pyright: ignore[reportUnknownVariableType]
-    if isinstance(value, (list, tuple)):
+        jsonable: dict[Any, Any] = {}
+        for key, item in value.items():  # pyright: ignore[reportUnknownVariableType]
+            jsonable_key = _jsonable_key(key)
+            if jsonable_key in jsonable:
+                raise UserError(
+                    f'A tool returned a mapping where key {key!r} renders as the JSON key '
+                    f'{jsonable_key!r}, which an earlier key already produced. The sandbox holds '
+                    'one entry per JSON key, so one of the two values would be dropped.'
+                )
+            jsonable[jsonable_key] = _jsonable_for_sandbox(item)
+        return jsonable
+    if isinstance(value, (list, tuple, set, frozenset)):
         return [_jsonable_for_sandbox(item) for item in value]  # pyright: ignore[reportUnknownVariableType]
     return to_jsonable_python(value)
 

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -6,7 +6,7 @@ import inspect
 import keyword
 import re
 import warnings
-from collections.abc import Callable, Coroutine, Sequence
+from collections.abc import Callable, Coroutine, Mapping, Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass, field, replace
 from itertools import islice
@@ -27,6 +27,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.tool_manager import ParallelExecutionMode, ToolManager
 from pydantic_ai.tools import AgentDepsT, ToolDenied, ToolSelector, matches_tool_selector
 from pydantic_ai.toolsets.abstract import SchemaValidatorProt, ToolsetTool
+from pydantic_core import to_jsonable_python
 from typing_extensions import NotRequired, Self, TypedDict
 
 try:
@@ -312,6 +313,29 @@ _RUN_CODE_ARGS_VALIDATOR: SchemaValidatorProt = _RUN_CODE_ADAPTER.validator  # p
 # Used to serialize tool return values before sending into Monty (dump_python)
 # and to reconstruct multimodal types (e.g. BinaryContent) from Monty results (validate_python).
 _TOOL_RETURN_CONTENT_TA: TypeAdapter[Any] = TypeAdapter(ToolReturnContent)
+
+# Values Monty holds as-is. `bytes` is here because Monty carries binary payloads
+# natively and JSON would utf-8 decode them, which arbitrary bytes fail.
+_SANDBOX_NATIVE_SCALARS = (str, bytes, bytearray, bool, int, float, type(None))
+
+
+def _jsonable_for_sandbox(value: Any) -> Any:
+    """Render the leaves Monty cannot hold as the JSON values the stubs describe.
+
+    `_build_type_check_stubs` derives each stub from the tool's JSON schema, so a
+    `Decimal`, `UUID` or `datetime` field is declared `str` there. A Python-mode dump
+    keeps the original objects instead: Monty rejects `Decimal` and `UUID` outright,
+    and a `datetime` arrives where the stub promised a `str`, so the type check passes
+    and the snippet fails at runtime.
+    """
+    if isinstance(value, _SANDBOX_NATIVE_SCALARS):
+        return value
+    if isinstance(value, Mapping):
+        return {key: _jsonable_for_sandbox(item) for key, item in value.items()}  # pyright: ignore[reportUnknownVariableType]
+    if isinstance(value, (list, tuple)):
+        return [_jsonable_for_sandbox(item) for item in value]  # pyright: ignore[reportUnknownVariableType]
+    return to_jsonable_python(value)
+
 
 _RUN_CODE_DESCRIPTION_HEAD = """\
 Write and run Python code in a sandboxed environment.
@@ -850,7 +874,7 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             )
 
             # Serialize to JSON-compatible form so Monty receives only plain data.
-            return _TOOL_RETURN_CONTENT_TA.dump_python(result)
+            return _jsonable_for_sandbox(_TOOL_RETURN_CONTENT_TA.dump_python(result))
 
         # Type-check only the first executed snippet. Monty's checker can reject valid later
         # snippets that reuse imports or pass a runtime-validated dict to a TypedDict parameter.

--- a/pydantic_ai_harness/code_mode/_toolset.py
+++ b/pydantic_ai_harness/code_mode/_toolset.py
@@ -890,7 +890,10 @@ class CodeModeToolset(WrapperToolset[AgentDepsT]):
             )
 
             # Serialize to JSON-compatible form so Monty receives only plain data.
-            return _jsonable_for_sandbox(_TOOL_RETURN_CONTENT_TA.dump_python(result))
+            # `ToolReturnContent` ends in `Any`, so every tool result is legal here, but its
+            # `Mapping[str, Any]` member still warns on a dict with non-str keys. Those keys
+            # are stringified below, so the warning has nothing left to report.
+            return _jsonable_for_sandbox(_TOOL_RETURN_CONTENT_TA.dump_python(result, warnings=False))
 
         # Type-check only the first executed snippet. Monty's checker can reject valid later
         # snippets that reuse imports or pass a runtime-validated dict to a TypedDict parameter.

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -163,6 +163,16 @@ def get_receipt() -> Receipt:
     )
 
 
+def get_prices() -> dict[Decimal, str]:
+    """Fetch prices by amount."""
+    return {Decimal('1.50'): 'USD'}
+
+
+def get_labels() -> dict[int, str]:
+    """Fetch labels by id."""
+    return {1: 'one'}
+
+
 # Hand-built `ToolDefinition` objects + a tiny stub toolset are used by
 # `test_conflicting_typed_dicts_get_tool_name_prefix` to exercise the
 # `needs_prefix=True` rendering path. Going through Pydantic's JSON schema generator
@@ -391,6 +401,36 @@ class TestCodeMode:
 
         # The un-dumped result is still what the message history records.
         assert result.metadata['tool_returns']['pyd_ai_code_mode__1'].content == get_receipt()
+
+    async def test_mapping_keys_cross_as_the_strings_the_stub_declares(self) -> None:
+        """A `Decimal` key reaches the sandbox as `'1.50'`, not as a `Decimal`.
+
+        JSON object keys are always strings, so the stub declares `dict[str, str]`
+        whatever the Python key type is. Leaving the key alone hit the same two
+        failures as the values: Monty rejects a `Decimal` key outright.
+        """
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(get_prices))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        code = "p = await get_prices()\np['1.50']"
+        result = await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+        assert result.return_value == 'USD'
+
+    async def test_int_mapping_keys_cross_as_the_strings_the_stub_declares(self) -> None:
+        """An `int` key reaches the sandbox as `'1'`, so indexing with the declared `str` works.
+
+        This is the silent half: the stub declares `dict[str, str]`, so a snippet
+        indexing with a `str` type-checked and then raised `KeyError` against the
+        `int` key that actually arrived.
+        """
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(get_labels))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        code = "labels = await get_labels()\n[labels['1'], list(labels.keys())]"
+        result = await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+        assert result.return_value == ['one', ['1']]
 
     async def test_run_code_can_chain_multiple_tool_calls_in_one_snippet(self) -> None:
         """A realistic LLM snippet that calls two tools in one `run_code` invocation."""

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -173,6 +173,21 @@ def get_labels() -> dict[int, str]:
     return {1: 'one'}
 
 
+def get_blobs() -> set[bytes]:
+    """Fetch binary blobs."""
+    return {b'\xff\xfe'}
+
+
+def get_sentinel() -> Any:
+    """Fetch a sentinel."""
+    return ...
+
+
+def get_colliding_labels() -> Any:
+    """Fetch labels whose keys collide once stringified."""
+    return {1: 'from-int', '1': 'from-str'}
+
+
 # Hand-built `ToolDefinition` objects + a tiny stub toolset are used by
 # `test_conflicting_typed_dicts_get_tool_name_prefix` to exercise the
 # `needs_prefix=True` rendering path. Going through Pydantic's JSON schema generator
@@ -431,6 +446,40 @@ class TestCodeMode:
         code = "labels = await get_labels()\n[labels['1'], list(labels.keys())]"
         result = await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
         assert result.return_value == ['one', ['1']]
+
+    async def test_binary_survives_inside_a_set(self) -> None:
+        """A `set` recurses like the other array containers, so its binary leaves stay `bytes`.
+
+        Sending the set to `to_jsonable_python` whole would utf-8 decode the payload,
+        which arbitrary bytes fail.
+        """
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(get_blobs))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        code = 'blobs = await get_blobs()\nblobs'
+        result = await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+        assert result.return_value == [b'\xff\xfe']
+
+    async def test_ellipsis_crosses_as_itself(self) -> None:
+        """Monty holds `Ellipsis`, and JSON has no form for it, so it is left alone."""
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(get_sentinel))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        code = 'x = await get_sentinel()\nx is ...'
+        result = await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+        assert result.return_value is True
+
+    async def test_mapping_keys_that_collide_once_stringified_are_rejected(self) -> None:
+        """`1` and `'1'` both render as `'1'`, which would drop one value silently."""
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(get_colliding_labels))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        code = 'await get_colliding_labels()'
+        with pytest.raises(ModelRetry, match='renders as the JSON key'):
+            await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
 
     async def test_run_code_can_chain_multiple_tool_calls_in_one_snippet(self) -> None:
         """A realistic LLM snippet that calls two tools in one `run_code` invocation."""

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -11,11 +11,15 @@ from __future__ import annotations
 import asyncio
 import functools
 from collections.abc import AsyncIterator
+from datetime import datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, Literal, TypeVar
 from unittest.mock import MagicMock
+from uuid import UUID
 
 import pytest
+from pydantic import BaseModel
 from pydantic_ai import (
     AbstractToolset,
     Agent,
@@ -140,6 +144,23 @@ class Person(TypedDict):
 def lookup_person(person: Person, count: int = 1) -> str:
     """Look up details for a person."""
     return f'{count}x {person["name"]} @ {person["home"]["street"]}'
+
+
+class Receipt(BaseModel):
+    """Fields whose Python type is not a JSON scalar."""
+
+    amount: Decimal
+    ident: UUID
+    when: datetime
+
+
+def get_receipt() -> Receipt:
+    """Fetch a receipt."""
+    return Receipt(
+        amount=Decimal('1.50'),
+        ident=UUID('00000000-0000-0000-0000-000000000001'),
+        when=datetime(2026, 1, 1),
+    )
 
 
 # Hand-built `ToolDefinition` objects + a tiny stub toolset are used by
@@ -346,6 +367,30 @@ class TestCodeMode:
             tools['run_code'],
         )
         assert result.return_value == {'output': 'Hello, Alice!\n'}
+
+    async def test_tool_result_crosses_in_the_shape_the_stub_declares(self) -> None:
+        """`Decimal`, `UUID` and `datetime` reach the sandbox as their JSON form.
+
+        `_build_type_check_stubs` derives the stub from the tool's JSON schema, so
+        those fields are declared `str`. Dumping in Python mode disagreed with that:
+        Monty rejects `Decimal` and `UUID` outright, and a `datetime` arrived where
+        the stub promised a `str`, so the type check passed and the snippet failed
+        at runtime.
+        """
+        wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(get_receipt))
+        assert isinstance(wrapper, CodeModeToolset)
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+        code = "r = await get_receipt()\n[r['amount'], r['ident'], r['when']]"
+        result = await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+        assert result.return_value == [
+            '1.50',
+            '00000000-0000-0000-0000-000000000001',
+            '2026-01-01T00:00:00',
+        ]
+
+        # The un-dumped result is still what the message history records.
+        assert result.metadata['tool_returns']['pyd_ai_code_mode__1'].content == get_receipt()
 
     async def test_run_code_can_chain_multiple_tool_calls_in_one_snippet(self) -> None:
         """A realistic LLM snippet that calls two tools in one `run_code` invocation."""


### PR DESCRIPTION
Fixes #680.

`CodeMode` builds each tool stub from the tool's JSON schema, so a `Decimal`, `UUID` or `datetime` field is declared `str` inside the sandbox. The result itself was dumped in Python mode, which disagrees with that in two ways:

- `Decimal` and `UUID` reach Monty as themselves and are rejected: `TypeError: Cannot convert decimal.Decimal to Monty value`. Every call to such a tool from inside a snippet fails.
- A `datetime` arrives where the stub promised a `str`, so `x['when'].upper()` passes the type check and then raises `AttributeError` at runtime.

## Approach

The obvious fix, `dump_python(result, mode='json')`, regresses binary: `test_preview_bounds_every_payload_shape` returns `b'\xff' * 50_000`, and JSON mode utf-8 decodes bytes, which arbitrary bytes fail. Monty carries binary payloads natively, so this walks the dumped structure instead and converts only the leaves that are neither sandbox-native scalars nor containers. `bytes` and `bytearray` pass through untouched; `Decimal`, `UUID` and `datetime` become the JSON values the stubs already describe.

The `ToolReturnPart` recorded in message history still carries the un-dumped result, so nothing changes for the model's transcript. `validate_python` on the way back out is untouched.

## What changes inside the sandbox

The walk converts by structure, not by a list of named types, so it moves more than the three types in the title. Every one of these already contradicted the stub the tool generated, so each is the same defect rather than a new behavior:

| a tool returns | before | now | the stub always declared |
|---|---|---|---|
| `Decimal`, `UUID`, `datetime` | rejected, or the raw object | `'1.50'`, `'0000...0001'`, `'2026-01-01T00:00:00'` | `str` |
| `tuple` | `(1, 2, 3)` | `[1, 2, 3]` | `list[Any]` |
| `set`, `frozenset` | `{1, 2, 3}` | `[1, 2, 3]` | `list[int]` |
| `Enum` | `TypeError: Cannot convert ... to Monty value` | `'red'` | the literal value |
| `dict[int, str]` of `{1: 'a'}` | `{1: 'a'}` | `{'1': 'a'}` | `dict[str, str]` |
| `bytes`, `bytearray` | unchanged | unchanged | `str`, see below |

Mapping keys are part of this. JSON object keys are always strings, so a stub declares `dict[str, ...]` whatever the Python key type is. Leaving keys un-dumped reproduced both original failures: a `Decimal` key still raised `TypeError: Cannot convert decimal.Decimal to Monty value`, and an `int` key silently contradicted the stub, so a snippet indexing with the declared `str` raised `KeyError: 1`.

`bytes` and `bytearray` are the one deliberate exception: they cross as themselves even though their stub declares `str`, because Monty carries binary natively. Both doc surfaces now record that, along with the key stringification.

## Test

`test_tool_result_crosses_in_the_shape_the_stub_declares` covers `Decimal`, `UUID` and `datetime` in one tool return. `test_mapping_keys_cross_as_the_strings_the_stub_declares` and `test_int_mapping_keys_cross_as_the_strings_the_stub_declares` cover the two key cases, one per original failure mode. All three go through `CodeModeToolset.call_tool`, not the private helper.

## Local verification

`uv run` could not be used on the first commit: `uv.toml`'s `exclude-newer-package` boolean form needs a newer uv than the 0.9.7 I have, which fails to parse it. I ran the suite against the checkout with `pydantic-ai-slim` 2.33.0 and `pydantic-monty` 0.0.21 instead.

`tests/code_mode`: 148 passed, 2 skipped, 3 failed. The three failures (`test_memory_exhaustion_reports_calls_without_advising_restart`, `test_every_resource_limit_reports_started_calls_when_exhausted`, `test_temporal_subclass_disables_duration_but_keeps_memory_limit`) all fail identically on a clean `main` in that environment, at roughly 8.41 MB against the 8.38 MB cap, so they look sensitive to the monty version rather than to this change.

On the pinned toolchain those three pass: `tests/code_mode` is 155 passed, and `ruff format --check`, `ruff check` and `pyright` are all clean on the touched files.

## Context

Found while porting a pharmacy dispensing agent to CodeMode. Its six lookup tools all return models with `Decimal` quantity fields, so every sandboxed tool call failed until we patched the serializer locally.
