### PR TITLE
Check the marked `spend` doc snippets for undefined names, so they stay runnable on the 3.10 floor

### DIFF
--- a/docs/spend.md
+++ b/docs/spend.md
@@ -106,7 +106,7 @@ SpendLimits(budgets=[Budget(usd=Decimal('100'))], on_spend=show)
 
 `status()` reads the same numbers without a run, which is what a cost display in a UI wants:
 
-```python
+```python {names="defined"}
 from pydantic_ai_harness import SpendLimits
 
 
@@ -125,7 +125,7 @@ Set `expose_tools=True` to give the agent a `get_spend` tool. It is off by defau
 
 The seam that runs before a request rather than after a response is `before_model_request`. A small capability of your own can read `status(ctx)` there and hold the run until someone decides:
 
-```python
+```python {names="defined"}
 import asyncio
 from dataclasses import dataclass
 from decimal import Decimal
@@ -163,7 +163,7 @@ For a ceiling that expands rather than stops, `budgets` is read fresh on every r
 
 A refusal can land mid-run, after tool calls have already run and been paid for. Re-running the original prompt would repeat that work and any side effects it had, so resume from what the refused run produced instead: `capture_run_messages` holds the partial history, and a run given that history and no new prompt continues from the request that was refused.
 
-```python
+```python {names="defined"}
 import dataclasses
 from decimal import Decimal
 
@@ -279,14 +279,14 @@ What bounds that is settled under "Sharing a counter across processes" above: ho
 
 Refuse the workflow **admission** before starting it instead. That is why `exhausted()` works without a `RunContext`:
 
-```python
+```python {names="defined"}
 from collections.abc import Awaitable, Callable
 
 from pydantic_ai_harness import SpendLimits
 
 
 async def start_if_funded(
-    limits: SpendLimits[None], tenant_id: str, start_workflow: Callable[[], Awaitable[None]]
+    limits: SpendLimits[None], tenant_id: str, start_workflow: Callable[[], Awaitable[object]]
 ) -> None:
     if await limits.exhausted(scope=tenant_id):
         raise RuntimeError('daily budget exhausted')

--- a/docs/spend.md
+++ b/docs/spend.md
@@ -107,6 +107,9 @@ SpendLimits(budgets=[Budget(usd=Decimal('100'))], on_spend=show)
 `status()` reads the same numbers without a run, which is what a cost display in a UI wants:
 
 ```python
+from pydantic_ai_harness import SpendLimits
+
+
 async def report(limits: SpendLimits[None]) -> None:
     for status in await limits.status(scope='acme'):
         print(status.budget.name, status.spent.usd, status.exhausted)
@@ -187,10 +190,17 @@ The sandbox refusing that clock is what surfaces this first, and `SpendLimits` t
 Refuse the workflow **admission** before starting it instead. That is why `exhausted()` works without a `RunContext`:
 
 ```python
-async def start_if_funded(limits: SpendLimits[None], tenant_id: str) -> None:
+from collections.abc import Awaitable, Callable
+
+from pydantic_ai_harness import SpendLimits
+
+
+async def start_if_funded(
+    limits: SpendLimits[None], tenant_id: str, start_workflow: Callable[[], Awaitable[None]]
+) -> None:
     if await limits.exhausted(scope=tenant_id):
         raise RuntimeError('daily budget exhausted')
-    await workflow_handle.execute(...)
+    await start_workflow()
 ```
 
 `exhausted` rather than `any(s.exhausted for s in await limits.status(...))`: `status` omits

--- a/pydantic_ai_harness/spend/README.md
+++ b/pydantic_ai_harness/spend/README.md
@@ -104,7 +104,7 @@ SpendLimits(budgets=[Budget(usd=Decimal('100'))], on_spend=show)
 
 `status()` reads the same numbers without a run, which is what a cost display in a UI wants:
 
-```python
+```python {names="defined"}
 from pydantic_ai_harness import SpendLimits
 
 
@@ -123,7 +123,7 @@ Set `expose_tools=True` to give the agent a `get_spend` tool. It is off by defau
 
 The seam that runs before a request rather than after a response is `before_model_request`. A small capability of your own can read `status(ctx)` there and hold the run until someone decides:
 
-```python
+```python {names="defined"}
 import asyncio
 from dataclasses import dataclass
 from decimal import Decimal
@@ -161,7 +161,7 @@ For a ceiling that expands rather than stops, `budgets` is read fresh on every r
 
 A refusal can land mid-run, after tool calls have already run and been paid for. Re-running the original prompt would repeat that work and any side effects it had, so resume from what the refused run produced instead: `capture_run_messages` holds the partial history, and a run given that history and no new prompt continues from the request that was refused.
 
-```python
+```python {names="defined"}
 import dataclasses
 from decimal import Decimal
 
@@ -277,14 +277,14 @@ What bounds that is settled under "Sharing a counter across processes" above: ho
 
 Refuse the workflow **admission** before starting it instead. That is why `exhausted()` works without a `RunContext`:
 
-```python
+```python {names="defined"}
 from collections.abc import Awaitable, Callable
 
 from pydantic_ai_harness import SpendLimits
 
 
 async def start_if_funded(
-    limits: SpendLimits[None], tenant_id: str, start_workflow: Callable[[], Awaitable[None]]
+    limits: SpendLimits[None], tenant_id: str, start_workflow: Callable[[], Awaitable[object]]
 ) -> None:
     if await limits.exhausted(scope=tenant_id):
         raise RuntimeError('daily budget exhausted')

--- a/pydantic_ai_harness/spend/README.md
+++ b/pydantic_ai_harness/spend/README.md
@@ -105,6 +105,9 @@ SpendLimits(budgets=[Budget(usd=Decimal('100'))], on_spend=show)
 `status()` reads the same numbers without a run, which is what a cost display in a UI wants:
 
 ```python
+from pydantic_ai_harness import SpendLimits
+
+
 async def report(limits: SpendLimits[None]) -> None:
     for status in await limits.status(scope='acme'):
         print(status.budget.name, status.spent.usd, status.exhausted)
@@ -185,10 +188,17 @@ The sandbox refusing that clock is what surfaces this first, and `SpendLimits` t
 Refuse the workflow **admission** before starting it instead. That is why `exhausted()` works without a `RunContext`:
 
 ```python
-async def start_if_funded(limits: SpendLimits[None], tenant_id: str) -> None:
+from collections.abc import Awaitable, Callable
+
+from pydantic_ai_harness import SpendLimits
+
+
+async def start_if_funded(
+    limits: SpendLimits[None], tenant_id: str, start_workflow: Callable[[], Awaitable[None]]
+) -> None:
     if await limits.exhausted(scope=tenant_id):
         raise RuntimeError('daily budget exhausted')
-    await workflow_handle.execute(...)
+    await start_workflow()
 ```
 
 `exhausted` rather than `any(s.exhausted for s in await limits.status(...))`: `status` omits

--- a/tests/test_doc_snippets.py
+++ b/tests/test_doc_snippets.py
@@ -17,6 +17,16 @@ model is a separate concern (see `test_readme_quick_start.py` for that shape).
 Illustrative signature blocks (API-reference pseudo-code with type annotations or
 a bare `*`, which is not runnable Python) opt out with a `{test="skip"}` fence
 directive.
+
+A fence marked `{names="defined"}` opts in to a third check: it must not use a
+name it never binds. That is the failure a reader hits when they copy the block
+into a file of their own, and it is invisible to the two checks above. The mark
+is per fence because standing alone is a property of the block -- a page may
+deliberately continue an earlier block's namespace.
+
+The check reads names only. A snippet calling a method that has since been
+renamed is an attribute access, which neither this nor `_snippet_problem` sees,
+and nothing in this repo type-checks a snippet's annotations.
 """
 
 from __future__ import annotations as _annotations
@@ -24,6 +34,8 @@ from __future__ import annotations as _annotations
 import ast
 import importlib
 import os
+import re
+import subprocess
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -31,6 +43,7 @@ from pathlib import Path
 import pytest
 from _pytest.mark import ParameterSet
 from pytest_examples import CodeExample, find_examples
+from ruff.__main__ import find_ruff_bin  # pyright: ignore[reportMissingTypeStubs]
 
 _ROOT = Path(__file__).parent.parent
 _HARNESS = 'pydantic_ai_harness'
@@ -117,20 +130,75 @@ def test_doc_snippets_discovered() -> None:
     assert sum(1 for _ in _doc_snippets()) >= 100
 
 
-def _spend_snippets() -> Iterable[ParameterSet]:
+_F821 = re.compile(r'^-:(\d+):(\d+): (F821 .+)$', re.MULTILINE)
+
+
+def _undefined_names(example: CodeExample) -> list[str]:
+    """`path:line:column` and ruff's message for every name the snippet uses but never binds.
+
+    Ruff rather than `exec`, because an `exec` sees neither shape of this bug.
+    Annotations: a plain `exec` inherits this module's `from __future__ import
+    annotations`, so they stay strings, and compiling with `dont_inherit=True`
+    only moves the blind spot to 3.14, where PEP 649 defers them anyway. Bodies:
+    defining a function does not run it, on any version. `--isolated` keeps the
+    repo's own ruff config out of the verdict, so a snippet is judged the way a
+    reader's fresh file would be.
+    """
+    result = subprocess.run(
+        [
+            find_ruff_bin(),
+            'check',
+            '--isolated',
+            '--no-cache',
+            '--select',
+            'F821',
+            '--target-version',
+            'py310',
+            '--output-format',
+            'concise',
+            '-',
+        ],
+        input=example.source,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode > 1:  # pragma: no cover - ruff itself failed, not the snippet
+        raise RuntimeError(f'ruff failed on {example.path}:{example.start_line}: {result.stderr or result.stdout}')
+    # ruff numbers the snippet from 1; the fence line is `start_line`, so its first
+    # line of code is the next one. `indent` is what `find_examples` dedented away.
+    return [
+        f'{example.path}:{example.start_line + int(row)}:{int(column) + example.indent} {message}'
+        for row, column, message in _F821.findall(result.stdout)
+    ]
+
+
+def _name_checked_snippets() -> Iterable[ParameterSet]:
     for parameter in _doc_snippets():
         example = parameter.values[0]
-        if isinstance(example, CodeExample) and 'SpendLimits[None]' in example.source:
+        if isinstance(example, CodeExample) and example.prefix_settings().get('names') == 'defined':
             yield parameter
 
 
-def test_spend_snippets_discovered() -> None:
-    assert sum(1 for _ in _spend_snippets()) == 4
+def test_name_checked_snippets_discovered() -> None:
+    # Guard against a discovery break silently making the check vacuous.
+    assert sum(1 for _ in _name_checked_snippets()) >= 4
 
 
-@pytest.mark.parametrize('example', _spend_snippets())
-def test_spend_snippets_define_on_supported_python(example: CodeExample) -> None:
-    exec(example.source, {})
+@pytest.mark.parametrize('example', _name_checked_snippets())
+def test_name_checked_snippet_binds_every_name(example: CodeExample) -> None:
+    problems = _undefined_names(example)
+    assert not problems, (
+        '\n'.join(problems) + '\nImport or define the name in the snippet, '
+        'or drop the `{names="defined"}` fence directive if the block continues an earlier one.'
+    )
+
+
+def test_undefined_names_detects_both_shapes() -> None:
+    annotated = CodeExample.create('def report(limits: SpendLimits[None]) -> None: ...\n', start_line=40)
+    assert _undefined_names(annotated) == ['testing.md:41:20 F821 Undefined name `SpendLimits`']
+    in_body = CodeExample.create('async def start() -> None:\n    await workflow_handle.execute()\n', start_line=40)
+    assert _undefined_names(in_body) == ['testing.md:42:11 F821 Undefined name `workflow_handle`']
+    assert _undefined_names(CodeExample.create('x = 1\nprint(x)\n')) == []
 
 
 def test_snippet_problem_detects_each_failure_mode() -> None:

--- a/tests/test_doc_snippets.py
+++ b/tests/test_doc_snippets.py
@@ -117,6 +117,22 @@ def test_doc_snippets_discovered() -> None:
     assert sum(1 for _ in _doc_snippets()) >= 100
 
 
+def _spend_snippets() -> Iterable[ParameterSet]:
+    for parameter in _doc_snippets():
+        example = parameter.values[0]
+        if isinstance(example, CodeExample) and 'SpendLimits[None]' in example.source:
+            yield parameter
+
+
+def test_spend_snippets_discovered() -> None:
+    assert sum(1 for _ in _spend_snippets()) == 4
+
+
+@pytest.mark.parametrize('example', _spend_snippets())
+def test_spend_snippets_define_on_supported_python(example: CodeExample) -> None:
+    exec(example.source, {})
+
+
 def test_snippet_problem_detects_each_failure_mode() -> None:
     # Valid: harness imports that resolve, star imports, plain imports, and non-harness imports.
     assert _snippet_problem('from pydantic_ai_harness import CodeMode') is None

--- a/tests/test_doc_snippets.py
+++ b/tests/test_doc_snippets.py
@@ -26,7 +26,8 @@ deliberately continue an earlier block's namespace.
 
 The check reads names only. A snippet calling a method that has since been
 renamed is an attribute access, which neither this nor `_snippet_problem` sees,
-and nothing in this repo type-checks a snippet's annotations.
+and nothing in this repo type-checks a snippet's annotations. A star import
+blanks it out entirely: ruff downgrades `F821` to `F405` while one is in scope.
 """
 
 from __future__ import annotations as _annotations
@@ -161,15 +162,21 @@ def _undefined_names(example: CodeExample) -> list[str]:
         input=example.source,
         capture_output=True,
         text=True,
+        # A snippet measures ~12ms, so this cannot flake; it bounds a wedged ruff well
+        # under the CI job's own timeout.
+        timeout=60,
     )
     if result.returncode > 1:  # pragma: no cover - ruff itself failed, not the snippet
         raise RuntimeError(f'ruff failed on {example.path}:{example.start_line}: {result.stderr or result.stdout}')
     # ruff numbers the snippet from 1; the fence line is `start_line`, so its first
     # line of code is the next one. `indent` is what `find_examples` dedented away.
-    return [
+    problems = [
         f'{example.path}:{example.start_line + int(row)}:{int(column) + example.indent} {message}'
         for row, column, message in _F821.findall(result.stdout)
     ]
+    if result.returncode == 1 and not problems:
+        raise RuntimeError(f'ruff reported a violation this cannot read: {result.stdout}')
+    return problems
 
 
 def _name_checked_snippets() -> Iterable[ParameterSet]:
@@ -180,8 +187,23 @@ def _name_checked_snippets() -> Iterable[ParameterSet]:
 
 
 def test_name_checked_snippets_discovered() -> None:
-    # Guard against a discovery break silently making the check vacuous.
-    assert sum(1 for _ in _name_checked_snippets()) >= 4
+    """Every block annotating with `SpendLimits[None]` carries the fence directive.
+
+    A count floor does not guard this. Eight blocks are marked and only four were ever
+    broken, so a floor of four is met by the four that were always fine, and #690's own
+    bug ships green. `prefix_settings()` is a free-form `key="value"` parse with no key
+    validation, so a misspelled directive reads as no directive at all.
+    """
+    marked = {parameter.id for parameter in _name_checked_snippets()}
+    annotating: set[str] = set()
+    for parameter in _doc_snippets():
+        example = parameter.values[0]
+        if isinstance(example, CodeExample) and 'SpendLimits[None]' in example.source:
+            annotating.add(f'{example.path}:{example.start_line}')
+    assert annotating, 'discovery found no `SpendLimits[None]` blocks at all; the check has gone vacuous'
+    assert annotating <= marked, (
+        f'`SpendLimits[None]` blocks with no `{{names="defined"}}` fence directive: {sorted(annotating - marked)}'
+    )
 
 
 @pytest.mark.parametrize('example', _name_checked_snippets())
@@ -199,6 +221,17 @@ def test_undefined_names_detects_both_shapes() -> None:
     in_body = CodeExample.create('async def start() -> None:\n    await workflow_handle.execute()\n', start_line=40)
     assert _undefined_names(in_body) == ['testing.md:42:11 F821 Undefined name `workflow_handle`']
     assert _undefined_names(CodeExample.create('x = 1\nprint(x)\n')) == []
+    # `find_examples` dedents an indented fence, so the column has to be shifted back onto it.
+    indented = CodeExample.create('print(undefined_here)\n', start_line=40, indent=2)
+    assert _undefined_names(indented) == ['testing.md:41:9 F821 Undefined name `undefined_here`']
+
+
+def test_undefined_names_refuses_a_verdict_it_cannot_read() -> None:
+    # ruff exits 1 on a snippet it cannot parse and emits no `F821` at all, because it
+    # cannot resolve names in a file it cannot parse. Returning `[]` would report that
+    # snippet clean -- and so would an output format that has moved.
+    with pytest.raises(RuntimeError, match='cannot read'):
+        _undefined_names(CodeExample.create('x: Foo = 1\ndef (:\n'))
 
 
 def test_snippet_problem_detects_each_failure_mode() -> None:


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Refs #690 -- deliberately not `Closes`. #690 asks for two things, and this PR does the first.
Closing it here would delete the only open tracker for the second.

Opened by @Neallin-917, who fixed the four doc blocks and wrote the first regression test. The
maintainer commit on top merges `main` in and rewrites that test; the body below is rewritten to
describe both. `393cb011` is unchanged.

## What was broken

Two `spend` snippets annotated a parameter `SpendLimits[None]` without importing it. On the declared
3.10 floor a copied block raises `NameError` at `def` time; 3.14 hides it because PEP 649 defers
annotation evaluation, and 3.14 is the dev interpreter, so CI stayed green over a real break. The
admission snippet also awaited an undefined `workflow_handle`.

## The doc fix

- `SpendLimits` imported from the package root in both blocks, on both surfaces.
- `workflow_handle` replaced by an injected `start_workflow` parameter, so the block is a complete
  function definition rather than a fragment.
- That starter takes `Callable[[], Awaitable[object]]`, not `Awaitable[None]`. The narrow form
  rejects a workflow that returns a value, including this repo's own `CountingWorkflow.run() -> str`
  in `tests/spend/test_temporal.py`; pyright reports `"str" is not assignable to "None"` on the
  narrow signature and accepts the widened one.

## Why the test is a ruff call and not an `exec`

`exec` sees neither bug.

- **Annotations.** A plain `exec(source, {})` inherits the test module's `from __future__ import
  annotations`, so the annotation is a string that is never evaluated. Compiling with
  `dont_inherit=True` fixes that on 3.10 but not on 3.14, where PEP 649 defers annotations anyway.
- **Bodies.** Defining a function does not run it, so an undefined name inside one is invisible on
  every version.

Measured against the pre-fix snippets on 3.14: all four blocks pass both `exec` shapes.

So `_undefined_names` shells to ruff with `--isolated --no-cache --select F821 --target-version
py310 --output-format concise -`, feeding the snippet on stdin and remapping ruff's line and column
numbers onto the markdown file. The verdict comes from `--target-version`, not from the interpreter
running the tests, so every matrix leg agrees.

## Why an opt-in fence directive selects the blocks

The first version of the test selected blocks by the substring `SpendLimits[None]`. That matched 4
blocks when this PR was opened and 8 once #547 landed, and two of the newcomers build an `Agent`,
which the `exec` then tried to construct without an API key. A substring selector tracks whatever
the prose happens to say.

Blocks now opt in with a `{names="defined"}` fence directive, read through the existing
`CodeExample.prefix_settings()` -- the same free-form `key="value"` parse behind this repo's
`{test="skip"}` and `{lint="skip"}`. It moves only when someone edits it. All 8
`SpendLimits[None]` blocks carry it.

## Alternatives rejected

- `pytest_examples.lint.ruff_check` only emits `--extend-select`, so it runs ruff's whole default
  rule set over doc prose, and its line remapping does not line up against ruff 0.15.
- A subprocess per snippet costs seconds each and still cannot run a function body.
- A hand-rolled AST scope walker reimplements what F821 already does.

## What this does not catch

Undefined **names** only. A snippet calling a method that has since been renamed is an attribute
access, invisible to both this check and `_snippet_problem`. A star import blanks the check out
entirely, because ruff downgrades `F821` to `F405` while one is in scope -- no marked block has
one, and selecting `F405` instead would fire on every name after a star import including the valid
ones. And nothing in this repo type-checks a snippet's annotations, so the `Awaitable[object]`
widening above stays a review-time judgement. "These blocks are tested" does not mean "their
annotations are checked".

## The repo-wide sweep is a follow-up, not this PR

#690 asks for the other pages in the same PR. It has to be a second one, and the reason is
measurable rather than a matter of taste.

A gate that scales past these two pages needs the rule "on pages that are already import-clean,
imports do not carry forward between blocks". Accumulating names across a page without that rule
passes `docs/spend.md`'s `status()` block silently, because a block twenty lines above it imports
`SpendLimits` -- it fails on the exact bug #690 reported. And the list of import-clean pages is
computed from this PR's own output: the two `spend` pages only qualify because this PR fixes them.
Inside one diff the ratchet races the diff. The follow-up's mutation test is "revert this PR", which
only reads as a regression test once this is on `main`.

That work is #706, which reopens once this lands. #690 stays open until it does.

## Verification

Run in this worktree at `9114ef25`.

- Mutation check, both ends of the matrix: with the doc fix reverted,
  `test_name_checked_snippet_binds_every_name` fails on all four blocks on **3.10** and on **3.14**,
  pointing at the real markdown lines (`docs/spend.md:110:26` for the annotation,
  `docs/spend.md:283:11` for `workflow_handle`). Restored, all pass on both.
- Second mutation, from the review below: dropping the fence directives **and** reverting the doc
  fix. That passed the whole suite at `d779bacf`; `test_name_checked_snippets_discovered` now fails
  on both legs, naming the unmarked blocks.
- The four fixed blocks executed standalone with `dont_inherit=True` on 3.10: clean.
- `uv run --no-sync pytest -p no:cacheprovider tests/test_doc_snippets.py` on 3.10 and on 3.14, plus
  `tests/test_docs_parity.py`, `tests/test_skill_examples.py` and `tests/spend`.
- `uv run --no-sync ruff format --check .` and `uv run --no-sync ruff check .` repo-wide.
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright tests/test_doc_snippets.py`.
- `docs/spend.md` and `pydantic_ai_harness/spend/README.md` take byte-identical edits.

## Checklist

- [x] Linked issue exists and is referenced above.
- [x] Tests added or updated for the affected snippets.
- [x] No changes to `pyproject.toml` or `uv.lock`.
- [ ] Any AI-generated code has been reviewed line-by-line by the human PR author, who stands by it.
