### PR TITLE
Import `SpendLimits` in the two `spend` doc snippets that annotate with it

### DIFF
--- a/docs/spend.md
+++ b/docs/spend.md
@@ -107,6 +107,9 @@ SpendLimits(budgets=[Budget(usd=Decimal('100'))], on_spend=show)
 `status()` reads the same numbers without a run, which is what a cost display in a UI wants:
 
 ```python
+from pydantic_ai_harness.spend import SpendLimits
+
+
 async def report(limits: SpendLimits[None]) -> None:
     for status in await limits.status(scope='acme'):
         print(status.budget.name, status.spent.usd, status.exhausted)
@@ -277,10 +280,17 @@ What bounds that is settled under "Sharing a counter across processes" above: ho
 Refuse the workflow **admission** before starting it instead. That is why `exhausted()` works without a `RunContext`:
 
 ```python
-async def start_if_funded(limits: SpendLimits[None], tenant_id: str) -> None:
+from collections.abc import Awaitable, Callable
+
+from pydantic_ai_harness.spend import SpendLimits
+
+
+async def start_if_funded(
+    limits: SpendLimits[None], tenant_id: str, start_workflow: Callable[[], Awaitable[None]]
+) -> None:
     if await limits.exhausted(scope=tenant_id):
         raise RuntimeError('daily budget exhausted')
-    await workflow_handle.execute(...)
+    await start_workflow()
 ```
 
 `exhausted` rather than `any(s.exhausted for s in await limits.status(...))`: `status` omits

--- a/pydantic_ai_harness/spend/README.md
+++ b/pydantic_ai_harness/spend/README.md
@@ -105,6 +105,9 @@ SpendLimits(budgets=[Budget(usd=Decimal('100'))], on_spend=show)
 `status()` reads the same numbers without a run, which is what a cost display in a UI wants:
 
 ```python
+from pydantic_ai_harness.spend import SpendLimits
+
+
 async def report(limits: SpendLimits[None]) -> None:
     for status in await limits.status(scope='acme'):
         print(status.budget.name, status.spent.usd, status.exhausted)
@@ -275,10 +278,17 @@ What bounds that is settled under "Sharing a counter across processes" above: ho
 Refuse the workflow **admission** before starting it instead. That is why `exhausted()` works without a `RunContext`:
 
 ```python
-async def start_if_funded(limits: SpendLimits[None], tenant_id: str) -> None:
+from collections.abc import Awaitable, Callable
+
+from pydantic_ai_harness.spend import SpendLimits
+
+
+async def start_if_funded(
+    limits: SpendLimits[None], tenant_id: str, start_workflow: Callable[[], Awaitable[None]]
+) -> None:
     if await limits.exhausted(scope=tenant_id):
         raise RuntimeError('daily budget exhausted')
-    await workflow_handle.execute(...)
+    await start_workflow()
 ```
 
 `exhausted` rather than `any(s.exhausted for s in await limits.status(...))`: `status` omits


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Two snippets in the `spend` docs annotate a parameter with `SpendLimits[None]` without importing it, so they raise `NameError` on the declared 3.10 floor:

```
$ python3.10 snip.py
NameError: name 'SpendLimits' is not defined
```

3.14 hides it -- PEP 649 defers annotation evaluation, and the dev interpreter is 3.14. Both blocks appear on both surfaces (`docs/spend.md` and `pydantic_ai_harness/spend/README.md`), so four blocks change.

The admission block also awaited an undefined `workflow_handle`. It now takes the starter as a parameter, which keeps what the block teaches -- check the budget before starting the workflow -- and makes it runnable.

Verified on 3.10 against a stub package: the previous form raises `NameError`, both new forms execute cleanly. `ruff check --select F821` is clean on both.

## What this does not do

Closes the concrete half of #690. The test-side half stays open, because it is bigger than the issue implies. `tests/test_doc_snippets.py` parses each block and resolves the harness symbols it imports, and deliberately does not execute -- so any missing non-import name passes on every matrix leg.

I measured what turning that check on would cost, across `docs/`, every capability `README.md`, and the root `README.md`:

| scope | snippets | fail `F821` |
|---|---|---|
| all non-skipped | 449 | 99 |
| only those carrying their own imports | 392 | 42 |

Most of those are continuation blocks that deliberately reuse `agent`, `store` or a name bound in the block above, which is an idiom the docs use throughout -- not bugs. Even the narrower heuristic leaves 42 needing a per-snippet judgement. So it is a triage job with a design decision attached (an opt-out directive, snippet grouping, or executing them), not a flag flip. The numbers are on #690 for whoever takes it.
