### PR TITLE
Enforce module-scope imports in tests with `PLC0415`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,10 +179,19 @@ target-version = 'py310'
 exclude = ['template']
 
 [tool.ruff.lint]
-extend-select = ['Q', 'RUF100', 'C90', 'UP', 'I', 'D', 'TID251']
+extend-select = ['Q', 'RUF100', 'C90', 'UP', 'I', 'D', 'TID251', 'PLC0415']
 
 [tool.ruff.lint.per-file-ignores]
 'tests/**/*.py' = ['D']
+# Deferred imports in the package are architectural, not convenience: `__getattr__`
+# lazy exports keep optional extras (pymongo, modal, ...) out of the base install,
+# some break an import cycle, and some defer a heavy data snapshot. PLC0415 cannot
+# tell those from an accidental function-scoped import, so it is off for the package
+# and enforced in tests, where every occurrence was accidental.
+'pydantic_ai_harness/**/*.py' = ['PLC0415']
+# `mcp` and `fastmcp` ship only with the `stackone` extra, so slim CI cannot import
+# them at module scope; these tests defer the import on purpose.
+'tests/stackone/**/*.py' = ['PLC0415']
 
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = 'single'

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -25,13 +25,7 @@ from pydantic_ai import (
     Tool,
     ToolDefinition,
 )
-from pydantic_ai.capabilities import (
-    AbstractCapability,
-    Capability,
-    HandleDeferredToolCalls,
-    Instrumentation,
-    ToolSearch,
-)
+from pydantic_ai.capabilities import AbstractCapability, Capability, Instrumentation, ToolSearch
 from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
 from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.messages import (
@@ -992,6 +986,8 @@ class TestCodeMode:
             return DeferredToolResults(
                 approvals={call.tool_call_id: ToolDenied(message='nope') for call in requests.approvals}
             )
+
+        from pydantic_ai.capabilities import HandleDeferredToolCalls  # noqa: PLC0415  # optional-version probe
 
         wrapper = CodeMode[object](max_tool_calls=1).get_wrapper_toolset(_build_function_toolset(needs_approval))
         assert isinstance(wrapper, CodeModeToolset)

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import warnings as _warnings
 from collections.abc import AsyncIterator
+from dataclasses import replace as dc_replace
 from pathlib import Path
 from typing import Any, Literal, TypeVar
 from unittest.mock import MagicMock
@@ -23,20 +25,50 @@ from pydantic_ai import (
     Tool,
     ToolDefinition,
 )
-from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.capabilities import (
+    AbstractCapability,
+    Capability,
+    HandleDeferredToolCalls,
+    Instrumentation,
+    ToolSearch,
+)
+from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
 from pydantic_ai.exceptions import ModelRetry, UserError
-from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.messages import (
+    BinaryContent,
+    InstructionPart,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    NativeToolReturnPart,
+    NativeToolSearchReturnPart,
+    SystemPromptPart,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    ToolSearchReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.messages import ToolReturn as ToolReturnMsg
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tool_manager import ParallelExecutionMode, ToolManager
+from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApproved, ToolDenied
+from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME, ToolSearchToolset, parse_discovered_tools
 from pydantic_ai.toolsets.abstract import ToolsetTool
+from pydantic_ai.toolsets.combined import CombinedToolset
 from pydantic_ai.toolsets.function import FunctionToolset
-from pydantic_ai.usage import RunUsage
+from pydantic_ai.usage import RequestUsage, RunUsage
 from pydantic_core import SchemaValidator, core_schema
 from pydantic_monty import NOT_HANDLED, Monty, MountDir, OSAccess, OsFunction
 from typing_extensions import Never, TypedDict
 
 from pydantic_ai_harness import CodeMode
 from pydantic_ai_harness.code_mode import CodeModeResourceLimits, CodeModeToolset
+from pydantic_ai_harness.code_mode._capability import (
+    _extract_discovered_names,  # pyright: ignore[reportPrivateUsage]
+)
 from pydantic_ai_harness.code_mode._toolset import (  # pyright: ignore[reportPrivateUsage]
     _SEARCH_TOOLS_MODIFIER,
     _TOOL_SEARCH_ADDENDUM,
@@ -96,7 +128,6 @@ async def build_ctx(
     Use this for tests that call `call_tool` -- `CodeModeToolset` requires
     `ctx.tool_manager` to be set.
     """
-    from pydantic_ai.tool_manager import ToolManager
 
     await toolset.__aenter__()
     _entered_toolsets.append(toolset)
@@ -780,7 +811,6 @@ class TestCodeMode:
         `BinaryContent` is the case that motivates naming a value by type: it reaches the summary
         as the raw object, so rendering it would put its whole payload in the retry.
         """
-        from pydantic_ai.messages import BinaryContent
 
         def shapes(tag: str, rows: list[int], opts: dict[str, int]) -> dict[str, Any]:
             """Return a mix of payload shapes."""
@@ -953,9 +983,6 @@ class TestCodeMode:
         It has a recorded return, so lumping it in with the successes would tell the model not to
         repeat a call whose tool never executed.
         """
-        from pydantic_ai.capabilities import HandleDeferredToolCalls
-        from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
-        from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDenied
 
         def needs_approval(value: int) -> str:
             """A tool that requires approval."""
@@ -1247,15 +1274,6 @@ class TestCodeMode:
 
     async def test_agent_run_preserves_repl_between_code_calls(self) -> None:
         """Code Mode keeps one REPL across model steps in an agent run."""
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            ToolCallPart,
-            ToolReturnPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
 
         def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             response_count = sum(isinstance(message, ModelResponse) for message in messages)
@@ -1384,7 +1402,6 @@ class TestCodeMode:
 
     async def test_native_tool_named_run_code_raises_user_error(self) -> None:
         """A native tool named `run_code` raises UserError (reserved name)."""
-        from pydantic_ai.exceptions import UserError
 
         def run_code() -> str:
             """A tool that collides with the reserved name."""
@@ -1399,7 +1416,6 @@ class TestCodeMode:
 
     async def test_sandboxed_tool_named_run_code_raises_user_error(self) -> None:
         """A sandboxed tool named `run_code` raises UserError (conflicts with meta-tool)."""
-        from pydantic_ai.exceptions import UserError
 
         def run_code() -> str:
             """A tool that collides with the meta-tool name."""
@@ -1730,7 +1746,6 @@ class TestCodeMode:
         assert 'async def search' in description
 
         # Second call must not warn again.
-        import warnings as _warnings
 
         with _warnings.catch_warnings():
             _warnings.simplefilter('error')
@@ -1738,7 +1753,6 @@ class TestCodeMode:
 
     async def test_tool_with_return_schema_does_not_warn(self) -> None:
         """A sandboxed tool WITH a return_schema does not trigger the warning."""
-        import warnings as _warnings
 
         td = ToolDefinition(
             name='get_user',
@@ -1763,15 +1777,6 @@ class TestCodeMode:
         sandbox dispatches to a wrapped tool, and the second model turn observes the
         tool's return value before producing the final text output.
         """
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            ToolCallPart,
-            ToolReturnPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
 
         observed_tool_calls: list[str] = []
         observed_tool_returns: list[Any] = []
@@ -1835,7 +1840,6 @@ class TestCodeMode:
         `test_tool_search_toolset_deferred_tool_not_in_run_code`; this exercises the
         end-to-end path through `Agent`.)
         """
-        from pydantic_ai.capabilities import Capability
 
         capability = Capability[object](
             id='demo',
@@ -1880,9 +1884,6 @@ class TestCodeMode:
         tool keeps `defer_loading=True` across the reveal (it records what the capability asked
         for), so the fold-in has to key on the run's revealed-tool set instead.
         """
-        from pydantic_ai.capabilities import Capability
-        from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
 
         capability = Capability[object](
             id='demo',
@@ -2079,7 +2080,6 @@ class TestCodeMode:
 
     async def test_tool_returning_tool_return_is_unwrapped(self) -> None:
         """A wrapped tool that returns a `ToolReturn` has its value unwrapped for the sandbox."""
-        from pydantic_ai.messages import ToolReturn as ToolReturnMsg
 
         def fancy() -> Any:
             """Return a ToolReturn with metadata."""
@@ -2101,7 +2101,6 @@ class TestCodeMode:
 
     async def test_approval_required_surfaces_as_model_retry(self) -> None:
         """Tools that raise ApprovalRequired inside the sandbox surface as ModelRetry."""
-        from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
 
         def needs_approval() -> str:
             """A tool that requires approval."""
@@ -2124,12 +2123,9 @@ class TestCodeMode:
         with the original denial message preserved in the trace.
         """
         try:
-            from pydantic_ai.capabilities import HandleDeferredToolCalls
+            from pydantic_ai.capabilities import HandleDeferredToolCalls  # noqa: PLC0415  # optional-version probe
         except ImportError:  # pragma: no cover -- only fires on floor-slim CI, which doesn't gate on coverage
             pytest.skip('Requires pydantic-ai-slim with `HandleDeferredToolCalls` (next release after 1.86.1)')
-
-        from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
-        from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolDenied
 
         def needs_approval() -> str:
             """A tool that requires approval."""
@@ -2156,12 +2152,9 @@ class TestCodeMode:
         deferral after approval is *not* re-resolved -- it bubbles up to the caller.
         """
         try:
-            from pydantic_ai.capabilities import HandleDeferredToolCalls
+            from pydantic_ai.capabilities import HandleDeferredToolCalls  # noqa: PLC0415  # optional-version probe
         except ImportError:  # pragma: no cover -- only fires on floor-slim CI, which doesn't gate on coverage
             pytest.skip('Requires pydantic-ai-slim with `HandleDeferredToolCalls` (next release after 1.86.1)')
-
-        from pydantic_ai.exceptions import ApprovalRequired as _ApprovalRequired
-        from pydantic_ai.tools import DeferredToolRequests, DeferredToolResults, ToolApproved
 
         def always_needs_approval(ctx: RunContext[object]) -> str:
             """Raises `ApprovalRequired` every time, even after being approved."""
@@ -2224,7 +2217,6 @@ class TestCodeMode:
     async def test_tool_returning_binary_image_is_returned_directly(self) -> None:
         """A tool that returns BinaryContent passes through the sandbox and is
         returned as native multimodal content (not wrapped in a dict)."""
-        from pydantic_ai.messages import BinaryContent
 
         image_bytes = b'\x89PNG\r\n\x1a\n fake image data'
 
@@ -2247,7 +2239,6 @@ class TestCodeMode:
     async def test_tool_returning_binary_image_with_print_uses_list_format(self) -> None:
         """When print output accompanies a multimodal return, the result is a list
         so _split_content can extract the image for native delivery."""
-        from pydantic_ai.messages import BinaryContent
 
         image_bytes = b'\x89PNG fake'
 
@@ -2276,7 +2267,6 @@ class TestCodeMode:
     async def test_tool_returning_list_with_binary_image_and_print(self) -> None:
         """A list result containing multimodal items with print output gets flattened
         so _split_content can find each multimodal item at the top level."""
-        from pydantic_ai.messages import BinaryContent
 
         image_bytes = b'\x89PNG list'
 
@@ -2306,8 +2296,6 @@ class TestCodeMode:
     async def test_tool_returning_tool_return_with_binary_content(self) -> None:
         """A tool that wraps a BinaryContent in a ToolReturn has the image properly unwrapped
         and returned as native multimodal content."""
-        from pydantic_ai.messages import BinaryContent
-        from pydantic_ai.messages import ToolReturn as ToolReturnMsg
 
         image_bytes = b'\x89PNG wrapped'
 
@@ -2337,15 +2325,6 @@ class TestCodeMode:
     @pytest.mark.skipif(not logfire_installed, reason='logfire not installed')
     async def test_sandboxed_tool_calls_produce_otel_spans(self, capfire: CaptureLogfire) -> None:
         """Sandboxed tool calls dispatched through ToolManager produce OTel execute_tool spans."""
-        from pydantic_ai.capabilities import Instrumentation
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelResponse,
-            TextPart,
-            ToolCallPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
-        from pydantic_ai.models.instrumented import InstrumentationSettings
 
         call_count = 0
 
@@ -2573,7 +2552,6 @@ class TestCodeMode:
     async def test_sequential_tool_rendered_as_sync_and_resolved_inline(self) -> None:
         """A tool with `sequential=True` is rendered as `def` (sync) and
         resolved inline at FunctionSnapshot via `resume({'return_value': ...})`."""
-        from dataclasses import replace as dc_replace
 
         class _SeqToolset(AbstractToolset[object]):
             """Marks add as sequential; greet stays parallel."""
@@ -2634,7 +2612,6 @@ class TestCodeMode:
     async def test_sequential_tool_barrier_awaits_pending_parallel_tasks(self) -> None:
         """When a sequential tool is called while parallel tasks are pending,
         the pending tasks are awaited first (barrier) before dispatching."""
-        from dataclasses import replace as dc_replace
 
         class _SeqToolset(AbstractToolset[object]):
             def __init__(self) -> None:
@@ -2692,7 +2669,6 @@ class TestCodeMode:
 
     async def test_sequential_tool_error_surfaces_as_model_retry(self) -> None:
         """An error from a sequential tool (resolved inline) surfaces as ModelRetry."""
-        from dataclasses import replace as dc_replace
 
         class _SeqToolset(AbstractToolset[object]):
             def __init__(self) -> None:
@@ -2724,7 +2700,6 @@ class TestCodeMode:
     async def test_global_sequential_mode_forces_sequential_resolution(self) -> None:
         """When the parallel execution mode is `sequential`, tool calls inside the
         sandbox are resolved sequentially via FutureSnapshot. Signatures stay `async def`."""
-        from pydantic_ai.tool_manager import ToolManager
 
         wrapper = CodeMode[object]().get_wrapper_toolset(_build_function_toolset(add))
         assert isinstance(wrapper, CodeModeToolset)
@@ -2750,9 +2725,6 @@ class TestCodeMode:
     async def test_global_sequential_overrides_per_tool_sequential(self) -> None:
         """When global sequential mode is active AND a tool has `sequential=True`,
         the tool is deferred (not resolved inline) and handled via FutureSnapshot."""
-        from dataclasses import replace as dc_replace
-
-        from pydantic_ai.tool_manager import ToolManager
 
         class _SeqToolset(AbstractToolset[object]):
             def __init__(self) -> None:
@@ -2813,8 +2785,6 @@ class TestToolSearchIntegration:
 
     async def test_search_tool_stays_native(self) -> None:
         """search_tools is kept as a native tool even with tools='all'."""
-        from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME
-        from pydantic_ai.toolsets.combined import CombinedToolset
 
         search_toolset = _StaticToolset([_search_tool_def()])
         func_toolset = _build_function_toolset(add)
@@ -2833,7 +2803,6 @@ class TestToolSearchIntegration:
 
     async def test_search_tools_description_appended(self) -> None:
         """search_tools description gets a modifier appended about run_code functions."""
-        from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME
 
         original_desc = 'There are additional tools. Search here.'
         toolset = _StaticToolset([_search_tool_def(description=original_desc)])
@@ -2877,7 +2846,6 @@ class TestToolSearchIntegration:
         pass-through so those flags reach `Model.prepare_request` unaltered. `search_tools`
         is native alongside `run_code`.
         """
-        from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME, ToolSearchToolset
 
         def later(x: int) -> str:
             """A deferred-loading tool."""
@@ -2901,8 +2869,6 @@ class TestToolSearchIntegration:
 
     async def test_tool_search_toolset_discovered_tool_in_run_code(self) -> None:
         """End-to-end: once `search_tools` has discovered the deferred tool, it folds into `run_code`."""
-        from pydantic_ai.messages import ModelMessage, ModelRequest, ToolSearchReturnPart
-        from pydantic_ai.toolsets._tool_search import ToolSearchToolset, parse_discovered_tools
 
         def later(x: int) -> str:
             """A deferred-loading tool."""
@@ -2944,7 +2910,6 @@ class TestToolSearchIntegration:
 
     def test_code_mode_ordering(self) -> None:
         """CodeMode declares ordering: outermost position, wraps ToolSearch."""
-        from pydantic_ai.capabilities._tool_search import ToolSearch
 
         ordering = CodeMode().get_ordering()
         assert ordering is not None
@@ -2983,8 +2948,6 @@ class TestDynamicCatalog:
         await toolset.get_tools(ctx)
         instructions = await toolset.get_instructions(ctx)
 
-        from pydantic_ai.messages import InstructionPart
-
         # No upstream instructions → the catalog is the only InstructionPart returned.
         assert isinstance(instructions, InstructionPart)
         assert 'async def add' in instructions.content
@@ -2992,7 +2955,6 @@ class TestDynamicCatalog:
         assert instructions.dynamic is True
 
     async def test_get_instructions_appends_to_upstream_string(self) -> None:
-        from pydantic_ai.messages import InstructionPart
 
         class _UpstreamToolset(FunctionToolset[object]):
             async def get_instructions(self, ctx: RunContext[object]) -> str:  # pyright: ignore[reportIncompatibleMethodOverride]
@@ -3011,7 +2973,6 @@ class TestDynamicCatalog:
         assert 'async def add' in instructions[1].content
 
     async def test_get_instructions_appends_to_upstream_sequence(self) -> None:
-        from pydantic_ai.messages import InstructionPart
 
         class _UpstreamToolset(FunctionToolset[object]):
             async def get_instructions(  # pyright: ignore[reportIncompatibleMethodOverride]
@@ -3105,7 +3066,6 @@ class TestDynamicCatalog:
     # -- discovery announcement: local search path ------------------------
 
     async def test_announce_on_local_search_return(self) -> None:
-        from pydantic_ai.messages import ModelRequest, SystemPromptPart, ToolCallPart
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -3127,7 +3087,6 @@ class TestDynamicCatalog:
 
     async def test_no_announce_when_disabled(self) -> None:
         """With `dynamic_catalog=False`, the hooks are inert even on a real search return."""
-        from pydantic_ai.messages import ToolCallPart
 
         cap = CodeMode[object]()
         ctx = build_run_context(None)
@@ -3141,7 +3100,6 @@ class TestDynamicCatalog:
         assert ctx.pending_messages == []
 
     async def test_announce_skipped_when_no_discoveries(self) -> None:
-        from pydantic_ai.messages import ToolCallPart
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -3156,7 +3114,6 @@ class TestDynamicCatalog:
 
     async def test_no_announce_for_non_search_tool(self) -> None:
         """`tool_kind != 'tool-search'` short-circuits before reading the result."""
-        from pydantic_ai.messages import ToolCallPart
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -3172,7 +3129,6 @@ class TestDynamicCatalog:
         assert ctx.pending_messages == []
 
     async def test_no_duplicate_announcement_for_same_tool(self) -> None:
-        from pydantic_ai.messages import ToolCallPart
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -3192,8 +3148,6 @@ class TestDynamicCatalog:
     # -- discovery announcement: native search path -----------------------
 
     async def test_announce_on_native_search_return_part(self) -> None:
-        from pydantic_ai.messages import ModelRequest, ModelResponse, NativeToolSearchReturnPart, SystemPromptPart
-        from pydantic_ai.usage import RequestUsage
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -3217,8 +3171,6 @@ class TestDynamicCatalog:
         assert isinstance(part, SystemPromptPart) and '`weather`' in part.content
 
     async def test_no_announce_for_unrelated_response_parts(self) -> None:
-        from pydantic_ai.messages import ModelResponse, NativeToolReturnPart, TextPart
-        from pydantic_ai.usage import RequestUsage
 
         cap = CodeMode[object](dynamic_catalog=True)
         ctx = build_run_context(None)
@@ -3244,9 +3196,6 @@ class TestDynamicCatalog:
         ],
     )
     def test_extract_discovered_names_handles_malformed(self, content: Any, expected: list[str]) -> None:
-        from pydantic_ai_harness.code_mode._capability import (
-            _extract_discovered_names,  # pyright: ignore[reportPrivateUsage]
-        )
 
         assert _extract_discovered_names(content) == expected
 
@@ -3263,20 +3212,6 @@ class TestDynamicCatalog:
              system content is no longer hoisted (pydantic/pydantic-ai#5509) — so the model
              sees the announcement inline and replies.
         """
-        from pydantic_ai.capabilities import ToolSearch
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelRequest,
-            ModelResponse,
-            SystemPromptPart,
-            TextPart,
-            ToolCallPart,
-            ToolReturnPart,
-            ToolSearchReturnPart,
-            UserPromptPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
-        from pydantic_ai.usage import RequestUsage
 
         captured_prompt_texts: list[list[str]] = []
         captured_descriptions: list[str] = []
@@ -3336,16 +3271,6 @@ class TestDynamicCatalog:
 
     async def test_run_code_calls_eager_tool_with_catalog_in_instructions(self) -> None:
         """An eager tool whose signature lives in instructions is still callable via `run_code`."""
-        from pydantic_ai.messages import (
-            ModelMessage,
-            ModelRequest,
-            ModelResponse,
-            TextPart,
-            ToolCallPart,
-            ToolReturnPart,
-        )
-        from pydantic_ai.models.function import AgentInfo, FunctionModel
-        from pydantic_ai.usage import RequestUsage
 
         def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
             run_code_def = next(td for td in info.function_tools if td.name == 'run_code')
@@ -3607,7 +3532,6 @@ def _search_tool_def(description: str = 'Search for tools.') -> ToolDefinition:
     Carries `tool_kind='tool-search'`, matching what pydantic-ai emits (since 1.95.0);
     CodeMode routes it native off `tool_kind`, not its name.
     """
-    from pydantic_ai.toolsets._tool_search import _SEARCH_TOOLS_NAME
 
     return ToolDefinition(
         name=_SEARCH_TOOLS_NAME,

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -8,19 +8,27 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from opentelemetry.trace import NoOpTracer, Tracer
-from pydantic_ai import Agent
-from pydantic_ai.capabilities import AbstractCapability
+from opentelemetry.trace import NoOpTracer, Tracer, get_tracer
+from pydantic_ai import Agent, Tool
+from pydantic_ai.capabilities import AbstractCapability, ToolSearch
 from pydantic_ai.exceptions import ModelAPIError
 from pydantic_ai.messages import (
+    BinaryContent,
+    CachePoint,
+    FilePart,
+    ImageUrl,
     LoadCapabilityCallPart,
     ModelMessage,
     ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
+    NativeToolCallPart,
+    NativeToolReturnPart,
+    RetryPromptPart,
     SystemPromptPart,
     TextContent,
     TextPart,
+    ThinkingPart,
     ToolCallPart,
     ToolReturnPart,
     ToolSearchCallPart,
@@ -28,14 +36,19 @@ from pydantic_ai.messages import (
     ToolSearchReturnPart,
     UserPromptPart,
 )
+from pydantic_ai.messages import ModelResponse as _MR
+from pydantic_ai.messages import TextPart as _TP
 from pydantic_ai.models import Model, ModelRequestContext, ModelRequestParameters
 from pydantic_ai.models.fallback import FallbackModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.models.instrumented import InstrumentationSettings
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import RunContext
 from pydantic_ai.toolsets._tool_search import parse_discovered_tools
 from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
+import pydantic_ai_harness
+import pydantic_ai_harness.compaction as compaction
 from pydantic_ai_harness.compaction import (
     ClampOversizedMessages,
     ClearToolResults,
@@ -66,11 +79,13 @@ from pydantic_ai_harness.compaction._shared import (
     prepend_first_user_message,
 )
 from pydantic_ai_harness.compaction._summarizing_compaction import (
+    _DEFAULT_SUMMARY_PROMPT,
     _SUMMARY_PREFIX,
     _extract_previous_summary,
     _extract_system_prompts,
     _format_messages,
 )
+from pydantic_ai_harness.step_persistence import InMemoryStepStore, StepPersistence
 
 try:
     from logfire.testing import CaptureLogfire
@@ -926,8 +941,6 @@ class TestExtractSystemPrompts:
 
 class TestExports:
     def test_exposed_under_submodule_and_top_level(self):
-        import pydantic_ai_harness
-        import pydantic_ai_harness.compaction as compaction
 
         names = [
             'SlidingWindowCompaction',
@@ -952,7 +965,6 @@ class TestUserPromptMultiModal:
     """Cover _user_prompt_text_for_counting and _user_prompt_text for non-string UserContent."""
 
     def test_estimate_with_text_content_parts(self):
-        from pydantic_ai.messages import TextContent
 
         part = UserPromptPart(content=[TextContent(content='hello')])
         msgs: list[ModelMessage] = [ModelRequest(parts=[part])]
@@ -967,7 +979,6 @@ class TestUserPromptMultiModal:
         assert estimate_token_count(msgs) == 2
 
     def test_format_with_text_content(self):
-        from pydantic_ai.messages import TextContent
 
         part = UserPromptPart(content=[TextContent(content='multi-part')])
         msgs: list[ModelMessage] = [ModelRequest(parts=[part])]
@@ -2179,7 +2190,6 @@ class TestSummarizingCompactionModel:
         assert MockAgent.call_args.kwargs['instructions'] == required
 
     def test_default_prompt_has_structured_sections(self):
-        from pydantic_ai_harness.compaction._summarizing_compaction import _DEFAULT_SUMMARY_PROMPT
 
         for heading in (
             '## Intent',
@@ -2338,7 +2348,6 @@ class TestClampOversizedMessages:
 
     @pytest.mark.anyio
     async def test_request_messages_and_other_parts_untouched(self):
-        from pydantic_ai.messages import ThinkingPart
 
         big_user = _user('u' * 5_000)
         mixed = ModelResponse(parts=[ThinkingPart(content='t' * 5_000), TextPart(content='z' * 5_000)])
@@ -2384,8 +2393,6 @@ class TestPublicPath:
 
     @pytest.mark.anyio
     async def test_capabilities_wired_into_agent(self):
-        from pydantic_ai import Agent
-        from pydantic_ai.models.test import TestModel
 
         agent = Agent(
             TestModel(),
@@ -2396,8 +2403,6 @@ class TestPublicPath:
 
     @pytest.mark.anyio
     async def test_clamp_oversized_wired_into_agent(self):
-        from pydantic_ai import Agent
-        from pydantic_ai.models.test import TestModel
 
         agent = Agent(
             TestModel(),
@@ -2413,9 +2418,6 @@ class TestPublicPath:
         # `parse_discovered_tools`; blanking it to a string used to crash the *next*
         # request. Drive a multi-request run (search -> clear fires -> another request)
         # and assert it completes with discovery intact.
-        from pydantic_ai import Agent, Tool
-        from pydantic_ai.capabilities import ToolSearch
-        from pydantic_ai.models.function import FunctionModel
 
         def hidden_gem(x: int) -> int:
             return x + 1
@@ -2469,7 +2471,6 @@ class TestHelperBranchCoverage:
 
     def test_a_retry_and_a_thinking_block_are_counted(self):
         """Both are sent to the provider, and a run under load is where they appear."""
-        from pydantic_ai.messages import RetryPromptPart, ThinkingPart
 
         msgs: list[ModelMessage] = [
             ModelRequest(parts=[RetryPromptPart(content='r' * 400)]),
@@ -2482,7 +2483,6 @@ class TestHelperBranchCoverage:
 
     def test_a_provider_side_tool_call_and_its_result_are_counted(self):
         """A web search runs on the provider's side and its result still lands in the context."""
-        from pydantic_ai.messages import NativeToolCallPart, NativeToolReturnPart
 
         msgs: list[ModelMessage] = [
             ModelResponse(
@@ -2513,7 +2513,6 @@ class TestHelperBranchCoverage:
 
     def test_a_binary_part_is_not_counted_as_characters(self):
         """`FilePart` carries bytes; its length in characters would mean nothing."""
-        from pydantic_ai.messages import BinaryContent, FilePart
 
         msgs: list[ModelMessage] = [
             ModelResponse(parts=[FilePart(content=BinaryContent(data=b'\x00' * 4_000, media_type='image/png'))])
@@ -2522,7 +2521,6 @@ class TestHelperBranchCoverage:
         assert _format_messages(msgs) == ''
 
     def test_user_prompt_text_skips_non_text_content(self):
-        from pydantic_ai.messages import ImageUrl
 
         part = UserPromptPart(content=[ImageUrl(url='https://example.com/y.png'), 'hello'])
         msgs: list[ModelMessage] = [ModelRequest(parts=[part])]
@@ -2597,7 +2595,6 @@ def _make_ctx_with_tracer() -> Any:
     The `capfire` fixture configures the global OTel provider, so a tracer fetched from it
     captures the `compact_messages` span without needing a full instrumented `Agent` run.
     """
-    from opentelemetry.trace import get_tracer
 
     ctx = _make_ctx()
     ctx.tracer = get_tracer('test')
@@ -2614,9 +2611,6 @@ class TestCompactionSpan:
 
     @pytest.mark.anyio
     async def test_span_emitted_when_threshold_exceeded(self, capfire: CaptureLogfire) -> None:
-        from pydantic_ai import Agent
-        from pydantic_ai.models.instrumented import InstrumentationSettings
-        from pydantic_ai.models.test import TestModel
 
         agent: Agent[None, str] = Agent(
             TestModel(),
@@ -2639,9 +2633,6 @@ class TestCompactionSpan:
 
     @pytest.mark.anyio
     async def test_no_span_when_threshold_not_exceeded(self, capfire: CaptureLogfire) -> None:
-        from pydantic_ai import Agent
-        from pydantic_ai.models.instrumented import InstrumentationSettings
-        from pydantic_ai.models.test import TestModel
 
         agent: Agent[None, str] = Agent(
             TestModel(),
@@ -2699,7 +2690,6 @@ class TestCompactionSpan:
 
     @pytest.mark.anyio
     async def test_clamp_no_span_for_non_oversized_or_skipped_parts(self, capfire: CaptureLogfire) -> None:
-        from pydantic_ai.messages import ThinkingPart
 
         comp = ClampOversizedMessages(max_part_chars=1_000, clamp_tool_call_args=True)
         messages: list[ModelMessage] = [
@@ -3358,7 +3348,6 @@ class TestKeepUserMessages:
 
     @pytest.mark.anyio
     async def test_bounds_text_inside_sequence_content(self):
-        from pydantic_ai.messages import CachePoint
 
         comp = SummarizingCompaction(
             model='test:m',
@@ -3534,9 +3523,6 @@ class TestAnchoredIncremental:
 
     @pytest.mark.anyio
     async def test_previous_summary_fed_as_anchor_with_update_instruction(self):
-        from pydantic_ai.messages import ModelResponse as _MR
-        from pydantic_ai.messages import TextPart as _TP
-        from pydantic_ai.models.function import FunctionModel
 
         captured: list[str] = []
 
@@ -3648,7 +3634,6 @@ class TestBridgePrefix:
 
     @pytest.mark.anyio
     async def test_same_fallback_model_does_not_add_a_bridge(self):
-        from pydantic_ai.models.fallback import FallbackModel
 
         fallback = FallbackModel(TestModel(), TestModel())
         ctx = _make_ctx()
@@ -3718,7 +3703,6 @@ class TestPinsSurviveStrategies:
 class TestStepPersistenceHandle:
     @pytest.mark.anyio
     async def test_handle_is_run_id_and_reaches_the_receipt(self):
-        from pydantic_ai_harness.step_persistence import InMemoryStepStore, StepPersistence
 
         sp: StepPersistence[None] = StepPersistence(store=InMemoryStepStore(), run_id='libr-1')
         assert isinstance(sp, TranscriptHandleProvider)
@@ -3726,7 +3710,6 @@ class TestStepPersistenceHandle:
         assert 'Persisted run handle: libr-1.' in await _receipt_for(_CtxWith.capabilities(sp=sp))
 
     def test_handle_none_before_materialization(self):
-        from pydantic_ai_harness.step_persistence import InMemoryStepStore, StepPersistence
 
         sp: StepPersistence[None] = StepPersistence(store=InMemoryStepStore())
         assert sp.compaction_transcript_handle() is None

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -8,7 +8,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from opentelemetry.trace import NoOpTracer, Tracer
+from opentelemetry.trace import NoOpTracer, Tracer, get_tracer
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
@@ -28,6 +28,8 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RequestUsage, RunUsage, UsageLimits
 
+import pydantic_ai_harness
+import pydantic_ai_harness.compaction as compaction
 from pydantic_ai_harness.compaction import (
     DEFAULT_CONTEXT_WINDOW,
     ClearToolResults,
@@ -1152,7 +1154,6 @@ class TestCompactNowSpan:
         return [s for s in capfire.exporter.exported_spans_as_dict() if s['name'] == 'compact_messages']
 
     async def test_emits_the_compaction_span(self, capfire: CaptureLogfire):
-        from opentelemetry.trace import get_tracer
 
         strategy: SlidingWindowCompaction[None] = SlidingWindowCompaction(max_tokens=1, keep_messages=2)
 
@@ -1167,7 +1168,6 @@ class TestCompactNowSpan:
 
     async def test_the_span_is_measured_with_the_tokenizer_it_was_given(self, capfire: CaptureLogfire):
         """Without it the manual path reports the heuristic where the in-run path reported a real count."""
-        from opentelemetry.trace import get_tracer
 
         strategy: SlidingWindowCompaction[None] = SlidingWindowCompaction(max_tokens=1, keep_messages=2)
         messages = _history(4)
@@ -1179,7 +1179,6 @@ class TestCompactNowSpan:
         assert attributes['compaction.tokens_before'] == characters, 'the 4-characters heuristic was used instead'
 
     async def test_no_span_when_the_history_is_unchanged(self, capfire: CaptureLogfire):
-        from opentelemetry.trace import get_tracer
 
         tiered: TieredCompaction[None] = TieredCompaction(
             tiers=[SlidingWindowCompaction(max_tokens=1, keep_messages=2)],
@@ -1191,7 +1190,6 @@ class TestCompactNowSpan:
         assert self._spans(capfire) == []
 
     async def test_the_span_names_the_focused_strategy(self, capfire: CaptureLogfire):
-        from opentelemetry.trace import get_tracer
 
         tiered: TieredCompaction[None] = TieredCompaction(
             tiers=[SlidingWindowCompaction(max_tokens=1, keep_messages=2)],
@@ -1230,8 +1228,6 @@ class TestWithFocus:
 
 class TestNewExports:
     def test_capability_exposed_at_top_level(self):
-        import pydantic_ai_harness
-        import pydantic_ai_harness.compaction as compaction
 
         assert pydantic_ai_harness.ReportContextUsage is compaction.ReportContextUsage
 
@@ -1266,7 +1262,6 @@ class TestPositionalCompatibility:
         assert WarnNearLimits(10, 1_000, 2_000).max_total_tokens == 2_000
 
     def test_the_new_fields_stay_keyword_only(self):
-        import dataclasses
 
         cases = [
             (SlidingWindowCompaction, 'max_fraction'),

--- a/tests/compaction/test_deprecated_names.py
+++ b/tests/compaction/test_deprecated_names.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+import pydantic_ai_harness.compaction as compaction
 from pydantic_ai_harness import HarnessDeprecationWarning
 from pydantic_ai_harness.compaction import SlidingWindowCompaction, WarnNearLimits
 
@@ -12,18 +13,17 @@ def test_sliding_window_alias_warns_and_resolves() -> None:
     with pytest.warns(
         HarnessDeprecationWarning, match='renamed to `pydantic_ai_harness.compaction.SlidingWindowCompaction`'
     ):
-        from pydantic_ai_harness.compaction import SlidingWindow
+        from pydantic_ai_harness.compaction import SlidingWindow  # noqa: PLC0415  # importing is the assertion
     assert SlidingWindow is SlidingWindowCompaction
 
 
 def test_limit_warner_alias_warns_and_resolves() -> None:
     with pytest.warns(HarnessDeprecationWarning, match='renamed to `pydantic_ai_harness.compaction.WarnNearLimits`'):
-        from pydantic_ai_harness.compaction import LimitWarner
+        from pydantic_ai_harness.compaction import LimitWarner  # noqa: PLC0415  # importing is the assertion
     assert LimitWarner is WarnNearLimits
 
 
 def test_unknown_attribute_raises() -> None:
-    import pydantic_ai_harness.compaction as compaction
 
     with pytest.raises(AttributeError, match='has no attribute'):
         _ = compaction.DoesNotExist

--- a/tests/conversation_search/test_conversation_search.py
+++ b/tests/conversation_search/test_conversation_search.py
@@ -38,6 +38,7 @@ from pydantic_ai.usage import RunUsage
 
 from pydantic_ai_harness import HarnessDeprecationWarning
 from pydantic_ai_harness.compaction import SlidingWindowCompaction, SummarizingCompaction
+from pydantic_ai_harness.compaction._summarizing_compaction import _SUMMARY_PREFIX
 from pydantic_ai_harness.conversation_search import (
     ConversationSearch,
     ConversationSearchToolset,
@@ -161,7 +162,6 @@ class TestSnapshotHistorySource:
         # compaction module's own constant makes this test fail the moment the two drift
         # apart. The cross-capability import is deliberately test-only; the source keeps a
         # local literal to avoid runtime coupling.
-        from pydantic_ai_harness.compaction._summarizing_compaction import _SUMMARY_PREFIX
 
         store = InMemoryStepStore()
         artifact = ModelRequest(parts=[SystemPromptPart(content=f'{_SUMMARY_PREFIX}older summarized context')])

--- a/tests/dynamic_workflow/test_dynamic_workflow.py
+++ b/tests/dynamic_workflow/test_dynamic_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import re
 from typing import Any
 
@@ -26,7 +27,9 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage, UsageLimits
 from pydantic_core import core_schema
+from pydantic_monty import Monty
 
+from pydantic_ai_harness._monty_exec import MontyExecutor
 from pydantic_ai_harness.code_mode import CodeMode
 from pydantic_ai_harness.dynamic_workflow import (
     DynamicWorkflow,
@@ -974,9 +977,6 @@ async def test_worker_crash_becomes_model_retry(monkeypatch: pytest.MonkeyPatch)
     # sub-agent results, not tear down the agent run. A tiny `request_timeout` plus an
     # infinite loop crashes the worker for real; `MontyCrashedError` cannot be constructed
     # or subclassed from Python, so injection is not an option.
-    import functools
-
-    from pydantic_monty import Monty
 
     monkeypatch.setattr(
         'pydantic_ai_harness.dynamic_workflow._toolset.Monty', functools.partial(Monty, request_timeout=0.5)
@@ -990,9 +990,6 @@ async def test_worker_crash_becomes_model_retry(monkeypatch: pytest.MonkeyPatch)
 async def test_worker_crash_after_budget_exhaustion_returns_terminal_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import functools
-
-    from pydantic_monty import Monty
 
     monkeypatch.setattr(
         'pydantic_ai_harness.dynamic_workflow._toolset.Monty', functools.partial(Monty, request_timeout=0.5)
@@ -1308,9 +1305,6 @@ async def test_cancellation_closes_unscheduled_coroutines() -> None:
     # In global-sequential mode (durable backends) deferred calls are kept as bare, unscheduled
     # coroutines. On cancellation those must be `close()`d, not cancelled -- covers the
     # coroutine branch of the executor's cleanup, unreachable through DynamicWorkflowToolset.
-    from pydantic_monty import Monty
-
-    from pydantic_ai_harness._monty_exec import MontyExecutor
 
     started = asyncio.Event()
 

--- a/tests/experimental/acp/test_acp.py
+++ b/tests/experimental/acp/test_acp.py
@@ -45,7 +45,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.toolsets import FunctionToolset
+from pydantic_ai.toolsets import CombinedToolset, FunctionToolset
 from pydantic_ai.usage import UsageLimits
 
 from pydantic_ai_harness import FileSystem, Shell
@@ -1140,7 +1140,6 @@ class TestPermission:
     def test_approval_names_come_from_function_toolsets_only(self) -> None:
         # A non-`FunctionToolset` session toolset cannot expose `requires_approval` without a live
         # run context, so it contributes nothing and its calls start `in_progress`.
-        from pydantic_ai.toolsets import CombinedToolset
 
         adapter: PydanticAIACPAgent[None, str] = PydanticAIACPAgent(_approval_agent([]))
         config: AcpSessionConfig[None] = AcpSessionConfig(deps=None, toolsets=[CombinedToolset([])])
@@ -2233,7 +2232,6 @@ class TestWorkspaceRooting:
     """A `session_config` factory roots `FileSystem` at the client's `cwd`, with absolute locations."""
 
     async def test_session_config_roots_filesystem_at_client_cwd(self, tmp_path: Path) -> None:
-        from pydantic_ai_harness.filesystem import FileSystem
 
         write = DeltaToolCall(name='write_file', json_args=json.dumps({'path': 'note.txt', 'content': 'hi'}))
         agent = Agent(_calls_tool_each_turn(write))  # the agent itself has no filesystem tools

--- a/tests/guardrails/test_deprecated_names.py
+++ b/tests/guardrails/test_deprecated_names.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 import pydantic_ai_harness
+import pydantic_ai_harness.guardrails as guardrails
 from pydantic_ai_harness import HarnessDeprecationWarning
 from pydantic_ai_harness.guardrails import (
     GuardrailResult,
@@ -16,7 +17,6 @@ from pydantic_ai_harness.guardrails import (
 
 
 def test_old_names_warn_and_resolve() -> None:
-    import pydantic_ai_harness.guardrails as guardrails
 
     expected = {
         'GuardResult': GuardrailResult,
@@ -44,7 +44,6 @@ def test_new_names_resolve_from_package_root_without_warning() -> None:
 
 
 def test_unknown_attribute_raises() -> None:
-    import pydantic_ai_harness.guardrails as guardrails
 
     with pytest.raises(AttributeError, match='has no attribute'):
         _ = guardrails.DoesNotExist

--- a/tests/guardrails/test_detectors.py
+++ b/tests/guardrails/test_detectors.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import time
 
 import pytest
+from pydantic import BaseModel
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
@@ -241,7 +243,6 @@ class TestKeyPastedFromAFile:
 
     def test_a_service_account_json_is_redacted(self):
         """Its newlines are the two characters backslash-n, not a line break."""
-        import json
 
         pem = f'-----BEGIN PRIVATE KEY-----\n{self._BODY}\n-----END PRIVATE KEY-----\n'
         document = json.dumps({'type': 'service_account', 'private_key': pem})
@@ -443,7 +444,6 @@ class TestForText:
 
     async def test_a_structured_output_reaches_the_detector_through_a_guard(self):
         """The scenario `for_text` exists for, driven through the capability rather than by hand."""
-        from pydantic import BaseModel
 
         class Answer(BaseModel):
             text: str
@@ -462,7 +462,6 @@ class TestForText:
             await agent.run('hi')
 
     async def test_a_structured_output_can_be_skipped_deliberately(self):
-        from pydantic import BaseModel
 
         class Answer(BaseModel):
             text: str

--- a/tests/guardrails/test_tool_guardrail.py
+++ b/tests/guardrails/test_tool_guardrail.py
@@ -1031,7 +1031,6 @@ class TestSharedVerdicts:
             GuardrailResult(action='approve', replacement='x')
 
     async def test_input_guard_rejects_approve(self):
-        from pydantic_ai_harness import InputGuardrail
 
         agent = Agent(TestModel(), capabilities=[InputGuardrail(guard=lambda prompt: GuardrailResult.approve())])
 
@@ -1039,7 +1038,6 @@ class TestSharedVerdicts:
             await agent.run('hi')
 
     async def test_output_guard_rejects_approve(self):
-        from pydantic_ai_harness import OutputGuardrail
 
         agent = Agent(TestModel(), capabilities=[OutputGuardrail(guard=lambda output: GuardrailResult.approve())])
 

--- a/tests/localstack/test_localstack.py
+++ b/tests/localstack/test_localstack.py
@@ -12,12 +12,15 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import sniffio
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.usage import RunUsage
 
+import pydantic_ai_harness
 from pydantic_ai_harness.localstack import LocalStack, LocalStackError, LocalStackToolset
+from pydantic_ai_harness.localstack import LocalStack as Exported
 
 from ._http_server import HttpResponse, http_server, unused_tcp_port
 
@@ -385,7 +388,6 @@ class TestLocalStackCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration(self) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -395,8 +397,6 @@ class TestLocalStackCapability:
         assert result.output == 'done'
 
     def test_exported_from_submodule(self) -> None:
-        import pydantic_ai_harness
-        from pydantic_ai_harness.localstack import LocalStack as Exported
 
         assert Exported is LocalStack
         assert pydantic_ai_harness.LocalStack is LocalStack
@@ -464,7 +464,6 @@ class TestContainerManagement:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration_manages_container(self, tmp_path: Path) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')

--- a/tests/media/conftest.py
+++ b/tests/media/conftest.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from pydantic_ai_harness.media import S3MediaStore
+
 if TYPE_CHECKING:
     from vcr.request import Request as VcrRequest  # pyright: ignore[reportMissingTypeStubs]
 
@@ -200,7 +202,6 @@ def s3_store(s3_credentials: dict[str, str]) -> Any:
     The key prefix is part of the URL path that lands in the cassette, so
     keep it stable across re-records.
     """
-    from pydantic_ai_harness.media import S3MediaStore
 
     return S3MediaStore(
         bucket=s3_credentials['bucket'],

--- a/tests/media/test_media.py
+++ b/tests/media/test_media.py
@@ -2,17 +2,29 @@
 
 from __future__ import annotations
 
+import base64
 import json
+import json as _json
 import os
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypeGuard
 
+import httpx
 import pytest
 from httpx import AsyncClient, MockTransport, Request, Response
 from pydantic_ai import ModelMessagesTypeAdapter
-from pydantic_ai.messages import BinaryContent, ModelMessage, ModelRequest, UserPromptPart
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextContent,
+    TextPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
 
 from pydantic_ai_harness.media import (
     DiskMediaStore,
@@ -26,7 +38,10 @@ from pydantic_ai_harness.media import (
     parse_media_uri,
     restore_media,
 )
-from pydantic_ai_harness.media._s3 import sign_request
+from pydantic_ai_harness.media._s3 import (
+    _canonical_uri,  # pyright: ignore[reportPrivateUsage]
+    sign_request,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -225,7 +240,6 @@ async def _restore_as_pre_pr_reader(node: dict[str, object], store: MediaStore) 
     The previous reader treats every marker as binary. Its missing-`uri` guard
     is left out because the markers under test always carry one.
     """
-    import base64
 
     uri_value = node.get('uri')
     assert isinstance(uri_value, str)
@@ -237,8 +251,6 @@ async def _restore_as_pre_pr_reader(node: dict[str, object], store: MediaStore) 
 
 class TestExternalizeRestoreWalker:
     async def test_round_trip_with_inline_binary(self, tmp_path: Path) -> None:
-        import base64
-        import json as _json
 
         store = DiskMediaStore(tmp_path)
         big_payload = b'\x00' * 70_000
@@ -289,7 +301,6 @@ class TestExternalizeRestoreWalker:
 
     async def test_binary_restore_reuses_write_context(self, tmp_path: Path) -> None:
         """A context-dependent storage key is found with the binary media type."""
-        import base64
 
         seen_contexts: list[MediaContext] = []
 
@@ -309,7 +320,6 @@ class TestExternalizeRestoreWalker:
         assert seen_contexts == [MediaContext(media_type='image/png'), MediaContext(media_type='image/png')]
 
     async def test_threshold_boundary_keeps_small_inline(self, tmp_path: Path) -> None:
-        import base64
 
         store = DiskMediaStore(tmp_path)
         small_payload = b'\x42' * 32
@@ -326,7 +336,6 @@ class TestExternalizeRestoreWalker:
 
     async def test_binary_threshold_boundary_is_inclusive(self, tmp_path: Path) -> None:
         """Exactly `threshold_bytes` externalizes; one byte under stays inline."""
-        import base64
 
         store = DiskMediaStore(tmp_path)
         threshold = 256
@@ -365,8 +374,6 @@ class TestExternalizeRestoreWalker:
 
     async def test_round_trip_preserves_unknown_binary_fields(self, tmp_path: Path) -> None:
         """A field the walker doesn't know about survives externalize -> restore."""
-        import base64
-        import json as _json
 
         store = DiskMediaStore(tmp_path)
         big = base64.b64encode(b'\x01' * 70_000).decode('ascii')
@@ -407,7 +414,6 @@ class TestExternalizeRestoreWalker:
         Closes #440: large tool-return strings would otherwise stay inline and
         push a snapshot past MongoDB's 16MB document cap.
         """
-        import json as _json
 
         store = DiskMediaStore(tmp_path)
         big_text = 'x' * 70_000
@@ -456,7 +462,6 @@ class TestExternalizeRestoreWalker:
 
     async def test_text_measured_in_utf8_bytes_not_characters(self, tmp_path: Path) -> None:
         """A multi-byte string below the char count but above the byte threshold externalizes."""
-        import json as _json
 
         store = DiskMediaStore(tmp_path)
         # 'é' is 2 UTF-8 bytes: 40 chars, 80 bytes.
@@ -480,8 +485,6 @@ class TestExternalizeRestoreWalker:
 
     async def test_text_part_externalizes_nested_binary(self, tmp_path: Path) -> None:
         """A large text part with a nested large binary externalizes both and round-trips."""
-        import base64
-        import json as _json
 
         store = DiskMediaStore(tmp_path)
         big_text = 'x' * 70_000
@@ -509,7 +512,6 @@ class TestExternalizeRestoreWalker:
         large `content`, but the reference URI is stored under a namespaced key,
         so the payload's own `uri` must survive externalize -> restore intact.
         """
-        import json as _json
 
         store = DiskMediaStore(tmp_path)
         node = {
@@ -583,15 +585,6 @@ class TestExternalizeRestoreWalker:
         a multi-megabyte tool return delivered as `[TextContent(...)]` would
         then be written whole into the snapshot record.
         """
-        import json as _json
-
-        from pydantic_ai.messages import (
-            ModelMessagesTypeAdapter,
-            ModelRequest,
-            TextContent,
-            ToolReturnPart,
-            UserPromptPart,
-        )
 
         store = DiskMediaStore(tmp_path)
         big_text = 'q' * 70_000
@@ -624,7 +617,6 @@ class TestExternalizeRestoreWalker:
 
     async def test_marker_mirrors_reference_to_uri_for_pre_uri_key_readers(self, tmp_path: Path) -> None:
         """A marker written now still restores on a reader that only knows plain `uri`."""
-        import base64
 
         store = DiskMediaStore(tmp_path)
         b64_payload = base64.b64encode(b'\x02' * 70_000).decode('ascii')
@@ -643,9 +635,6 @@ class TestExternalizeRestoreWalker:
 
     async def test_text_marker_requires_current_reader_after_downgrade(self, tmp_path: Path) -> None:
         """The pre-PR binary reader cannot reconstruct externally stored text."""
-        import json as _json
-
-        from pydantic_ai.messages import ModelMessagesTypeAdapter, ModelResponse, TextPart
 
         store = DiskMediaStore(tmp_path)
         original: object = _json.loads(
@@ -782,7 +771,6 @@ class TestS3MediaStoreWithMockTransport:
         Otherwise the signed canonical path and the path S3 receives diverge ->
         SignatureDoesNotMatch. The wire `raw_path` must equal `_canonical_uri(path)`.
         """
-        from pydantic_ai_harness.media._s3 import _canonical_uri  # pyright: ignore[reportPrivateUsage]
 
         captured: list[Request] = []
 
@@ -1029,7 +1017,6 @@ class TestS3MediaStoreWithMockTransport:
 
     async def test_no_client_branch_opens_one_per_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without `client=`, the store opens a fresh `httpx.AsyncClient` per call."""
-        import httpx
 
         captured: list[Request] = []
 

--- a/tests/media/test_mongo.py
+++ b/tests/media/test_mongo.py
@@ -14,7 +14,15 @@ from bson.binary import Binary
 from mongomock_motor import AsyncMongoMockClient
 from pymongo import AsyncMongoClient
 
-from pydantic_ai_harness.media import MediaContext, MediaStore, MongoMediaStore, media_uri_for, parse_media_uri
+import pydantic_ai_harness.media as media
+from pydantic_ai_harness.media import (
+    MediaContext,
+    MediaStore,
+    MongoMediaStore,
+    make_static_public_url,
+    media_uri_for,
+    parse_media_uri,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -257,7 +265,6 @@ class TestMongoMediaStorePublicUrl:
         assert await store.public_url(media_uri_for(b'x')) is None
 
     async def test_with_resolver_uses_it(self) -> None:
-        from pydantic_ai_harness.media import make_static_public_url
 
         store = MongoMediaStore(
             client=_mock_client(),
@@ -277,12 +284,10 @@ class TestMongoMediaStoreProtocol:
 
 class TestMediaLazyExport:
     def test_mongo_media_store_lazily_exported(self) -> None:
-        import pydantic_ai_harness.media as media
 
         assert media.MongoMediaStore is MongoMediaStore
 
     def test_unknown_attribute_raises(self) -> None:
-        import pydantic_ai_harness.media as media
 
         with pytest.raises(AttributeError, match='has no attribute'):
             _ = media.NoSuchStore  # type: ignore[attr-defined]

--- a/tests/memory/test_memory.py
+++ b/tests/memory/test_memory.py
@@ -1381,7 +1381,7 @@ class TestTelemetryAndComposition:
 
     def test_temporal_durability_accepts_static_memory_toolset(self) -> None:
         pytest.importorskip('temporalio')
-        from pydantic_ai.durable_exec.temporal import TemporalDurability
+        from pydantic_ai.durable_exec.temporal import TemporalDurability  # noqa: PLC0415  # needs the temporal extra
 
         Agent(
             TestModel(),

--- a/tests/modal_sandbox/test_modal_sandbox.py
+++ b/tests/modal_sandbox/test_modal_sandbox.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 from typing import Protocol, TypeGuard, runtime_checkable
 
 import pytest
+import sniffio
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import ModelRetry
@@ -17,6 +18,8 @@ from pydantic_ai.models.test import TestModel
 from pydantic_ai.toolsets import AbstractToolset
 from pydantic_ai.usage import RunUsage
 
+import pydantic_ai_harness
+import pydantic_ai_harness.modal_sandbox as modal_sandbox
 from pydantic_ai_harness.code_mode import CodeMode
 from pydantic_ai_harness.modal_sandbox import (
     ModalSandbox,
@@ -25,6 +28,7 @@ from pydantic_ai_harness.modal_sandbox import (
     ModalSandboxTerminalError,
     ModalSandboxUnavailableError,
 )
+from pydantic_ai_harness.modal_sandbox import ModalSandbox as Exported
 
 from .fake_modal import FakeModal, FileInfo
 
@@ -778,9 +782,6 @@ class TestCapability:
         assert ModalSandbox(sandbox_id='sb-keep', max_command_timeout=600).max_command_timeout == 600
 
     def test_exported_from_capability_submodule(self) -> None:
-        import pydantic_ai_harness
-        import pydantic_ai_harness.modal_sandbox as modal_sandbox
-        from pydantic_ai_harness.modal_sandbox import ModalSandbox as Exported
 
         assert Exported is ModalSandbox
         assert 'ModalSandboxToolset' not in modal_sandbox.__all__
@@ -789,7 +790,6 @@ class TestCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration(self, fake_modal: FakeModal) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -801,7 +801,6 @@ class TestCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_can_call_run_command(self, fake_modal: FakeModal) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -829,7 +828,6 @@ class TestCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_context_does_not_create_an_unused_base_sandbox(self, fake_modal: FakeModal) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -848,7 +846,6 @@ class TestCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_run_failing_terminally_still_tears_down(self, fake_modal: FakeModal) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -898,7 +895,6 @@ class TestCodeModeInterop:
     @pytest.mark.anyio(backends=['asyncio'])
     @pytest.mark.parametrize('modal_first', [True, False], ids=['modal-first', 'code-mode-first'])
     async def test_run_command_stays_native(self, fake_modal: FakeModal, modal_first: bool) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -912,7 +908,6 @@ class TestCodeModeInterop:
     @pytest.mark.anyio(backends=['asyncio'])
     @pytest.mark.parametrize('modal_first', [True, False], ids=['modal-first', 'code-mode-first'])
     async def test_file_tools_are_still_sandboxed(self, fake_modal: FakeModal, modal_first: bool) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')

--- a/tests/playwright/test_playwright.py
+++ b/tests/playwright/test_playwright.py
@@ -2067,7 +2067,7 @@ class TestDurabilityRejection:
 
     def test_rejects_temporal_durability_at_construction(self) -> None:
         pytest.importorskip('temporalio')
-        from pydantic_ai.durable_exec.temporal import TemporalDurability
+        from pydantic_ai.durable_exec.temporal import TemporalDurability  # noqa: PLC0415  # needs the temporal extra
 
         with pytest.raises(UserError, match='does not support durable execution'):
             Agent(TestModel(), capabilities=[PlaywrightBrowser(), TemporalDurability()])

--- a/tests/pydantic_ai_docs/test_deprecated_names.py
+++ b/tests/pydantic_ai_docs/test_deprecated_names.py
@@ -31,7 +31,7 @@ def test_shim_warns_and_aliases_old_names() -> None:
 def test_fresh_import_warns() -> None:
     sys.modules.pop('pydantic_ai_harness.docs', None)
     with pytest.warns(HarnessDeprecationWarning, match=r'renamed to `pydantic_ai_harness\.pydantic_ai_docs`'):
-        import pydantic_ai_harness.docs
+        import pydantic_ai_harness.docs  # noqa: PLC0415  # importing is the assertion
 
     assert issubclass(pydantic_ai_harness.docs.PyaiDocs, PydanticAIDocs)
 
@@ -40,7 +40,7 @@ class TestPreRenameSpecCompatibility:
     def test_serialization_names(self) -> None:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            from pydantic_ai_harness.docs import PyaiDocs
+            from pydantic_ai_harness.docs import PyaiDocs  # noqa: PLC0415  # importing is the assertion
 
         assert PyaiDocs.get_serialization_name() == 'PyaiDocs'
         assert PydanticAIDocs.get_serialization_name() == 'PydanticAIDocs'
@@ -50,7 +50,7 @@ class TestPreRenameSpecCompatibility:
         # deprecated class through `custom_capability_types` must keep it loading.
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            from pydantic_ai_harness.docs import PyaiDocs
+            from pydantic_ai_harness.docs import PyaiDocs  # noqa: PLC0415  # importing is the assertion
 
         agent = Agent.from_spec(
             {'model': 'test', 'capabilities': [{'PyaiDocs': {}}]},
@@ -62,7 +62,7 @@ class TestPreRenameSpecCompatibility:
     def test_experimental_shim_exposes_the_same_class(self) -> None:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            from pydantic_ai_harness.docs import PyaiDocs
-            from pydantic_ai_harness.experimental.docs import PyaiDocs as experimental_pyai_docs
+            from pydantic_ai_harness.docs import PyaiDocs  # noqa: PLC0415  # importing is the assertion
+            from pydantic_ai_harness.experimental.docs import PyaiDocs as experimental_pyai_docs  # noqa: PLC0415
 
         assert experimental_pyai_docs is PyaiDocs

--- a/tests/repo_context/test_deprecated_names.py
+++ b/tests/repo_context/test_deprecated_names.py
@@ -13,6 +13,6 @@ from pydantic_ai_harness.repo_context import RepoContext
 def test_fresh_import_warns_and_aliases_old_path() -> None:
     sys.modules.pop('pydantic_ai_harness.context', None)
     with pytest.warns(HarnessDeprecationWarning, match=r'renamed to `pydantic_ai_harness\.repo_context`'):
-        import pydantic_ai_harness.context
+        import pydantic_ai_harness.context  # noqa: PLC0415  # importing is the assertion
 
     assert pydantic_ai_harness.context.RepoContext is RepoContext

--- a/tests/shell/test_shell.py
+++ b/tests/shell/test_shell.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import signal
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -12,6 +13,7 @@ from unittest.mock import MagicMock, patch
 
 import anyio
 import pytest
+import sniffio
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import ModelRetry
@@ -1166,7 +1168,6 @@ class TestShellCapability:
 
     @pytest.mark.anyio(backends=['asyncio'])
     async def test_agent_integration(self, tmp_path: Path) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -1203,7 +1204,6 @@ class TestCodeModeInterop:
     @pytest.mark.anyio(backends=['asyncio'])
     @pytest.mark.parametrize('shell_first', [True, False], ids=['shell-first', 'code-mode-first'])
     async def test_command_tools_stay_native(self, tmp_path: Path, shell_first: bool) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -1219,7 +1219,6 @@ class TestCodeModeInterop:
     @pytest.mark.anyio(backends=['asyncio'])
     @pytest.mark.parametrize('shell_first', [True, False], ids=['shell-first', 'code-mode-first'])
     async def test_command_id_tools_are_still_sandboxed(self, tmp_path: Path, shell_first: bool) -> None:
-        import sniffio
 
         if sniffio.current_async_library() != 'asyncio':  # pragma: no cover
             pytest.skip('Agent.run() requires asyncio')
@@ -1273,8 +1272,6 @@ class TestKillProcessGroupEdgeCases:
 
         proc.wait = never_return
 
-        import signal
-
         kill_calls: list[tuple[int, int]] = []
 
         def fake_killpg(pgid: int, sig: int) -> None:
@@ -1310,8 +1307,6 @@ class TestKillProcessGroupEdgeCases:
             await anyio.sleep(999)
 
         proc.wait = never_return
-
-        import signal
 
         call_count = 0
 

--- a/tests/step_persistence/test_mongo.py
+++ b/tests/step_persistence/test_mongo.py
@@ -28,6 +28,7 @@ from pydantic_ai.models.test import TestModel
 from pymongo import AsyncMongoClient
 from pymongo.errors import DuplicateKeyError
 
+import pydantic_ai_harness.step_persistence as sp
 from pydantic_ai_harness.conversation_search import SnapshotHistorySource
 from pydantic_ai_harness.media import MongoMediaStore
 from pydantic_ai_harness.step_persistence import (
@@ -446,12 +447,10 @@ class TestMongoStepStoreMedia:
 
 class TestStepPersistenceLazyExport:
     def test_mongo_step_store_lazily_exported(self) -> None:
-        import pydantic_ai_harness.step_persistence as sp
 
         assert sp.MongoStepStore is MongoStepStore
 
     def test_unknown_attribute_raises(self) -> None:
-        import pydantic_ai_harness.step_persistence as sp
 
         with pytest.raises(AttributeError, match='has no attribute'):
             _ = sp.NoSuchStore  # type: ignore[attr-defined]

--- a/tests/step_persistence/test_sqlite_and_media.py
+++ b/tests/step_persistence/test_sqlite_and_media.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import base64
 import logging
 import sqlite3
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -85,7 +86,6 @@ class TestSqliteStepStoreProtocol:
             await store.register_run(RunRecord(run_id='r1'))
 
     async def test_list_runs_chronological(self, tmp_path: Path) -> None:
-        from datetime import datetime, timedelta, timezone
 
         store = SqliteStepStore(database=tmp_path / 'runs.db')
         base = datetime(2024, 1, 1, tzinfo=timezone.utc)

--- a/tests/step_persistence/test_step_persistence.py
+++ b/tests/step_persistence/test_step_persistence.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -17,6 +18,7 @@ import pytest
 from pydantic_ai import Agent, CallToolsNode, ModelRequestNode, ModelRetry, RunContext
 from pydantic_ai._agent_graph import GraphAgentState  # pyright: ignore[reportPrivateUsage]
 from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.capabilities.abstract import AgentNode, NodeResult
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -44,10 +46,12 @@ from pydantic_ai_harness.step_persistence import (
     StepPersistence,
     StepStore,
     ToolEffectRecord,
+    annotate_tool_effect,
     continue_run,
     fork_run,
     is_provider_valid,
 )
+from pydantic_ai_harness.step_persistence._context import current_run_id
 from pydantic_ai_harness.step_persistence._store import _validate_id  # pyright: ignore[reportPrivateUsage]
 
 pytestmark = pytest.mark.anyio
@@ -1468,7 +1472,6 @@ class TestNonToolRetryPrompt:
 class TestListRunsChronologicalOrdering:
     async def test_in_memory_returns_started_at_order(self) -> None:
         """`InMemoryStepStore.list_runs` sorts by `started_at`, not insertion order."""
-        from datetime import datetime, timezone
 
         store = InMemoryStepStore()
         await store.register_run(RunRecord(run_id='z-newer', started_at=datetime(2026, 5, 24, 12, tzinfo=timezone.utc)))
@@ -1478,7 +1481,6 @@ class TestListRunsChronologicalOrdering:
 
     async def test_file_store_returns_started_at_order(self, tmp_path: Path) -> None:
         """`FileStepStore.list_runs` sorts by `started_at`, not by directory name."""
-        from datetime import datetime, timezone
 
         store = FileStepStore(tmp_path)
         # `a-new` is lexicographically first but chronologically last.
@@ -1491,7 +1493,6 @@ class TestListRunsChronologicalOrdering:
 class TestToolEffectMetadataPreservation:
     async def test_completed_preserves_idempotency_key_and_effect_summary(self) -> None:
         """Metadata written during the tool call survives the terminal `completed` record."""
-        from pydantic_ai_harness.step_persistence import annotate_tool_effect
 
         store = InMemoryStepStore()
         agent: Agent[object, str] = Agent(TestModel(), capabilities=[StepPersistence(store=store, run_id='r1')])
@@ -1516,7 +1517,6 @@ class TestToolEffectMetadataPreservation:
 
     async def test_failed_preserves_idempotency_key(self) -> None:
         """Metadata written before a tool raises still appears on the `failed` record."""
-        from pydantic_ai_harness.step_persistence import annotate_tool_effect
 
         store = InMemoryStepStore()
         agent: Agent[object, str] = Agent(TestModel(), capabilities=[StepPersistence(store=store, run_id='r1')])
@@ -1538,7 +1538,6 @@ class TestToolEffectMetadataPreservation:
 
     async def test_annotate_tool_effect_outside_step_persistence_is_a_noop(self) -> None:
         """No `current_run_id` → `annotate_tool_effect` returns without writing."""
-        from pydantic_ai_harness.step_persistence import annotate_tool_effect
 
         store = InMemoryStepStore()
         ctx = build_run_context(deps=None, run_id='r1')
@@ -1548,8 +1547,6 @@ class TestToolEffectMetadataPreservation:
 
     async def test_annotate_tool_effect_noop_when_prior_record_missing(self) -> None:
         """`current_run_id` set + ctx tool fields set, but no prior record → no-op."""
-        from pydantic_ai_harness.step_persistence import annotate_tool_effect
-        from pydantic_ai_harness.step_persistence._context import current_run_id
 
         store = InMemoryStepStore()
         ctx = RunContext[Any](
@@ -1999,8 +1996,6 @@ class TestLiveHistoryInvariant:
 
     async def test_node_boundary_messages_are_one_live_list(self) -> None:
         """All post-`UserPromptNode` boundaries expose the same list object, and it tracks the run."""
-        from pydantic_ai.capabilities import AbstractCapability
-        from pydantic_ai.capabilities.abstract import AgentNode, NodeResult
 
         seen: list[list[ModelMessage]] = []
 

--- a/tests/subagents/test_subagents.py
+++ b/tests/subagents/test_subagents.py
@@ -23,6 +23,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import AgentDepsT, RunContext
+from pydantic_ai.toolsets import FunctionToolset
 from pydantic_ai.usage import UsageLimits
 
 from pydantic_ai_harness.subagents import SubAgent, SubAgents, SubAgentToolset
@@ -347,7 +348,6 @@ class TestDelegation:
         They are bound to capability instances registered in the parent run; sharing
         them is `shared_capabilities`' job (see the `_inherited_toolsets` docstring).
         """
-        from pydantic_ai.toolsets import FunctionToolset
 
         @dataclass
         class _ToolCapability(AbstractCapability[object]):

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -7,6 +7,7 @@ from pydantic_ai import Agent
 from pydantic_ai.capabilities import Capability
 from pydantic_ai.models.test import TestModel
 
+import pydantic_ai_harness.coder
 from pydantic_ai_harness.coder import DEFAULT_ALLOWED_COMMANDS, Coder, coder_agent
 from pydantic_ai_harness.compaction import ClearToolResults, WarnNearLimits
 from pydantic_ai_harness.filesystem import FileSystem
@@ -48,7 +49,6 @@ def test_coder_agent_export_is_lazy() -> None:
 
 
 def test_coder_unknown_export() -> None:
-    import pydantic_ai_harness.coder
 
     with pytest.raises(AttributeError, match='has no attribute'):
         pydantic_ai_harness.coder.__getattr__('missing')

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 import pytest
 
+from pydantic_ai_harness.coder import DEFAULT_ALLOWED_COMMANDS
+
 _ROOT = Path(__file__).parent.parent
 _PACKAGE = _ROOT / 'pydantic_ai_harness'
 
@@ -363,7 +365,6 @@ def test_blown_out_example_is_identical_across_surfaces(surface: str) -> None:
 
 
 def test_blown_out_example_matches_coder_defaults() -> None:
-    from pydantic_ai_harness.coder import DEFAULT_ALLOWED_COMMANDS
 
     block = _blown_out_block(_ROOT / _BLOWN_OUT_SURFACES[0])
     listed = re.findall(r"'([a-z]+)'", block.split('allowed_commands = [', 1)[1].split(']', 1)[0])

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,12 +1,14 @@
 import inspect
 from pathlib import Path
 
+import pydantic_ai.models
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models.test import TestModel
 
 import pydantic_ai_harness
+from pydantic_ai_harness import LLM_API_KEY_ENV_PATTERNS, Coder, FileSystem, Researcher, Shell
 
 
 def test_import():
@@ -43,28 +45,24 @@ def test_all_exports_are_importable(
 
 
 def test_lazy_import_filesystem():
-    from pydantic_ai_harness import FileSystem
 
     assert inspect.isclass(FileSystem)
     assert hasattr(FileSystem, 'get_toolset')
 
 
 def test_lazy_import_shell():
-    from pydantic_ai_harness import Shell
 
     assert inspect.isclass(Shell)
     assert hasattr(Shell, 'get_toolset')
 
 
 def test_lazy_import_presets():
-    from pydantic_ai_harness import Coder, Researcher
 
     assert inspect.isclass(Coder)
     assert inspect.isclass(Researcher)
 
 
 def test_lazy_import_llm_api_key_env_patterns():
-    from pydantic_ai_harness import LLM_API_KEY_ENV_PATTERNS
 
     assert isinstance(LLM_API_KEY_ENV_PATTERNS, tuple)
     assert 'OPENAI_*' in LLM_API_KEY_ENV_PATTERNS
@@ -88,6 +86,5 @@ def test_tmp_dir_fixture(tmp_dir: Path):
 
 
 async def test_allow_model_requests(allow_model_requests: None):
-    import pydantic_ai.models
 
     assert pydantic_ai.models.ALLOW_MODEL_REQUESTS is True

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -8,6 +8,7 @@ from pydantic_ai.capabilities import Capability, WebFetch, WebSearch
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.native_tools import WebFetchTool, WebSearchTool
 
+import pydantic_ai_harness.researcher
 from pydantic_ai_harness.researcher import DEFAULT_RESEARCHER_INSTRUCTIONS, Researcher, researcher_agent
 from pydantic_ai_harness.subagents import SubAgents
 from pydantic_ai_harness.tool_output_limits import ToolOutputLimits
@@ -27,7 +28,6 @@ def test_researcher_agent_is_model_less_and_composed() -> None:
 
 
 def test_researcher_unknown_export() -> None:
-    import pydantic_ai_harness.researcher
 
     with pytest.raises(AttributeError, match='has no attribute'):
         pydantic_ai_harness.researcher.__getattr__('missing')


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

## Why this PR exists separately

This change was previously merged into the `media-marker-collision` branch (#518, base
`media-marker-collision`), not into `main`. It was stacked there on the assumption that #514 would
merge first and the base would re-target automatically. #514 has not merged, so the rule never
reached `main` and instead rode along as ~275 of #514's 279 changed test lines -- and became the
entire conflict surface every time that branch merged `main`.

Re-targeted here against current `main`, and re-run from scratch rather than replaying #518's diff:
`main` has moved a long way since, and seven of the sites cleared below did not exist then
(`tests/playwright`, `tests/test_coder.py`, `tests/test_researcher.py`, `tests/test_docs_parity.py`,
`tests/test_placeholder.py`, and two in `tests/shell`).

## What this does

Adds `PLC0415` (`import-outside-top-level`) to the ruff config and clears the sites in `tests/` so
it can be turned on.

Net **-131 lines** across 29 files. Every hoisted import is a plain convenience import
(`pydantic_ai.messages` names, `TestModel`, `base64`, `sniffio`) that had no reason to be deferred.

The rule matters because an inline-import convention spreads by imitation: a new test copies the
file around it. A lint rule stops that; one more hand-corrected file does not.

## What is deliberately not hoisted

Three exemptions, each for a stated reason.

**1. `pydantic_ai_harness/**` -- exempted in config.** The deferred imports there are architectural,
not convenience: `__getattr__` lazy exports that keep optional extras (`pymongo`, `modal`) out of the
base install, imports that break a cycle, and one deferred heavy data snapshot. `PLC0415` cannot
distinguish those from an accidental function-scoped import, so it is off for the package and
enforced in tests, where every occurrence was accidental.

**2. `tests/stackone/**` -- exempted in config.** `mcp` and `fastmcp` ship only with the `stackone`
extra. Module-scope imports there break the slim job.

**3. Thirteen `# noqa: PLC0415` sites, each with its reason inline.**

| Sites | Reason |
|---|---|
| `tests/compaction/test_deprecated_names.py` x2, `tests/pydantic_ai_docs/test_deprecated_names.py` x5, `tests/repo_context/test_deprecated_names.py` x1 | the import is what emits the warning under test; hoisting fires it at collection, which `filterwarnings = ['error']` turns into a failure |
| `tests/code_mode/test_code_mode.py` x3 | `HandleDeferredToolCalls`, which two of these sites probe for with `try:` / `except ImportError`; see the note below |
| `tests/memory/test_memory.py` x1, `tests/playwright/test_playwright.py` x1 | behind `pytest.importorskip('temporalio')` |

The exemptions are file-scoped rather than global, so the rule still fires everywhere else.

## Duplicate imports surfaced by the hoist

Hoisting an inline import next to an existing module-scope one exposed five `F811` redefinitions.
Each pair was verified to be the same object at runtime before one side was dropped:

| File | Symbol | Kept |
|---|---|---|
| `tests/code_mode/test_code_mode.py` | `ToolSearch` | `pydantic_ai.capabilities` (dropped the `._tool_search` private path) |
| `tests/experimental/acp/test_acp.py` | `FileSystem` | `pydantic_ai_harness` root |
| `tests/guardrails/test_tool_guardrail.py` | `InputGuardrail`, `OutputGuardrail` | `pydantic_ai_harness.guardrails` |
| `tests/media/test_media.py` | `ModelMessagesTypeAdapter` | `pydantic_ai` |

## Verification

- `uv run ruff format --check .` -- 322 files already formatted
- `uv run ruff check .` -- all checks passed
- `uv run ruff check --select PLC0415 tests/` -- all checks passed (zero outside the exemptions)
- `uv run pyright <29 changed files>` -- 0 errors
- `uv run pytest <28 changed test modules>` -- 2894 passed, 16 skipped

The suite is the real check here, not the linter: a hoist that changed import timing surfaces as a
failing deprecation or warning test, not as a lint error.

## `HandleDeferredToolCalls` stays deferred

`tests/code_mode/test_code_mode.py` had three inline imports of this symbol: two inside
`try:` / `except ImportError` probes that skip when it is absent, and one with no probe. The
unprobed one was hoisted in the first pass and then put back.

Not because the hoist breaks anything today -- it does not. The floor is
`pydantic-ai-slim>=2.33.0`, `HandleDeferredToolCalls` is in that release's
`pydantic_ai.capabilities.__all__`, and all five `lowest-versions` jobs (which resolve with
`--resolution lowest-direct`, i.e. exactly the floor) passed on the hoisted commit `b7e2002`.

It is put back because a module-scope import of a symbol the same file probes for makes those
probes unreachable: the module fails to import before any of them runs. Either the probes are dead
and should be removed, or the symbol must stay deferred. That is a question about the floor, not
about import placement, and a lint PR is the wrong place to settle it. This PR now leaves the
file's import behavior exactly as it found it.

## Note on the dependency gate

This PR changes `pyproject.toml` -- that is where the ruff config lives, not a dependency change.
`uv.lock` is untouched. The gate cannot tell the difference, so it needs `dependencies:approved`
added after the final push (the workflow strips the label on every `synchronize`).
