### PR TITLE
Allow `SummarizingCompaction` to stream summary requests

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -343,6 +343,8 @@ agent = Agent(
 
 Both prompt surfaces of the summary request are fields: `summary_prompt` is the user-turn template (it must contain a `{messages}` placeholder), and `instructions` sets the internal agent's static instructions, which Pydantic AI sends in the request's system prompt. Override `instructions` when the summarizer endpoint requires a fixed leading instruction.
 
+If the summary endpoint only accepts streaming requests, set `stream_summary=True`. Only the nested summary request is streamed; its events are consumed internally and the parent run still receives one completed summary. The default remains non-streaming.
+
 ### Usage accounting
 
 The summary call is a real request to the model, so its full usage -- tokens **and** the request itself -- is folded into the run's `ctx.usage`. This is deliberate: it keeps cost honest, keeps the request count consistent (a model request that did not count as one would be the surprise), and lets a `UsageLimits` request limit catch a runaway compaction. The nested run receives the other parent limits unchanged; the finite request limit is reduced by one so it cannot spend the slot already approved for the parent request. A run-request or iteration limiter will therefore see compaction calls among its requests.

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -391,6 +391,10 @@ must contain a `{messages}` placeholder), and `instructions` sets the internal a
 which Pydantic AI sends in the request's system prompt. Override `instructions` when the summarizer
 endpoint requires a fixed leading instruction.
 
+If the summary endpoint only accepts streaming requests, set `stream_summary=True`. Only the nested
+summary request is streamed; its events are consumed internally and the parent run still receives one
+completed summary. The default remains non-streaming.
+
 ## Usage accounting
 
 The summary call is a real request to the model, so its full usage -- tokens **and** the request

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import AsyncIterable, Callable, Sequence
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, cast
 
@@ -10,6 +10,7 @@ from pydantic_ai._run_context import AgentDepsT
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
+    AgentStreamEvent,
     ModelMessage,
     ModelRequest,
     ModelResponse,
@@ -236,6 +237,12 @@ def _is_kept_user_message(message: ModelRequest) -> bool:
     return message.metadata is not None and message.metadata.get(_KEPT_USER_MESSAGE_METADATA) is True
 
 
+async def _drain_summary_events(_ctx: RunContext[Any], events: AsyncIterable[AgentStreamEvent]) -> None:
+    """Drain nested summary events; supplying this handler selects the streaming request path."""
+    async for _ in events:
+        pass
+
+
 @dataclass
 class SummarizingCompaction(AbstractCapability[AgentDepsT]):
     """LLM-powered conversation compaction.
@@ -322,6 +329,13 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
     `summary_prompt` shapes the user turn of the summary request; this sets the internal
     agent's static instructions, which Pydantic AI sends in the request's system prompt.
     Override it when the summarizer endpoint requires a fixed leading instruction.
+    """
+
+    stream_summary: bool = field(default=False, kw_only=True)
+    """Use streaming for the nested model request that writes the summary.
+
+    Enable this for providers that reject non-streaming requests. The nested stream is
+    consumed internally and only its completed summary is returned to the parent run.
     """
 
     tokenizer: Callable[[str], int] | None = None
@@ -638,5 +652,10 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
             cast('Model[Any] | str', model),
             instructions=self.instructions,
         )
-        result = await agent.run(prompt, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
+        result = await agent.run(
+            prompt,
+            usage=ctx.usage,
+            usage_limits=reserved_usage_limits(ctx.usage_limits),
+            event_stream_handler=_drain_summary_events if self.stream_summary else None,
+        )
         return result.output.strip()

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -237,7 +237,7 @@ def _is_kept_user_message(message: ModelRequest) -> bool:
     return message.metadata is not None and message.metadata.get(_KEPT_USER_MESSAGE_METADATA) is True
 
 
-async def _drain_summary_events(_ctx: RunContext[Any], events: AsyncIterable[AgentStreamEvent]) -> None:
+async def _drain_summary_events(_ctx: RunContext[None], events: AsyncIterable[AgentStreamEvent]) -> None:
     """Drain nested summary events; supplying this handler selects the streaming request path."""
     async for _ in events:
         pass
@@ -372,13 +372,13 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
     """
 
     keep_user_messages_max_chars: int = 20_000
-    """Per-message character cap for ``keep_user_messages``; oversized messages are truncated
+    """Per-message character cap for `keep_user_messages`; oversized messages are truncated
     with an explicit marker (the shared truncation-marker convention)."""
 
     receipts: bool = False
     """When ``True``, append a deterministic compaction receipt after the summary noting how
     much history was summarized, that the summary is secondhand, and -- when a
-    ``TranscriptHandleProvider`` capability is attached -- a persisted-run handle.
+    `TranscriptHandleProvider` capability is attached -- a persisted-run handle.
 
     Opt-in for now: the receipt text is content, so defaulting it on is deferred to the
     benchmark eval-rig pass.  The mechanism itself is structural.

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -237,7 +237,7 @@ def _is_kept_user_message(message: ModelRequest) -> bool:
     return message.metadata is not None and message.metadata.get(_KEPT_USER_MESSAGE_METADATA) is True
 
 
-async def _drain_summary_events(_ctx: RunContext[None], events: AsyncIterable[AgentStreamEvent]) -> None:
+async def _drain_summary_events(_ctx: RunContext[object], events: AsyncIterable[AgentStreamEvent]) -> None:
     """Drain nested summary events; supplying this handler selects the streaming request path."""
     async for _ in events:
         pass

--- a/tests/compaction/test_summary_streaming.py
+++ b/tests/compaction/test_summary_streaming.py
@@ -1,0 +1,107 @@
+"""Regression tests for streamed `SummarizingCompaction` summary requests."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import AsyncIterator
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, SystemPromptPart, TextPart, UserPromptPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from pydantic_ai_harness.compaction import SummarizingCompaction
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+def _history() -> list[ModelMessage]:
+    return [
+        ModelRequest(parts=[UserPromptPart('first')]),
+        ModelResponse(parts=[TextPart('first response')]),
+        ModelRequest(parts=[UserPromptPart('second')]),
+        ModelResponse(parts=[TextPart('second response')]),
+    ]
+
+
+def _outer_model() -> FunctionModel:
+    def respond(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart('done')])
+
+    return FunctionModel(respond)
+
+
+def _summary_text(messages: list[ModelMessage]) -> str:
+    summary_message = messages[0]
+    assert isinstance(summary_message, ModelRequest)
+    summary_part = summary_message.parts[0]
+    assert isinstance(summary_part, SystemPromptPart)
+    return summary_part.content
+
+
+class TestSummarizingCompactionStreaming:
+    @pytest.mark.anyio
+    async def test_stream_only_model(self) -> None:
+        calls = 0
+
+        async def request_stream(_messages: list[ModelMessage], _info: AgentInfo) -> AsyncIterator[str]:
+            nonlocal calls
+            calls += 1
+            yield 'stream-only summary'
+
+        summary_model = FunctionModel(stream_function=request_stream)
+        agent = Agent(
+            _outer_model(),
+            capabilities=[
+                SummarizingCompaction(
+                    model=summary_model,
+                    max_messages=3,
+                    keep_messages=1,
+                    preserve_first_user_message=False,
+                    incremental=False,
+                    stream_summary=True,
+                )
+            ],
+        )
+
+        result = await agent.run('continue', message_history=_history())
+
+        assert result.output == 'done'
+        assert calls == 1
+        assert 'stream-only summary' in _summary_text(result.all_messages())
+
+    @pytest.mark.anyio
+    async def test_non_streaming_by_default(self) -> None:
+        calls = 0
+
+        def request(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            nonlocal calls
+            calls += 1
+            return ModelResponse(parts=[TextPart('ordinary summary')])
+
+        summary_model = FunctionModel(request)
+        agent = Agent(
+            _outer_model(),
+            capabilities=[
+                SummarizingCompaction(
+                    model=summary_model,
+                    max_messages=3,
+                    keep_messages=1,
+                    preserve_first_user_message=False,
+                    incremental=False,
+                )
+            ],
+        )
+
+        result = await agent.run('continue', message_history=_history())
+
+        assert result.output == 'done'
+        assert calls == 1
+        assert 'ordinary summary' in _summary_text(result.all_messages())
+
+    def test_stream_summary_is_keyword_only(self) -> None:
+        parameter = inspect.signature(SummarizingCompaction).parameters['stream_summary']
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY


### PR DESCRIPTION
## Summary

Add an opt-in `stream_summary` flag to `SummarizingCompaction`. When enabled, only the nested summarizer request uses Pydantic AI's existing streaming path; its events are consumed internally and the completed summary contract is unchanged. The default remains non-streaming.

The regression coverage uses a stream-only `FunctionModel` and a non-streaming-only `FunctionModel` through real `Agent` runs so selecting the wrong transport fails at the model boundary. The new option is keyword-only to preserve constructor compatibility.

Both compaction documentation surfaces are updated. No dependency or lockfile changes.

### Boundary notes

This change uses the public `Agent.run(event_stream_handler=...)` primitive. It does not add provider wire handling, model-specific behavior, or alternate agent-loop semantics in Harness.

## Linked Issue

Fixes #619

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (not run locally in this environment; the repository's full CI matrix has passed on the fork and will be re-run for any code follow-up)
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)