### PR TITLE
Pin maintainer workflows to reachable upstream history

### DIFF
--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -32,7 +32,7 @@ jobs:
       issues: write
       pull-requests: write
     # Pin merged upstream history: GitHub cannot resolve a reusable workflow from a deleted PR-head ref.
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@2ee6c6658b7c1cd9a4ff09c9ec24f99db5d59946
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@252922e206ba0064eb8a96ab1e37616ba016b06a
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -49,7 +49,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@2ee6c6658b7c1cd9a4ff09c9ec24f99db5d59946
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@252922e206ba0064eb8a96ab1e37616ba016b06a
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -59,6 +59,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@2ee6c6658b7c1cd9a4ff09c9ec24f99db5d59946
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@252922e206ba0064eb8a96ab1e37616ba016b06a
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -30,8 +30,9 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@c44fbca16651e6dbf142228b816d686a280d1051
+      pull-requests: write
+    # Pin merged upstream history: GitHub cannot resolve a reusable workflow from a deleted PR-head ref.
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@2ee6c6658b7c1cd9a4ff09c9ec24f99db5d59946
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -48,7 +49,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@c44fbca16651e6dbf142228b816d686a280d1051
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@2ee6c6658b7c1cd9a4ff09c9ec24f99db5d59946
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -58,6 +59,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@c44fbca16651e6dbf142228b816d686a280d1051
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@2ee6c6658b7c1cd9a4ff09c9ec24f99db5d59946
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/tests/test_maintainer_attention_workflow.py
+++ b/tests/test_maintainer_attention_workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-UPSTREAM_SHA = '2ee6c6658b7c1cd9a4ff09c9ec24f99db5d59946'
+UPSTREAM_SHA = '252922e206ba0064eb8a96ab1e37616ba016b06a'
 
 
 def test_maintainer_attention_uses_merged_upstream_workflows():

--- a/tests/test_maintainer_attention_workflow.py
+++ b/tests/test_maintainer_attention_workflow.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+UPSTREAM_SHA = '2ee6c6658b7c1cd9a4ff09c9ec24f99db5d59946'
+
+
+def test_maintainer_attention_uses_merged_upstream_workflows():
+    workflow = (Path(__file__).parents[1] / '.github/workflows/maintainer-attention.yml').read_text()
+
+    refs = re.findall(r'uses: pydantic/pydantic-ai/\.github/workflows/[^@]+@([0-9a-f]{40})', workflow)
+    assert refs == [UPSTREAM_SHA] * 3
+
+    owner_routing = workflow.split('  owner-routing:', 1)[1].split('\n  operations:', 1)[0]
+    assert 'pull-requests: write' in owner_routing


### PR DESCRIPTION
## Summary

Restore startup for the maintainer attention workflow by replacing the deleted upstream PR-head pin with the reachable merge commit from pydantic/pydantic-ai#7762. Grant the owner-routing reusable workflow `pull-requests: write`, which is required for PR assignment. Add a regression test that keeps all upstream pins aligned and checks the caller permission.

Boundary notes: the caller continues to execute immutable code from `pydantic/pydantic-ai`; all refs are full commit SHAs. Secrets remain passed only to the existing reusable workflows.

Validation:

- `uv run pytest tests/test_maintainer_attention_workflow.py`
- `uv run ruff check .`
- targeted Pyright
- pre-commit on changed files, including yamlfmt and zizmor
- staging workflow dispatch passed end to end and assigned PR #647: https://github.com/pydantic/pydantic-ai-harness/actions/runs/32861334280

## Linked Issue

Fixes #685

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (focused checks listed above pass)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)