### PR TITLE
Decode the brotli-encoded cassette bodies, and guard against a recorded encoding no stdlib decoder handles

### DIFF
--- a/tests/coder/cassettes/test_coder_integration/test_coder_completes_task.yaml
+++ b/tests/coder/cassettes/test_coder_integration/test_coder_completes_task.yaml
@@ -184,21 +184,7 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        UEkAAFBVVVX9n+5yDcsMN3c3CzcDqIO5ubuZhbtb+GLu4WYJBQZqZmLm6qamam6m5uYL+AAcjAWR
-        mCQGuNPm6PEvqESGDExIGeky/JOThOEfDRSgGZhQtUU8UFUbR36Q7rm8OKFT1MnIXq0FKCAfNYIJ
-        FbYtKRAUaARDMIG0LW0l4RIUSAWXyCWY/14gHzWCCfJMeUl5AQrIM+Ul5QWYAAq0tOBEdg2CCbbl
-        7eveW1Jr7s2nhb0srVI9/XyimOLe0Qaudd8cbVbpnnt8Ptuv6NGs7edpUt6iIGE+P/yud/3m6OYY
-        nPxy6k0+yq9+Ox9Mkttot4yq87rWak1114V2SZyFGjkHGVULmjgH6QfFdFucB8RhHRmyLlJF6c92
-        5ygIR361lj/BYRzRwSCaheNVUN7Xs0JGvwv287tj/tB7+peIzoveoZ5hjHJtVG4+8HCwyGwauJWv
-        5RPrmH4TWufU6+2PlbB2x1stjkbgfN71fb7c1GrafVWhvPULf7xMpL4Nk4WWXD39UyvG7tCTh/H+
-        O7wKYS/L/ksLz9uxXs3zo1dbq8Bd0J3oh5Nd+bMyBq0aGjNZ5vfuqRtau8nK0ApOd0ffXnK+psNu
-        1t9d41sOw+J49aMjs5rn/rbvq4kmKPE9V5W6ZWiONf8P3srLRWorBIu7Fj2XPupSCNbFA3V6XT0f
-        F5eT/NQH94297139noMCnFQIJlB+Qy5F84hJgVzGqeAS7xIUoLzuJJivtwIpYQwbMF8gHzWCCRlt
-        MJXwfisvkA+LqEDfzys6Sasdh/P9+PdZ2OMs9NeAZoy2Ms6MaaNoHuYukqEm8gwm/IW3VYTlfwVa
-        Keq4QdIKTgu1GMEqw9LitUOeIpi8Y0yFthlKQlmLiO58GinmywJqkViKEnkLpq7qYwVSkp4xThsk
-        kgoeayZuQDhRgyRTL0z/0gLmC7A+Y4UNYbFW6WOAFpRUzx55KyA6qZhShm6AvYl/+c9CVccmmKrx
-        VqDF5kZTjCXFBkxoJeEZaTJnH6k5NshTjAsUYELBREIYvN8D
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NTcSntjGYGgpb3CLMo","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"CAISpwIKiAEIEBgCKkAk1XO/eoBeSG50HAxPVClm6IHVzzs7ZyrMCzX8kvZTblNnUWMRwPVHfeTXNkBI8+k7wQE08bv3RKZmhMp5p51HMg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgwGiI993f53kP+eUUAaDBTHmN5f8AVcJaipfiIwC+LoARVvpoV9TG/x6SfKPp1cu7mYtvwFN4Kbt6QYbF5bqI6/5g4H2ItU4SJYqooCKkw75YhQ46mEfVIpALTHFiRow28RkOL90s1Y9Dtkfxuz695sPdkYATXxG6QjfnMi2uDwxH9Jt2YgVqNZVlArzSvSwm85oiaNIH1t6A95GAE="},{"type":"tool_use","id":"toolu_01BqLzyjHnafXwTxPCSwH6xf","name":"inventory_agent_context","input":{},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01JzqeGbs5V2ES4WzgC4dYNM","name":"list_directory","input":{"path":"."},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":6164,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":96,"output_tokens_details":{"thinking_tokens":19},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -234,8 +220,6 @@ interactions:
       - a2b322bf8b826f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -449,18 +433,13 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        cEYAAFBVVVX9n64KclZPCM/wCAjXW0RkJmRkJkQmRHoCJGRAgIG4qpiZQKiJaqqIeoangw/AwVgQ
-        iUligDtt8vYTLCVRhgAxY0+0GnGfaXUFHjhBgEWn4WK9vqfLx93b5n+yp91mf3MnN/XjDB7sWAkC
-        LKSKE4GHVjJBAFRlNRQDD7GIkRiE5xPYsRIEsFLy0JXATB0KKyX34WL9W++2n7e77Yft19vjp/3m
-        z+Pt3Y9f4EFwIQjwr7HRUDMKeGCp3SCcgI0WhfB8Mt0D1vDUxTXCtCqSjy6WpaLxnjPb0bEcSI0n
-        NC7iyuhsJlf7PnN0Su3AkbyLRbQv1NS72viA8ehqyRyP3qEk10gSNWpuX7okbEwKHtTQukIAlqG2
-        MjVSBQ8YjQ80jKUtEOBBDqTGExrL5GJZLK8gtLcRI8HZ21D4HpaaaSEx9+Xn90dn/tCiJDeWtqA5
-        pUyRl8ZiI4K10e3+24N3tZHy0MnkjN7MJRqxZ6OF2aGP9zTjgUsDW/HlSpJYJrANYRYlh2UihVmK
-        J/VaSzN7KLS3KTkjNXVjaVYYe66izepYYn7nWIyaYHal2orFayi7dXFNisees7G8stPORhYbfTtS
-        Y5ng/HL2EDFnahA8xahN3CganM8vHtRKHRqhFvEoxQweqWCVYVH620kiQZCeswptExlyVkR09w2k
-        hJPHGdmDlVcShXB9fX3pIWKcaYiNPDxTDJqJuyCcqBEm9cL0Ly0QTkB1poUa5uFq0ccALSi5nj1y
-        9lC6KbbV+8sNaoDNBeUENrO8skyqhRhFqFsM7WBMDQKooSRsyb+M1JEaSaRhogIBplz2mOF8NgAD
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NTx4zdtRT4b8Bn8pEh","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01XsB9H9T9D9KAyFb4ZNABPU","name":"write_plan","input":{"items":[{"content":"Run
+        read-only compatibility investigation of the public service, consumers, privacy
+        policy, and renderer boundaries","status":"in_progress","active_form":"Investigating
+        compatibility surface"},{"content":"Implement JSON renderer and format selection
+        in service and CLI, preserving text default and privacy behavior","status":"pending","active_form":"Implementing
+        JSON format support"},{"content":"Add tests for service and CLI paths incl.
+        internal opt-in, and run the full test suite","status":"pending","active_form":"Testing"}]},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":6663,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":234,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -496,8 +475,6 @@ interactions:
       - a2b322dc49e36f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -728,41 +705,33 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        wMcAAFBVVVX9n64CeukIKAv3WDzCI62hoMHD91jcI8LdwzO8vcFD3VTMTMPURDVUxczdMiAA+nLo
-        w+HUVFVVVf93vx/9eBU11YOaux3MwexgsBzczC9u7hc1Vz+4G7iCHR3A7w5+9JPf/XC05WLg7gBu
-        Zu4HO5q5H05+OTj4ycEB/HD3w/XgVFVVVf9g4K4ABuDgdhLdWISFxfQP71uUVqERsUiMrBSepXJv
-        8OxaREIrEYsyZLvzi4s+Xs1W94/P/pb7z829fVwsfn+KSHDjUMSixBBkhiIS3hoUsZAh6MCSWEQi
-        scRILOJ/fwtuHIpYcK6p0JSJSHCuqdCUiViISASdkeTKo4hFvzdddHvTB90bTod3Wf+h6I/Kxcvk
-        8em115Pt+n6xOPiRSt736+QqPNHln/ldtZ9txr3nv27a85d1e59qs+p272U2m/RXo4fy4XozeZtc
-        v4b1/cHNuu3nJz4/PGXXn/vx6GIzXvGmHOn9eMWzZXb3kuXncmwqeWmqzYUtZoPXfLN8v5qVTzxf
-        rjobfX6+Gbx3HpfF8WmQ8WY9MvP1q5ldTv/MPjd6mB1cd55lb1/rvJ52mk9/kINh8nkvi2FRrO42
-        f4YTvZgeHrrLtJfTMvwaL9ulkuN6UJh3TF5Hb1fZtJ0t5itc9eswma11/6/jy82KFovh+ep31nkc
-        doc3D65393RVPySFl0UIdbjl62E1nty2J/znpui0X+iZ3qavYVFMxp358cJfdv+U+8H+vvO1eG5+
-        GUpuzHVv4H+98Wi4nm9SNTB0Nbot/Pzra/qs6ircNJ3x5LMzXT+lPFotPidXX5Onp8ERf+/T92X3
-        8iaf9G+v5PROLjPNg89m/DDuYr54G7V7s+lL52jvijRM1yH9VT3+1XxumpWvll83nd/1+qjf7se9
-        4d/iJ/oW3DgUsWA8sogE45FFLJY5gkdnQQcIpTTmn+DQA+cILEMRwfQfxoBCg5lkBM4RPEp1Zsk0
-        kNjSSdZ7bTQ3oKnGwDqTrC0BW+AcAY/OWI8eQrU/kxkSt8RP9C24cShiwdaaXRVQREIr8blNtTu/
-        uHu9vn2um8evr/vq4vGdf/c3nduNiATJEkUsFKiyO5ahEJHQ5CoW8beQGRLvRhp4dAAMEYm/HYtX
-        /OuaasSN2xQkhFIaA88N55bAo7NwkmqDIYbE6JZrIlAy5HsrvbIMdYaB71lNiVZIHC7GWaOT5mID
-        +lon2JIZj7zzSAo9emsrmM762Y/7OuwNnoatUkXQGw9ny0WrVKctGFiYzZdQWqXTBiQ1nGvKWjAF
-        ZyQBW5BKgYRSJrkmPPMoldwbhJP7xXx2Cpoggmc1eYbU+lIyIClgC0gqgkOOHiGRxqAPYFMGOVft
-        jU4cKQ+SFPQfpyCVdIweEkngZAhrQujv8fdWfAZLWxGB81ZViaYM7hfzGRw05yAJPhAVCR8gvZcN
-        2BTs/hMTDgPZD9Zs8GPPyh8Ba/Samw/QBJpcxWC9Qh/BIdcGI8tAYNkE2FMKU1kZNy+UpACPOrCm
-        DDQxepLmDEUj4LyuZdLAHnNZa+tBB3AeA/oaVWtLW3qNWn8vkwLgPvGWLlqwDFAFJPYNOKuJT8Jp
-        DHiUCUNaUZJlpASfCBE46WWJjD5EmNlamgpD1I555MoTcOMwgKZtvkXLNa0tXbagZwwklkJVog9t
-        3lY7yd9MxsDhNIbcHoBzbBKhCGiO4JBLBumzqkTiMMB0MiCFH9hHeHSYxMn+/3//l6RvBc4lw8FW
-        RsHeoyxAp8HotP1PDJDkkjJsbekqvBI1SExBMDbTCWiymS3XhFg1DXLMrSDFkiA9QqoNo0fV1pSY
-        SqHySt+KSddZx2eatgKMtUUAowuEE4p2gGSJPGnh1HkfegRNIee0Q6Npx3RNGeTSOaQAJzxYdQDp
-        e6etLXUcxeYg7G1FSvqGhrBKkQQH64sQgeYggaeUZAkhlw7hJPW2dN1pueZ09NhW7ColIOiwgZ5j
-        duQIaDDh0NZU2wIDaCaQarJdjyBXiAGPmQ7sG9AIiC4+l14lVqH615aufcJIEEY4/yDZoi4aqMuT
-        ajQqRIDBYaKlMQ0IXotA6wgwYSk1NTILrS3dtGCoZchaICGkhsoxx1jQ4MwPNGBsUoCm1pa6Lej5
-        JNeMCVceIbFUI7G2FECXzmhUsG+qr9IuyTycKFtKnYURENBJLxmBA6gaKvHrRI4suq/VSDIInMto
-        bOXBY2LLEklNcyG1PrFkWS5xCsAsiQlEGZQTmqsqwugagS2kWopCqXMC+8pJ/0FzbisWoKspg3oB
-        1a3Gl8oygkeDtSSGxCqEQNo55AA1+r1kXUKwMC32i7p0BkskXln2L5s5TRlgjV73Xkv8RGIrS8Tf
-        J9NPUdpjwuLn5z+RCGzdzqMMlk4B0Hkg4FeFlKCIqTKmg1fIUpvwpdWpuBd/v/rz7tgWSEHEF9ed
-        SCQyyXGXeAzvkt2oQfe886tt8yjV0z2/8RIvE/G3QJdjiV6a3XU5By0pDGp3kTvnP5FQIzFv6l53
-        m+Ch8n1sl7onRdw5/4mEajN3rNGLWASWpKRXZ59zU/RICe4ytCIWmbF7acTPjwED
+      string: "{\"model\":\"claude-fable-5\",\"id\":\"msg_011Ce3NUJLPr8tCPyJoLSSXj\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"CAIS7AIKiAEIEBgCKkCFmSQHLMRAAa/vJSSwrFdcYbWc3sMn2zOBubNZGAP+6/OQW/bfilU77JagNHCUFKmK5ZHVH5RsWJwpN7/PMt0wMg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgwp7OggVqWhvI4yjrwaDEcjJakEkkUBZzEHiSIwK7TfAhnTs9GT/mdaGvDklYecRFV3gI/gSOUeUCvsHNWiC+xQ6UnSSE0UXg4LE7E6KpABM3vKckrakssvs8t5EuGH8/Htz6k4/QnPnVIRsSkHG4Ox1r27zmbDbJ4qSPy9lnc6l5ADr9VtFEWOZfdDln3F8krOqqIPdvus6y4GHj4IWMftFUSjH3qHMMDxeXbfYT726hHC83aIBaTgitDjyGKG7ehSVF/ANIQ4xoBkfsIWsf9uL+yjZyUruTq64XvWxiVJGAE=\"},{\"type\":\"text\",\"text\":\"The
+        repo is small; per the task, I'll delegate the read-only compatibility investigation
+        to the explorer sub-agent.\"},{\"type\":\"tool_use\",\"id\":\"toolu_01BR58PvyLqqJu1LYtXCZ48Z\",\"name\":\"delegate_task\",\"input\":{\"agent_name\":\"explorer\",\"task\":\"Read-only
+        investigation of a small Python repo (files: cli.py, dashboard.py, digest.py,
+        incidents.py, policy.py, service.py, text_renderer.py, test_reports.py, README.md,
+        AGENTS.md). Do NOT modify anything. I plan to add a machine-readable (JSON)
+        incident report format end to end, where callers of the public service and
+        CLI adapter can pass format_name=\\\"json\\\", producing JSON with an `incidents`
+        array of objects with `title` and `severity` in input order, while text stays
+        the default format and existing internal-incident privacy behavior is preserved.\\n\\nReport
+        back with:\\n1. The public service entry point(s): exact function signatures,
+        parameters, default values, and return types in service.py.\\n2. All consumers/callers
+        of the public service (cli.py, dashboard.py, digest.py, tests): how they call
+        it, what arguments they pass, and what they expect back \u2014 anything that
+        would break if signatures/defaults change.\\n3. The privacy policy logic in
+        policy.py: exactly how internal incidents are filtered/included, what \\\"internal
+        opt-in\\\" looks like (parameter names, defaults), and where in the pipeline
+        filtering happens (service vs renderer).\\n4. The renderer boundary: how text_renderer.py
+        works, its input data shape (from incidents.py), its output format, and how
+        the service selects/invokes it \u2014 is there a format registry or is text
+        hardcoded?\\n5. The incident data model in incidents.py: fields, especially
+        title, severity, and internal flags.\\n6. Existing tests in test_reports.py:
+        what behaviors they lock in.\\n7. Architecture conventions implied by AGENTS.md/README.md
+        (domain policy separate from presentation, preserve public defaults) and your
+        recommendation for where a JSON renderer and format selection should live
+        to fit the existing structure without breaking callers.\\n\\nQuote relevant
+        code snippets verbatim so I can implement without re-reading everything.\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":154,\"cache_creation_input_tokens\":7049,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":7049,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":757,\"output_tokens_details\":{\"thinking_tokens\":40},\"service_tier\":\"standard\",\"inference_geo\":\"global\"}}"
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -798,8 +767,6 @@ interactions:
       - a2b322fa29d56f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -921,15 +888,7 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        8CwAAFBVVVX9n+581khwj4Bwj9RbQmZk5CEzwDPTMiAgEgIUJFQlzBRCTcRCVSwyLQxsAA7GgkhM
-        EgPcaZO3rxg1cYFHLDQnPnump8Jnl3DICR5j68Nuv//MF7d3n/585PSQRX8t3+z1a4aDLRPDY+TW
-        qGc4VC0MD2otNyMxOEQVYzH4vytsmRgeplrC3BhmynxNtcxht795+NJ193d1GH5+P9533fX7Mb2f
-        4CA0MjyyvLGY1iVQz2Ihqhj/NzhkmWaDXzeHSKVwhV9hixUWTSlXjoZtc6tFVKCr0z8+/bb5YEuS
-        W6rtgn4cOkBNyc2CMW3Uupi7CMdENsDjA6wiLI8OzXQKlamp0EItRrDKsDR+nVkiw8tcigptExvl
-        0hDRs/OW4lcLqEWC6QtLgz8/3105RIoDh1iZLKsEzcTtCCeqTEm9MP1LC/wKngYeuVIJl6M+BmhB
-        yf3gkc1BZ1NMqePBAHsLygobsrxk6VULMUjkNq5vOXKwzBUezUgS1eToI/WZK0vk0LPCoy/6RAXb
-        ZgAD
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NVAU9edZinoRyHtqFi","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01GZDTTXVrhhQL7XTTEz7dzP","name":"inventory_agent_context","input":{},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_018PwePStu6tydnNars3aM6T","name":"list_directory","input":{"path":"."},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":2208,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":76,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -965,8 +924,6 @@ interactions:
       - a2b323437dd46f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -1094,18 +1051,7 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        AHEAAFBVVVX9n+5ytggI8yXcQm/mbubusJiDh5mDZ4QlJBioqYqbabqaqoWqmoWbOfgAHIwFkZgk
-        BrjTJm9/QKM5SiDAJO04vlxpKfFlDh4IDgQaWxVvvr/C6fGSXtRpvupdX6qPgH2/gwduaBEINGgt
-        rRA8MFoiEKDWCuuocuAB08qhckD+PsANLQIBp7UsOotgpsTutJZd8eafze7Qv/v71TEMt9P0PEky
-        dg3AA0UbBAIGKS+uQuqcfFTbOSAPaKmrgYBF0wuGr+0ATw8YlRINENMGhwuDzMHz6Sk2IiupRljZ
-        20zbrGRqXXe1cfg5nf3/Bew3k8IqqhG+M1rFpqfxx+Ksk+t9NYsW/hzwvzm1damp4Ww1xna3nFXZ
-        4OrdbaxO3+Ux26s/I+C+RYXWEdUIm3uzVTvK/eXYi6m55H39Gy0B7rrVUrChGiHsd9l+GwepnXxe
-        D80iGHIW3AH/WygmOCpnwWqEY7Tdlrdm2eeDxXqfrXGpxjVQ/HZ4d4VBxdGgsZ5qlI09/pyqaFm7
-        0opwlyfDAQMBgLL2v9XG0VQjfKXitvZH7Y9xes8vVOezeZQA/msah1ESvzYcrkYIMPpapSEdE73p
-        aH6amslPcgC4WriJj+csLP88sE63hUFqtTK/UFiwyrBY/OlQMQSiOilVaMvRUSEtIroLXkshDwup
-        RQqnb6gskMl7sPCAUVZjwQxSJ7QqNBP3Rgi2HSNRL0z/0gLkAdjW2KChspg3+higBSX92iNPD3Tn
-        FNtqFkxQA2wuKA9wtVA3oSrVQowiNLwQ2sIJNEDAOqo4NdwdROoVDSqGRYUaCFRSl1TC82kAAw==
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NVRVnP5Cvtvbn98cY6","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01TrJLv61KCNAAH3RT2MScf8","name":"read_file","input":{"path":"service.py"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01Csk4osSbcnFhuhrteQ34jw","name":"read_file","input":{"path":"cli.py"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01YSagErvaE97ToMfxC4D715","name":"read_file","input":{"path":"dashboard.py"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01HJB4gSythJkzgPYbNSKnWz","name":"read_file","input":{"path":"digest.py"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01GxmHnJad1Bzvi3rVZvhwDB","name":"read_file","input":{"path":"policy.py"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01AvJSKHE8Rs2QfLm78yZc8x","name":"read_file","input":{"path":"incidents.py"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01NDHHbkmBvZysehKSFeBnzF","name":"read_file","input":{"path":"text_renderer.py"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01GsNqPgDBhtbsiAJZMyLe8i","name":"read_file","input":{"path":"test_reports.py"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01XRikF1zo1zERxZVaoZ45DM","name":"read_file","input":{"path":"README.md"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_018eDXCRAazMoGuaZP3r2qML","name":"read_file","input":{"path":"AGENTS.md"},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":2687,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":482,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -1141,8 +1087,6 @@ interactions:
       - a2b3235928c76f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -1315,75 +1259,109 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        0C0CAFBVVVX9n64Clgd3tzK3CM+MjMywgmjoyAiPSM+I8Ih094hIj7QAVzVTMTMNVxO1UBVzd8uA
-        AKhTA/S1oeDet77c+3RMqqqqqv97HvJ+yMshTxdhUT2YudvB3MwPZuEXM/c4hHlefMmDe3iIqXlG
-        eLhDAARA5CHyGA5xSIhTekRe8mwe4YcIjzh4ZF4CMhMgI/Oah7NDZEICJOQlAPJwy9MpDpd7UlVV
-        Vf2nR2a4ewJ4eCSkq5mqioiysIiKx3/vr0FtFZogCXIjW4XDQmYGhx+DKNAqSILal6v90egUP0zv
-        vSxHt1fz5+z6+vJ2tr0OooC7BoMkqNF7WWIQBc4aDJJAeq89S+IgCnJLjMRB8vM14K7BIAm40rTW
-        VAZRwJWmtaYySIIgCrwuSXLrMEiC05PJ/Gg7udQn48n4S3l6uT67XY7qTflxdtuNNsvi7srNv066
-        m73F9dfHqWxHI3d0f/B484O3nz4t33/+fHY01d8OJ/nn6bddR/pkfTC5PLn79iu7vrjPl/XsbDkq
-        Ph1clx+fs4vz0ePFHT/W5zq7uOPpovzyvaz25YVp5XvTPo7seno2qx4Xyw/T+ppvFncHj3p///Fs
-        eXC1WO+uz0p+fDg3Nw8zM30/+TV9ftTjcjee7R5Gpwf7i3q7/7hPY3l2my1ao+jr15u9bKIPutPJ
-        drZH2/NDVXQ13l0dTo+uxwWdzw9ePmTt7tuJrI/c1c3dzcPs6GT2cLG/+2VvHn7ddz+Wl6duNHs4
-        LC4b/+Vx1ma+e/hwdvR9sf/4vFjeltnX9c2zOZUPv8qz8mH/vbLung6ev75MPrjTP4qb81/2i3m4
-        26NvLzS1D1+6z/s39c289kfyx+L5x9nItPt/PGT5cjk/nR09b+3s0xjNt+pxwvrg5eCgaW++3Mwv
-        Ll6uyk+T8Us1uvzqjPPz6aeve/ZonBfPi+r7r1Hlb2t+2GTrfHx/frm8z9b3VxqXdDXebMd4+rg/
-        /3CYZYcXW3O3t+Tvz93yB50sT74fHwdv0WvAXYNBEjDuOIgCxh0HSTDpbRAcSgVcISCxdggOGwt9
-        zT0PvpbGwO+//gbcoOug0Aah0OwhQ2O3gximljEBoWmDxNZ1K1ki8Sq3xLhjAb6yWw9hSBZyqzSV
-        Q+m99iyJwSO3DeBOe/ZhCH0R50a2CkUEIpYlEnsRgYhzq3AnIhBx6exagDQGBO60Z59AIY1HMYjA
-        W+AKwZLpILe0QWJtyUNua4TC2RrEycV4upjHtRIgSYGYjU/OrsdxrUScUkrD4TCllN69g1EMt21m
-        dA4e3UbnCEjsOmisJobff/0NwqPb6BzjphMppbSo0CFoD7iTOZsOLCEgseugsZo4mvUWGHcMDkmh
-        01SC9hCGlXQqtwpVGIJkPT4NSYEtQHOSUkpCiKbjylJK78Dj1CH0cc0+stAGBykVztagKdcKiT3o
-        urGOYdLI57Q11ui8u2/YaK8zg6uefGbCuOOVqD66Dmi7ZMW445RSSklhceB5h4113B+rPQGjPf8U
-        4Ds8RRBGoCk3rcKVJkZH0iSQWWvgGM6l8TiA4T/As0tSAgDxfDh+JQQVU2WMO/S40R4M2eaQW0ci
-        1xl33B/bGhiZIFCHMJxr6qwnYQiiy0PR8JgipSGI540FaA9r7LbWqaEl00WgsJCtYQ9sQQxTEdDv
-        I5e6t9JKIUHWfTUO4pSGMNN5owfh2YkYEErOeDNRWFdLXpGsUUAjnayR0UGHHIZYnU4WHJbas+vi
-        1C0WfR/DqSXf1uj8Xi6NQefBFphlYP77UkopDEVudNx0Igzh919/gwSuNEEjvR9y5WxbViCVbBhd
-        pHfNyxpVyUA/hmaUCiMwQtWC8DkslXqkF1MiOGypjxE95mavr5/SjfFrABwmFgjKGDITuIzLpcNQ
-        KOmrzEqnDNvp0Gj0YGkJvDA03B5hiC/v+BxAl0hSoOvG6Fyz6frzNR9sy03LkKGmkgNGDFYhJQ2M
-        qBS7y1UuneprxtpfXtw+Yxhrr/jrukTP9xLupC+CbmeBbXioCTZaQilLajWUeqK/vTqGubdG6KzF
-        PLhwLepSZfTccdBrlOTSGB+uyGUuci0J6HtE+P//DgfxAJ/3xaFcyxLBab/2oAvobAt5JalEyPE8
-        v7eMkU/CkGHEUqWXyBJ++Aw9kDXaPXn4/a//gKQOCLfg8KXVDhUrxBFYNykhQ0IGLJKA3Mouvp7H
-        uOMIMody7UEzEdW+WK6mI7V/EHjN6KH1iFVLWCdSlno+my9rBM1gHdRy/TKnsV6ztiTNDLUTY4CL
-        LpZEliXjHu4azBnEMloiMzBQ+WkC6tYzrBGb9Q01lVx5IRTWwbf5zRTYWujL1/M9O01lBGQZJCid
-        02w8lwUaaCImIJWi1s4EPDs4hjTpOj0NBEgPkkAqpYcyDvEfzN4OW80VSEMXYvY940MMt05vZN6F
-        8OT3X3+DeD0+bjoBfX0YF452MooC3rrN6Ab9Eh8TnqEPu8seuuiIo9KZ9MT44CPFn5+0DrphUPcJ
-        QBcfqrEYz+M/pU63MoRJu2IIV3voZtnbDMJAQD9C8grUoUKHLptCvwrIVaM36Macud1D02ZG55DZ
-        lpR0HWjKFE0wHNhzfQAqPteG88JbXSM2HjQ1LYN1Ch30jfYMua0bhxWS15agcejRSWG7hBJj7QrD
-        W3clmwbJg2Z7FmcOGNmhiyDDwjrktremqQzDRGRQ1giBpWvGcTwQUGjnOQKukKCSpOzeKY1Dqbph
-        IZSLCjcBsD0Bk9TRxTB7NcsD4QYdeESu1uv9nh5aMug92IZRgaYYlrZ1WDUenDvKELZMRnpfKWuE
-        reyg7zBHvUFFbOHUJI8rt/K1DMBbaLytrL2dr1AgW7a1ZJ1LY5KigQP5xbqTd6ZT6GwnNZ61qfm8
-        TmJoGOS0uovRo0cPgtrX6qUp9eJnq6lf9H6+asY69rhBp7mL26ZB1x+8PcHBZtZs8K3noK8y1s4p
-        gt7aEMJwgt7YV7LJow3yrAjoY4OJSkNEYdi6SUaoO1h8GUsIRhNCg+yweATi53x8P55NFsvV3e3t
-        eHZ6Mh+fPYG080QEIk1JDJ+tJlSj/+YcDeasLSVhCJwVg7113suur11ipenEOjg+omCLGyntcMtX
-        khTmzvCgGVrKLZF9YroYzucoeily95T2jeS8AmWj8oIMuNOeoUP+Ezrb9oyBDENGicqYSsArf4yR
-        0ABKsoTCEyRW9hntYZc6IxtyTUqyzE2aAIVFM1Dn/PPZ3i+c/YWU81C7Fo6xRqtBsRBtCmDyW/k6
-        wovIqTWkrPOphCzL/AmFRqN8AmKKgyICcT2EiEBcV0UMt5lEB+SWPLt2VXwQKpzf753cTkDZLfUi
-        6OVO+77bG2zU3NZT0ARg9OyJ6FSbPWPOHghRCWgJYOhHk4C+k1vqIR9ry6VHBTFGNdOaBx4kTzwe
-        gpACYilvU15ZneNwibK11GbaNfhTd6q+BK1RnRvaWmam67LeoFyDJraik8cphF3zMIYrm69RDTVB
-        hpXcaOv8r2GczQ5JvwlGldxo+PiuPaDBpw4rYwNYgcLCooUVL85orONVpRX66FxdZd0qBFt9QqtO
-        LSHSxAzlY6CavpbRieZfpN+bY+6QobKeexH0tjIZLPciYALg9tNUsfQeNRNce/UAjo+h9/N0NllM
-        Tk+unmDifrUbm0taZR+botgWi52R2aEbtHnXw8lsOplePMFkxdQjgY4NoClJaRQnMWKC0kAksak9
-        xvzGWdXm6CEMGXcchqgj93DDcK21CrvDUPvg97/+4waI7K5DpKeSMeZt8jOzZvB49D/gWXbXaXFK
-        72MY72TOs/Boo8RyVgT0nbOMisb+ItAEmZP5GtkP4pQ+xGIstXAtCnC4QWn0FFdyvHDWkuE+QDQd
-        o2cYvgjoN+jgpF6JLWH07h18qsLo2ma+JAUOc1vXSIobsHXUnSmO1i4RG55A1O0Gj410knHzliaX
-        UJJqLLtNTsuWC30s5vBm48IpXRRCezwgMToo81h5xaYYDQQPoESWOZiT6H2aINLa0XYlTxvNHbjW
-        oD/TAfnp0SNJAcq8ghMv4cxKetDswW4JqPNNtVWtwXhvoJcA+KCNXV7ToHSgCXBHcSrhtGRUL6Mr
-        QEwxHdiGPWgySLyoEG6p036FniWjhzQIQ1GjMEyDXetUrhAKzUOucBil8luHoNDrkkD7Wse6UQxh
-        OMVt/wkgnr2lvDJHhGEEtXbO7ggyMlMQjuRxH4CmvWfftrOCxfcDQDb6dJ69JfF39rO3FKu2bnz/
-        tTfEai+Bn2c3AAC89oJr3EtAp6WVCHp+SQdUg/2WrabverTg6W3wmrjtJwGACQPLNe5czEksfE+W
-        WClG0m7jjnJL7GTOIHPFUgypMW3YDPuL1gxz2XoEuQ1zB5rKuY7gSnvY/a1mlqshMGgUw5nNZU/C
-        YQhNy4Tkib0p1owtdb699aDfHP7+93/HZCIA5xz5PoYwTF0d8NtUetwdhtDnSnLPii+XBn5fSoMd
-        aPcghhOlQMJ7TLBWKzqoZdNUm1yHRqjjjpH2c6rqdS3IZL7eSqeGua0byTozHaoMeJbQhDh9fvVb
-        9FDpox+lGDL8A9dOF35O0GPccQ/wRHAP5H0N4ULLrmbj6dl4Np7Nf4o0+PQ2BwxE/7cv4zPqIc4f
-        FJ8BHA6k26Piln2soC1gQ1WIBDfouj1MRVPJmzvt1yJbudJU/gkVX7hXLHKjT0OBJUM0VwxOJmfQ
-        M1uclLspBeTjhOGicijLco6ITyp9scVeEP5LlYLBtX30+zAeCL07BxEU1m2l25gN5+oiifDowD2z
-        0WUS2zavwrBeR9sTWKTg24St+EK/8dzLOvIWNcFtmk16C+ugcIhAK+Krn3IQ14FqkjqYIwbXki3t
-        j45KxpWxhN6jVJZPGqldspswpHPyTSk7OoeXUn57lip1COuUjiHXA5nwGEfBtkJazW+lPdhaM6OK
-        g7enKPBsm5VD6S0FSYCkVtw6Cg7O8fjSIuUYJNQac6BdIUtt/B+r/dGLGyevgaam5RXbNZIPkoPD
-        z/tRkMu8wlXukCSHrE7T90M5lOq46v9HguQ1wKbCGp00q491H3HGE0dV+BYFCYVuHvf+09Hnm9DO
-        ef25ED7cGiQHh29RAIEvumKNLkgCz5KUdCqIAk0FOqQcVyXaIAlKYzNpgrc3AwM=
+      string: "{\"model\":\"claude-fable-5\",\"id\":\"msg_011Ce3NVsag1PLSjbMMKPRwM\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"CAIS9wIKiAEIEBgCKkDPY1mvg5RPy1vYfULrSHIyO/TMHZNau11r9V4ZOXtw77Y288D9NiJ6Ic8NJxyniAk4IKAUJzbMGVcYmRDY1f74Mg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgxERxW1C40Tmw0Z0nEaDPbTuldnHHO/bIi4yCIwR/nwF6dfymeUL6N9MEfnFS4q3buxJAam9rLOUOWR9ARWG0xzoOWzVyXYKCr1RW6fKpsBZRubsyW3D9QT0ZjTYPgbHkOjlCaWzgDgW02dorVn4jHqI3rC+fOFzoBlWU/nJqnNoWBy80OmOSms9aXTjXD1lu0+WbcYYSCR9jwoR7EelJhZIti4q44puOBOSGGqLg7IEqh1KHrlrsSN7H/o9EcfjThQz1hsPmtWvbkcEVFKYVbkVLieYnLEvwEeCZ0S36bb6GwlU/YtQjyYXnAYAQ==\"},{\"type\":\"text\",\"text\":\"I've
+        read the entire repo (it's small \u2014 every file fits below). Note: `inventory_agent_context`
+        shows **no coding-assistant setup exists** (`.claude`, `.agents`, `.codex`,
+        `.grok` all `exists: false`), so the only conventions come from `AGENTS.md`
+        and `README.md`.\\n\\n---\\n\\n## 1. Public service entry point \u2014 `service.py`\\n\\nThere
+        is exactly one entry point, and text rendering is **hardcoded** at the end
+        of it:\\n\\n```python\\n# service.py (entire file)\\nfrom incidents import
+        Incident\\nfrom policy import visible_incidents\\nfrom text_renderer import
+        render_text\\n\\n\\ndef render_report(incidents: list[Incident], *, include_internal:
+        bool = False) -> str:\\n    visible = visible_incidents(incidents, include_internal=include_internal)\\n
+        \   return render_text(visible)\\n```\\n\\n- **Signature:** `render_report(incidents:
+        list[Incident], *, include_internal: bool = False) -> str`\\n- `include_internal`
+        is keyword-only, defaults to `False` (internal incidents hidden by default).\\n-
+        Returns `str`. There is **no `format_name` parameter yet** and no registry.\\n\\n##
+        2. Consumers/callers of the service\\n\\n**`cli.py`** \u2014 a thin pass-through
+        adapter, keyword-only, same default:\\n\\n```python\\n# cli.py\\nfrom incidents
+        import Incident\\nfrom service import render_report\\n\\n\\ndef run(\\n    incidents:
+        list[Incident], *, include_internal: bool = False\\n) -> str:\\n    return
+        render_report(incidents, include_internal=include_internal)\\n```\\n\\n**`dashboard.py`**
+        \u2014 relies on the **default** `include_internal=False` (and implicitly
+        on the default output being text):\\n\\n```python\\n# dashboard.py\\ndef incident_card(items:
+        list[Incident]) -> str:\\n    return render_report(items)\\n```\\n\\n**`digest.py`**
+        \u2014 explicit internal opt-in via keyword:\\n\\n```python\\n# digest.py\\ndef
+        internal_digest(items: list[Incident]) -> str:\\n    return render_report(items,
+        include_internal=True)\\n```\\n\\n**`test_reports.py`** \u2014 calls only
+        `cli.run` (see \xA76).\\n\\n**Breakage risks if you change signatures/defaults:**\\n-
+        `dashboard.incident_card` passes no keywords \u2192 any new required parameter,
+        or changing the default format away from text, breaks it.\\n- Both keyword
+        call sites use `include_internal=` \u2014 don't rename it or make it positional.\\n-
+        All callers annotate/expect `-> str`, so `render_report` must keep returning
+        `str` for JSON too (a JSON string, not a dict).\\n- Safe change: add `format_name:
+        str = \\\"text\\\"` as an additional keyword-only param with a default.\\n\\n##
+        3. Privacy policy \u2014 `policy.py`\\n\\n```python\\n# policy.py\\ndef visible_incidents(\\n
+        \   incidents: list[Incident], *, include_internal: bool\\n) -> list[Incident]:\\n
+        \   if include_internal:\\n        return incidents\\n    return [incident
+        for incident in incidents if not incident.internal]\\n```\\n\\n- Internal
+        opt-in is the keyword-only param `include_internal` (**no default here** \u2014
+        the default `False` lives only at the public boundary in `service.render_report`
+        / `cli.run`).\\n- Filtering keeps input order (list comprehension preserves
+        ordering).\\n- **Filtering happens in the service layer, before rendering**:
+        `service.render_report` calls `visible_incidents(...)` first, then hands the
+        already-filtered list to the renderer. Renderers never see internal incidents
+        unless opted in. Your JSON renderer must be wired the same way (receive `visible`,
+        not the raw list) so privacy is preserved automatically.\\n\\n## 4. Renderer
+        boundary \u2014 `text_renderer.py`\\n\\n```python\\n# text_renderer.py (entire
+        file)\\nfrom incidents import Incident\\n\\n\\ndef render_text(incidents:
+        list[Incident]) -> str:\\n    return '\\\\n'.join(f'[{item.severity.upper()}]
+        {item.title}' for item in incidents)\\n```\\n\\n- **Input shape:** `list[Incident]`
+        (already policy-filtered).\\n- **Output:** `str`, one line per incident, `[SEVERITY_UPPERCASED]
+        title`, `\\\\n`-joined.\\n- **Selection:** there is **no format registry**
+        \u2014 `service.py` imports `render_text` directly and calls it unconditionally.
+        Format selection/dispatch does not exist yet; you'll be adding it.\\n\\n##
+        5. Incident data model \u2014 `incidents.py`\\n\\n```python\\n# incidents.py
+        (entire file)\\nfrom dataclasses import dataclass\\n\\n\\n@dataclass(frozen=True)\\nclass
+        Incident:\\n    title: str\\n    severity: str\\n    internal: bool = False\\n```\\n\\n-
+        Frozen dataclass; fields: `title: str`, `severity: str`, `internal: bool =
+        False`. Positional construction `Incident('API down', 'critical')` is used
+        in tests. Your JSON objects need `title` and `severity` (raw, not uppercased
+        \u2014 the uppercasing is a text-renderer presentation choice, not domain
+        data); `internal` should presumably not leak into JSON output.\\n\\n## 6.
+        Locked-in behaviors \u2014 `test_reports.py`\\n\\n```python\\nfrom cli import
+        run\\nfrom incidents import Incident\\n\\n\\ndef test_text_report_hides_internal_by_default()
+        -> None:\\n    incidents = [Incident('API down', 'critical'), Incident('Secret
+        host', 'warning', internal=True)]\\n    assert run(incidents) == '[CRITICAL]
+        API down'\\n\\n\\ndef test_text_report_can_include_internal() -> None:\\n
+        \   incidents = [Incident('Secret host', 'warning', internal=True)]\\n    assert
+        run(incidents, include_internal=True) == '[WARNING] Secret host'\\n```\\n\\nLocked
+        in:\\n1. `cli.run(incidents)` with no keywords produces **text** output and
+        **hides internal** incidents \u2192 text must remain the default format and
+        `include_internal=False` must stay the default.\\n2. Exact text format `[CRITICAL]
+        API down` (uppercased severity in brackets).\\n3. `include_internal=True`
+        reveals internal incidents.\\n\\nRun with `pytest -q` (per AGENTS.md).\\n\\n##
+        7. Conventions and recommendation\\n\\n**AGENTS.md:** `Keep domain policy
+        separate from presentation and preserve public defaults.`\\n\\n**README.md:**
+        `Incidents enter through cli.py, public report composition lives in service.py,
+        visibility rules live in policy.py, and each output format has its own renderer
+        module. Internal incidents must not appear in exports unless a caller explicitly
+        opts in.`\\n\\nThe README explicitly states \\\"**each output format has its
+        own renderer module**\\\", so the fit-the-structure design is:\\n\\n1. **New
+        module `json_renderer.py`**, mirroring `text_renderer.py`:\\n   ```python\\n
+        \  import json\\n   from incidents import Incident\\n\\n   def render_json(incidents:
+        list[Incident]) -> str:\\n       return json.dumps({'incidents': [\\n           {'title':
+        i.title, 'severity': i.severity} for i in incidents\\n       ]})\\n   ```\\n
+        \  It takes the already-filtered `list[Incident]` and returns `str` \u2014
+        same contract as `render_text`. Input order is preserved because policy filtering
+        and this comprehension both preserve order. Do **not** put `include_internal`/policy
+        logic here (policy \u2260 presentation).\\n\\n2. **Format selection lives
+        in `service.py`** (that's the \\\"public report composition\\\" layer). Add
+        a small renderer mapping there and extend the signature backward-compatibly:\\n
+        \  ```python\\n   def render_report(incidents: list[Incident], *, include_internal:
+        bool = False,\\n                     format_name: str = 'text') -> str:\\n
+        \      visible = visible_incidents(incidents, include_internal=include_internal)\\n
+        \      return _RENDERERS[format_name](visible)\\n   ```\\n   Keyword-only
+        + defaults `include_internal=False`, `format_name='text'` preserves every
+        existing caller (`dashboard.incident_card` passes nothing; `digest` and `cli`
+        pass only `include_internal=`) and both existing tests.\\n\\n3. **Thread `format_name`
+        through `cli.run`** the same way (keyword-only, default `'text'`), forwarding
+        to `render_report`.\\n\\n4. **Do not touch** `policy.py`, `incidents.py`,
+        `dashboard.py`, `digest.py`, or `text_renderer.py`. Privacy is preserved for
+        free because filtering happens in the service before any renderer runs.\\n\\n5.
+        Add tests mirroring the existing pair: JSON hides internal by default, JSON
+        includes internal on opt-in, and text remains the default when `format_name`
+        is omitted.\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":4680,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":2798,\"output_tokens_details\":{\"thinking_tokens\":46},\"service_tier\":\"standard\",\"inference_geo\":\"global\"}}"
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -1419,8 +1397,6 @@ interactions:
       - a2b3237efab26f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -1779,22 +1755,7 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        MEoAAFBVVVX9n+5yDUsIM3e3cA8DyIOZr+buZh4evkS6JSQYqJmJq2mamqq5qZq7uTnYAByMBZGY
-        JAa40+YZJLyglBlycCDlpMnw15UkHH/ZYADLwIFS0di0rCkOw4u3IcX+S2XPLO+2afQFBuhnheBA
-        iUoRimBALTmCA0QppjQRGgxIpdAoNDh/X6CfFYIDOmeiYIKCATpnomCCggNggGJUEN3UCA5MXf/Q
-        7f0Nc+f+3KPTTTELQj3jd/zcJN4ZP91WF7tjN3RPwfm4u1+jlZyPUzwcZZ7uqJgnd/5VufvLusOn
-        0tYkK+fdndzcx2QXpu7kbTZVRS3eAmr/T5YLK1qedFQuWLI86fBIvT3NTbLkDRnwJrJkEc6+8+h4
-        GYZloHfH0yhiphnNLqPtsWiDGdXRz4Lvfr55OPC78H/E5vQZqOdjRYO8DO2xqzY+mc31ZNu+ny7z
-        w2bNwnN68B/r56S5e4fqZ+pZbbjybPXwlu98M2Tb9tBNoj+F7LaT04poyszq6tt7TNZT4dWJPrxf
-        991GrJ/ZSZRzT5fJLb+u71V6yoodW19be03Gt+FtGNzvz9JNkzffXnlLeetm2XjbYOINpkVrXfVq
-        dT5ped58kMeHWZbH+py/D97qhRhxP93O63awSn4sHJ1n/nPb+RPdclUoOi7Hg0vT3k5/3jfHo9U9
-        6Hc+a2hiLVzZDKS6uPvfv6E3XL62UvK4UeiJZS1aSt7EpjUMvm/nYJR8DjwbZVVP2Kr0KBggSIng
-        QFNlRGOsiSpipYluFCowgImq0eC8tJGswDtTTFQRm0GJBQboUTLgQCrLiqPGDHpDQ5IG0c9EXNWS
-        1qgU9P96A1LCOdbg2EXUZqzGVEPf/zNAaVnFNRIlhf0ItT/BKsOi8NagSBEc0XCuQtsMNWFcIaIb
-        X0eK87KbWivWskChwLHskQEpSXOM0xqJZlLEWikz7Q8Ld1SNJGPEmeqFGaOUgfMCrHIssSY8tkt9
-        hBrTAK0oZeUeM3sDZKMV28oafKAG2KP4l98tVHVsgjO0ewMU1neWYqwZ1uCA0kRkpM5caKResUaR
-        YkxRggOUy4Rw6HsDAw==
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NYBKakQPsdydhzLcZP","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"CAISzQIKiAEIEBgCKkDMNtDlve9KbBVe9AxtkOTz3AUMVTOvfZHoE7ceSTohcOgnEbvlPpAQYJzeyst18dmEzvaqAw8ONcA8+DCskrn+Mg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgyMsywHgMhmN57AsKIaDEt8Lx/UYESKJiNVcSIwJy8uvBSpWCB1xNHB5swBG/lK3iLxSz8ZXkozL8UHatgi0pfI5QebJCnBrbtS/fQzKnJydUnmEBtmbqhfJvpcUdkOiJfx5Ja7q3q3MvvymAcb+I5HBGoqzDd7LuebB2Ckx1ftHHVUtoVK6aw60mmTrVh/2+rFn4lIcLErx2HbW1e4VDIyLzI8txlsksg7m72YuxqUX/KTT1zwgRhDugb1FAou2osYAQ=="},{"type":"tool_use","id":"toolu_013MRqVM4b92B5eopr8iHmBg","name":"update_task_statuses","input":{"updates":[{"task_id":"1","status":"completed"},{"task_id":"2","status":"in_progress"}]},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":154,"cache_creation_input_tokens":10561,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":10561,"ephemeral_1h_input_tokens":0},"output_tokens":126,"output_tokens_details":{"thinking_tokens":35},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -1830,8 +1791,6 @@ interactions:
       - a2b32442ad7d6f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -2192,14 +2151,7 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        YCQAAFBVVVX9n+581gAw8wh3B9BbREBABEAEBAREQAREQECAgoQqh7mGq6laqIoFQISBDcDBWBCJ
-        SWKAO23y9gVjCUyw8EnmwJMv+Uw82cIgBliMbXBd31/y9P7t+e33+mrD3cuDPv5v2cNA/ybCYmRr
-        MhAGtSTCQlqLTSUrDHzJyqyw7wv0byIstJTk5kaYKXvRUtLsuv7x7v52xyOvX/fh+/nnnPXp8uYC
-        BllGwqJSgpuSZBjEPM0Ku6wGXlJihTVH1IZY6RXr+mHQtEyuUlrJZhPjzC5YZVgaf2ZmT9g8p6RC
-        20CVmBoierY/KXYxba3ltByZG2y/PTPw4g90vlI0luy0UtbtNztcsPUbQhtxnXphxihlsAs4HTiy
-        SnLbUR+hxjRAK0r1B491q0GZVTGlNnsDbDEoC/QQ8zHmQbUQg0RuY/2Nnk4jKyyaSg5Sg3OP1C9W
-        Zk83sMBiSOVTEtbVAAM=
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NYUYvGE2e6VPtRz5e1","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01RLNK6ekeGX7djUqAerSCHB","name":"read_plan","input":{},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":154,"cache_creation_input_tokens":10726,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":10726,"ephemeral_1h_input_tokens":0},"output_tokens":27,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -2235,8 +2187,6 @@ interactions:
       - a2b3245c3d3f6f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -2603,15 +2553,7 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        cCsAAFBVVVX9n+581gAwi3CPyNBbQgREJkBCBCQsHrlBgIKaKru5pqupWqiIBWSAgQ3AwVgQiUli
-        gDtt8vYVU43MsAjZL5EXRz9kXuxhkCIsJhld1/d3vHr6nT4eHl755/744fnrp+df32Cg7zNhMVHE
-        j4RBq5mw8CJJ1BeFQahFWRT27wp9nwkLrTW7RQgzZS1aa15c198fftw8/rt7PHz5/333OUzxbXjQ
-        nzAofiIsljl6pVMvZyfqdREKDFKZF4VdtZEsMJ1iL2dnhiCF7tgP4Yow0LFkYBHqNGcqIzajPU9u
-        fLge+t0++lNxc6tjowi2l80g+JzZYO0pamNqDIptezEQrbNr9FKL3YlxditYZViErwtLIGxZclah
-        baT6lAURvThPKXa1t1rLaT2zCGy/3xkEH050odFrqsVppay7vbzGHdXoIyOuUy/MGKUMdgXnEyc2
-        n91+0keoMQ3QilL9yWPdZlAXVWyrvrtEDbDHoKzQUyrnVEbVQowSucL2lgKdJjZYiPoSfYtuN1KP
-        bCyBbmSFxZjr4DO2zQAD
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NYiAUFqeZDf8VPGVXR","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01DUT7MjCMUKxS4HcmdvbFtW","name":"update_task_statuses","input":{"updates":[{"task_id":"c0f1bc3e","status":"completed"},{"task_id":"7ac6b145","status":"in_progress"}]},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":154,"cache_creation_input_tokens":10926,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":10926,"ephemeral_1h_input_tokens":0},"output_tokens":102,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -2647,8 +2589,6 @@ interactions:
       - a2b3246fffd46f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -3019,31 +2959,21 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        sJQAAFBVVVX9n67acvGICssIt3D3CA8D8AbwPTwi3DzCtwj38AADdTNxM3VXUzVXFXN3cwcfgIOx
-        IBKTxAB32jxDkQukOkIJHoSS5xH+2/C1xH81cEBE4EFq46Dsum2s+ItCV88W/Zenno6+TtETOEBF
-        huBBitbyGMEBoyWCB9xaYYkrAgdCrQgVgfd7ASoyBA8oEWonVAwOUCLUTqgYPAAHrIgVp9wgeNBu
-        Dib0NXgXze6g24rb77vOwzzdN78O6TBtmcXdS0tX3Id5B8dv6c+6Zar1oxX6ZWjjt+qiQ+nD8/zp
-        jSo93n55tNGhJdfDr7cfP3PdHX5++pufTaX5/p0N49p23e+5y/6MlmlPrPsz8qdx6ytOyrwvc/4o
-        86Wrd35nnCyni4qfDmk0nVWXolxedhbVj+nuNOzEtPzuydH3WPqPg7O/XYpufPZ7Iv3YP79ni9Ph
-        Ja83eWcweGiaqpmO/Wm4TcaLYnDkx3pRq05mx+H4825SLEQ3KsYPu747G9U35d1L/TPdDTv1yquJ
-        uZu2Pl/mrvv59K3DvD9a59PquzSJOce7h9NddXbY7GfqYzE9u0N/8voTLivrns9bleewn45rn9/t
-        9tDGo+U834z0gzzvmrWPybpwn5qH6fNwcKcHd0U0HZmO0OptP9+fx/0pHVsLt12ruk9J7ymb1t0w
-        fPOXRTV8/1o0vxoNuDoXoCJD8IDwROAA4YnAA18fmUgziSkqEiq+Zz1hLDFKkCk8srfJyGcGVYQG
-        DUt1lEt0GCWo2FEYoWK20SblxCxKDEloxYQizShBZtEcRIiMq4i1PwYeXB1PTFutZZBb9JATP2kt
-        86DszkN6jl+rE3O2rXw/jbuReY0JHFA8RfDgaARhsBFS7yhUWU7gXSDjlIAHW6tVYNCCbbrPCq87
-        bkGkmTbEtlarlVqpjdEpEyoUESqyTAuxA4WiV9opiXDDDKldsLVa3eiirceksPSLRObfLfv3f2bJ
-        eCvFGGMGKTfKdFreR3ma2Rt1LjDG2EVWPWOMlYzriJLHftUL1iU0JRIkseQxQZjeKwiWw0oWD2gE
-        FeqE8aa5GkX2RhvtbGBC2bMheBP+FAk1SPhuVwquDoRcSjTguTqfRMJgSHD1pozIbVZb7D9+ut11
-        tT1LeP68fj3Em/10AniqRXMQIbpHwS5OGyoyoWLC77a5lHwtceVeBWtjsIciTDshygS7aaGaapNp
-        KcJCG/0Owoq1xMAEQrV0IsITGVA24clbir5g3PU73XF3PPFYJEL6tWQca7fE7y8fjD+HWTJ/f6zh
-        uXisRHiikmdosY5aBrZWK1/eWq2clbp6wFoZzLQhD1G4bRjSQxZqYLH/ScelUKHMIwyEIjSKS4+t
-        tZaswXpcWtQwKjbapJwCxVP0mCXDGpZsK2elfAy5ZAo5Ib6JUOdmQYM5IxN/DSnUuywZPIWYEXvH
-        omuMNkYJDBcW2ZzLHFUH5WZTytVO6aOyMjkeu8gINqZm/zPX0i1zcUp8rdBYQl2tNNaQM8AlG+DD
-        m9pxHKZsKBRza0ih/r4w+xN7Y2Cj86HC8ueAJZ0FBrnVyj8S6l8JVhkWi/scVYjgqVxKFdpGSFxI
-        i4jOQ/FSvIv/VGsFpHeoLHhureJAyMMEg9AgJ6FVoJUy160+4o4yyCNGXFm9MGOUMvAugFmCKRou
-        g1qqj1BjGqAVpdzEY+WrAzonxbaqVeqoAfYo/hIVIlS1NuBVylcnQBHagAQa8MASVxE3USAlUjdo
-        UIUYxKjBg1jqNZdwvRoD
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NYyo4zseN96FodQxd6","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"CAIStQIKiAEIEBgCKkD/VmqAQvmMmBrY+9Bo31/VDeRJmXbBr48wsio9MsgJ4YDtm/7V6Jt3FaC92sdvBlbMQJXNp11kePPNfXf3AKWpMg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgzNFimLq7KpYxv9u8AaDII/Ar4rTRNTcjhRYyIwaw8y54SUwMRP+SyYiEdyR/kG1UO8f0k98PmkMD83Hrga1mBP9V11P6WocuGObuT4Klrhrzgk/x+4UvfqUnLYTz1MNSHXcZ3bFNaB37cGmR5PWCCMsgOZVufOo/lzkA5LSby16AvT7MI+oI+ydTOrDionJqVqzRGTtwBY1C5416hF6pT81ccJNZy4cKQYAQ=="},{"type":"text","text":"Now
+        implementing. First the new JSON renderer module, then wiring format selection
+        into the service and CLI:"},{"type":"tool_use","id":"toolu_01Vct7gH4SrzsBuqTgEdrHgt","name":"write_file","input":{"path":"json_renderer.py","content":"import
+        json\n\nfrom incidents import Incident\n\n\ndef render_json(incidents: list[Incident])
+        -> str:\n    return json.dumps(\n        {\n            ''incidents'': [\n                {''title'':
+        item.title, ''severity'': item.severity}\n                for item in incidents\n            ]\n        }\n    )\n"},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_01VqLXEEb4CUhau7bHvgfqTS","name":"write_file","input":{"path":"service.py","content":"from
+        typing import Callable\n\nfrom incidents import Incident\nfrom json_renderer
+        import render_json\nfrom policy import visible_incidents\nfrom text_renderer
+        import render_text\n\n_RENDERERS: dict[str, Callable[[list[Incident]], str]]
+        = {\n    ''text'': render_text,\n    ''json'': render_json,\n}\n\n\ndef render_report(\n    incidents:
+        list[Incident],\n    *,\n    include_internal: bool = False,\n    format_name:
+        str = ''text'',\n) -> str:\n    try:\n        renderer = _RENDERERS[format_name]\n    except
+        KeyError:\n        raise ValueError(f''unknown format: {format_name!r}'')
+        from None\n    visible = visible_incidents(incidents, include_internal=include_internal)\n    return
+        renderer(visible)\n"},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":153,"cache_creation_input_tokens":11142,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":11142,"ephemeral_1h_input_tokens":0},"output_tokens":538,"output_tokens_details":{"thinking_tokens":30},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -3079,8 +3009,6 @@ interactions:
       - a2b32486fd276f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -3468,18 +3396,13 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        kEEAAFBVVVX9n64KcomMBIsEtwzwgAgF8LwEQEIGZHpCQABkZkCEBWhomLKbKYSaqLmoaGY4GDhA
-        Xg55OJxyAA7GgkhMEgPcaXPoy0JTDkhkqU++Bpzt/EvC2ZoaioEsTWVwq7a9xvn3h/vDfNdv+WL/
-        8GOLIJfUkB5mkKUJpfgB1JDkBLLkS4lFPSs11GdWsJJ9XEgPM8iS4k2pIcWbkqXrzBq5Rh5MnOaE
-        CaxeY2bz/+8/o6PAh8iDed5lmbw69hOejY6S6zAaHWGuv90YH/ysEEvHZiE9WJs+mnNytcCOEr/m
-        nKpbtdvxa73dD/c/91vcfvT5y90vqefUEPsJZOmPRIXbxaR3YHmuSnah2evosByKH+aDzUU17SRP
-        JnIfA1iLidOcRc2NQskda6NtgfyOPbAaJuAAcYI5i3bccccBOyOV33VsjDGmttakWPQRkfLUwGLf
-        S8dl5D7VABdZIeyTNS85J7Mxn30q0NBAxxcH1hQVszEnijc9aTo+NWefTFGxmnuCQKuwNQq1LKGm
-        FGwpFpdGucGWYcoNZ6D2BlqNiRt5oVqF77RjOjbU+5QgZN1m1IYo6JWOx6eGiubZCXzJ7F6FumfB
-        KsNSsK/gHmS5pqRC2wD1MRVEdPVipdjF/Uau0/wKLmTb9XlDve9HuF7gGZrKaaWsvVxd4I4S+MCI
-        W6kXZoxSRnYhzCMmiE9uPekj1JgGaEWpdvTY6thQrqrYVu3VFWqAPQZlIR0jv0YeVAsxilDvL7RO
-        I4QsFfUcvAQvPFJ3EHAPNyCTpSHlF5/oeDQAAw==
+      string: "{\"model\":\"claude-fable-5\",\"id\":\"msg_011Ce3NZXypRcMn6qZUMedr8\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Continuing
+        implementation \u2014 threading `format_name` through the CLI adapter:\"},{\"type\":\"tool_use\",\"id\":\"toolu_01MhKuPqgXVqMeP2aoHRWru3\",\"name\":\"write_file\",\"input\":{\"path\":\"cli.py\",\"content\":\"from
+        incidents import Incident\\nfrom service import render_report\\n\\n\\ndef
+        run(\\n    incidents: list[Incident],\\n    *,\\n    include_internal: bool
+        = False,\\n    format_name: str = 'text',\\n) -> str:\\n    return render_report(\\n
+        \       incidents,\\n        include_internal=include_internal,\\n        format_name=format_name,\\n
+        \   )\\n\"},\"caller\":{\"type\":\"direct\"}}],\"stop_reason\":\"tool_use\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":153,\"cache_creation_input_tokens\":11806,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":11806,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":199,\"output_tokens_details\":{\"thinking_tokens\":0},\"service_tier\":\"standard\",\"inference_geo\":\"global\"}}"
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -3515,8 +3438,6 @@ interactions:
       - a2b324b5eeb56f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -3911,23 +3832,8 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        4FYAAFBVVVX9n64Ocg3LDFsj3A0gD+buZu4e7uYebu4enmEJCQZqZuJm6qamam6q5uYeDj4AB2NB
-        JCaJAe60Oe6EB9QiRwYuZIx0Of46kZThLwc0oDm4UMsi0Q1jgtY6vjkn6xrth9GXWfGY/AUN1L1B
-        cKFGKUmBoEErGIILREoqFeEKNMgEV8gVuP8eoO4NgguqpLyivAANVEl5RXkBLoAGkhacqK5FcGHi
-        LXbXYrGknr/wx8VkWU1rc/Ly/rbf7bqvQr/f1mpL6+4STPrrPLiL8lR1AVOFc1041u71sorX+x8z
-        MO/5MRIBWU5y+xzp60PRWF+bngTHsfM6PwVh4ZzTWWDEs4OK64Cms4Na74vxtih1MmMdMVkXG6Ja
-        T6My3n9b6zpUm/3Bjqmux9Nve7WvbuG0UPExYJtjxNbm4md9jqlf3M6OJT9fszCc9S+7410n05U/
-        G9LZtcCmPW83K7pb9Pv3j7Lr1OQ+3aw+80tz9NZj3nN19qxjYxxevB//zLNhc5h40Sbdh2XpvPsk
-        XnzMuyiOF+GyDlc0ZPJCRbCYM94sTZNnb6diOyHTip57f9vYtlpGrLduN3bVPyl5+fb68Wi4//Ts
-        v8Yuy9ej3ul1b7TVP+Y+ycfexotTthpP8oueWsGBzreW2UTxLPRLy7r0gWVV319yST68V7vCdDTz
-        v73tnz/w1B6gXLQavCnQ+AbehUXdMKyRK6Ko4AMqB5moG4YKfw9CcaW8GCgxUCiVdOFpJG2FYEkn
-        0aPMWpQQrEt0Y75rsy8zRzr66Pr4Pr+Rc2QI0ICTGsGFrsmJwkQRWSVSEdVJlKAB5U2nwH1oI1mC
-        l6mYyCoxQ5DeSfaWGrYDGugoD1ywVjG5pQnXniepblnZm2lHP+VJ04qiRSnh+f+pQUYYwxZce/Kb
-        OW0xU/B82mYFGu0OwhT7sz+8TW/dbPmZttNhCfisRZInJ8rQ3hQ3RJUuoAyXKmmxEa2Sv5s7WE5Y
-        /msglWiSFokU3CqEWpVglWGReOmQZwgu7xhToW2OilAmEdFdUECK+7CcyE2UqJBLcA3H0iAjWYlJ
-        1qIHYKpEK2Wmbtu4YPsyhDbidPXCjFHKwH0ANiXW2BKWOLU+Qo1pgFaUMkqP6U8NRKcU28oY2agB
-        9ij+EaASqjo2wbWMpwYS2yvNMFEUW3BBKsJz0uZuJFJP2CLPMClQgAsFEylh8HwaAw==
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NZx5f3vRT8RV2knZaX","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"CAISvgIKiAEIEBgCKkDm2C+76TSSuVg0yxNtQimuqFCwvHFyohfkuFltg5vI53S/qLZNTz2F2ydWRoFaKCd4jR0NUgp3VOwaFWB5/HfFMg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgxj53sP/cMMGw+SWy0aDLEG8iGvgeprjQOLiSIwT7JhuutCyDOLPdqpWANBnwntjA3Wp1U+AzEjnc8pUCARObTMhh57EaZIJHuRZZIMKmMLiMlsqioFIHlnpK22nc6fgQCaDkijwEQp44tKRlw3xxlv0Pia+YAwB98TPA4X1ScdN9w5w0A9Q0JHEadBAOAZblLBCdq0b3FUiHQ32pRZGMEh33qwF33kYVsKaJA/4keb9GEYAQ=="},{"type":"text","text":"Implementation
+        is complete. Moving to tests:"},{"type":"tool_use","id":"toolu_01HSrcV2dei9JuwZyHxajR1o","name":"update_task_statuses","input":{"updates":[{"task_id":"7ac6b145","status":"completed"},{"task_id":"b033c624","status":"in_progress"}]},"caller":{"type":"direct"}},{"type":"tool_use","id":"toolu_019SUo2oTjE8xDxuGKPbrD8h","name":"read_file","input":{"path":"test_reports.py"},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":153,"cache_creation_input_tokens":12044,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":12044,"ephemeral_1h_input_tokens":0},"output_tokens":194,"output_tokens_details":{"thinking_tokens":31},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -3963,8 +3869,6 @@ interactions:
       - a2b324d918f46f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -4372,16 +4276,11 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        EDkAAFBVVVX9n64GfMoEME9w8wiPhNBDAiQEZEJmBEAARBwiDukJCuqqbO7qoSZqrioWGZ4GNgAH
-        Y0EkJokB7rTJ22cMOTDBwCc3Ba56t09cbdEiBhgM9WDXXXfHq0f38PrzLLevT0N9etDx5QYt9DIS
-        BgNrdQeiRcmJMHC1xqpOFC18FqUozJ8ZehkJA8052akSZkrsmnOa7Lq7jqdf5/fN/Y/7l+d66v5/
-        P0/D3TNaiBsIA4aoto9J59Qv46QwM0anRxgoq9rCMRetX8YLWuQUrPJDYdCXPDQ+xSYOYy7alEl2
-        okLfKD4GilbVYn8rDMxOdrKTwL4xujzlhymSqj3GwGqjKIu4ZPcXG9i7Kemnz83qW/OYhQYthP+s
-        NQjlZJ9qNrI57y1JsDbaVpb36IlpVSiBxdqMq1UHb2nhXUosMG4rakMs9Ipl+duiah5toatZ3JsY
-        6x4FqwxL5XmieMLIlJIKbQPVxVQR0ZOXIsXMLrDWsprfKBWm225aeOePtL7QacxitVK2ubnucEcV
-        usCIW6sXZoxSBjOD45EDi0t2O+gj1JgGaEWp7uix9dIiT6rYVt3XW9QAewzKDD1GeYtyUC3EKEJd
-        WWitRhYYVHUSXAmecKT2LBRPe2CGwSHlvUtYFgMD
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NaKWFqn9WQmsQKtpV6","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_014ijHqv2JEJVRsj1zAqumCR","name":"edit_file","input":{"path":"test_reports.py","old_text":"from
+        cli import run\nfrom incidents import Incident\n\n\ndef test_text_report_hides_internal_by_default()
+        -> None:","new_text":"import json\n\nfrom cli import run\nfrom incidents import
+        Incident\nfrom service import render_report\n\n\ndef test_text_report_hides_internal_by_default()
+        -> None:"},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":152,"cache_creation_input_tokens":12641,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":12641,"ephemeral_1h_input_tokens":0},"output_tokens":179,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -4417,8 +4316,6 @@ interactions:
       - a2b324f81fef6f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -4831,31 +4728,39 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        IOIAAFBVVVX9n64KcrEICIsMN/dwzwgD8ATwJcLTItzNM9w9wiMsI8BA3VTcTN3VRC1U1XwJB6eq
-        qqr6PxzufryassrBt4vf3K/uJwezi4PZVUVMVf3iftgufnMw8MPFD2c/2MHBLw5u4Cf3i5/9cHa/
-        ml/95rfTcrz66ehUVVVV/wAGDmAA7g7qAA4qqqzKzKpqqv/4E5RaoIIQMsVrgddrvlJ43QYfpIAQ
-        SpunjSAYYCvmAutyONkt2+X2ZVE8v4EP7lghhFCitTxH8MFohRACt1Zax8mBD5kmh+Qg/H8Cd6wQ
-        QnCFpK2kHHxwhaStpBxCAB+szIm72iCEMOhF86oXPcveQ/TQzwfP2+EgHxd1vGqYZfQ3Owz6P/+e
-        OI8OQWch4uH9YH3zW2+pqGg81J12730um09JLdU9BlffZmdfIr67uis2ffn+ajtte9DF7Ptjkrc3
-        q9FjkIxeXVI+ytXo1cWLvP+SFw0+UjVvqjoJ9DYezopk8dGKy4mbLl5vE9loJMOP2/Fie5gMc5cs
-        H9V0OVNxM/qJN4l8yPctGlPW3/WmD6158CEafNgXN1fvhzk+xvfBVfl0dYz2TZ3Enc3vzSGrR5u4
-        ORyNxXL8YrCcmJ4am+ZRv+1bP3w9nD5/V+tOpBt1NaAAp7b59Dyl7+ct2aeiXSWL6uZ+/fYW/MwS
-        2Zc020/ky7zxYjvbQhb9ycfVNKqjQG3v+pQU2/bfIfYSk+30XbCcdkq6708n+5u49Xd8tVHq/UnP
-        9YR3HtyqPH6Meg9dOPsncMfKxD4eHPi/Wwwh1nvGqwpJSMqZK5A9zacxc2idZZneoZGUM4tmJzNk
-        nAQbjCNWcVdYn2kj0LDKoEWz405q8hknwSojdzw7MoFrXitnb3TlriWFcPZPXYlrrdLa4oi9uNNa
-        1WkjGAc/fPGRtIadxVgLOeTHF9FagQ/ES4QQUEiXrqWqvJGq2kF4goq7gl4h61KDlTbO/qqO4INW
-        ImXbFrimFuSh5FXSjFMqKVO1wFSSQ0NcXVyy6z8s1oThJzHGmKRMCiRnWZf9j9I5F94cM4OOFdo6
-        z2fenhuSlHs+AxvsLkyNl19AedxaNI6Zmi4wp/qsfVWtDOt2mfd/2ZvFUTz6Yo39HsAHwn3KK/FJ
-        n/RJfDDgwnRjNV1RIQVa1G66Oqbjy4Gcyl5ijDGaz9r7FzGh9+T5zMuMdDLjyrv0i7OO2iqSXv/I
-        MXdI2ZHZSm7R85lXStKmMah4SsWPSnPBumxjNf1Smgt7YZAEGvpM3YPW2pTcpcRL7Hobq8m7vMSC
-        GwTZ6bJTMGKMMQ9mwgt1KckYYyfPSafQC5k4d1rcoZHu6IVCzXf268uMGYhizxIUGPfsvucRrbIF
-        Rxg/4jTz0i/u0XiwIfGZlyq8GmOMuSqyC/DTzVaA+PvRlks6MQitGXtDKNHyxUxJu7/eRAcdUp95
-        Lq2FaUZ6ttAUnvFiiTjWzx100voNppVH7YT6jA5R0MXBhBSylVm8RutOIc/qG7EhTgAJgdFniaRg
-        H8ghmqrXSjz5w5JLsvOllgrg4KmTG2gbitmsYHis5wxm0SIa9MZfDC8Xzj5kXCk0EB4eigppMHNw
-        Pn/5YJ2uUoPcatr+YTsYBHdY/K6RMoSQaqUCcYGOS2Vf1frg0gpP+8DXSp3eIlkIg3bTh4xnBaaZ
-        Qe6kprRUr3l3e3dnGeTi22jENcbDIDwBVgWWaLhK22UdYBqlKgXFusbZB1277Kyg0bq9DZLN0+EK
-        4SSEzduzD85vkWggBOs4CW7EXnjfNRqkDNMcNYSQK73iCs5nAwM=
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NadeumDMvW5mkQThKV","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"CAISpAIKiAEIEBgCKkDCgLhuNb0rWIHcxCBzPJaaIx16TdND9Cf/7oknhpnLDo65AXSi2JZuil9e1+qrvsQIav+8hjBiXUs65sxohRqYMg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgw3nLncBvAOE3S1Yd0aDBd/+XxSeFN91+mJ+yIw2oZN6j7jxcuGjN2DGLdWLQremMrAlLr2yoVw3zafDOKqpf6Io0upCn1eOs2JKOnqKknsJh5pZTp/9fVV1zRZiBinRwMiQS0Qs6khihBMY+OIuI1lk8BnZhk5HDeAZrcvo81WO6mn9BOMw/N3HL+jllXJoSoMa6EtbmyYGAE="},{"type":"text","text":"Now
+        appending the JSON tests covering service and CLI paths, order preservation,
+        and privacy defaults/opt-in:"},{"type":"tool_use","id":"toolu_01L1zaTYZ3D6TLodiDayQd3b","name":"edit_file","input":{"path":"test_reports.py","old_text":"def
+        test_text_report_can_include_internal() -> None:\n    incidents = [Incident(''Secret
+        host'', ''warning'', internal=True)]\n    assert run(incidents, include_internal=True)
+        == ''[WARNING] Secret host''","new_text":"def test_text_report_can_include_internal()
+        -> None:\n    incidents = [Incident(''Secret host'', ''warning'', internal=True)]\n    assert
+        run(incidents, include_internal=True) == ''[WARNING] Secret host''\n\n\ndef
+        test_service_json_report_hides_internal_by_default() -> None:\n    incidents
+        = [\n        Incident(''API down'', ''critical''),\n        Incident(''Secret
+        host'', ''warning'', internal=True),\n        Incident(''Latency spike'',
+        ''minor''),\n    ]\n    payload = json.loads(render_report(incidents, format_name=''json''))\n    assert
+        payload == {\n        ''incidents'': [\n            {''title'': ''API down'',
+        ''severity'': ''critical''},\n            {''title'': ''Latency spike'', ''severity'':
+        ''minor''},\n        ]\n    }\n\n\ndef test_service_json_report_can_include_internal()
+        -> None:\n    incidents = [\n        Incident(''API down'', ''critical''),\n        Incident(''Secret
+        host'', ''warning'', internal=True),\n    ]\n    payload = json.loads(\n        render_report(incidents,
+        include_internal=True, format_name=''json'')\n    )\n    assert payload ==
+        {\n        ''incidents'': [\n            {''title'': ''API down'', ''severity'':
+        ''critical''},\n            {''title'': ''Secret host'', ''severity'': ''warning''},\n        ]\n    }\n\n\ndef
+        test_cli_json_report_hides_internal_by_default() -> None:\n    incidents =
+        [\n        Incident(''API down'', ''critical''),\n        Incident(''Secret
+        host'', ''warning'', internal=True),\n    ]\n    payload = json.loads(run(incidents,
+        format_name=''json''))\n    assert payload == {\n        ''incidents'': [{''title'':
+        ''API down'', ''severity'': ''critical''}]\n    }\n\n\ndef test_cli_json_report_can_include_internal()
+        -> None:\n    incidents = [\n        Incident(''Secret host'', ''warning'',
+        internal=True),\n        Incident(''API down'', ''critical''),\n    ]\n    payload
+        = json.loads(run(incidents, include_internal=True, format_name=''json''))\n    assert
+        payload == {\n        ''incidents'': [\n            {''title'': ''Secret host'',
+        ''severity'': ''warning''},\n            {''title'': ''API down'', ''severity'':
+        ''critical''},\n        ]\n    }\n\n\ndef test_service_text_remains_default_format()
+        -> None:\n    incidents = [Incident(''API down'', ''critical'')]\n    assert
+        render_report(incidents) == ''[CRITICAL] API down''"},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":152,"cache_creation_input_tokens":12848,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":12848,"ephemeral_1h_input_tokens":0},"output_tokens":1034,"output_tokens_details":{"thinking_tokens":24},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -4891,8 +4796,6 @@ interactions:
       - a2b3251308896f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -5338,14 +5241,8 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        0CUAAFBVVVX9n64BfFYHcIsAS4DQW0BcEiAgAzwPmRAJCQkKYqrsZhqhi4WqWEA6GNgAHIwFkZgk
-        BrjTJm/fkWtggoVPsgWerjIlnkYYxACL3Gd3HoZnPrxOv9++r/FlCpfL1+X69n+Egd5WwiKzd5kJ
-        g1YTYSG9x65SFAa+FmVR2L879LYSFlprclsnzJSutda0ufNwyX9+yP3TT2nvT9OrPPZxXr79gkGR
-        TFi0rThfc5YSYBDLuinsDsXRa7HelF3vTp84DLykxAZr6qgNsdErjuOfQde6ukbptViEGGdRglWG
-        pfNzY/GELVtKKrQNVImpI6I325Zid2uptZzWD5YOO4z3Bl78QucbRWMtTitlD4/DGXdUowRGuHph
-        xihlsDu4LsxsktyY9RFqTAO0otSweOx8GNRNFVNqHAywxaDs0CWWj1hm1UIMEoWd7St6Oo1ssOgq
-        JUhzGZF6ZWPxdDMrLOZUJ0k4DgMD
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3NbVXHpiKbdPPvPfXx5","type":"message","role":"assistant","content":[{"type":"tool_use","id":"toolu_01PmYMa2AQarjAbNa9s5gh6U","name":"run_command","input":{"command":"pytest
+        -q"},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":152,"cache_creation_input_tokens":13910,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":13910,"ephemeral_1h_input_tokens":0},"output_tokens":51,"output_tokens_details":{"thinking_tokens":0},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -5381,8 +5278,6 @@ interactions:
       - a2b3255b4f5f6f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -5831,21 +5726,7 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        YEMAAFBVVVX9n+5yDUtwW9zcwxUgD+ZuERae7m4e7m7mnm4JCQZqauJm6mamamaqFuEeDj4AB2NB
-        JCaJAe60OXavBzQyxxoIsJoOOf660KzGXy4YwHMg0KgiNS1rgU6YibE/qfLpfh4u4uQnmoMB+t4i
-        EGhQKVogGNDLGoEAVYorTYUGA5gUGoUG8u8B+t4iENAlFxUXBRigSy4qLgogAAYoXgiqhx6BwMJb
-        HuRuueLe2/JtXixWlfeXxdfdli9aeQjFcf0xDUalU/mVNWWjtsi+Z6fRnqmq3LtNEiTFEIjj1Amd
-        7Ve8tCeH7/jInPt9dMGh88RLwWPa/yTZpnCvWfBuJUGsk+adZ0Gsw6iY74rSpEE9ULseEktWob8v
-        k+jshM1Gb6N4nHDTTPzzeB1Vt41f6OT0Xm9P+zq0lz/hNeFvxc1cbje58+nvPppDIrNX6ge0767i
-        1c5eGzsvb+vD8jvpoujk/enyY2t6o5fppOyXN9dyF/Z2chyFRyZXu95fyp8Pt5xvl/3LhH1M6Gd8
-        nd02Jzf6WlVUnaeXc3SzNpFltvE4mHuqX30VVeWXfem8HK3uMx668TbrwrHrN6P95IKbdWd/j+zj
-        5vz3lbU8idRxvR29+14UNf1+t2ceC7o2el0F3ttveBoP0PcWgYCWsk4HhWAAz4GAlrIeUtPasdMJ
-        L+PNz9i5dff4w/vjWXcLDBC0QSAwtDnVmGqqqlRpqgcFBnDRDhrIAzRVVcpzIJCZjsMm9hgMUJrq
-        QQEBJpu2Ro05PA1gtK6xB/IAfW8RCOS8R6bh+fxvgNKyTXukSgogoKWs00EhGKC0bFOF3YCCIRAx
-        1LUBKrTNUVNeK0T04DnLJg+wvlor1bJCoYBYrm0Ao6zElPVINZci1UqZM5u5uKN6pDkjzlQvzBil
-        DMgDsC2xwZ7WqdvoI9SYBmhFKav0mPk0QA5aMaVmMwNsUfzDhxOqOhUCse2nAQr7L84w1Rx7IKA0
-        FTntczCAiwv2KBimBUogUNQyozU8nwM=
+      string: '{"model":"claude-fable-5","id":"msg_011Ce3Nbn4D6kd7RBNCUZzTB","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"","signature":"CAISoQIKiAEIEBgCKkAXcUjQOiCpoSNnVLH7G/h3kDk17c/pgbw9W/RcskhR5mZGZguGnV73N3OvUI26SwUVc3yy/feuqAn+giUarzZbMg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgx0IOMd3PDQHmSZob8aDGarqjn82b8m2dhxLSIwZqTTWAJqdVp0A/+76hrIx515C2O6V/NVcoKQrDIozH5hBOIr+6cH6aPUj9xMW5TvKkasY7fYTx1MT10pU4GBAsrKvgkkDhrh3+V1qPUuq4ObqN45Dm/R6feMLq2w/2VMYX8cpiZTsVLO/FDATTmrRQRcAcGqpT8KGAE="},{"type":"tool_use","id":"toolu_01QcWWef4Mz43xqyUHAJA1y1","name":"update_task_status","input":{"task_id":"b033c624","status":"completed"},"caller":{"type":"direct"}}],"stop_reason":"tool_use","stop_sequence":null,"stop_details":null,"usage":{"input_tokens":152,"cache_creation_input_tokens":13995,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":13995,"ephemeral_1h_input_tokens":0},"output_tokens":99,"output_tokens_details":{"thinking_tokens":22},"service_tier":"standard","inference_geo":"global"}}'
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -5881,8 +5762,6 @@ interactions:
       - a2b32573b96f6f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:
@@ -6333,40 +6212,35 @@ interactions:
     uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: !!binary |
-        AMEAAFBVVVX9n64CWoeM8DT3cI+lI8IKqgE8Ijw8PSPCI8LDI6PCKwrcxFTFzTRdTdRSVczdLQIC
-        oE8N94Y+HE5FVVVV9X843P14FRW1g9tysKO5mx/U3eygAH4xV7ssDuoOfnCww8ncT8vJwW9+9PMC
-        dnBzv6iBXxzMD8vpsBz95Fc/3C9OVVVV9Q/g4AbuBz+qmsrCzMJuf94fqvKGnEqVdtgY6q4wd9Q9
-        UYmyRqWqisWyPxhc0tFUn482P/TmafYwejp5f58/q0RJW5NKVUUxYkEqUcE7UqnCGG0UZFGJ0p6F
-        WFT614eStiaVKiktry0XKlFSWl5bLlSqVKKiLRilCaRSdTmcPPF2cmOHo8noori8WV++Hty/XPmv
-        Z9X028H8/HE+KV7XeX91c3K29T++vg/Wpj8/3R6Up7v3UX+Gw+i2q0t8PZu8lM7cPI43Dxfu/Mfo
-        7EwP1+9j+V6f329f7oqTn/n4erAYP8uiurb5+Fmm8+LisSj7OHYNHrpmMfDr6dWsXMxfj6bVndzP
-        n48Xtt9fXL0e387Xu7urQhYv1+7+Zeamh5P36c+FHRXbw9f28ai9WcRvzYQPjvp49XB2e+n/9edg
-        dHC6KdzxkZ1sH6ur+n43+7V5LvJ7nvbPrsXWV7PqSGiV48F1zY+D4WKW9xua2Xr4etzHW39zd//1
-        fKdPxg/FzXp2VK94dLs+k9HrJOin6vb+aNocv+hhS3ffnr/e2M3t7ny8OB2OLw4uVoOr8fBnuNZm
-        Zk/W27b/cnHXnp/czbl5PFtg2X+aLvRh9f0u1oM/Z8WF+kw+lLQ1qVQJ7UQlSmgnKlVD58B4Jvjn
-        P/+HCnVpmbqB0GDuCCxra4gFAtU+SAQMBFsbyACxAfFAbHrw1FQVhjZ94zf+7TeY8Iai2ALFeoa9
-        QGi6nl2bwMYi0K52PlCA2ORdLIhl/43vsK7JgJQE2lc1is2ts9JCbMIKNUFOKx8IxDe6tFyA9obS
-        N+5Cp/PQ5M5qiBQ2VlOnk0IWKWyspl4gNhSWgWofZM+ytoZYYgKdBCxr1xhaWhYKjO6Pa3SR9qH7
-        b4gSsgS2VkoQ2gkEYkPBcgElBqO9IQPIBtjDyocKBQIVNkpoe2/chU7n0nNsKgqx00kh0872QsMZ
-        7K2p3fpgoMYYu1IG3xTlfgKZwVjmHoPpWdbWEMtSYzAZ7AVyliJ4BnQODK2wcRL3E8iMLShKr4V3
-        L40tKEoGe1l3gXloKNunWSl6YNpCjQErEgoRSiSzbE6wpnbrg+l6di1srZRgKOd5CSAbkJIgkDSB
-        QdqaTu+Jgi1kUUKGwFUPwW5Qt51OClntndVtb2OjzR0tLQ08g5V1NdBKNcGxCJbz6ZHVKDhsKUAn
-        l8FYh5FOAtGvFFKIwLShAJEIGk4gkgGDgqXdfxh0aYW0NIE6HdibjYZXd6OD4Xg0nT/1KrOfAqEu
-        wTdSNwIrz25uQRLBSgS/5YRxqLxpHP0OLQIMqhEi1RhQCFbBV1AHisQyCKz3xm/T0a1qR9UOKS2U
-        /Yyel9F/2avbrNOBPabtfgqVDcGHCJnQTu7b9iWC9iwBtXDLBdcUkYuhC4Sm7ZZnddEQM2ej/DUB
-        uvl3lvBZFAHh+9P9FKIEywX5PjJknDwkAwwBW/AryD7EiqMEIm0oWGk/M/D5T9LMnbJcNwI+GAo9
-        mHqIlpwvrNaRmdEuZLByWJDHHOFaEYZnAakzMikQdFgKaEYwH7LlbDS9Gs1Gs6fssmEPLidLAFo7
-        20+cgvLWM3q/smSsKIUoAf6AL0I7+ZINR/J3aHjNfstiqBghoI0ECNoRBsh+oGtoFIIPWQ9kj8Iu
-        bbmAKNY5KLGuiSN41pSAigEHyieH0HAUs597KfMFYomBgALBanRQ5+jLqcSN9QEfVzuLzXopA6GJ
-        HbIMpDSaORAPYwVEw6KLFY06Bt70zOIbXZIZ4tm6zRJZ4NpwaWYSyPwMX+BNrFe3mVjVaEOhBdrZ
-        KJYL0OgcBaawkgbYOD9e2JD5RuYUJb7xkP8yK7shEIoSAZ3nIloDbEa2PvpBzxRhb1taXYLzeu0s
-        YdpJN2+76VrIBl5cT8T99I278AQWTMczNUqZQmkNRcuy8mM27EEK0pfK7wHUwce5JNJIkoEC6/0E
-        TFoOqOAZaFc7q62Ar6VrmZCJy9tJFUCYV6MNYTKWi7OjeP9AzF1z2gkEqtBycbQLoptVsC2JRfSy
-        jeArK0IGvDUDPZd2OteNcxAbK5RCVrdCUaD7K4N//vs/OP2zq06m1+moz78TFcXXy0AYPatUEZul
-        NIHV5pFIvxpiTSrlxrmNsCFB6+K73jynOumHchvVpfg1cVTp4OQwURp1SUsdyGDTlnd5x4Pjo8+i
-        QGh+Zn+fxviYSj8U1SVVFNAtT6ozGFO6q9agbPc/E2Vm2vK007P+JfVofTxK47ao0sHpZ6IQv+lS
-        LAWVqijIBoNRibK8okCsaVmQV6kqnM/Rqc9PAwM=
+      string: "{\"model\":\"claude-fable-5\",\"id\":\"msg_011Ce3Nc9EvVcvSRPES5zzTU\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"CAISnwIKiAEIEBgCKkCY/OWDo+8mNH/T9QTIgYkb0fK58woV+z1kd0T7w/h7xzE0RaAslwfCaY8IWhldKQGvPBl9VE88cAkzGtJp9OwWMg5jbGF1ZGUtZmFibGUtNTgBQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZiEgw2YyQ3yKZsHuIn/30aDP8LCo6X1E/7vgl43iIwQmDpOxRqvUgbOnN08FtipDRm3tefba/FpnQ1AZRb0ueRipAY40aLoKMO+9xc5GPgKkR3pfnELk8tEYIrcSmLO3Nu4WcAyeMHU+KivLx9GZ7AGB/Bf1DGAjrFcdRi5kwy0WBMy95MTnuQ8Zah0SNZc2mJMsp1XRgB\"},{\"type\":\"text\",\"text\":\"All
+        done \u2014 machine-readable incident reports are wired end to end. Summary:\\n\\n##
+        Investigation (read-only, via explorer sub-agent)\\nMapped the compatibility
+        surface before touching code:\\n- **Public service**: `service.render_report(incidents,
+        *, include_internal=False) -> str`, with text rendering hardcoded and no format
+        registry.\\n- **Consumers**: `cli.run` (keyword pass-through), `dashboard.incident_card`
+        (relies on all defaults), `digest.internal_digest` (`include_internal=True`)
+        \u2014 so new parameters had to be keyword-only with defaults, and the return
+        type had to stay `str`.\\n- **Privacy**: `policy.visible_incidents` filters
+        internal incidents in the service layer *before* rendering, so renderers never
+        see unfiltered data.\\n- **Architecture** (README/AGENTS.md): each output
+        format gets its own renderer module; policy stays separate from presentation.\\n\\n##
+        Implementation\\n- **`json_renderer.py`** (new): mirrors `text_renderer.py`'s
+        contract \u2014 takes the already-policy-filtered `list[Incident]`, returns
+        a JSON string with an `incidents` array of `{title, severity}` objects in
+        input order. No policy logic, and the `internal` flag never leaks into output.\\n-
+        **`service.py`**: added a `_RENDERERS` registry (`text`, `json`) and a keyword-only
+        `format_name: str = 'text'` parameter; unknown formats raise a clear `ValueError`.
+        Privacy filtering still happens once, before the renderer runs, so both formats
+        share identical privacy behavior.\\n- **`cli.py`**: threads `format_name`
+        through to the service with the same default.\\n- **Untouched**: `policy.py`,
+        `incidents.py`, `text_renderer.py`, `dashboard.py`, `digest.py` \u2014 every
+        existing caller and default is preserved.\\n\\n## Tests\\nAdded five tests
+        alongside the two existing ones (which lock in text-by-default and privacy
+        defaults):\\n- Service JSON path: hides internal by default (with order preserved
+        across the filtered gap), includes internal on explicit opt-in.\\n- CLI JSON
+        path: same pair, including explicit `include_internal=True` opt-in.\\n- Text
+        remains the default format when `format_name` is omitted on the service.\\n\\n**Full
+        suite: `pytest -q` \u2192 7 passed.**\"}],\"stop_reason\":\"end_turn\",\"stop_sequence\":null,\"stop_details\":null,\"usage\":{\"input_tokens\":152,\"cache_creation_input_tokens\":14143,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":14143,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":780,\"output_tokens_details\":{\"thinking_tokens\":17},\"service_tier\":\"standard\",\"inference_geo\":\"global\"}}"
     headers:
       anthropic-organization-id:
       - 44ae676c-958f-4d68-9108-eae9de7b366b
@@ -6402,8 +6276,6 @@ interactions:
       - a2b325926e136f22-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-security-policy:
       - default-src 'none'; frame-ancestors 'none'
       content-type:

--- a/tests/researcher/cassettes/test_researcher_integration/test_researcher_completes_task.yaml
+++ b/tests/researcher/cassettes/test_researcher_integration/test_researcher_completes_task.yaml
@@ -65,44 +65,92 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: !!binary |
-        G3YYAMQ3U/Pvezm94SnFrSq9/tKd0UIUJDOmQH0SXK+S8X37pUpEyLhoHeFmdkZ8CheCrAhndv/d
-        2wLxzxXBAkoiI6uvpwokY6tc7iGbXS5k0D6GfoE/rwDjalPARE59OeP1rtktV3Na7De77Wo229C2
-        2S3tvFrMZ7v5frOfr+aVne32Da0WvFuZ0RVgQvWdrZoCBtbAlNF1mL8A1yWpKTDf7jbb1Xyz37ar
-        kpQ0JwIxrB8dF8+dZwo05BMX0XXId7WmAORFAaangaMpYC5iMWKugMvKqVv9WbGdze7LMYZoCkj2
-        vv+XbCL/n1nsUPYs5HUwBWaTBkI84nJatw1Sa0WIPlPAzGyXIG/Tdj9gnsEVrCOdnbSwQazPyQVJ
-        k4P8ylTvZ+RdU8jRcsJMxTy9nId9vGfiejhyAH2Tg3y9avgYEtxHUmMuuSlOSd1Nh3eYHOSFU8be
-        3s9DQ1Yz+Z7ugLPTIwiJxxoIXgXeyWlykJcuqZM2u3QsDeoeZN6u/9UQckQ4C5w0HFksTw5ykH9C
-        hiVBzZ5bUkZi31wV/V1qKKVTws5KfkNipFyNqWXRBL0YXz98WKmUTtfQEPwEr8geEbMkOIHTBECm
-        iZyOCa/W3yoeWIYyiRl67AX+TZAbjonUBRkhBfSUEpj/eDjFjljCIO7y7Iacp8rDN7k4yBiRZ0sc
-        5Vjg1//3AyED26BuQYK2AY6tQPOZK7h4Gga5b5SIdlLmALVEfZiY/7s7ui1D1j5rqeHEwmwl6ei2
-        1BB8acmz4Zt1oWZvCpi21/F6shmn4E1pEJGg2BZX020K/CdLKFGsC3azsU+VC7us7fP29bpe22W1
-        pvlqtt/dQEfdOvT8XJ9FMABkUSWV4MMHq62xpoD5eTCUKKIU6vhgioOhxtyDGR2MUjqVjX0nN5zU
-        sV6miczjIz3wmJprfB30GESq+LJ3C8n7AU7wok7vcjJf8iLnoktWgPswIjr2Th1smvQF9zYJsR2h
-        536h/H/CG6dvc/XZMLV/98M1MAcHuzuBzkDWiUg1IOztTlrBrsevfFVsgY40R6fD9CAkjO9YlDxQ
-        vHiEYzhDAyaUjKczQWxsevUzj4bTEWIWdR1j2snmxlk+AVl69Jt3H6Ghbb2TFvblM0bgW2VJLghs
-        6HpSVznvdMAlzIBy3MeKNuR9RfY0wrPn76bnI7OHUts6aUdardm7Tm8dHyRNLdMdYOmGSVPOwv0k
-        A2z/YxJChCd7Qi6/pQrNBO/E+lyzPtvvj18/phns0oDYt1+rugNIBpW2nbmw5Ygl70sjCf/+s9+P
-        33//+Ef/vfnV3/7252r547fTS7v6/zUjNwt1QqAVWmDYfPhyBXwT23voKZL37KW6R2PmKtcXObFY
-        tkjkVMSlsUUIWVX8cn0MXa+lJXvk8sRD+WhkZVEPPWaxOmoNkQKyNrVG0z7QFDDkfak5is7aDzCp
-        Ji8yBYwE4ZLmLtRoID+DPiel3HUUwWJ7PTlRwzqUDLkhW2eeR7Wh1LLYeH7Y+gQNkZE3V7nrOZLm
-        omiONzME4zoAr4llUm9BXVBI0QXqsTccq5AcFa5kOq5d7vwMpF/3MTjbQ4ayBlOYyYlaXvPdXEct
-        ly3L645O9D1AbC+Ungc15j4dn2bIsmNTGF9qGRvgXLUuXV3v4uBNWCsRtnvOXJXGViGpW3JXumfb
-        J22mqbCJZMysdigxw4/ruaCCvmBOAfOa1R59r5AdirGiCA3IihfsqWWcUXZu625Y8MevH/0NPd3W
-        ZyQ4BSV0FE91OAtCROWE4tCfN1k5aYYSnrkqG1Z7NCS5YrJH7khkoa2INyykEGHRV3yNoeeojpPH
-        jD93MH0FQclrAkyOfrEDRfW/H7VpNzQAbjEmbMTCc+Wk0UlrOkwunXuXdpGxGElNNiwEgLim/60R
-        SWcYYgzTm2Dn7qTRxR5ZjZmvWN0u37nxQ/zSe90kPS+HBlCCD17tJEqGAO9UpBwOLuX+vx+5br5d
-        2J0f5DG8do05K24DodulFSyfwh5ZlUE5cV9Cnl1uTJj9TB0jnXSB+W/WgJhlgk85KSrG1ghAeZHp
-        IN4l5Rrpj6s4LW98rGqDy5kb0MHvygQjxo2OeEmCAv6JHtnqlC+PUO4YE3dRjoIHUfAYQvLO0vEK
-        hNQ7n3p6U/BCJbogB6snMtX+E8pdWWtUmrBuy5lFsHqCbUnW88eLcZ8bzVFY9TpD0yRWaNB30mbb
-        CedzPueu4ojQoCO12qXbO+EA/rh0cj30NLXdnXAnRLDUd2Xy9B4/woylR5wot1trCBLLICAySP22
-        J4vZ8x0+0a3rcoctevxgFPZ97zx+hPkDWE9dj/u/EghVdl7HTmCpvzuEMU0MXcmbr9J92/SlkxLj
-        X4QsimuKNl9PrzHjXeNfbEPdKAQF/2Coq7MKwTMJXT9K6gclSJvGG+WasB95ZCA/4pFypb3CB3E1
-        ksEoRGOyWimyCd0512MoRDJ8aRSaUjRiORPIoS7tLJZLLyeX7P2TfvC/LcmjMjZ6ghfnX+2Cqd3s
-        K2dHOtM0+NAgGoON4bLKdasldDwFdXFrV1S6w1ctdeg5kcEzYZK0G7rtlW+1TO4HB028isI5cSwv
-        faZdA0aC3EXtZbeuIzVZDcaGYRZeTMwclhCf7fDHb01aIre8aftcoK7jH0GYrU0hElkE6I/T0Jc+
-        tH0MVYgEBUEfizfsdwvbY5bRxGajOwx4oyb+s4R651nt56tRqes9NOH6Kc/RadyFVby6NLvabedX
-        nrA93DvkfLm9c66etwakitpsIV3/eraeB2c7ySmSf1bHSjUpmQI/L1cX
+      string: "{\n  \"id\": \"resp_0e58f8341a296874006a7f83c1b21081969141bc089fa42e84\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1786741697,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1786741700,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Search broadly before drawing conclusions.\\nRead the sources that support
+        each important claim.\\nPrefer primary and authoritative sources.\\nCite every
+        factual claim with a direct source link.\\nDistinguish sourced facts from
+        your own inference.\\n\\nYou can delegate self-contained tasks to these sub-agents
+        using the `delegate_task` tool. Each runs in its own fresh context and does
+        not see this conversation, so pass everything it needs.\\n\\nAvailable sub-agents:\\n-
+        researcher: Research a focused sub-question on the web and report back with
+        findings and source links\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-5.6-sol\",\n  \"moderation\": null,\n  \"output\":
+        [\n    {\n      \"id\": \"fc_0e58f8341a296874006a7f83c2c3dc819699d5d5c3b5a14098\",\n
+        \     \"type\": \"function_call\",\n      \"status\": \"completed\",\n      \"arguments\":
+        \"{\\\"agent_name\\\":\\\"researcher\\\",\\\"task\\\":\\\"Investigate free-threaded
+        Python support specifically in CPython 3.13 using only official Python sources
+        (docs.python.org, peps.python.org, python.org, GitHub python/cpython if necessary).
+        Search broadly and read the supporting sources. Report: maturity/experimental
+        status, how to obtain/build/enable it, runtime identification and GIL toggling
+        behavior, extension compatibility requirements and GIL fallback, ABI/wheel
+        tagging, important limitations/performance caveats, and any guarantees or
+        lack thereof. Include direct source URLs for every factual claim, and distinguish
+        any inference.\\\"}\",\n      \"call_id\": \"call_ThjTLUpjfRlxSV43zSkDc4qF\",\n
+        \     \"name\": \"delegate_task\"\n    }\n  ],\n  \"parallel_tool_calls\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": \"24h\",\n  \"reasoning\": {\n    \"context\":
+        \"all_turns\",\n    \"effort\": \"none\",\n    \"mode\": \"standard\",\n    \"summary\":
+        null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n
+        \ \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\":
+        {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n  },\n
+        \ \"tool_choice\": \"auto\",\n  \"tool_usage\": {\n    \"image_gen\": {\n
+        \     \"input_tokens\": 0,\n      \"input_tokens_details\": {\n        \"image_tokens\":
+        0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\": 0,\n      \"output_tokens_details\":
+        {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"total_tokens\":
+        0\n    },\n    \"web_search\": {\n      \"num_requests\": 0\n    }\n  },\n
+        \ \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\":
+        \"Fetches the content of a web page at the given URL and returns it as markdown
+        or binary content.\",\n      \"name\": \"web_fetch\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"url\": {\n            \"description\":
+        \"The URL to fetch.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"url\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": true\n    },\n    {\n      \"type\":
+        \"function\",\n      \"description\": \"Delegate a self-contained task to
+        a named sub-agent and return its result.\\n\\nThe sub-agent runs in its own
+        fresh context and does not see this\\nconversation, so `task` must contain
+        everything it needs.\",\n      \"name\": \"delegate_task\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"agent_name\": {\n            \"description\":
+        \"Name of the sub-agent to run. Must be one of the agents\\nlisted in the
+        instructions.\",\n            \"type\": \"string\"\n          },\n          \"task\":
+        {\n            \"description\": \"The complete, self-contained instruction
+        for the sub-agent.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"agent_name\",\n          \"task\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": true\n    },\n    {\n
+        \     \"type\": \"function\",\n      \"description\": \"Read a slice of a
+        spilled tool result.\",\n      \"name\": \"read_tool_result\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"handle\": {\n            \"description\":
+        \"The handle from the overflowed tool return.\",\n            \"type\": \"string\"\n
+        \         },\n          \"offset\": {\n            \"default\": 0,\n            \"description\":
+        \"Number of matching lines to skip from the start (or end). Must be >= 0.\",\n
+        \           \"type\": \"integer\"\n          },\n          \"limit\": {\n
+        \           \"default\": 200,\n            \"description\": \"Maximum number
+        of lines to return (>= 1; clamped to a built-in cap).\",\n            \"type\":
+        \"integer\"\n          },\n          \"from_end\": {\n            \"default\":
+        false,\n            \"description\": \"Count `offset`/`limit` from the end
+        of the result.\",\n            \"type\": \"boolean\"\n          },\n          \"pattern\":
+        {\n            \"default\": null,\n            \"description\": \"Optional
+        literal substring; only lines containing it are returned.\",\n            \"anyOf\":
+        [\n              {\n                \"type\": \"string\"\n              },\n
+        \             {\n                \"type\": \"null\"\n              }\n            ]\n
+        \         }\n        },\n        \"required\": [\n          \"handle\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": false\n    },\n
+        \   {\n      \"type\": \"web_search\",\n      \"return_token_budget\": \"default\",\n
+        \     \"search_content_types\": [\n        \"text\"\n      ],\n      \"search_context_size\":
+        \"medium\",\n      \"user_location\": {\n        \"type\": \"approximate\",\n
+        \       \"city\": null,\n        \"country\": \"US\",\n        \"region\":
+        null,\n        \"timezone\": null\n      }\n    }\n  ],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 0.98,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n
+        \   \"input_tokens\": 4914,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\":
+        0,\n      \"cached_tokens\": 4871\n    },\n    \"output_tokens\": 137,\n    \"output_tokens_details\":
+        {\n      \"reasoning_tokens\": 0\n    },\n    \"total_tokens\": 5051\n  },\n
+        \ \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       access-control-expose-headers:
       - X-Request-ID
@@ -116,8 +164,6 @@ interactions:
       - a2b2ef19c8eca619-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-type:
       - application/json
       date:
@@ -218,542 +264,555 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: !!binary |
-        i/8PAGRE59fXT1NFr97sGHAODYD/viyk2JzTTlwOJLDwo/CFA8n4mwOzNSzc+3xNLBxzkMVp9yAh
-        BsAh/QWiY6kM5+5SSPFlokf4/79er5+2+Pnz+lnLbUmAIodzvMCAFIPKqiIAAEvxioBzFC3InABJ
-        LIOgjMwKnMgxCEaL6uevX6/Xz5x1Zb7//Hn9uJX+IyONw3yDskjS/efPC8QJDEdAHADtgbY93Y+N
-        5ERGcbAyeK7Oz59XlQ5bKSKNQ15Y//x5ufyk1+tnSZ9y/fnz+hnEQv3z6/X6RzkJ1vyBJmCyY7mu
-        8/rz5zUdw4C/abWWn6Oc8idZyikd9ufnzwv4G5CbZA9WMlk3t822WUSYyeAY0zuZj3059mSf+9JA
-        Gfs8D0meDpCHjXNRDj9/Xj/1sr/Rv7H3Ng8/zyJrurfzZIegRvTz5/WvcCGEjkm8+rgdAQwHiokp
-        iZcgjoIIlhdghhMVBCTen6VMHoXSbZ7aqRabTApQ9uf1r38LTiinfH2WvSwSI/8L+KemKIqi6E+F
-        2CYvb7zaFfVjcrKUC12OV1+ISpHs+4VmQILjmqU6ji15m7dSdp4oNy5ScIaePOvzREWNzmEonuej
-        rkNkgHAkAmrlFC5FpHJngDKFSFsun7wnoMORRijpC0Sy6ojXKNRsII7xNKvlqZBPYJkw4zx0moBc
-        V8vFaly44WorZF70XETlw+n1QwbVM/9sj7Hi3+u98256vvcbpr0Sfs/8tuYp1OiqP/nvqM84qr2i
-        6x5g77t6XbNEM2nvGP3UqrbGtAsIqGFwJzWiqDF1clCtsyAr7sDLNrW2ycJN+OV5i/EAZjjHHHpo
-        qkyoIfxVPaXzbBQ0QCZjvHtVQ4IQkc4JTssMdV/jSARlPpavcIcHJcxsfbiJnOP7w6VYY53IpmgG
-        9hHFzxA0/YO2oZVCbJRSXwx+TPb2Gu3pKXVkLtCnr3eyVfYwQETl+YJL5josqu1WEvQtm+STs2pU
-        uu98PAzr2UWozvMjc7MeJ6k0uJK0TNNYEAckstixPkUR3AB0DK6VxC9AGd/bgsvBWJzkJCL7CIdS
-        AX/FrtjoNURkYMd0akUyad27GqfCwI/9N9h8HEPo32+sOQpVS+HoDAc1FFrANQdC9Hr2qlDESUVr
-        QO012VGMgQHaA817uMFwP/N38MCNryUNKDSGkgkFLGH3NKmFsse9AvOAcKjAY9M0IWYeODeVBJdE
-        6VcRD5nOSXBj+U4cKPEv6Qp32kkoHqLfV0k7H9dVEJGwArHOq2p/uA2BmhhbXb362EWAEz1B3YoO
-        lItVxdOWqNnGphhu4RAjB1vrtI3T33vuuntEXZc+oOAG7ogqJZGY7yEAjqzygHQ71VOeQ5ntr8yW
-        4cXb2wuSmp7+dBcVZHCiQMUkNDxt5AD7Zixwh8Pvh73oOF9cAay6aSdTFSIQx6HewnuLTr6ofBxp
-        ycVAbV1QB6qI86FfgyiZg8A9i88RZQBC2FGnV0RsfvHKdhyzkAa8t6/FkGAqcQppiz2qkhnOyESe
-        7CvZtYO2iDLDDVVF88wt2UuiMb7MNWhIB1NWd7mLq4KI5xPszLjCWjIAEKX2w+0MM5CdbTuSRqkN
-        +DyZDToshvsDX4LprAjlZ14IAMlRh6PPUdqfrePGSgrvKaila5TG6UviH07cNDPRIrMfl6IlgSCU
-        uKx4LEIlzLPFO1UuKBg503NXMhSMNmDzv65gpwvKD8op5LJdRp9aFuhckY578L0AGTSm7VIGCJ3m
-        w0yQjjuZv8ZTIj4WbuU6e6MTTuSM6IF0wPElbXKicSCDQwHDFM3zPcIIRUbqYGOm6QXvxtlZeBaq
-        bQ3yOQ83DwXv90nfLItlBYLXTakX9xKlDwV6fFm5qWSQTA+VE+i8JWHrGL+nYQ8JgFl1xO1b2kI7
-        VdLVbDtjlxTp2J6FZNhikSb46T0H60DX3qfFMwxfjRiVKr/qyrnf5orleCLuXbbDQzl1LYikJtRo
-        iMZMfOJ4gYGMGSirfBwGZgznDE1JVsJOh3A11WY1Xos0vGGyupzMxYXlwXHOa9Dr9/TVKsoLLtYG
-        EG/gaubmIEuv5FA2rcZyNYGmyNR2kXR3CDdUEm4LVmdFYr8TFQIWlS7RS6+R2XI7kYkTaXuyIUiS
-        IkykRAswTCD2mlzle4jeTmuyEo6+UDQM1Vj194eqkC6jBQ6ZrjOQJ/7G7rNtrNtvEd0HjM93jaj3
-        Zw8fSTJP6hvyo6L7Imx3mlWQqWV6oCVa64zpMi+SnyEvjHWoqUMgYnr2My6++VPzZ4vh22E7pIq9
-        Szn3Orlk0KxdzWTVpsm4H7SKAd8SZsnYe7qtNBYRE/kzqiAzWBK/bU2sG8MBnVC2Zcv4GCjEVBp+
-        lx679XhRo37VXPfEAGQCOvXRl+ospjo3olloQ+2ppYGTrI4TtF9QxeSojfSRIBuxMCSFtkE+NnwZ
-        UNL9rNlOAATOUT4WX5x8gDPLeY8R06F6MbEUSLBERUFRDc273itbhlUmDM57q0A1LmJo/23cSMy3
-        8jziQ5dG7Wud5ELPPO+yi+jsOkBw2PxIB7LQjpEFKLYLpihKWsAB4jkjcUN8WoIRDoJWIe47hdte
-        N7k/3gN3rcO+hfiT3RbkcyT7nJhn4Wl+MN578oVzEng5cSXgTD5c/V8/f/16vV6v1+tnO8YxXZ+f
-        P69//fvX6/V6/fPXr9eL8OB6YUm8xBFYiBwpUSgjkLKoYLAiK+lVZsn0kSGGZmLIJs4KGSBPzYfM
-        T80pFAGRDDbg9fr5HOXalht1I7xd7Gdr9/JPMefb38uzN/P097zWv+G/QfhVrWX5XoERGkVZvBjT
-        CP0llgqS+qL8rq81UpE3ltOeut4OfI3fzXztsxbU68x2ql/lvZfT1s7TptEaLt5SLmW8TM584QDs
-        UAt+gImipdee1q98gUF43xao2705srVyQUAP73e+IJKmcwQFxULzSQRJTVjJoWiVY3+wPf07/OlP
-        1FxPG+JEj9D/8RDjH39ZSqU2U3JRTsLlBumSOVCkMAhWGAzhFbZ5HFRtCk0Cn4+yZ3ZRj75TgjYl
-        kTNwhnOit4ZqH0bXc35g7G1yTG0txLfUJXVatBMUkj22Q0QYLnu0tM1yfSkUt8iZ/fBfNLx0FJVB
-        cftISPDUe22oulgBAFJ+T0gcBK5XZCguAQ7HKpd1h23wNQZqMMMOgby6GsL9ykjd3cr89ut8oTMn
-        z9pmc+bR8rCYSGoPaeMqQRGKRm5Nl/qlsyIbl8x74buCumH7TBOe8sDajihub6HSQFYc4YbmzF3H
-        IuFGWbazXD4uDhv5p1l00baznj4Gga0keMIEfzB6DsT4r5PPQMFJmmKDanTsgeOBtpwa+tisSjLg
-        nSt+2zWbgjjvPXQMRJYfIH6UAg5wJdDGwxD7QHRWv4MKKcXIQPKaMbVQY9KhXO/8/e7OXHuGjSo/
-        MO6KINsF8exgVpQntIwSAHPPN/75TNY1drEQgJ8K3HQ0cHbHxuJZobK7Xqfvwxrg9JHiNL8OPtQ/
-        I5H6QaR5+bgwVioFV+sKQomlxbb4WHzRg3/57jDshsk1Z+M9NY3Bi8Z0wqW9vaLY1Z6aHRzHbNO1
-        ypIaCHQRDbWE5RiHHaCYIoR7LHp7rywcj4G0ZDDpEgxL9jLvUbNkhbhDfiAjob4Ch0R3xSvLEmyy
-        Y6vFQgU7HrWVvc12S3ki607BpYXihFretHj80iTOhoDg/Tnozy5vj4t6SouUDhcfn6wl+WUaETLG
-        D+v8WPikNmW0GtUy4PXXdpEgzitrZZR+LrtybK6Egz2S1c4TmNEUzcb0QQfXiBe34CGET4BR2Uh1
-        5OdvPDSH0im4CfoLNjXy0FiQUDXgbmSEZ8rHccXQ12XyueijoGP3xyvqJKVaQJ4OHL7kISQaAMG5
-        apwqrhjQZmU/38ogs3t0TqckkdF3LemJU9ZbiYbIsTftbpeJuvF0Tio+Hppx9TKOUr4WKmhDSRzs
-        Ff5XSIae+B6xdFndByuTzvLIiRz6lb6dx2jt0e+hoiLKRg8ceFbhT7aKcvLhkie19ice4YjzbQ5l
-        getTBo4ZfOKxdbcbKETDn+3giNnGrJpuaQw49MT7EJCiRxvCoB0P27vx0xUg2Kull5YktvYBfp0C
-        18y1JPEbC4Dv7VbjasautPZXAx32z1LlIqdE7DzzKc+sFST11yAzTXn1bM8seCYpFO8OxXbbxTOn
-        lEHDqMXPnjXckSHQNNaUFnNxHa2kohQIPaOULvqNoE7ELcKM8nK/PsmKzPjUt+anJmMSGNYGhOU+
-        /+xW537VRZg9uSF7SCZwBKVAnge+KMYXYONJZqgtTAUAPK2ULC4R8Dtyt0gxxYqHIez5dAfT5Bxr
-        AhX9Xb856xrlgvejTvzXz1+/Xq/X6/X62Y5xTNfn58/rX//+9Xq9Xv/89av9i82UBChAHLkLZjgA
-        pwSJARWG4WmOVNq/rybdt6m8CIqFeZZK+fq/H77OGfp/P8rspCKuv8mCpJ3qt/LoNPtIaTrk73Rp
-        f7dTu1st+jIfb9pmgqVXos3FMZSJU+6MQaAZLGuoE91wE8/hWPd2G9psTdfn9/ZsispK2i2p2yEZ
-        xWtQCvbhwMAlojuFdWCqIiuQKlEhMEqSZYZDBUrm1WechO3ZlwUI03iplteY+r6fSWi/RlVlV8bA
-        /U60qwDZh8bhkGAd36aMP2VkpUJTWBRYtNG+r64Y4tquA/QmnvLqWF58S9YI4eSBkoh4sgTaYygV
-        PF/HG89kQe93hxy8Q1uHJuEw2Aw90aeub3XzYeQAGnw7apvrFiUcOGauvN/G93XsZY5mYhbbYpwH
-        xWNdNMHXDAkiHqeFzs3wEJwSJebR3spq6xcb8FBHrN7UmZalpvcjUlFT1E4Kn5mvd4h8a1D3yfNI
-        5RiBtiINqNxyYAn+jYHwYm7+YS3Jd9uYy581mwBCcKb8UGZGj1DW9/hlpzYI39FeBQMJsFQJGV9A
-        EiJASJm0z/ZpQvpw2ZMTCW3oettBQ4Ffzj0aWD3HdTrfnVn3Nc2xjXFcQ4R7b7a8YGiSt3u63VKO
-        wac+j1wHP50fSyslzJjaIKAzoXZbEpA9jPHXWKQ8rmHZMkFtddavctaVcTc4HmAyNeQBpmBTW8s+
-        ggxuOfrs+DTGBoI03ZljjEXNRHzObfTsLAmnRKq+whYXapsWmuIzTJlhXoNUeJRTff4uZTVvSnP1
-        ho8wrJ/MAMLUpnX6+KJX+56TGeDO0bEkWckyPX5DQVfWTzHbABbcaBz2AWpll+xMnb7Pj/VYGCi8
-        7WMxoVFowcGcHAnxbdQwF1hljU/dWxENmg1Zsyjwpd/Z2tMrg/LD4vmhVm4xzuX744CjRuX7LjrQ
-        8E490VLsi0dze+CdgwgEaMixYRaLuIeuqiqsMVCO1Uo/8o5NjqQJ4HU77KPHisjl4Zh4LJzSUt1J
-        6fPZOJIZ2eibViWWQlLFqdWAmf07G+KAo2MotVKHGalJuz/XLvRVINEuu+/siJ66lfNNTgFy+1kY
-        tm7MrbfT/WKHzAxXn6V0stgyC/I6G2lcgNnRVkFJmFd9UHD3xHfuhwsaBiOM1ol5/dRaqzaQyR0Y
-        MBEVCXUtotodQYj2q+G6owa1+mn6GeFrPhyy66TVxi9Ly77BvbC9uGvjkQV37XHjVs3DPNETxh4o
-        plo1oddY3C4F3lY7Jpsrndt6r9PPFY179KiD531w6CGvgCS9QctGKZpN0NQF+zvC9pysQiQEmio8
-        3z2nnSzKBWRiRfebc2OGa1Sf01G2jBuwVc+rE22pRBYL0/2DIiI/EJZ34yRFnqOOlCJUhNBMuvPD
-        7ULCrQcMX3rfdcuygz5X+ivNhhXAEgMlKMB064WLk93nl9ePYYfJXUViaAO8RWpz3RbGjXexSNmT
-        bUMnUGFfvZs09jIR9+vAJb6IKsvQMDu7wGE9HzsGCwXoF/R8HWNTbrDzCH2nsqBb//VfP3/9er1e
-        r9frZztGhgEqALCACUSfFkSBIEUOARkOFRlRlZqXckqWtC4v/GPtrtUAzb4v25/fvzkAUZ8zanmS
-        AkLBrphItcAAPAcqlAAQogTAze0LaCuzru7IxJUMwpMbRQP4NLPzVxArG/0iLA0ABMARiO501wg2
-        qgNGdC9I7PpuMIE6i9InumGL6v28JHOEDgMuoYlwuqkFy9EROBRFuY93A3y+C49VITGkTigyxifX
-        9Q+AT9dNr0Uy9GomU1wNHLgVF/q+IRxYw24Eh5mGsmd6GNt1KN46+azJk7AwN848yuGMoJmqvZvW
-        ipZozbMVmc+ykDIoAU/exTLkWy4LHUMu3X/59OkL7zTKaXB1U0bSS+pOreFWwoEkmpNhXeWAoHvP
-        n6dSB92Nt2sxvXUPWOHwsrwJSOLNbzd8naEAfcAhOL+5Z5Nvqbhnskk4IucmBwVxgLnrfrtLDmWe
-        xFyqoackR8bXDDSuxUFhwAi3MQqCiguDXC9jizoJnBWNR9YosRDTMVH5wK06ko1bcxG0lHqecAhC
-        hE5h27knHBfmy2FcU77EIQl6OU3h3gKbMIuvnYaPY5bMG7xcrxSwoVivkOizRtER15N4OOfQm57x
-        dF+2tqfvWsh7VGa1Ujs88d2fn4wb7g2aJXa8rHyFFsEVUVjx1E5O9a+hJ3X/FIO9Yoou0yG4ewZK
-        OQMJB4y14mQnC8f2QeKKyecQKg/GGQCIDTY/WhltL5Ot7y8ZK4U5VzaMH/ErWmjiWT0zHBsnDmuR
-        1vNeALazWE4QG9GArbfVAPj/AEBGdD2f9dtUT79eKwY8NgAmOQtwjPB/Nw06CkRviWRrgV9rAgcc
-        xcU+VQpEex7xB7Gs1OniI/h4uq4OIU1bxVeAtrpf5/RBH6ehbHfEB5CxPzttHceNERjdRR91lRhO
-        Toj+2HbLdXNvOSNOtcrt51ajp6qgmldUw9zuBZNmID6JrjKrHl5sXPqa7xCOl0OI3f1jLRARXbhk
-        fbNxGAx31XaOfJxARaUrHyFTBHWh2usrpz+eL03uIGGEcrvwZ+2BVD8jykg4sglpOiF7Aw+HJInc
-        k1kUtQmUo2oDfLtrEoZOJsdKFiRraYNNyPpmKFIFAqJLaSWsFRYzwTYInIV21o1HzCFmLMFvAkz8
-        I+O9kSlYXmUeQSD9YK+7+GNnoBU6bdA2dJE/j12kHhHOQs4hu4ambZsmMFlZgatX4gztaYJBl3bp
-        GrwjjejEvhRSxNOfy3JGl5JEfIx4Q7SMOAOMwK7yTIFZ3eVq199vf+Cco8JL/95vHBCXeEc1TcIz
-        2pz149J53vcFlf0BUuPXoc/dHe30ENZocG8mUcFyKGSqp0dVP2vImzXf1+johyYSunn1PDA6xZNd
-        YyPQyTlccYO//GphFgtd3Z+5pOMdyJv0vdRdV+h6xSBJ9u1WOk0d56sukU1Pv/dosWoPW/f//t//
-        /Ptff39/f39//+znSFkSTEIE6CmKJCGkIAoQQ8EMxjGg7qYy7Q720dD+P//j758/RxNlWDDOZfX3
-        bc3CPjIx10XIvEzZTUZRDAbBmhE4QeQghhUlASNYie81f9V+VNXnW8fUzn5UbpjhDPGB6VQhyJ6k
-        +/SDKcSjHBvqIZ0ZL1SJVkwuwgIQ4RsBxePEdcRh1rRFaoZu+3pEkqFqeFEk/RXpL3T33hSHtcGB
-        Zze9PLDN29CcUx2srXkwF7XkVH0nAJ5CmCmQ9qIGZzUNVyJB77c8YEpSfJI40k2jAnu4gyc2L05H
-        ATxs40f0Z+vz9htESsQZS+ZnbQKHDvIB1g8LJU7F3MOL4dHD+Z3UOsMH809XPhoTEwThnKSbMz1B
-        cow0EDqbZ+tj2BKCSu5oVPp3WF2UtdYt0ZedRx5dfuYF1cBvCqLFWdjfmXLyrmtQ4Wp1b1gD529k
-        Vd/XRU3WtF7bk/OpJazwrJOllz89PizB7sk6DyvhD7A5Z6YkZm+uHCMThKLfEtZrWp4C/oeczwJi
-        ToTbCj7g7jUXE8YMo4ChLOE8uLkiWXfye1Nmb7pUweVmOWh85RqkJ/IiahlKx6Ec2uLDTYjdXr3F
-        BfEBjxvMVV7HC0ApjFyyVu9u0ca0wyhUcNJKQwGG8enlIj9RWHOoYshCHtMwdDXXD1g+/QOWzOWF
-        RxP2bZZiI17r9vvcSaE/HVdC8MzdcodgCyy27coFg1iGEP616ll8ZtbNRovISgQSZ7CoXwq/S9FA
-        AGE6roxMgA5guKsEd+rXu+4RyrPPpQsIwj78esS5G2i9Fi2xWiAzETOOuIQv5gnG+DfISIQdnE78
-        lAFt2ZUj4UjMrtkqH90c9QOTJPiIhCGB7jrfiUT3marmalE0cZ4tKis0R3Kt9ySUWMHHI3CeSdit
-        MVKvBEwD+lECud5vbwFpYT4KLo9lbBooIPZu7iNwtydXaCJU5EuV6grPZ5r5sEkKWRS6v12jWZa4
-        KrvIo1rYHHdGmCTVrQZwPCD3FZuyBeZGvM2mwvIN7EBuYeY3DIlLaN0MQ1FMdIZMVykV/36aDHJa
-        oSl5mh82giiyRbB4ebCG1zdruGaS14m7HLktk25Oe8f09mkCGG08/JlbaKkpUcPXmP/CJ807GGrl
-        kn1WEr4u9apxjmCs80M8VFuh6UAOo7iGkb1irguIJqWEJHkGJa5+Wbm73967ExtuRKgfNLiGJUNW
-        zzxljlfcDaWTILtTTbiJpn/LQQDewK07xMJVM3gyXYHv3qywq82w8eYiBXA98j3gq8alnJfQLnLY
-        5qrpR4rako/MeJi4aRYK8AB/9lxb2+nPdYxh4nSgLR9+Cy9m41waBrsHDgVy9/SqlhI06cVCgotm
-        q04dEmEu/Bp940L5KBw9K62NxDrXvzoeSSBnm5lRNJiUQW7SPecOtQtMCLGCdTh+lttDd0LDUuXu
-        2moIAWrgPWpfJ6Wp9y8TR2yeqvbdvl1B7frk5lV2nc2CJbOtZkLllGdrwC1bapU13zmd0VaP5ufO
-        dayyIc4xeTKy8l/56IMfe5WUU7Ah5uLaJIuW3aluJlFFeHEywkUviXmFFqq0baxgzyDYRZaguHpn
-        uL2aULCKzhfg6GdCFr/7tf/3//7n3//6+/v7+/v7Zz/HMdvef/7H33/+97/+/sQowlCEhHxBkQgO
-        1SVEgkiJY0jK7mNhW1XDn5c114Tp1bAS94L+x1ItAEiAyH8wt0pgRbZAh+Q5RKEEhdcVWNQlluMc
-        Kdj/Ji1k+xhhcm8B0HEtgHvgB5qygNKYdw7XpiExSFEoD/OxpI+Qlh/usASTyziSNnV7nS095IXO
-        oIUrlIVw3emRMEq8GVPAE03hzz2GB5MXND96Dk/aPpFSqFFXx5/EN4RhTJUjlrqK47oZqqhOgIkf
-        yLWvnsO0uWcDgGRnxDzrCWTusHvoEDVpBZSe9t5JRChAD1m4LDISj72+MhpHcZu3o1l++tW+Tt4R
-        8Tlt4M6ckGCkIqxPubGaCfFwALdBj/tVhfzTK5PboVpXeWwUJx4Pa3/egKCxFdSMOUH9tfk7u0wX
-        DKynpVGDCgbCbojacb+BdhH6mbvZ2n/+Z7qIHN6T+IRWShrLtkIfYYecnErONz9esfw6w9RE8S4j
-        yuKaEcO5WOFrZs81fx/AIAYNCsq1O3ygfbpDrMeFMZzfzEaw+eCK/ABJzsDkxZVjeimYsnaJFcDS
-        aQy41hvUJOvrW8RvOl2u+wYpXIcqYjWfO/89KvRVkI99XZu6EJnyH3yEZ6ZjAympKa1E9nc4zq69
-        CO6wv8tMgE06YcNzB1bmVb/5MFUTM4+RRUXo3Zll/SVpJbWtu6tWOrCKs7ZjNkN4mJqkqjpSNsPN
-        j7eR6OLh5RaG8NXaY6ht3dfkOgEr23zzDoiLBpnI6KJseBV9sVTNSrmZ2LA9siPAsjlLmIG0yJCe
-        h1DfUk/Bn2A3za4F0nC57GrJhcjCX00q8RZ4iN+uMrwDmXPWTJi0/poVqG0IFGEcH43MTFkHk8yM
-        XS8/1QuDDfRcNL/CgOOkQE22g2YdSeoZpCR6CnCh//HmlGQk/GOqk4bsSHLV6vbY3ZKkF0pl37Al
-        88jAFl80Z6nSwoj4YkTxXZzmYhxLl4FCNBCz1sypelhNnNuQ6Ui4rZGT2Y+xzxrAr7SbIP8pI+fH
-        WIsuAjnB78sTEMMp/rAighKQYn9kcuTnhByZlAkZuCBe0IV47aCBlDsotRui2AfeHSXyzMRBsMAh
-        mX8i9KNx7HynngNlFgu5lg8IldrByllDHbiUi+hdPI8hktTf9eZHgI82D8sBDvVgz/IyOu7fLt7W
-        YhmOtrPc2pscDuTTtel8YDZ/fIAMFTziclwF98P7oJzsMr4ZOfIW1q+OzvS4UJKn8r7Q8RBZyM+X
-        MD1Nh47FADPypYk03RKogzmErGuumSrawUO/6Bo4A3kBoZgrDwOWFyR9W+5CNGBh94zDrBiDsPnV
-        D35YKv2L0vVyL92as3Pgl+mAbl5SV6MlUiZfoMI+q3wsm3brQDhhPoeWk6/zRc8+Yo7whVJ8kSKU
-        kvWDONSlWMyJfRpMq3bVhQhovC6qF78jXAsgIOEpWOX4zfmpl2nISD0Jzrw9B4/qsXfn8p8SDxh+
-        uLOsRda2cOlotzTeB6Tl4wUCD6H+v//597/+/v7+/v7+2c9RJ2skTKIJTODjGUiBeJHBGQzmSFqX
-        JIm5sbSLxsrff/3T75VOSRiPwuq5HjA2XqeY9x/HVlWTk330726ravg72D6ZKcFzfqu5//YlaVE3
-        ykwmMYOaF1Sp9MFKElVBkSCclxkFojWMBzj/3lFwjS2+nEhqcX+FlUDaTAVX9tU2pzVMf6Wk2pXU
-        Ux8QxlMlS3M2fBi/Dq9uf3GGW4XQZDIBY4ZS+HOoEnR24eMyAlCdFks2RTMHWl1ud4NzrX3JTSUh
-        oOC7pwpPWtHN2DLY3KnAhyjEygKzqCMR0b8L6DWSXgp1vCHp+JfFhO8ztOMN35n5t92An81D2oMg
-        Yg6WxiWm9OL6EH0GJypZVJmMVFV0dW1jsce10TpU3nx3x/X6W7AApyXo+vk9Us0PEE6vgE0w/dXa
-        QWMVoibR7OLI48bZilpvN2rF5xQR8IDgV6JdX0j9mPjE1RdZGh+jihX8MiBFjhMz8sdnT0DCeGRq
-        TsODg33jA30B0rSjPmq3n+4t8ay7UKC/o3aDUEflCsrZiyZAg5+3Xasnn/pK69IMZBEuOIKMYcb4
-        mW50yPOSqIFZbIHHmkNs6bzyG0w8M83XAlEhZavx3IVh4D9m4sK9niGNeNIKlZT6kBSCdfs7g9+4
-        hywT8JpBFfMTao013h2z672pvoa1DeqZ119FidKEqnPh6CgDfLzZAu48Kj2ruQEAuP3lZ5t9u6a4
-        tMlszrYL7dE9IvrzFBjNRlWdOmMe3xn81o59+YhcGoXgj/a6/v5sXvJhoLsO1aJMx/mhAGAs4eYp
-        UwF5nr8Linbe8aLNvVvzrJ2Gh48HCAyll1tKm7CiIdjaAoDMpfYtvv/oewcznXcHHFeNJjGzDiOk
-        3MdFhrG8J0Q4fFPgVKLM/p571Zo1vxZzhNy1dpnfxYUhtHOmMSU3QjJGNGzTuQ5Y5KwMgr5G7Zzl
-        bt/Obk4d+pnTRPuwrVvJuEmGjyMDP0nIUxH/if6GEBRKfiJbLby2yJ2gknEhWyQdybXGaBMHFVmA
-        0iq+abZARml7WGnbRFJH1ptjQG87B9t600iIlaFrtQxpNStagT8vxG5CiquBPm5ZoiAblRJ4hYYY
-        MH4Apd8BE0EnTDANlVWvbIU+s7VtEccVbx32Nr9wYK/T/vPvy1Qe4QUMXNQqxxU0lK+KtJV+KKPd
-        AaWTejSRiJMqfF5PTXgHZ8DF2Vtj3djusXO5P6b+hgNYqIvYvcho1Ttlkk6dW09V6k82bmA3fO8M
-        wQFL+Nl2RxPy1bxtjjEVaCkvAt4d8RKGYapvf16piJnFzeWlH4ZuSyiQtDaOy4MVlwxp2ZnuOjlH
-        WQ9QC0HH/bYbPDK3QNKvGRUp0j3zHUqwUbrFinoMYI3w0DfSv3Nbep5wgo0JtmRilLLE+mBztk4v
-        PSZRIZflBynxhdHrC2wligpZ90rBijfp2X5DAaB02GFu9fFFgLsBz7I8hoX1FmyknGEqpPr1yALY
-        O7xlIP60F4lgA/J0KVPnyri+x1Xc14Vo8TrlTiDdfR4OFyLBOh/yRO373H4zVq51TJ0qTBLUiX7u
-        Qo1Lb6qKtus30q7dvRDcqAQjzu5v5mlpbuH8e6Ua0FDqcFEq39Zrkbu2prnpMA8RcxdQUshvVeyv
-        8uXt/tZ6wx9iRFy5+meb5rr1AkUTECESbtpCw4FWzmiqKr1wbu9EqPrPv+ml270P3y2LEq5I7JAM
-        w/CshLAcyUkQRUFcOo6JGV2gfJjzhfuvf1yTZuT/+ucvXBGMTvCRl7q+IMiR5SxPo+mG9OUA6mmW
-        Ps7SjJx6ksPT3H/9E1YlbnbrsFlQOksWqRavAmsQffKOqHIqxwoQx+qKIrEa59huNE8ToXEoMbNu
-        CwzvPLGR1oW9sDPYdI2o1upREJ1E0h3nqlQUn6in5FRXOUcHsj5D1Ab+o08mRuz7aQC+ffOujjr7
-        DfLD5KRetGtXJ2EpU+Hi1xFgABWoxUSeR01TFdLLG5BHzwul6LPZKzD1tlBtsmxzsUOelYbCO2KR
-        ETeActlVpwnUpgH9QcmCpxcu6FOFDuoGX4rRZT3f3FSyxsLdakkkKmiWAu2BeeJlsczwwSVMAZmA
-        hB2wD+etWyKRPTor+Hnj6KwNju5XvcwnI2bgQFhI2ZjsCY8og6E20u5+LUb58LEvuk9SfvLHjr5t
-        7A71TlgD3qTtiC1xV/z2SgXuV1A/tM+MgvsOd5rhEZ3yZ7PcDQ8+vFrPQBAyrdWkbvuiI2zezjCa
-        6wKTghXb+9J/hI7wKClDFrgTWzw8J22kqY3ql3BsY080WvOQtDO8WKxrBZ/Jv58ajB8RWrqRoxUQ
-        wx0pDJVF7PuvtIYWgu3UdDyhE5oKUj8fqJxIcWjCy9rVXy7rKyvt9T/g5/Z7SZpGMgnJrwlbpsvO
-        LwnR3bGIndVWjc/KQUWWfDzoEr84irLCVHdg67e1wNyXfcK13a35z5iGjVcImiDs1iuFD0vyQXaO
-        95W0m7IgpXTk/PV8DmvFfLsatAZre54/dBOPwwUBpC1JphmsdvxxKru/Mscpptn7jwH4/wFAJtwi
-        qnyTaGpebPlDNDhBRF8o9wb+/lSDBCwIMRgTc6FB+RbN+RwmEwCyW675j2oNW5LiuwJQwb5VN9V2
-        O+4hw8cQY34TVPIU1RD8rOAWsUBG6FsqpfaGB+GgZfqUM9MzgBKJT9tMeyRwdgDoIAK/sIoc+kR2
-        jWaOUDaghrNYNIOphuIqgKywWrvL6tNq8JnTNU28b2Lml87lneCEE6XxaojpKckx9I6rJBKQV8jo
-        gMHcc3M7zkBEa593CHupXEOTf94hX7oG5krOYydYHPDPAuMYetjINjYI9NLrI/dIawIHs6k6lhA4
-        Y7Oca6gSN35XShRj3wEnyr4pxA5Fb4D2W5QwVXRfRFsKE6/WdMZbTWdRa2onAC9a6tQO82iKPsEZ
-        txJxpXa/nJwBfZ0rW3d3bOgZBpdsNnJ5/9x01RyiI5lW/0UZeVNYpNR/44qrfXoYduqe1s782DzV
-        OT481mDSO5lsPKax5loeGwSl/KE8+ua0lqLc0Bq7/e6UCQN2sOYePDW9JR8a3zryuZjqE0DvzMeF
-        wJlq2610NBz10XLkkIDwTv5yStUAsBLyCSCtxqsMnssBIVjD08B0fOAT+tz6iYgNYHg+4RbOjAB/
-        L/W5p1q4BCxok+s64jmT4Gqbr+OLrjN57zvVBRZzHV3Fqiyv591kkfOgiU5rc8Op8xr5xqYoi/0K
-        ysRWV9b0B6OCEAQCIU/lIE6ABQpTEFyjRSRWtCXtcY/5X4plrrvm2qv/nRX/vo5ZN/8rRArELg5C
-        MwSbsOgQLGzrhkNZTtbFg5nUL6l2guvqxr/+N3hSAL68ShVj4wNE5CR1AIuCZYbWJJmTNQHDNhjk
-        Zg2SmP3mw/NaVa6nGY/shlgi1giN0nE5KyT49tjIB2thHODAuZy5QtR6jngiW7N3H2KNdFesO5JU
-        DZy3Ham6qaPhgiOCIsGhIdx+uVl6+hI5IiqrpaIu6ybtya/06OSyjlLAj1qEZUBaJ5CEhGAE9nHk
-        WiHH4Q52B+7kElM/KsXat16+v87Sb3t53nlyNqHdYxZdduqLnpPkgB8iAvdX1apQFAuCdPwRsJS9
-        KHYHFqMu5lyMkgi9pHccKr8A8QrWR3lV3hN6H0KRvY0l7KUE08R331Us6xYi+Yl+07Cv0YepG6hy
-        IrwQjeF1ibLInc6elYWJxbtNy0dKdxrQriy0rrkLNi47tNDYCgvbeuH9QNHc0nTe8PZPqlni81Ot
-        FdbZiVGE5nb738mfFVQehq9HFF7AsIulEyCvLf6ENco/dBXnCB4EpdsLSfuTJ3ElhJ1EnFZTbHdh
-        OGLLf+JG4ZN1vGZM+oD3aQQg8UBLuxR0zobDFit5WUHj92yFHOfrwV1wpuvDi7JioWnl3JTmhKkP
-        +LCPocvaS2nU6+9Vchoat1vL8T5nQBZlC+FCYCh6r9oUnuT18EStkBHwPYixi9O6SmRay8TZTGht
-        bIcE8BGU0UnL0RPos+7o8cXt2+D2QUnC0FxofEMLnOeiwdz6uInjJVXqkMwvNifWQQDAxOoP6WtL
-        JJjjnQ0xc+Zc+dj6LgBwbbqCTBwJ8EYu0DCBLLETNtbtdIg0jmbnY74e/ZW/VgCJzIvGwiYHeQrN
-        /Lwa+lLM2xpqqX7ybgtfsLEeFs3ZOHReaigYHLPgodhZHUsAf6dL7RV6wbChj0xLu1TDUAlSB0ep
-        C+MprFiZs/OVX96vd+9jtsgWib+rROHyl3sSR7G6YHMB7BAf06sSZ3S/en1Wo6a2N6gTo8geJzCp
-        UCaOZNIGMDTSo2mUJ6+a+qW/1OC9SZjt+alYjrMN+0XAhv4KEofS3PVFE3kj0PIxU73qE5pQUn9/
-        IaqBM8dRYU6DoAzk0y1VRHs5KNLkVZNz0bAcig9ySQ0F9XrKH88wNm5QOkLBCYzXxQmHej6GrjEH
-        bbktRdxnkO8LA5kAtt6dgRhUQv0wQNaH3LgYxNeZ20YHp+xn2lDppjXY4KclCkZjrwjMvEi9swdx
-        1VMghui9zmm1/RKFu89ATacAaYyRLX2eiIw8diiX9204y8JsO7dWZi+mkrDCYcjijgg/TVa1lGpZ
-        jTC19Ds1iOq6jPCCVpKWxanQ5KQDBI9cr8Lqge55WP5osN+FNRk+IJ37vcAzUH1rWOGsv3R02oYm
-        2f3lNhf93jElOJVy7lVjrg2Bw25kwe8C+B+fqlm7sDOJdg3wnMD5WJuOBNjdr7pWgxcXl24NrbZy
-        p4klFFz6MxGhRx63ZwrRfe+4mnoxBHJB8R1UH5F2IShAOpcxfRHjzt2Owgnm8p2+KHOxIuR3kuhA
-        cu1DB93ADN58s+oAbxwpfLlFwY4QqgZfxkKTsNCAPK5jBmtAhV0Y413Wa5qj6L25tJJ0Odt9R1d3
-        PK+pKS3Z1fxh2W/VVgHjgVURC5HkeFgbZ+H7XlPNQMrrZGq0lu/iYiUg6qysDH8zICrEk5LvoykL
-        i7ksamEGNRctZNHOe0FBjt2x8gM1HVkzofzaGPC6q85SI9bMLPbSEo/4Sp51TMRhYZYdOo1r5tdh
-        SPm6eG1ctq79nBRzZPi6FV/g+JvI7bD5rtuwlURfGaq6SvFOjyrGPXOv5HQHIekSupmSkgXh++Vi
-        WGwpZ4LejQks99w8AtxXniqOyZsobTlXk4poSxA2Pv2tSN5FStEqGVZfTxhj60YuU+dzchy7Mo2I
-        4QwMSPQDqDTV+sRwHREhzs43MIZbC4N8Z9pd1wFihH3dw+2SzTVshSR4D0XbzgkhAOc4SJMQa96X
-        HIEn//XvP//x58+fP3/+/D2uCYtSVE5hWkZlPTd1WZVkgROljQSPujhHBt8MqvDHyiCoafWnjm0W
-        Yf75v39HadpBe63s/HNcdd09//dvwjAZjfhfrQOcVEQC6S37fxXyrVumWhMhbSbQ0ioJHJzfJc8I
-        BCVLCi1BOMfxLPBQ95CaGbZRYwCXF5Y1r/mFeG/js4llaiCXSkBeSFNpTeOgZe8jk2l+OicQljqv
-        gUonc/kV0wdASL4ZW9K4MT8D1JTt3c6RUlIRmnZuPZ+tC3uVzLIZG2krCTmLU3wc9FH/yo0E3UpQ
-        yvvGRKRE2fkNexVUfFd/D1l51rQXMhj8ER6MqC5ZlpHBLQE5BA4GFO9A9fxroUDVeBdGu+QMXMlV
-        sBmNuWRAum3FaJGcYdi0tewPm/Xp4q8iso/opYxsComEeXeWa3UwDQy7W+ow3Q6jX+VuTb9oIdfF
-        Fp2QT7BkVnNvOCOPxvKWGiurbAQg1ZL21RWVqqt38nD7VY5OSOssM5AgQSUMjwitndTUCJ75fdyt
-        IedrSmIiX3W4O2QMWOvwTdEASg2ppT/+4YesGiVaduTmIGnSSiICyfYVZMdMuJLEzs++e1CrUAGv
-        MXeb2isQNs41udUfUpCQWregO5JcaPI23qFiP1oRB0Ni01T8Cuk1lk9CbmlvtDaFr7csA1Gqc1tG
-        4/lpkXK8HxWqRsz4b9HZW045nglSlsastLWMj65e31/MMz2lAhy3ifkMOzo4NkpTkaMkSt5tKZI7
-        T5HgcH3F1+YPJp5lvXyszTR+YaKm0+PSVSdfOcgZK14687W5BNda3ke7JTi24SOzZIiBPEVqNi8O
-        cVdRFX6JjJ2r7dKohG3CyRbx/Kd9QVyTsZUeQbAX/j5SEYPD4pOtUlL9+rojU1t38IUbeScs5XHy
-        H04l/UC2VNY/diqwP1WF5qc3u/6dnVNkFCY8JCUg1baC8GPL52LhWAI36gFBOHtuiaTcSq3yBG45
-        bJ2AgQQhvo+TNCnPttsciB4Cdkv8YWskY58JVsJ7JK0p+yfTEq+kqaOixsQBupFig0d1PK7vtrwE
-        oY5eCGeN5ZAM1EgzigGsYOi5mbzTnKduo+/dcHBhRzhZ1hWdNaxVs0mxKikyW7PG3Jcad/fGQEbr
-        ezTNrBReYnoJ0YLLF1r7IqA16K5pz3BL3DZwtJP8DLQBjxZqr698/ugrma2YrtVT5C1EPxnyEfX5
-        ZRj6UesEV3ojxLMR5viIbvnXnDDVEEnhdvz3a9k9GbzNz1surVJBhmRZx+xZ0FdzbtWWKOJxN+gH
-        V/ZQ/jQnC0gXhNeWCrlpJVFoAiJrjtONOfe3Ul/j7ijmajD4ik+pUOUiDe0bhEWw0jW7pI/mZZIn
-        Jhte0ydlY1b0uPbPLKqodJf++raoXllcSTFocmtjcsno8bgtAI8g6QaZ7vZqmPogt6dnI3bWo1UH
-        CzwrsoR0TwBZFsd4NxSwod7UQGpffoca8oanxAKwxX6VM06mah9jEnFkZK6s+DM+FcrmJHsoBZdT
-        VnNDqRryonYTkVClElksuQZEAygjKru7IQuitR7vspfalaU5kLBTgk+AGDbDYGwLZv6MA+S9VtvO
-        HEww70J3MJnvM7ysQR6n0eR6W4qg4RRNoXcJBUDslRqNAX9U87VnnLQ7J3EibKJuviNqbhUfI/Yo
-        Kw/MqmIIburmTnvzYk1mZJ+Wwj6G5I4nxkJwbnqAGJ7bj3+CeccvCY5QoBZfODWFo0quI1mEtpDF
-        ibnWPamPYc0KHxz9MzgxcStKPPY7nawoProssjVcIJPgRfq4NORZ5iyXsdrDRSKBXOBx7bU5QFbR
-        8sS69I7axbozOYaeeEAqOyESbDu5LTv2kI8aGKHP8MG8OBtcQvtUrA6WMKGzKVne3C0ZrHdTxe95
-        z/G0BYKvA+ppgL+PZXbZdZBZBXT49bwUoRQi3BlP2uWzcAyoiRgOhf1JgDFdOm2bl7ZCUlSJYatr
-        8fcgewLL1dBjORyoF5NF9JVuuJRdNQ6ASmB+NyzxVsswPzT3nKsDQjKmLaXNAly87GKIpO2K+KQM
-        n9Oxn4MmbHzRKGfgQyJU3Phf//7zH3/+/Pnz58/fg+J0ahgveai7kCVYFCCWYVlBYESNxAVPGILj
-        RdCsojCBarDAZsJgpWocwjMEIvASqzMKh0rv1wa+UQ1jjH9SvuYShf/QXllMvBByygoE7hVJXaVa
-        /f7kt/F3U+eKct7XawmTir0kWqd0zgXMB8hubtjcrsZ+2ZerfR/XQizh1KZCT+inrtEvb+F25iRt
-        ISO7vlQc+4AQ6+N568Ic6za2cKbzlB519VKJgSjUyvCbZ77hhkRx/JuRipHi8UU/spsI4NWWf26I
-        qPZ3rw/QstKEFFVH/X5bDyQNTzU99GmKfsQSXzBjhTJGpXQ8maxeAtWzFAJnVCb6p0F64QHIwZFs
-        /OP4tYVUoNiyB/6IYRkpMN4aO77bLEjyB1DCmqpTbefxh/vVo9rcyjUgMOl0GuhLoHkprFbgePLW
-        PEoM56JrNruGvA8FO7f6pRW0+gYrMyD6IsNrw1dB5RGcRzeNiIxBFBPnowrpudOzDnYQqQHIRsID
-        oXYk9ajBM/DA5Rjp6cU1ug8lg8xIOzXhQVjLWACufVNRxUbFVizDlyuXDnrGLb3B+s5B72+lx9yz
-        cWMqFrqyk0GJ38T5+b8BfcBqRcOvbIlddIokfcW5m9UoUoVtAgKL2Y10cdcF8WOYMFttycoQr3W9
-        nJFNHYzJFQqrXbgeeYF77Ub4bQSCy9wjGcBy69rpZhBJTQZwThCVElpZyVoG5HR4gPWff7iuHsQj
-        9CHjjqsyvyOyHtpvHMOndgbFq6aXVibo8mLGgxgCSptzg6dbZYuA3RWwMCvLuhV4l0kBTCHwRZAf
-        EA2ImHZhazgS7P5AV7pDDmr474D4nU+YLWmxKi0CH3JNUYAr2Jv8TrcL0IIO7KhpT1TzRnYNzU6h
-        lSfa8lPED/j14RuWG00PNvc9X0G7sxmCdoYmvl6Y80vcpxqGHoTW5s1v+k+Az+xuj8lCyCPhh7lg
-        yV9I+LbQb+QhFyVS8UtEIrYjDGBN31EYhCOaI7XVYoHlc0GhUUSTPOsj8ejcUMQQJJKGsfNr1w+O
-        tcokGPDpaGsSYR7ZThnC40401h45lPmCqaowBo9TNy+/OV1MhjJQqfTyy6QCd2mDtM2hR76BnZqf
-        qz6k4j+tIuF7D7ng0YUVMo5UBT5Eo9LiRAFlgjPC3GQ7eEv1E0U5g7GAJrU6NTEEiundpqfCukIF
-        zyWKgQDyqKqf++NZ2rKlI08Tv4vvmcy5UZiy/EcgocickAjAUqgUNuukkFoMMF3/zBTxSm2xv96S
-        dOOxShDLfOhHIPdGJVd8FPBNZwmnl525qHF6ABIjBMhh8HAvOZl3iXuZK3CK8E96W/JG0nrdq9C8
-        emssBrddeZV/4cTSH5WCixYA1vxZBi0zAy1QDOvxeY7FaqfqRm6mQU24dB0+i+MDU4NdQh4lnYfN
-        KeiWzycxnRb/M5GMf2MFdS6mLinM7r99JEQI94XnUujAtbtkmy9OFgCGE+B3WfDre+xu8+gYmmUo
-        aSqES3Yp6QRSnmMngFRLhJi57n+y0F55jz4wO+Ph7iPJd2C87LM/gwk7ucxnALboGeODzhxkOBPG
-        PA4WWDUL4Etv7XZk19T75OR8PJ5qsDBy33tx+V///vMff/60hownkW4NVWAuwgY9SVE4XiNEDSNV
-        keNQZOOrsT3X0c3NvxRTOXZz5aQRuxY2SpKQBfhIhhJ5joMEXFAUIuRKurD96VuxJ5lGKsra33rF
-        BjkOXpCZyRZks6yEoCwjiQrOChje8iL1sDDN5zaxzWpv7dcU54EXYI000PHytCuj72xDhtTAmpzK
-        QStUzC8eGPTS9XGgt2NVqYITLiODbnxRfptxZBd67LEWEPIJHUJTDGCKBEAOvXBRPwRDdTxEQXXK
-        xN31QngbWiYQ8mokJE70Q1sEPnEEBtmeY1OtH5b6gnukShfH3874AMYUnxHPcKXdArJBoCC+Zl6z
-        yiOzGxY5Bhk4DVM/tkhpyMZzpoo19GE+faZBlKZK3i+8q8gkmtWeIzbg8ZoZB2VekElNdsimtZJS
-        1a5De309PEApEYpC7jAK2fcQbVrzHj8QAL1HQ5C4wiIeeMXJN4DrFaSM9BV1k31J1hIErl9G/FZf
-        wW3kQ0VYpjApj0kk+DW262ycFj4XPnBXvBBSGKi1leN15JwCSzN6Pq02aJ8EGBeLdTIJM7aJowtW
-        nyRlajXXBrv9PjHsKr/mq+UhEzIMjWvjoIWQlqC1hE456khU/EaBay3O6HDWQZ2PPKHQAAmMbm4m
-        ya0FogpUsU1DGnagA6ZRF1Z+SAMCqK6AkVoPblVq86pdJBo35DeraNOcF/lPZP34kNYwf8BO54U/
-        dauyEYbeENiwOO1DgME/IxklV/FsfwbIXWOIpcLv6A5UtkANLf6xrUSn/oxxv92coMTTWynvBe4Q
-        SHfAFX0UKu83jOwd8KHMrlT67BUrErzl9guFuTtUphnCeMgGtwi7IGbaTJ+I6BvVAVnGPOtb6aV5
-        71GfT8LFeLqVKljX5ukVdmS5ZJv3dq79vSpA30FUjdoY+qi3w9+tCN7mgwSa4SWwcvQ6y10Xz0C9
-        WDaS9F88wyK6b1sNcwyV5kYCMcOrW2yp+mTnSgjmUno9V+iBD67H5f13OCL+oGCTefnq/uSL4ERS
-        vJ0AdmjiKusxjHqB4c/sQ+yep/nX7BpWllMDL8abcK4wQzxe962GeOeoF3Amh6/eJAXmVzl+4Ub7
-        wdALh804hzPE4Ri//eaeJK3XKG7QfM0POEifKgkBolLOeuzrV8twNcwYM5kSzFFac6/fHue7oOjA
-        FNXbhFWc5wspYWkw/60Jd0yBuWzxise5+ElNhzG2wKwKK+5/V1+ePFx53JOZMB9/rkm0ndkHe77B
-        5cA+YY7SgQZcUcXl8iV1+rVCbDoS4/dDcD1ZtZ6jKHI7Ze+qIjpAtHhkVtFwxztcao0Oc5VFNGHs
-        GVyxF/hHnqPsYzGp7Rovn94uOYm68HENUPyBeFYlF6m7ISSxMXx2r7aTEEJGrtez+ve9Jpojrsts
-        4aLBNgZnjL9ZigZ2MgkFevOP2X3tXMHIQoF182ALv+tEcwNIwT95Y8FfnRFzWfu6utr/+vef//jz
-        58+fP3/+HiCBJsAS/NaBUF7mWYXAFJrBdR3T/3VzufyOxkdlJIGDNa9rqgQLPCPRjITxMv5wWXRJ
-        UdFUeRuE27a4eql9uKuB/UY82m8Qy3/0LrxOdYw3zn2gr9rSB9v+TbhRzAWUINzvSzLA9iRfCawu
-        YnRfu4eIU8ZSSFQ/tBERKVPJqQkDbdzqp+oDLzA2p90xXycP/BciE+wKXaxTc3OYflerjzf9Wnep
-        srnmapkdCKiJ3O2ACb5Jdovh/H4kBOYDmd7YzncgkXuZK68kfkh8Xkh/SiXyxUU0oEdV3v4qfvTH
-        bxPVaYO3yviYn95vKn6B6D9X+m7q3EV7DGIMSLWwT3Ch3DD6LonOc2t1mySrV0xwm9YnDBWhCidl
-        jDfAraT6+TUnqmfMEIBGP1Yg2Xp2o1BbX9VlpoDU9iLP4a9xRb6DAjPxS2PfGFIxkQ4RqYpZx0sI
-        03aXv823Gq9SWDDJuQr0TkUlC8SO+hHcRG4qTgNwvRs9r2icYn9ozFEK29vR9slgEudFcMgwxopj
-        PAQ1ewhqAW4a6TlEKbkx6SH9IGQKgcAyQUnSDTYd+gt8beVesICVlNpbpXTQdqah79JJ4PHOb+Mw
-        IR63XSMWMGw37Z20JyoM4PJ1SY4GeYEAtd0petF+2cIudRB1sYSRO7FB06/7DKRaMmCjevltgdUl
-        HSu8I805EJOcALQPoOpeGsxf5qAjt57P0g/4yPOoE2WNwQn53Z7h54Rsao8GonAkCpOTtgVpQM03
-        jPyik7ZuK1MigTICz90akB4uyjDOMlAU/xSGPMCo8XUcVupA0GV9pmJv74C2Fcdsmi7fyMpK2si9
-        8i+BG2KXL9auFKqlTUVO+iQqt7gwQivXroMHbe3TQkKgbfoeMZkoahAWAvhAyN2R+gCUeUlkl1gq
-        x0HDfyAwt9/u+THBXnFRxqv3t5bS80i7sq6sST/Nfv6qNG8B4FWvMOECUiGaDGVFn/Vv+UCdx8l/
-        zAB1WMKh3jqghWpMekk2oDTr3YdTJsOIUOaBZsI8r/wz6gG2R2K1cD0aa6GM7eVMCw+RlJHhvbtM
-        echh5HfvgckrOfERrlVOrkiBDZeMW00KNhzNhtx+ZbtpuktJiU0/QkMTnKUngqonpZYZpMkSkZMq
-        PXumBLEej2u7k0e3ViI5FCUALJK0FCk+y93vdEltnagluf7nnv097/Nat6SjEyXH3dNseSea6f1C
-        VOlrbUm6PSbYUW1tvcmN+R85puWnGFpF9a7dFUgtnbYHDpiUJD48/4wQGKtD3trJV1jzYWycsRfZ
-        6uVfNGXNHp9GQ3vOUduLLvX54SVY+T5+nn4NfFoyrho0Wg9xeV/aVeccEqNFf1zpK74AuOjDL8QA
-        nFJSHBbsJguO0NzIJkKjM36CuAD4NVl74775N5x/mPu5Qsl/hkAbnNfVZRWBReWhI32VWO7Cy/H0
-        t/EzQisVoRbX1l8KsOykidqijwjwAhP5CYv/dN5JtP4IOe2x3LxKCxh94tptk+bvtclQn3aNNAg6
-        3OrYnX5vtDtSZdJSNmttioowbuA5Y/T2zZBQZ7k+QKOxtinLVmq+z41quOC1kFOJDiRJsQm/B6cx
-        sIkmSyF/jPeqOfUO1CW297DGHutXOiebXzesjVt+kYKpp3vNwzUXHYkBDvOeHIyj5nLr8XlGsK61
-        nuQTbzuJ3liX3DGY8zsY79hB3le2P35n88RtRVyl3/qVqKvzHO685klTD5eFfqti7zMchi4T4kQC
-        PBmoJ8uALqKxDIrADODTKc0n1+jQ6KktppAnoT/KMg4y8kYmW7aRbtZvfiYVSa3h3TYccGWvNS9s
-        PzaRthsLTCq8rRVgi1cgZTRJu4UCaKqNTVhSYdpNtlb2JXfGqvFf39OyDfzYJlMXGAvEwcQQKUhC
-        UipOmniQMUXT1j6TlD2Vamd0XwyCrPpWaeOmoeTwOm65MottvnEx9PcYA2/k5kGkUYzEijia5DLD
-        eOsWRBhBuPConWqOF94r2C6H+Ev3UOylP5XmYoP7IpRzglAUTFuEyJtLxCfs1k56SWELlUelEgTI
-        Syoux3VoPMxkXHu5oNRsPJhvhX58T5ha16/rYRWuC3TgvZpKMT1WQrKTm+H+wQiIXLiVtqoSzM9j
-        IIZlWZZL602puE0EotvBhJ+YpiPqyodZ44S9iLrKlZ/SZZsz6bTR7Y7jpRbCxiyBrYtvc4QttcEi
-        31H16+rtbTqg/x1YXC4lbHWALa5cIXqsRZcdZFp+CR46weyT2EQPzL8E7rmLC/5YaCG53eVbC0F9
-        Rij8aM296HAwXxNXKwCmIyfTjn94cSdv9WCNV3lrPaQ2RfgcM6v7PGITeqXYNFkM0ugPlTDBg1i1
-        XslJdu7tDiPmmYoJ98BSHJw33WoOMzz38VAhtbCiSJZ19Ld9dVQtm1VoY1RxNTpx33R2GKSfJS7L
-        FgCRRc3uVRdi8BqLOft8osQI2iUEylYIgZNBUIocvl6nmN/EJsZgqBEDG0xbhc4StNIx0EfdyyL4
-        SuKIUpUuqTpZEe1U3h6efMhGSz/jyzuURg3c9DKJU9qk2GbMV8tx7c/pVXkGoU00NKx3T+YgRqWa
-        3hB4jUdU/OUe+pNl5TuPsL75WRdeW4UCQS7ykhOzwAKv5kvcysaVEwXRozpV3MPCATppXMfLPUjb
-        4RjUglGI9p+mApkcY43V3ZrybuIZdwEwkDnhe3uol+0J9TfEW4gPDM+AnknKni749D4NMYbmxm9V
-        Yqt85Vs4hWheQQsafPQr8xkHnOENcFeg5xxNqx/zc7KUuZtp2S70udY4bEU/7+ASMPgrRsa9ulSg
-        ARAS7X7Yzg6dBsDhQFnOZAR9T92Fl3DhkFunzd7Kqk16YGWOBtgzsQHes0drAegiwjzVl0Atof6q
-        CuUVGma+liGcr7zWglauwUAl9EjZ9yTdXIKBj127bmu8xuBQmczAY5m63YJlQy5jW5ap6luY1mWn
-        ANHdjIceKOPNkbjlOIZEBUD9jNwNFnETiGw85WiOU569TNfx1ANEe/dEHdiLcRslc6oQeJs2S0an
-        WEaEGEycT51iQl/27Wz83xDkH+cnRapt6BJfbHjmLjqZQtGUOGY1csw3JOf2JY9nCHqUs358Upn+
-        uCciYY24MozjY7eaTwtv8/myoMG2C3l6QH8BWjNCbrebsz2qNOmwNou2oZEMoVmNJeRJElH48p+A
-        t1QLJHjZoa8VA4ldGhn45qRR5ZKQpW+WYtSkXqS3FOzXgFslxakST2LbAyIltAwESg6dAsay+nMp
-        FfBaYmrU6wDs24Floazt/yqPJbHnmVK0T4FrpETpjNUZtsYdoCnvCKsN48pJYDdl7NgckCK14CTd
-        3dV6w37bTfGLAI0LpCttV4KxBSBeWhtLoXHIQ+6vMAjaIRa/rCekOobv7kirGll8bQU4HJTVX+Zp
-        fiNk7fRcKj+jeSLHIGjnoKeXlqey3RKOlkYzaers54aCGEtU+A/izN+GxRohetvSIbx6CYfZmuBY
-        9ym4o/0ipKvwuhqRMD5WM8myYEdkryknG2NCTAJatNmj9CsvRs6bPF8Yq0WhqzGPpyEZzXhjscdI
-        PmlwSTqNDxRCK4ADv5Ii71gp1QSA8ePA3ivX9uAH2DH/w24iHhKqJBl0mkQ0M64jB4GMlscE0syb
-        N0y3Z8xBzLVnv64J3X+qhr9paWF0BipAjgaDXFhJIF5sjg8m0tp9x7d2DGJEqSxC0LKNTV0RufIt
-        CJRKDQO513lDWGDGwx7uQb1va5Gb/dP5RNw544xCbY1ZPAGTdgZVbDF+KDPhUP9iKWIwq5B62r2H
-        eg6t4U4x2BmzVMx7kwskxe9yqK2ropJUIKf6qnthTOOKrtjiSubYlGEep6Z00AGWST6SGiQknQJG
-        ihO6cyuMlh93d66AC4Q7i8yXWwdat9PC2+eXYuwjIVyBVDrXS/uRFwxCw6Cu/qTftY5hEqpwNwjr
-        cqmAb5OeoPyyTqjH1rdbI1k/wjhL1g2VpW6Snw6GW2eGkL1u7iLnWLQr4A4CYupLsLcqkgWipZ+a
-        ENqE4UVVK4mFz5K68iayy7FPP2liZIyekwGcgqeOmmRYeoXlnG+wPaaEbCUzz/1tNLC9teR2VUBY
-        KSOi1ltqrUGNf9vuBa8SLqzg1C1no98d6WIoM3d2ftgXqt0WzrNqVnmBt8wp8p+uGNzevxZYI3HL
-        NevAROTY1WcQ/BrnUDgKa2xBxiTAhoW17xIA3X8N83Ayt+vFsQno1lMG/D4GahaUCTmszNa8AwbZ
-        6P72Txe3Pgfb1kfeEtpkufzNlq5OcYbdpnh4uprsiLU+CjpUtm/OnCxBLlo5OTiDGI1GwgUQ2WFo
-        OKh4jLMLi4ZaiXJxqP5Nhik9OTYIPZBeWTL6t59tPpgJe3F424i74mStUKkKEFAPGMT6PBSzlGLU
-        1Bx/LDjZoc8ixkaaMK6BCILpIw3SlRPmci5/88sTojLQ3s/U7l8PZ6Rtkt/EUY2Jm6+WtoEzJrKU
-        mZGNs8BPReADiuxZqVqaCUvqtMkidFiAfX3vgV8fmF5Q02PvEU1akqDR19TgBjnqx8ismGDWot+v
-        nzUqOV7SUYUw0I7eZWIQLzj3yqNCQKyEjWT1B/O+sS6ErR8M/69///mPP3/+TOZiTlk8KIjCWaG2
-        nZfAKryGKpSqCBDXZeNxX4tsgBc3PnXElAvdw6Tdi99jnD/dCGUv+5dIzXe1dobq1U8BW4vSHtXD
-        EStxmHUGKKZCdg9aIVFuvHpizcZyt6bTbCVezCcq2f5iDPuBS0PtXW4rC7obyvL01BAmPwBw9roQ
-        W43GN08NbEgcUlxFngJWXKiVW2gnjXBNmgCZ5g+zLhxpIjMDbYFm59UkMxCp2GU69na9gFxR+WZ1
-        +ywOCnpuzfn9VTNtJYzRTu6pQkYcOWUUWYZsyiKY+m83+jcx7lmNfWzz6wEpSLlocXimp5zWwSxX
-        d7vENDN6QHBkfGjuQawjwH6Ozy9wevhvViPCFUZizD+AvImGWEUEozyWqJxvZJcQ4md7R8rR+EwR
-        crvcec39Atl2gWUCSaM03vOhF47sp0RdHSNZUOy6u49ushY2l8k79xtSwXetOO46OH5uGWIyco1R
-        KtlJOghT4ZQR9LjwnQ7HlUGMuEYFdxgm6vdLmpBWUT3r/Qb0AHxQI+21sAIUhxYFjjmQ+irRCcgJ
-        JlwyCQQuu9rfBoz59g0ieV4qXp1gvylQVBqcpmSeW8/zTkcYn3CK9EXF4y4rGswaKaeVh5Mqf52p
-        /eBXVtTlkZ7m/HlOAfS7yn0nWR2sHBmJGgu/jD6ZxbTGTO2ufqbU7mRyVAERyIhY/AZdqrrIINSt
-        EFBIjuG34mXoUcGb5kIrijzagm8BhhAUeyt7BpO5l4Etuh2PwChkOPb3mudB5VNzQIYPhfGcStw6
-        A2SRki92P2rwSd7zqCCQF+W3pSseBt3d9wXIhK4Dxd0XqjRFPeJa9ce3lDbTya1b8/SY6ejF/uuN
-        ik4/ac3u0wV0gsqbV7WcwF2dYouZ9/ikCS7jxdz6MytvdQIzRjBhnmpOSDuzBVSmz+8LKy2qQA6x
-        bhH41tL86gvlRil1A3Pgoqkys0+wvYVSk1g18mOQ4LyBK3stCtM5apqdRXW+5jEXZFCDqEmy4URZ
-        8KxG5+cp+8VqUGXseu3a23qHvRFMAMLYb+B4JguUex44XD0WkshQ2rCiynFgkzHB2RC0VHibHXaU
-        LrUSC9Fs226+CBjSyVQ6MosOZab0J218PggOfheX1KCBlIxf3Ilb6xMBtvXvJhgE5tIrys7l8lH8
-        HO3Gz9wklpGOuJZLq7BH47QQHIxnGTaexzFzwrsUs/OYTgia9oF4y5t88KQMyBbKECxSjVn2pH5G
-        ag9RfiI2ocNCjLb+UVziGRu5vxLzFA1vIpJSc7H4/zMiVe2HiKgm9QCoI3Xhz59/f4QMc4/Mi+kb
-        HAGXD/D/e7XP//35uluTTDsgilC6S2mzxYsRthhLyA+Q20n86s1VX78vxnuAwhLQ3XPBQPRxOfqA
-        GHrO9YaVrkpJuZSytJUpG83xf0tNngCcEBCcxzsgeRaTEfp/ZsGsJLArG6ik7F61bAPJPiDZmZld
-        dRddK8qVXiSlXa0spRLgOKVUBsZR0mGtsDSAUGAAIbExtMpe+1o0ijAUNeFUzFEtPAHvynEMktxp
-        /wckTuD6Nn9zwwuH+mGEWLKS5OorWnJjVwU+uKlUUxchaK8v8+ou4cWFE0zmKE3NAqPyhzE0v7GN
-        OIeqJfzk+NjYMHzaiNWRHnakYVVsfDysv624mQvzvMyigGRtyiTuGAfMppm5VHL3EPSybwIKqVwJ
-        I0PYggyodqubLmDYz4LBCWZ1rrUKNHCC3TXBLM4yhTNrhXMjI5bYDy6cTgft3IKS89DwOFW0JXTA
-        LiRX5ZT/CPMywKNlCnufBRCCCtamYPa+5Uayz2xhlF6mOyQpscXmJKD8vTLZFSWyIaOH7fy0dW67
-        ZK1HANOFvuxK2Vx65EJlPR6Hp1jmG8MfzvnSeHoCb55cOJa9lrkeeP8lQPOoF5a23qLg3/5LNbk3
-        4KDCgvyHTv3WWlKrhKr7GSJhQHzn2CDIqL5P/CkhRQNqwyY++6NUskJi/+6ng71OtW4oHT9u8iSY
-        ra9efp7tukcVv3PsazMxc1PMnUuxIHGykJo0JoSgQxEaUse9uuFDXOSugs4J/AcpViZPlI8dHnvW
-        FqyiNB/jW2M//6xVGHD6CqHgeoSwxg+AtnJLSQIH4p1BskpKvzbGbtNQSLgQKRCFlEB8665m/UM8
-        4DAw6//sIBhPdsytfngcZcIajizB0zKfe7WzBq+Eua/lvwQhbdsyyfiXrSYyBXXmakoiMWE12bKc
-        MGZZSQhEzidyngzKOMObY7JIKs3DeDsFqCmKWEix/h8Q+o/QsuQWFxYiNIzXwmeWl5dS0Qja8caR
-        Tji+cBA6Z84yB4k7KSuqXhuVBEgiRsQQQ1DoUjLZQE37UcLsSQWUMC9BqpqIjFlO++8wu/afPP80
-        x5jZaPxb0xyDH8clKpV5XOPVqhBIuKWw+tKlzb0ved1SEB4mwRncalAbmXxPoRGwfwMjF6X02k+h
-        UVHmjFyzu2ogjfPnoTH1rWAJhoYzku8fJoXLYEV4v4RusqCwuY7ZtM/dQBjNoRUXSpVbIzJa9ux+
-        aFc32lHWvbFxlzRUfuKfwQgFea0QpgcRpUPaY3w9kjV0Iez3xptd3Uy39W3cIdoiCykjdWJPpo5D
-        fD3LYCgYrf+Yn0TAbOb/7wl+9D464N+rSfxRi3T+UfPfZCxoG0CzwpRWYHRTw95XjsjVzsJ5tAUz
-        bR6aw9kyRAFdNw7mE4TkOOy/Vmf3JN3erCfENlJg4sqvgXH8fAQy9G12Sjoc+jjcRbehmoK2nC89
-        V32BDi5bmFRKE4r/Aaif+lfh/1o2AF0W+qlyJf2eYInTLW+Y2qCN8fADaYxrWZZRSmIg/3eWv0RT
-        RCvr9j6Kf5O30Tj0GAK3LwGHAaPxdGLN27K0Q+QlR8mFAosRtUAmpqAcNE14IDi4nMCAxR4KT0cd
-        VXKEXeyXqgv4hy7Tl5c7MI658bX+Nf05T0PKhbchQHcBSJ923nUP96N7ojfRf0rDuxpG1d7u0VUB
-        43/s7gp3RHYvWU+IZBjtJAKA9ls7/Ler/iKB1WVnLNVAGs2yE2+gkhITqmGRmPZWktTkd0UPI/ZO
-        6mHyOhJPV0fzfCXHWQ8MNK5OlUAlmFkuAT4weTU0YDAqdF6h5UrBujL7lvR1cgWNrs65Z6TbX4IX
-        kKEcTf4HRhSYvef9bJaETXdtDRqzAAoIBOdp62jTJf75/OawWDAkvFcfkpNrlZDu6gFLujGndORM
-        G20Q7P2AEjTkVQPk3KUDIHTfQALg9Z87JIFEbde7Olc6MB0T9Ox/5zyTNOJggXAI8xqZ3/sCYkfG
-        9axSbIies+45W7VTWDE5cpVleYYmb8+2cP0G/OIRKFKP8j765PRx8U+fNs6o4gQrxipy4zlFfyWJ
-        KcEKAslEobHe3XHz3NRjKrTZnUw68+uXCDwM8h6pbkOPzAjky0GV8tMBNrw+mfwmVcmbfnGiwkZs
-        Pk+TjRG52WAcLuFL0CvGJ+YDTZWC9JX3NnxHG1EATU6vtvRtJDnJU9eFDjMEUkzyl17kw7oCyEIA
-        3MGWh2IPWpqNsPkBCi9gMuKyNs8ybdlf32eMjTniA+T94jUCPZv+UtlZXWJ5gKyzvfHftQUg986j
-        2+rI2vc4SpU89sKa6jtIXvcR9Y++dtaRQ3Doa5Fe3YdnQaO2WMJXc3L3IAULVCUTnnSbJkpIygRY
-        O9ZRnEIKsUpEoI5cBDqnLevrTLf2nCUour3c9CSkrLiB+RmmtKuQlToWN7sTKRWHTG27VAn5H92q
-        WIQ/6eWQZIFuYDg2L1Qdg0UlQy/DTduTtHP3VHpAl/gtb2ZTHZI0OWhoT4oTmEHCVW8uzIGrKexx
-        brU/nYKrYLXAkY0q2BhQX3b6k1wtJHHVFDBF1AXGWsgq1p0kGuZgr2FlV4PwUz5/OXkvHS1p/qHI
-        kkBxB8A2ho2v/il1Y+mUUsdDFoY/X5gYiLBPYUrz4qttHPGtdabY8ZTOBt7JK1GDbKiiow1Awr90
-        fWGNpzJbHxGBNrNx6ANTSCSd/ipkq88rhTL2d16OCdCH0r2tUJXtEjLUS+7WpGTFz1u2WhV3PtVc
-        j9++cMVRH+tPpFK7dqgzxR7em1K0fhNvuq9NwB4uVR0FkknZmi+IGIoie4ifNwNyL+QIP6+bzTJ0
-        zW15vrqSoWNDv6fFdrivnoPh3Nb8aPLcN9Rt8cxSzeXwSz7GvXXmHlty9+mjuxShnl0MH416g2mV
-        DjpqPZ10krpHVedW13173G/P27aRo+x5Ru9VchhGTzSaD8atb8Mz2y1H8rZ57tCG8yOrf9F2//NG
-        9ydlPjerarMN9aQ1dQ7NoumDhu3XoNm6XfF8f1/th0vdvhOWim4+WxRpwRcNPNxX94zuXZRObu0V
-        a8TVitFJ+njG6+1osu40GIqWdOZI1kbv9TConybr4xduPVfbwbXRHfTP7y3Uypmr1qtpg/bKOp93
-        JyF5KtS4ZrPP+/HW6nc65fi9dl6F9/shmPboXo6e/V6sv+j1tJsU7fHh0Go3G41Vk7f3VXnbms1E
-        LK47M7uc5u3Lw7L7rtNXjb19PqYIX3ZXO09X8y1C88WKXbuLNXJDTASOlXoOx6JJjA8L1ou7bH4j
-        I5nKJpbiU6xj25oWPSkHdrf1uv6etZxft+OaCIG3E0v2reKrmxTqkHJq72rvo+hzy9aqXFVjvbtZ
-        /rWQrcu3+6Ge3AafZ9Ib3trLcJyoKT1/K3otNul968R+HTLenG7fv5o7LkerzpVbWSRfSbN/mzRa
-        yxWKG+fjZhR3Vno5nEfPVVPdH/RaH2/q8zvq7MfNxvOxWUwinqzH45FB3RpWFQ5Zs9XWd9Jdhp3v
-        1QcqzvfzblsRHyny2RmjFirxzsXVZ1/S2vqHt+8AAAB+8FVRyB1YM1j4UxQpohBKDuFJ4hglKRea
-        IplivhFptkJ7v10qja1X3FWVuT363C4sfmEzTRRmXPqeDUEnaW0ZZHIxwt2ZJbXlwT6xhMrle2WK
-        ilWSANfgp3tjU33/4e+QEPF/2n2QLny4asG4FUzIKUISIxCSThhU8NXlUroAx9LllLCa36oIYXod
-        gqQPzCAtVVXeRZM/KNWtI/HnAv/vVLZJOT+YJNHrnDGJ6H/TvlibTAYKbS7xMNY36FlKKUo8l/ci
-        w+pUI5dHIhHf+ARBR2MizKiXEYqjj4NTEW1MRCn3MiKx6EY/YOWNPUmhXVrYLJlVlHAuV+ZiVarx
-        nEexiBsaE0Iy/wDIussJjOTZ2BOETEMnLw8yh54N2l2cDtrBsFRnmFyCKa3Mwdg0O8b1P9hxnB4N
-        nXcoC7dowp8Uk9KyCOGA9k2XREKJekRi0VAS4zroqTEUMeIlSQSrh0jlCaN4fJRSU7MzhpMPaFxu
-        lDKPI40+IPQIqMub/sudhSL/TxWKvS8rp/S/you20rCXJwlFE0yFwVEnmbEesSj65scwP3rJyfVN
-        l2OqJMviMbXPvOSc484NqE170MrqqBQWhDyv/WFcHlyiSeqr0bJiRK2NhvKE1Vv6oaw4ZhZaQ2Mu
-        /qvGH9Aoi0LaFHJjNUibgrZX40pbaBvMNMfrH2B1ijnujRFRzLwUWCR1obCWJ+KImA3kLK6TjJKJ
-        S4jz/k03IUhBlJUkXIC/6SYiPuYLY4y81XnFGOFvdSI5PaOEf+MlDB2eJRj1WEzW1IePRkUMxTMa
-        UYyX9ZYxPX84Sqg8f+ONBD88I5R4SQgnmA2YAZPUZVUNgmJCYqzIPWwIYF2jKGWJl5QiVl9N55SH
-        qTCklwNTQQjdLqQRO4pGWVxkMAeTm/CApTx5Qd1LvTJ5gKbxwZlDtbpDiWmvLzeN2FEeZtROnmfM
-        iKAVdLXeWzlSFhNRbOXXLmYxReQsj1Mmwb90OYkZZ04cT4Ivv3gxF1TIxxdHpJKRc4JjHLqvEx+e
-        JYh94hURZ3omKP/GK4g4GpUgQWdUJMky2nprSmm+IkTZJPovjAiRePExf5q838+5+R/y8nRx5cFf
-        9xK7bej7FQjG/yNkgQngtP/f7G/2xx+hddeqCuaq4Xrns/1mf7P/94UDxgZXppXSKUh4efH6Ip0M
-        +k3H5B9PBtn1Vnt5AWPhlhmVOYIH6Q3BeLClK2SeP/IPtj+gF/6RBYdxzFQfZZWH9X2Qqu/JvUEm
-        PUhIjQ/GqgC1eu8tnTI/tMzIH5n9WgGs7BgXZGBvk4iVlbQgq1AWMhjVkrDT7/l3au1c1S3TFqQt
-        D6d/QLYMkGqVS6fTHkeNPXFSgQ8ik7UtohjeX3CTznooj3CoTv4NKuvlUYNOTxqU9Nq/gbHKael1
-        CoUuSveAyusOPJeurE5Z/oCXF4p+Bm/sKR/g26C8apdpmUJp4c/L46LdsXSFtEr/+fLy8Zv9zeak
-        1knLUDndwOOTSulLkFZpuEkPqc7NQRMz7uLKq/E+Ovu7J3/0i6C1M/YEjQ/LswZJKGxcDhz9fB85
-        rkfjGSWnhD2FB0SxMk/DEZuouCFVrVzAB1ZQSn/p7zJAjmuArd6jy8Znl8BWfzAzenlTjcM67fwV
-        Q/vqmwhKqnMXd5jTDU7+I/qT778nptK5np5udatV9Yl9yDGn3C/Q7HxZVdjAk+WHUMuaHriYZE0/
-        WcKFyWSg2YdcrHvjwLbMayDjlHhkdY7Y80AHyaXBl4Ex91korNgCJg9ENdMR4sap+7J3H8hx9+bO
-        QIUx2yxwz6Vmx0iiTqIcQZ3z+cHcvJE1LGOD2ZgtoJSRFpsrKbJJr5D04tg6J2hMbz9ISVAcmbXI
-        luORwXMzy03SS/BK394Mt8OeABzgSF3XmFzposEn8rmIL3IvsT7hlk1QSNBNlPoxMRCylj06JNJ+
-        pp5RODEZr7Gfh0mG1pCVXiUx8OOUJIhDjIDu1atqDTFUlWYHWg6P2C9IbVYVPoVnY4hO7jourA5W
-        Lu20T7xmAb2lyeafNhdPvUUufxlr+JFbvhMtlyQYLQbP5DCCgyeQZ/AJNu/NSV0oQSKPgRYG8cGe
-        LMAHV7CgBhNg3y2OEiQaZLfm+9tfvtyi8MTkUhX1gRMJXMJIosYjKAOv4MhxzOUBYsjaZ9GeAGnC
-        qoIgF6gXYCeKmlNKHEARCTh8qmSZW9dipPLAkQ6ATjWCDXlOEXvmnpPjCM8IA2nPEEU3+1yEJGgN
-        pmWKXA4Lun2r9s8u2tfCtiPXe1EqwsY3DmeiRKMg2XQkbX7iHHEUH0DoC8WZUl1ySnl20PNdEiHJ
-        MNKCPetrk+OHBOngA2v/RRmesw6PW2PKzvKWlBaIhjRHEGajlKDCrS+D2HidPaacJCx14gMnJAoP
-        yB0mLiMpa+C1RkgkhEQycrhdckqNCdi4ueJfd0p4y1aanW9w8p//xVHa3ZwBYUYNkKs/aXC7dxIV
-        7dcpo8OfcDlaKu2TaA9xc/rGVrjtOglCCeONrK39k8SyBl4xuQT546tqpHB7D/tEFIZVFfIUCRAd
-        ykhtbcJYoK7Zom6pJd09lyhKZTkzqXNlLw1Xlicw2lz9CYigUgAS3OubWlGSbpiRghRlpmKlxTMj
-        6Ba43V1yQmuEIWdjVNWr2TyP8gcPMJDtLaSq1vCBFcaJg6OqXuejpkxx/J/HqmrwNhfMSu6skWOd
-        bG1OGe1GaDvxrivMnQ9eX+jcWUcSVdrTgZh2ZleTeUmJZg0DF2eKtNIUx53kdloafmTUBfuu1bpD
-        Gk3JCO0Dn+d37JgoPFDP9mub0sjRWsmradjUro2YaT5+982/NpMWXAKV8Ztn/yerBJJIB22zIlQJ
-        rVariUeA+VhX8oiIz963utVbxZTIu1xGQyUwz4u+fTPaxcd6m2T/wC63utW2bW3YarM0OYK6DgJU
-        qXtJWx3pgX9HRULHTy0r5IJ/i1ByxoBKoW6xpsFqEbkTZUOb1T9rx+TYKUZD6y08o7XFGtpLl6i3
-        A9/Sdj2RdJJl1vYqjBG0hc71840fK0PVLDB+WjE8FAZOgRtVNYB+9NNP+ISK27KjeGjnpsjhc1ED
-        qdqReKD6/u/XUtQzCMf0BYjiCtucXKvyuz5DA5nnMnY+opRB+g4hZHLoVHL32YpMl659tYmVYYBy
-        iEXgo321WmGDh9pnkIC9TzK1ePKsuUAuUD6yqUwiY2DyUnmiMDEMIatVU4JXYS7dxsjvTr9M3ay0
-        WVJs3GW1fSjNiT6qpw1+nNVlZEhkdekkKEPk8cfOxggDhwcDqR25uK3W/2e2K2dQ2MIWWFuVca3B
-        VLbYnxEC9rPVrU5F1E9ssSYKk3v69/hfY03Pviu1ZrsDlZPtVyg11far05KFmuTgrz45PQU+f61c
-        bNQ//4xuuW0D/O04zxOqqg3UhkV7iA63VRX1nMoHljISHS9k01wgdaxG0Ax1bgxcX+OiHRODbWGQ
-        hM/cgA7oUl0K0QmNVI4oHPI4WjxhZ1vOBn1KriNPrJE1ZAsxzFxruANt7RaFexvvAyPMhR/ip5ID
-        m4VduvIl2i9l5tZJ8iGabVJwjg7cvqVk3CL7wOUoxlHtAMWxJXEuHe8SEu1fVc2OfqZC6iy5TzY/
-        ijlEwQcuCyr6ADXRUt9KYoosRpcjMDpLqDTD/WIromdY7jNgaFd7mwteIeRxEuOX2h6DGLa6ki5y
-        B6lbEwWAs4oZ9ZqTTtomDtJJQMiRUZ1tdcUapftwIo5noxENyQqH/CMolpwcXwQZ2ov2CqIgFO7n
-        RMbbDGFCyAq5Te0A3HzpGk47Os62dCLEMZICbTCh8VpAjR7rSdTQI8khkyS7EBlUWsCHc90j07iL
-        X+fqA9eX+ccgWgeLkB0CBs9V3yp+UnlMO8HpjcvW+R8BNBinh5mcWeokg85TiB5qf9zk95Ljc5X8
-        cTH0Es9S3m0+wnPf2xIA0pQVMztCa5a01a2+mAp8IIFK8WIuKaHMStlAEtuECgGvCZSdzxHqX9FL
-        ur7AVHJfaGymZasfp3eq6wusISxI5yjzI0AEkMLbFbpcAkfkritb0zmAK3R+pc797VbC64t2xyTC
-        mLm86hhSh5aTcwEfH0R7tOfeooUOJOkKGlnBnyDISWjDSYA+WQGE9bwe+ibPrxFE2jucHtgwFQ4c
-        WQPzhSVoz6qvWh9ATItvkeSrH+PXm8CW2a2sivVwoFIfVXZMnt8yl0P7X9C+ovHOtulAibCNmDki
-        82ZDeF8sd9BNA23b+Sg+5NltGswpfNEgXURs0MREnocMxP0ORLS/Amnc6hO6GOdCwOaGTY4yBzXe
-        FpXg5Gh8lEQAAwPcSG77Thqxn+7fvG5zurE1r8XECBa6sXryIGvE0Vdi9ZuqRcWFkvxBCGAaPlQu
-        da+wCs3dshtz3BXQikaIWb4M5HIAzTZgjLvP01TYjGPSN7fZuPgSOm7UpwjTyrw+Z7moN/C18HiF
-        icsobkj5AGE7nG+llkUPiVJ3aJ5AxAWrChEJqIJA2wSe94qsjTpOEVViwvXV4MzaS6r7tnfk+kBF
-        aJ94cB2Yemnwsr5u8JnU5jpLICXkJPVEMdI2srp5B/Z6mvBCDppPHoQwzsmlngYyhnHnciQcsQbF
-        INYStmpuTubd8sooR/Wau919yg5L2e0//8U1/sxHzw13v+1+fvPj/eb28+79m19xc43zx/On56/P
-        z8/PM9OcPydC0fU7p5T8vU5KQWU1oPM1Pv/08ePfW/37KhQ5rb1mLciMC6moz8iv6N2CpFVOIt5t
-        PjbYTIewpVzfGHuj4XNdtTMeMYeknsfhRudt0+1E3+ai3JFZVl9R0eLq1WT0k4YhZ5MZ9+lVDdOz
-        dlvmaVuDBiwJkdQOmEnTAjZhouLIrpJutAUv7jZX0J1l0qvoaArkQudGRlqoSC2Ukhi5KYhiFM2F
-        mlXNhoSBUOKbiwuqbBQDnF7nOKK5/ioQxVQouAD2KC0QUwEY2SCpL5hVsl5FEUbyIFJhhim4eKNi
-        4TEfGGQ2j2kl70GS3m0+YirZe+LafGApyS3bQGdTk7r3pSUXJOD+enUT/R3/YoHCwAbmGxkp/L+k
-        Hw4TZySdaHLfHSmHB0MuFyOUclDMXCQX6vnKiJlxTopSOHhatG/MAFEC+jSnZZ8Jr+oXdxu8oOPq
-        0AmnaNuJm40xK464F44YKZRssDkM9f2B75aPYr579+bLbvPlzacWNbjz7ghYZ3LZy16mwh0XmJes
-        ff0fIGWf3ou7zW5qsW+cxx+5OzkFApd4t7yW8H+TjgMXBilCRczFQJBHkKGFLCdBI5e0kNpT8Xg1
-        PHTbNT7zo5+cthB/p0jk/vykRwqFIspKG8ZhEYQj6HWGUdUS0oRsJvs0ROZsR8Jya6WvFj8aMZOT
-        /iwAI1kzLkhEnWRwV0Up5UBOfadgP3cdFzvMcHu3dG0au09Lh05O231fL2R10ZmpLJxLYGbSC38U
-        7zYf752cd2/U5sInpy3ck/rmQGl3Twfuo4X/RQak5u7lm3ebz7sXHz/e/vIIrOH7di1/1GBXooyl
-        r4cGYs0MFGNpBx9lfZAcoMoj3SyWreBKNHhqOhMZPWdcX3ByWCLf1DhJ4oI9B7ILKqEgmFUJl1ot
-        RKVEkjn4IKbtzRRjkX7aQdQEyl5TLp01vmnUjWHS+MC0KXDqe9Heazq8WkaUNFKwEvpNn6N1sLCG
-        b/iLl5s6Lx6euKrSZi4IEGwxtmcUVlNTNBSCAescbVEGP/MaWhuLy37H1YcTkWSC81R3uUCLhW52
-        7pbB2zyFhyOVaHWpoOy0cRzA6IuXGwVlpPX2AelIwThINE1MxSDKWfNocJczG6hwrBFEC0qjZIkT
-        YRJ3ieY0rRcvN+RYzQZ3t/ebX9FODz2h2dqik6SB6JjkgY9iYgi2bn3qxo80TonXKgdWo2ELuplC
-        awl9OOOoQ96wnHfuxHzCJMwSLZw5FLcoGhDE80GfIIETaENbVR8YH2UU54jbv9i54D4puvrFy03D
-        G7dBeZdFrQYvMJX8Pw4uDYm107JLG47taJJrIg3igpUnB9gBmZsp5q8wrtOGDtkZgDtEu6Qst+h3
-        su/rySGzGpwK1aQZwV/xPnFNe/EOOW3Zn9uquu0k5tyRUG3xo9NqooGjMNuDkiXkaCaKZySqjNW0
-        tJenbbwGKQYfHTC5c6SNtPtxF2ncGc4XhlHHiqOV9vnALMBCoGlKssPeBKAw3c0MtfGXHzmCVi2r
-        1Qq/BPZunSRWGrnLXitpgqLJP/Z++Df/CcVYYl4kpgqz1E59yIaXC26/rCqQZItjNkWbEAeSZB1j
-        hKwHVgnqtAYyQG24U2+1//AulxELW7Xzo281PG5jU/3DMQRuEIict4FEsjKRsy1eXzTn9Yaes5F0
-        SaLz4+7J7uLb3eN33+y+edYcBz2Y/8fHIfJd4vEEZnfhDyEW8uRf3hUyT1cjqopCZxQ+mVAhpx72
-        gmPt0F5t9WmTs9HhtQysJPLV7Z/Teh3+rv+kvfyLXh74T4G2VUucs9gLoNWvmlwAiQO79bZOHMbH
-        8TxFp4puFIFlzU2QDpIWmzglvww+mX50GjpUmsm6BGXcpls9ncVS6W3m4f/syddnq3zgchA+rjOw
-        b89WnSSulUauzbmXNwCPghlElgTprXdz4dogcASx8DY0jzAPruSsC9aDTMvTWrNyTbq0a2m4YfOd
-        i2jFVVARc4go9pTE9b7Ucohr53cnqQtSQtbARQ08GeeZVhWZNBoY8X+OtJfaqR+0C549+ZojJfK+
-        RcG4wIjoqdCitEigAxMt0cP7biZpg64L94ahGHpmE6ep5EcZu2Oxd9R9ryh4PX12LqSqjL7bfCzy
-        9DtKPN4Q8yjaejjQ/YLN2S1ywStrgh6kYxlpgTEjsRlknCh44pCYqPRszoGbEeV+rpASIMCxKMkf
-        IhYjUhOKKA3lURMTAqZkW7vonLKRBXMH8FizGH4kVUBb+D2iE4Ba0H52/k/Ijbk8QItLtGVM1jnX
-        fZ64GEe2ViFqMPFMJQkXiG/x7MvE/XIhNrcZt1NXteuXnmeAUCKupuAlB8Vt+zjm4rQAYDGkHzuu
-        L/nog/IF+lchTe4qxRwUo3xsGpy9DDcomHBbG2gzZH/QyV7hwIUSHkRjgqXBnZitRER7wo50VoW6
-        WR/U0bI1xg7h6ohsocjkudhav6ZtB28oh+QNYvVGlMd8hFYShFStkMiIl/jP88hFAg6VZF5EeyTs
-        tzTZf08xFPa5qDMAWT3MVKawtFm4a48/Tys2uK9Z6H+np6kFqqbIeK4Z13UDSWdbEAqTRtweSRd0
-        lm7ACIQ1d7V5ZIy58JApM/0LiGEoa4P220JjAxl7QVWAJ2xDV2gcUWzLEFpuMWJEISYMAMNNpAWh
-        kJVzRNYKt6Nn9ubyEU+LIM63g+nZbk/MkP54Q8/KJc4TtQG4W1qw12rQitrEwRuQHw5TYyRAAFra
-        8/8pLbxZkC8Ayxg5DnILBq4PAFbUOl2Jm48ajbfUUmZ4YX++2p6UHVy2IU+MXH6Z94P2IJKVWZWm
-        XIa40579yKzpKGrjEb4EhwCtm9OM84SpwhG5II/i8winvBhCNePIzqU0ACHDAUB8NbX+nsuJ0Jbf
-        Em/p/biwGek5FkYSBYpKJvsRP37tfy2QIqlQAqHNmZmwhuzD9uG6D/G5d+WLS0K8mtRCJBPDQ2O4
-        qFP/h4W22EgmlZ3JjrTvYUxeeM1ojmE3VYoAliF30JPUjsUvKmUOz3sppuxjNb88hehtWtOUYjN3
-        zekGm/xQmMAanLyK3PUEF26X62ERYN2pCWnGoICw5d+0mGNiJRN68+4j14ihYiG/m/VDHiWpN+v/
-        pTbQWzlgD10H+xMPySLsoTpgEBzwt0XfE+vwQUSpLVbdblDXuzS/I9EtRBb2Y5GSI3DBrGNliaJG
-        Hd482AwqO0aiAdVKPaCY9mMDvXLVJpOo88LDR/FnU2NR/IqC+9umf2IwkZe8Paz8XIJnmH/pKyun
-        hBRbhvcr0EwUfKz+AgZjbV+GO5EdnIbvNuNGtcgmScEkBdVz3FAo8t0bY8J+nOPXaJKNjkAf9pL+
-        fWoy24EVtEXBHM1vFj9PQyBFROL8tSQc1ssMaDgaa7r7H8JCGT1SQvYxurLDAs8zetUUUYNQQfgP
-        GtRYIHglDQz1i9FVdcg2jVeqoeMYENu5uwO9GTlMloPjOAJbpIhg2GD4epS36Uhz1KwJ0VTWnNkL
-        Et1uwMJd1/DfIWtCLBeFMIiY0G0MnjHObrVd33mAgjg4JoWCDJoaRYTVbAJuJx9R3zsCueq2dZfu
-        57inC0eq+lZVsnHXKm3W5joKLvCA6fRf0NHAThKIctIlUcaY0DIVN4FoAUvLAVGY14vFQokNsC6N
-        uw6vsB84ESlnKPERhWgYiWjJd2jHuKQu75ZtkqmCWb1abJtY1judkHWZYnIKhQF19tZVLv/qC5XW
-        bIEsgzN4iFQj8r2q/GbUGI+c24chAC2J90qvFvrh1hQVRjgjXS08wocc0fKYvn7NoLtsQ8+My0uM
-        dzvYK0ft+pc32mNIrLTQ3k0ZinQEc+yPRlTCII/eBCzB/mfPoYNAjlC8BBm9jaiQIB4YOB0K7D7q
-        fad/A+YdGae8effRQso9JvgJiKLF2RxkLJQJL3f/RDrElGgLLxk0czPoA74hQ742JLZJ7/wsSh+7
-        3RhihJqFDfBXFMYxklqRbeBQ+Tihea6ghc0vBQtTioULdbiRZiAeF2ONvXUU1X8eRFlNEICnvFa6
-        D0e+KGeHb0tN/6F//30uZpLPbnb8/r//qgVqyEyoBEQlhBE0CACGzr8g+eCok+HW5KVL0ZLIuHOV
-        FXM32aemxD8i351tA72Ls1fElUeyVIeRiP37o5HJ5Sio1A3uNJXwQDPypKiJvQZBA6GYGqDTQBoq
-        LJfmgmUJnMvXbtvkNAZrJy5LqsILf5pbixxgKK9xWt1QUuwkZ8/j0thh2gHVZVuPseKxbTxZFfso
-        vY1PpCMYL+JTn7RGvqrkaiNSdXXjGY7pDYWA3OLuk7t+8y4M7BXbypV14x7bQNl5mlMaCRWYWzTn
-        MM+iyXdkhNjzlyxLOERPNOMSWMNbc8nC50tP6bF2QPOJx5D4rniIHY826D56jJYWOW630GVYYqI4
-        fJkh66lBT4quHTneCd4rsuya/2eJcikvJUSnrc7voVtpsR1kR3Xb0YJnFom+yRd1E5cY9Otq0Jrf
-        EzPvMO5w0eJLXCz1UXrouXzcRPuAPmSrtcyCl/Mu21T+oCT13bon+NGLq+/bq+5tTYxTJv5k7+bG
-        OUinS8/jUwxpbdbcfbr1MrcVzHVE+NtUTNCJ231rLMi7++RewyDdAHiSzvg7kpmYDthS5R0ISP7w
-        Lu5R6Nf3j8s6DMtRm2guZ9azMD8xeVV8LK/TUHlWOG/WHzxgO84wv7gmeWbzCzIPWsrwYZWVMwza
-        FMak3/pVpULtVvf1wZIg8xBXM5iWVHpl538XHKLs54L9zkxou80+8WuEYRoWd+cUOYYauPNpkwQb
-        5b3HwsFdCdc7/36RVAJjuszLpjufbqbxEZ1sNu1YVam9qJ7+kH0H8zaeSdGjI2StxqXorIkkG1ZR
-        q55RcJjMke2/btzXvnAJCV+R3UJ3nrWHzkkO+72LdS0oTxumqOWd3C/rZJ4bbGswjbszSOF2/upz
-        z1soyUyZzS+Onv0FkaWL2lmsW0/+rM/S36KEEv4Z6BNQeHWPH9HVfXiVsRh20I+EDyz9bSzXr35+
-        +hOfx9wzlb3RbzjAn6a/Hz+iaw/IJ86VFqcz64gLxPWfXcjNKnnEA2cp99vXtwp7S+sL6cVoatFs
-        ujIdmU7T8SdjHMBWGAXltnp3bkUSuJhr3i73zRlIPdM3PXETOwVBxRpohDP5dNAMrH9zODSQm/AX
-        +o/69lyOX+bLVSk4O4mdcgrGh3+Pq5SyfOkpfXL/X+ffOWqcc3me0DLqn3bpIcZ0XjWkrtwyc9t1
-        XYtA14cAcnnc9rCbJbSRNa9cSzIsucuNdqz3BdPJSWz2Ru3c1774uY0t/oGQ+hCR6w06xuWgp5vG
-        0HXHAlRsp0idlwg9fbHFeenF7g9vyK8fL2kqdmPJ9/Mxixl/pEBK59KwdBptYbFJHbn0k6sJQVUM
-        0nt3cx7XXvYmduATkjK6daJo1yJ1Xr12/frt6zNxpd+h0x4WHzSa8Hnw2rVTHyBTpyBcbr55697N
-        1Uj3S58r3r1x61Zy4Rbo1aQb4XWaG9duCZI+KfOuazeu3rtzS9cYpjf14kcZxoGN3X36/7Q6AQ==
+      string: "{\n  \"id\": \"resp_0dc3c7d60a62eff8006a7f83c55d9c8196b22b9bd78c6235df\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1786741701,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1786741839,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        null,\n  \"max_output_tokens\": null,\n  \"max_tool_calls\": null,\n  \"model\":
+        \"gpt-5.6-sol\",\n  \"moderation\": null,\n  \"output\": [\n    {\n      \"id\":
+        \"rs_0dc3c7d60a62eff8006a7f83c670dc8196a97e175146cd1b78\",\n      \"type\":
+        \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\": \"gAAAAABqf4RPFJsFLjdgyPEJIcGjc7fz2Aa4bzz2o0I3ZgDAjEDeFRFQaDonATZda1o2ycbkc_L5OjSCAFFFYjj4J08SI82iJa3eH4fTo0APGYMpwV9xn0j74hGeBw14bfuZrYXMR0ZZ7abgJndJv0pn6OvuNB82TTMcHfmpElwif4opNcH5JuSkNuJ1LvcqsyOr7zw-tFTav-tx3BUe3-oFsrca2hNLVnV-YkbEAiwYwxl3UzrUjhpYo9Rt6BygLMrZBT0G5OOEvAm55OnjJWfroGJKTlFJRAri_pEn7wUUpOy0PXoZE5uMLJ8LX3zLUKjUR51O1CbCUxrLX88H4jSWvQPXNVME945CqQVKEuU2_CoQqEn9oZxqEa6hQv4sKMO6qHHqlWhky5iXQa2DYaAz63yPDxUhMykALmCw1VBw-_sfRll28fUVGT9cN3HLise8BxJP9ycDLYeT-cmuOQytH2gccubTbk79AaWw_aeaaZGHl4YQDmgvHH1s05mWwr97w0Km-sp7JWmdv9nH4tm3XId3zHjdsBrX4J0t6NAr4bIrtjg7AXWVZV-1hqSOGk--6hudLMa3YvXlLXGi0TPl8HUkDwf54SaHQl5Rr_t56C30BU1Pxlx1Xtvc-Wy3hVM_h1GhOKbGd3I6xnnLdKtZkK3F0GuL0yRBB8HbU1ohfI3e8eVfYF2PSv8Eme-_S2_VwIwXtBS_AF2B-weBSqTTK4H8QWHgcfftyEs42hZ6rTNfqRdW78k8AxKN0epQfZns_LbsDa67Q72CJWsiSihSkxtcTTtYAwwNl51s1t4LI_YHctX01mDKy1Bingncc2bRVrCsb7d-Utd9AnykvTpL1C78d5H_XOUMmE0RxCQ1t3XzqDwBZcpTG1fjnt9aL284SSA-G-sYvFdfV74i9pO5RNGLlAdZclkrWY_oWWTvdquYb048RYjNf8ZPz7fRSSPdIl7kRwpOI3A_SdIsZUAfJCEObHF9kfJTRWidYbOTXLKMUPs_te8hOzCwlM4j3AQjwTpTL14UV8DoCTGreC00YaRyEtCCl9jRRSIMALh1yybR1SD67VlFe1aoKGeqop804c5SEBvmItysjEmfIXxnWgIwmImnz97qEHsMP_MYPkmpdi90WXIEbdyQ8L8Pvi7jLJdA34vavtKb51Ys0sVzTGRap5FlKvGcJReYqgJGBcKIuxlVUW4lMCijaC0XShqCn2N7SbVrZn_HyQ7QcNDx5n78cCHU1BWEFeBPEHOu4lSA0lnYooxm34A9YLlR6PPUW-hStD3oGfsrWcocXsU51x-vBxDD6bd47gheNdxpYayA1UFefTaIO9Ck2en1S-IGsjCVkB3U4W0oLSHszeRGinfIwhstCReA9SRUQ4b6pQ9P1qkUS6j1TRtnpUOOVLYCLAezLrETzhwZJZn8xtJRXuKvNMWYIhXMB2B6P7nEFGC2Oo0efcmllCmXob5a9DI6vS8TMLRDMFMYM7hCbgenPpT3JlSSvwlNg-nzMfAUWwDR04UlEgCxE2QNfJXJPQhQTMGBA9aRT4atS8TXK_EsWrSr4ZVjHK83HKj_NeUhJDesv4nEHBRnR22IIY6HAHQ0OP0ZUhcLFk2BsvQnQ_EBw55XXLZLVtyAf4jbBGE4nwvWJnFx6xvihQxVi4NV0OqzrYA-qtXyIIPvAzXFmKNVH3RjMQd9aQPU1QHQro6NJFH9qlcdOrlgAuG8ZBoVbEZxFvMVoQCFilsuIfDxeJcUjJeC5birP_rMnnOxy5fZ0VQGoIOtkBifMD4H_JqmL1ClQIFsshZNOlu2v2bsbpmyO52CfM7xeUDsk7dg5VfhwxnC09_1SgukeLoHaNEm5bXR2ivMaWS_rSSWiz1L6JYiYNm89hHdOIKBR1FZOVJ0KatvgDjG0GESKqQFdvFW7CpvxmYCj5NdnDA18D8fA2Yg2otNkKsb6fP31otiK2g7H65kzhTYHcsevuZuNImMzQv9pBoFFTDpHStN08E6oyIu4pBSObW56tGPHHIMWE0Hvo4Zh8qi8CGu8BL2EznXstghcVmxlEwrltsX7ybxQ2VE9Dyv6UQ7acuCU-nVGvnGFJ_TI0v_qEg=\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83c97e7481968c4e52b84edf31f9\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"search\",\n        \"queries\": [\n          \"site:docs.python.org/3.13
+        free-threaded CPython 3.13 GIL disabled experimental\",\n          \"site:docs.python.org/3.13/howto
+        free threading extensions CPython 3.13\",\n          \"site:peps.python.org
+        PEP 703 CPython 3.13 free-threaded ABI tag cp313t\",\n          \"site:github.com/python/cpython
+        3.13 free-threaded build GIL Py_GIL_DISABLED\"\n        ],\n        \"query\":
+        \"site:docs.python.org/3.13 free-threaded CPython 3.13 GIL disabled experimental\"\n
+        \     }\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83cc93e481969c0da311f6327f68\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPFgPGh_3vyKtbRdgmVSe1RAI9o0vXo_NiOLRuOjkEVWOti_unigGZxIj_gadin2X9k6t28XXptYpihpwzA57Q9oDqFz5XwN55J1HsqI4WygtgOLNHf004ezv2HlGEkKJ2Ze0E76fTDTlslVMC2h6ORX0cfwh8TzJ4gjxKo-VgcpBbScbihsSomQU6Z8_gU4iZf_54AB4xMNIkpjQYR7IPxpFjdAx3Rva_FAU1gRYAEti2eO4r74ElhvcTSQ93hKpsvepqT73OcqhpNHRRbkBulGDfI3n6GVlOkE16FzSco0dEIMKR1LYutWSU1RJaONmhrK_l7jTHzirbnWZckU5mWHDFl2FmIWE0TI1R7XX6q2Bbg-Wf4eHYO4cgCPMXMCalerxc--jvcMylsAeq37TH1DjWZoS6QYc_BJ580Cxox7qqnQwmjZGW1qf1sN5WStSR6ZoKAbxgrnzyDO1nqIZacwuFXNqm8aVWYMUcmpCQaIWwiTGGe6adspV6ZwBlVwVTlltOPEhvhUygB63pMCjGwM-UddtLkAoS776RPTQeeAl85pHOLe3JZ73S0dnY4EyQBs-rD3ZmWIpb39T8CD9kJFUAoIQX7S9q2O_AzGE4YxfFKppWsJSRLdpAWt7YifRsoRiAUHDTnWwMXHn5QUnpUFph_Ss411xquBqtJsyT5UKi4eSEZuqbi9Fpnm49Z7uQvqQ7nLheYrOfpl7gzRT4WZcfQrCKkoejemhw_E3U9DMvv0o5a5bmay5lTOZpTdF24F_0mKs9LmFozZlhuKjK7P1Vp6nhJlhQ2Gfh1tOb8UPJuuwZ2zTCcodkYWjDtyUdg_aAi0Jnu73wJlX8h047EfmnfEdl5hrDqzfO9bxmSvSe94mVTQIyZaDUr8h8c6-BTswP5TZnvnL7muMOwkJ75AVMXK5hAIE3UdVzG_lk8zuZIwQjq6e_jQU9n9lkrBxSyOiRmVk2df8ehNWS3oL3qbrHJ_qE_yaQtyZm3YEVRE5D0wqeWSPWqZmiTsx0dHOVoRWuZDhPfhjphO3XUHxuG4dk5h8OBSU6tjmqjd11kLeUae96rkW7wvGEhogIIFsD01-sxLZfo6wagVrO5ltqpfcHEKYDooFaFCrf2IkwlJChewkDkCp7bIKAFTldsxRdyoaAOB35QFoUQlxYOGBB6heQCwEjBKaHIWGkCKeT5zY2jH7Q8PYcetwq_r4o7nkiPqg9Z90lrh13JkcqtQjTzLpGoUJh9k2J8745A1FF0z56Fd1hUIPXMpCf00FBKeD7I83-YTsYKPHfF326yqjuChcEDP0fBzrzcDTOep7kmN8=\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83cd17448196b703a8960f667ac4\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"search\",\n        \"queries\": [\n          \"site:docs.python.org/3.13/whatsnew/3.13.html
+        \\\"Free-threaded CPython\\\"\",\n          \"site:docs.python.org/3.13/howto/free-threading-python.html\",\n
+        \         \"site:docs.python.org/3.13/c-api/init.html PyUnstable_Module_SetGIL
+        Py_MOD_GIL_NOT_USED\",\n          \"site:docs.python.org/3.13/library/sys.html
+        _is_gil_enabled\"\n        ],\n        \"query\": \"site:docs.python.org/3.13/whatsnew/3.13.html
+        \\\"Free-threaded CPython\\\"\"\n      }\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83cfdbd4819698f43599eb72d59c\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RP3RoVJG26MFIgJrZAz-ynGizOffbwbC3kt8irG2RuME72GQuzheZqeYQaGhdQA1diYttrTHX7MtN0BsHvJrSQUZxIQm279u594HvD85k65AWyzSUmv_p5x-j4uFSBQuMI731hlk8kaTVQjouOc05WzjAsogi58S3ZCwcksm-wutec5bHbZRHZcWdyQwB8FgC914UEMXSxCF23a8e6UBUrDMrz6l7XN4QkPNCiDAn-yHAYhdgSa3vbVNj4JxM2jqccYLECGBQYM0fTelD8F-613pPsVuQp_zssCwVoMR80X1oAVXJCmU8Kr-mzDniWX-YtfWl90DAe2Oz0IGY0GaCakbtnn4kXpt_v4XR2w-RWhA1zETuh3Lvmrnv-jPgkgBEDhOuwlY7U-Dew32nJsxnxTeJZ1ygvucN1qjVZIrAGo6Lh41Sn5Rie82RlmZzOpIcZg3JQP1MrSrzKvgfOxh77W6JAlcW6K6nigJV44lTemVDmyhOs11BBjPmZ6Yhn8qvsmURb_Xn_IfzGsZdLiadMKVCCeb6Uh4f7YcAkc-eJLchePrUlqGlrqbO0XaRBNBuz5wi-o_o0EvmSQIJKbbNZ-2WjegydoR06Wx5ZXkW5QbwJSnjNtoyQyQ61G-RupP2mGi1lPnSI4VR5OPp3LDOqgkQYB1Ph9gD50zB-brkBrC5FlpUVXMesZ7EctyS1mMActtHS2l-aUHQKRwF5cRlFSu8WG2lc6loHdZk2wffdQmWKurQaqJt6nSIMG1wxSDyNZKHEcXm_UD3aBIgjIayqsE9CmDYzafe6a2IfELfl6Pk-blZWEBZ2aQaSCmAnMxqwtGkfWIBTDttDm5vNQcFhcA0JiqpCDghPskRatwDlbPXrVDAN9dsbQ2UjR4hT0Ct5iK593FLV1GTt_VSxyEWhC68OiSZFNvMiQgO4nTlC1_HKI5TQ8ftSGGYtwhEjug1Mgyhko4FgFXlbwvBLhVeeQRx1tdRUZjiZmD1tMyTZiLcXc_N_CRlACfrMGkMD7ReGFRLjCbofNEskUjNvr5Zk5ugWy-uE5uJr0II-1QR5ABD_5aT1kxY6tc9fX4X0hfXv-kEMvD5EW9_QYx-ETZCEhLVEN5DeZh1iLvwjHRIe4pQ6NVuA8YVWGp-hS_dcc5SIa4AY4BCatFlxT2GxNWCFeUzrsbbuBvrBzIoOQW3IC2_50Cjrw7HnRkcwUkmXj6Jjf965h0-HAsTTi37O-dpIbybsljGAXkf-haZUbH7VgWT8z4LJJ2loStGE6kFZSOD2W5z1UVN6DaElRcY5-aJGNQ==\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83d01d388196ad8d44dc20b72db8\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"open_page\",\n        \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \     }\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83d2519c8196bd607c0f58048e01\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RP1RKoNLt4nEeC4F9sAB07noDozGHfR5z4DB0080E84NSjwm1hLS1YBkGIDr-h6GAvdeV8jlsYgtvwIPm2uO3e2n8Sjni1emSGE555EqUx0FctGyQf4Z2Ln54mZvEjky07nwxBrd_lkLbJAEg0u7QZdNts4E1g3TY3XbM5DvauOswuKUrnVDPF93GohSomJXo45bLM-hiQYpYrcbr4ovedIb2_1vFT6b4zeppBZ2TBkzFaykdUvOenlTNPJ4awIjvMhEr8S2IBEJ3NLE0Wj-oqyfLlNTZswpPUrtWDGuUbchW98-Fsx3wvXG2q1lWvzcUR9-Idxo9h_E8cEnS5170CxgksxeE5Cy_PpflkAISJ7rb1OwpS530OXsmYWWfEXWcNeZQAv87DHOyJMAHdHam_LFWTfj9DZiPpGMaAyyXlWX4Ba3RSxn77GowSCTPJwHl_WkJaa3kQ1hXbZwtB3uuoIPx1wTUeG6ldrwX8kbhKN4TUIF3cE5xBo7atpsikBxgGck5JDMeMuUH-kvqbElxs2oIDmwQcr2pGTH53KULjJaNzON_gkydlRr6KNJBX1tUO5ASl93WCQr79jJGusq4ZfCcoX2euCSl02DWsVYrCMte_skkwJ6eGocKs6Fm7wYpB8yrUPXmhSZXgHBNckG0svdpv16m5WDgsrhMUfbAtAtuNJrwXEV1NsxsAPttw575AiXz9vd568n3MxQQhDiokPRm69hJwUbPgM_KFKOvXf2DsTVnLN3U84qICKtTYNvMqbs166dlW5wkxPp17Xv6HPzoNtNBDvfQb3zDF9XdSItWBcVfcKQqyI_jEEdODt8239SiWjPsVHfxm4BH63rF__n3sg2ltHHGDxaP99rF9RKLl2wSqZWWRaIYJaVZqdQ0gWCUOWG9c304pdPZCPWco7Cg32aWQaimtYD3OYH2yZ-nExI6kNaJ5beaT773klQqsGjCo-hFiLlLr4pIzTCpHk3FucIb1Qf1nrrnn0ZqCFDfq7uWQnn20SASAf0wXL7iGkdF_3TMxvPRmS9HG6mXENGPNYa-NVQebaJ2CMSDfSUswUlDRte6dUwsw6-GpYs4LLH6aAOoMtvMEEUUFKCj-HgUfWUDwiARk15gL2kOZXcCD41OKuT9ejPlbgqbsqXtklgXFioqTT0XuGuCqYNVM8oWq6NEvUepBpP4qSjOp_mwVIrHzy9wfe4qvY088khrdRgfYbqMH8gkAywmPCKk2Pw==\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83d281788196998813c7c0540a26\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"find_in_page\",\n        \"pattern\": \"The free-threaded
+        mode requires\",\n        \"url\": \"https://docs.python.org/3.13/whatsnew/3.13.html\"\n
+        \     }\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83d445208196a7677b055cd7235d\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPyKkmKKxzqm_Qaj9bNOWo1EVOReW0Cu8SxklOFYmIYNKtHuaEFeZLcnS3C-17UNV9E67vtYWaghc_OWShyT7Za4KWv98Azc_jWSskOGlqg6-xsOTbVQOwNLRuKlPrgx5S4PI_Kyn-2nW2Bc3hv9lRqONSH80Tjpx0_89EZZRHwA4FCtSlTGgy6AXV2lrmz7kuhUEQyVXJXDNpaUahZ2WR3z-Pj5WHDK5StTY2mT6Es8LiNU0bzMJzA5GZ33DRZioaMZ3b58N3AaooPzBCd11dDtgKAjtPiXahPwHAvQbXTAdzOv1f-jnVXpRpCju_DIsML1cSLfkNPlDUr8efwvv9nPnqvrxbE_PFq2oM8dTbxk6lpVsTIME2JWj-QDRo9HBsgvb58Z39Ayd2MfAInVEj3uxp05RX6QJ6l6Svocn5BlmF54C7Rx6Oq3aiuEsgday_peVvSab0NzdqV_u3y3KdWHttJtLpU2gW5wTfrYc7z-xSVoebfYp-9JBIdCPkSrXrBhlmFe2ZhHlc0WYuTbGEn95gtKGWC1TBgBAeofx0dxkx0dBvTWtgWkha_5m6fMQyxwZcMxiDd12oDwIi35p2GhhqDVlGdW16zhKuczOaioNh3IJX07uVpKz_2ypcg1-7ORSI3n-M-56SJVw_UfsMT7JxsodS-FFsljk3Rwg1qvpLZPh-aO3OYXDZEcon25EyVa83ClRiGzJl4hCqD82XGavoPdxMOmMt5HH2tXFlZ1wfbs7ZMUBefDfGGO6ECcePWOm8qfsZWHCFU6X0oo82Sf58MeF5L-kmH0DkUhwF3h2EXVvTCBQA-c1CwgwtVSrxbJA7WJIvKHfe6boABz5nHWC41wzsLACC7veQcbXfFrRSo3BZ_MPg-RT-bUJQ9QFBw3TrQ9WdyVQVIh2BjllZS7Lio21XY7iNIAe_9YjjLI0DLcLJb_btQ33JIP7C6dtCNTkgqWqaHTiGsIXShB_rRhwYArzLF0XrE2zOrWPK_7f2vmbjWx_bi21hIdCxq82vvKvf6D7BPuz3T4Lq1nt3tNcvlmCvYDiV7g_9FZZxlJYejadsSzskSnCWr7WMtA0qWdB8exonaRTcwg9M80Cs9gWrGOUwIVV0w-wMR7pDeo0uBic6sToJCqQBCYrS3c-vxIwl6qLD_DTZAS3tQOqLMt_4QHU3o6WZS_aWF2l2zQofPruUofY55Gnt4hEWzpEGamodNNCsVR90DwnyKPJVg_vC1FS4aqM9tH7OpEqXzmp9U42XxqALm7qofjfYm8-bCgoBJL28I0DnMTRwWLv0Z7Ge2M2YxpwT4s7L5_JwihelW-9lET9sqnJgfszaGm5onehyrzsJ4QfuDoqISRrP2HOheo7KDJxrg0rapfKCOyo_o4hMXoxwbM5eQ1DROE8XPbjdxMlUYTeHb92NGbGqgZpLaw_MOZXe7TYZm2ckHGbe4cKHrrCFQo00iXPFJSMiNSkKZ92K4ov-RMuZ8cjwyQ==\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83d543888196ac98361fd1803d65\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"find_in_page\",\n        \"pattern\": \"Wheel Tag\",\n
+        \       \"url\": \"https://peps.python.org/pep-0703/\"\n      }\n    },\n
+        \   {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83d75ca88196bb194796fe0cfd5b\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPcIQtm28sh-0RSP-Dx2x1naV9LByoWqgg851JJ9T5U5ZkX3hElwWd0ZvNtZh_SkMCdT3y1uVh2e4C16MRk3WXZTo5J0u4_2zStlx5Ip4btkD6ZhkZH_1gKqRUnGyW225KIXC9vctvwB9ceu-BYx1SQvkD5LokCV-8Co3Oufn0BwWixAW4OAJ0Hxhws83Fc0T3pDaXNZTCvzdXmmGrortgpjMvhyRbi7Yunr0sBu1FN_G2MnbNqOZ7xD-Dr1xSzecIjMeODs1fMKE5mGnE6WfUor-VgQJ4OYDFKjhbyoSBiVlCTL_Xg4FN3Cr3KiDjlAS3AxoioPsjUzOS3IWwnGxWP_8Nprq1z7QWDI_HRzoxTcpjiNOLGGwdX9PDgm56DYJEfBsbLUsl0VY0N91bLwWx1snwW5k6FmWoyaQ35otDcbt08DN5IpSIYApcBdfS7q-5_nmVDhTlKZakfwG6wA_pvww096M1e7qOxwbjxK1ze1U5zih_S18_Ez2tWuaM5l8HK_AJXQztRRsLy36RCjvOZ-rHu2NTSlCIEKUgz5KLGaTBIGJFkSoCCUpZhHKhfivfJi0eYahiBrNFxBf89efXJrNSbtygHAcxEIh216qPsY1hhSyODiF5dhbrTt1DXlI7aAcdgEK4y5_KadIgnCWhtatV5aoaZBl8P8WAolWMr_TJ6xVsOOih-_WpvQepbFXP6yLHd6h-x7jsKBER1Ooagn5Hqjgq-fQ10G266mNaO_CR5HOaCqvU_McNCVMbGOzcN2YZc4OCi1oM3Zfo09HAnV6FkjEOnZa82jBeuA1QXHSKewTCsPHHy1_IUNQHOta0h6pLRpe_cNXEcm46sGnocmmdSB1W4VGahOb9flqO6Dr3ntZDrgIZoUY5zPl0zdQgVbjJmDUY5h4pF8n2yyE71BDJUlq3FJV8GktaIXUb7IXO9O1N6FGv1v3ThlL09SlJfSW45z0wi9GEBnD12FD3aUu3AxLDCow_TR1aPC1SPU-FeKi2Juf1i0pdpGTvEE53HHkwfrUX-U4gxCD-R9x5xpyBM6UwS6hfGdWmQRpwLyZtR1UAfORz0aozEV3le2m6IYeVwxEU0IZsI6rNb3ycPjfXu_tv48E9bkcM6W3p8zUH5M__liC5-OXUHn8OSd-fVoW1PvofBeXs0tMvAf-uVIp01YDdtN2Ip3_yhDv3L-pCsaD5PY515oyMtElpeMzX_qvSvMPoaulEpnt1wEHKqNh7_Bbp1cQuebmdghri02ZBzRAIZziUGTQtYD7UFdGy3cWHZqz1D4S9C5RYUA0_ehqMFX-gTiXfpUi7SP-71FxcCJtjobuMd_WBHk80oEQoVxKTCwiSEzJYl56tSoILXPrpD_mQhA6kV8PU6c32lWM=\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83d8284c8196b6a0906ca2a20b38\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"search\",\n        \"queries\": [\n          \"site:docs.python.org/3.13
+        \\\"cp313t\\\"\",\n          \"site:docs.python.org/3.13 \\\"cpython-313t\\\"\",\n
+        \         \"site:github.com/python/cpython/tree/3.13 cp313t wheel tag\",\n
+        \         \"site:github.com/python/cpython \\\"cp313t\\\"\"\n        ],\n
+        \       \"query\": \"site:docs.python.org/3.13 \\\"cp313t\\\"\"\n      }\n
+        \   },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83dbc9d0819687ec9802bda904f2\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPUws40qYPEdn89pSjcPZ1Lo9VvazfQDLgBkv_8Kid9xft15E9dCADQ2tNji6ewUpRlwK14ZnO-No1_2zR9d0RsFzDa7-KRh5ZrJLOlAKpwSr2bLhy8rK81-cEixeWuAJMOYPNCbRe0x7cGeP0aXi83GUwc1yNZkHWM6g8AYjaY7UUBARTlzuaUwQg0zQE1Lx33Gb0dNvG_ApSU1AuVu4HP9dZm9eciffQ5YTDhXqleTowitvyUrVp-uPFMMuzxHfEl16Aq-Q7BkvhQVgPcGLHACpRImrDQJKfrw4PYunX72l36vZLvzW9jBYu6Ky3pgU59cq0za-_3tu5NbxUCu-H5E3nguNT2VsrEVMp-__i9z9sQxiyd6aiv4-kwXhr14RKDc9RscgV4VjTrvqTIuMqAMHo-aX6FRFI55NmzOSXtIopZKVOcrVTCOlYPMEJjlO6aOOyP04F_CemusFllEzBnDWsfo1L7x_e4HJftHJ7CSkwa2yYk1PO-TglKGbu1hNqYsROikTnfvlqhVfoEMyJJX_Z9fbFti9N0xToP-wbXdTPgw---wUpjQOkhq_6HrICbChpATAk3GUonVNgr9eiKo5TEiNErhmkdxGD_XW0jATikwzQEHU2-ivtKP9ORRj4--NpWrTJnc1TTUsFJLuwYpLokSfECQ_WtU6V321_vSdHrFq4W0hQF-3odLzpUUxMsi2BiTwVDDemO7oCRBF_DzDXNNpyu17REgc69ZJoUsbTeqagjh5RFbSPsIEsGpB7LuoA5JbNW8Y3L5rMDi-pIadVVkf4QbCDwUQawDKlkoDLGQtQPwJaDnI2tta0zHFb_G6jGUr37948zGCepELpIiFK8YcIP8AXIfLBLnD1caV4AK6rLQF8X_htP_hgXHi8frRN1yhoVrqwA3W5dWSPhB8Pgq4e0jTW5w7HYelAtwIH91Q4HZ2q1lY-Nj-9MwVBX1u27Bg9aeyIPWUBrhhcYYeEPtQroy2VQqnsjUwvOJxFy-N6GLeRSFL4Eec_hHj4BLwV9M8MXn83R_JEbfngWwVuVDYayf5imhsYRvSjBfzlt-p9v7sTXNhKw_BZiKohTKJfzINw-sNUTuW0l5ZEoQSmO1UKbhgtm_FAHbcVESm6d2229khjTdJGaPDodvMtNMQH4-ZhQ66IlPYdB8PQaMSRbD9Px-fFViDjrw0taSc3_zgmJHXMTOyld0gJipPXk5-CNWtMr8UwbQHxxWn2Nn2PI7mHaZPz2OoPuT_tnGJ8ppj1JYv5Aqy-rd44FaiyHVq6g_uhzlc-4AWi5SezEcV6SVECCE55WfrVr8Ia5K1KUfmC-5ylydVGjLy3X2N1TMHaKoeNvzxSJSyS1AGvuIiF8SsoltS180fblbZKkkbQyaCIfM5Kne5HFKnAxwcKYdTnechikr8QfSscFSXd0XDQkwBxhADpDUwq9g0NJfWpJeUQMfGDvrggwAWbW3OsF48FbwKGkvdyEQkwLkNUlY3GqDfjQOOqrkF9A717G7S_h1lt4eRmOKKApDSkRX4K\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83dcd2e08196a556ad15b3b80440\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"search\",\n        \"queries\": [\n          \"site:github.com/python/cpython/blob/3.13
+        \\\"SOABI\\\" \\\"cpython-313t\\\"\",\n          \"site:github.com/python/cpython/blob/3.13
+        \\\"EXT_SUFFIX\\\" \\\"313t\\\"\",\n          \"site:github.com/python/cpython/blob/3.13
+        \\\"gil_disabled\\\" \\\"cp313t\\\"\",\n          \"site:github.com/python/cpython/blob/3.13
+        \\\"ABI_THREAD\\\" wheel\"\n        ],\n        \"query\": \"site:github.com/python/cpython/blob/3.13
+        \\\"SOABI\\\" \\\"cpython-313t\\\"\"\n      }\n    },\n    {\n      \"id\":
+        \"rs_0dc3c7d60a62eff8006a7f83e0f0408196aeb9b5c065fe985f\",\n      \"type\":
+        \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\": \"gAAAAABqf4RPxgX4YWHBoMQFBERxYN_fcQpCo0gigGKfKtc7iH8AiDSK9XYu4TJb9ieRti0CUB7fN6jAuBY3Qwxg-EhybifXiQyVbtODHkGQfSM82HaK2cji70V1c4PBXTT9nneWApyV8tkEFdGUCayFBfrp9hZprocs1TP_WFym5XNYg-JvQeiLF9rL-kt9IFTMcS0U9cM0MNEdGXvPxzogeILC2iqPH84FLPJ1sVOu6dcpo2tDZBc1O-H5t2U2bhSd3XQmRq0zTmmRqg64svfpouBGa0l7P3dgOCu2m4B54Q3hsUfGXblzCy4snHbuEts4yhYSlfs7Pl6g_hm5pYicjseK-wyFKz4kaNcDztSno2m4nbxrPSr6Vz6equVFFaLhLHirzXtWgyiNNgvv0ZcCGhwvMj7M3E48I1P0s7rYlxuAN__Q4MvFtrmk7gLgx8ARly5YMLcEaIjjKVmz7WPMNb4e-Y2i8FleP7ssjdPlh12Q_ORTFiFge1KzU-eRXJRA7TahqUpvPzdeLyUz-jSksd8ONZnFZjgWhBiauzZW4sRP7sCLqLEadlK3pbmtAd6vD99PW_MR2Pjrh-okdkZDhiwLUxm_WgTcFLFFsPyHWxC8EVaumwvZhrJp3dHtbEvxzRCPYEhqNAL2LsbbxAgYmlv1-8QHHOOVqQYzDKCsyIDDJOOkUxeImXf12xp0qXC-a7Mq_H_Qq6VWkLaMmbBmxk0H86mqnAT8-ti-0R3FEoCJIWU7aulOb39Q-KWnGcgkOKWGpF0CFpPrSCMmpNEaRiggYrqGaUdRuTt0m67dNyL3OTJZskjRSJZH-be3lR0VnjDnhln-XALzTsFrdJukgbzTsIuML0bJbE5t0cs2wP0YY1xCXQNq10T_uz8rXLgVR5Q9fYH32aCabDg9d6Nwu_7clji-t4Cy_1CkcjN0Qycd29cizXAPJBYpPmtYqfAaXhOLt-2oL_RfRBxLJMm2aDp7YeKiwb8n-MpneQMSr5kjBB6HQCXSEUtqMKOkXsZmpUy4BIqJC3dMwlp6Kj_sNQ_StPrBwCb_MDEWspVmMiI8gTBgPnfIlg349UkdsjgtPocdq4f5vUitI7N2R5gvkTK_vHU1lyfXUDY9jZ-MiOxS10n9hhqdRL64U4dlD3V7TtEuRdKN-5d1U7-_eludVxuR012L6_VORU-zFjbPwG3Q-56bm6P6Bl-Evoftr_LWoVC0Q8ppl6bBZ6Khbply4pn8vrr9iVPBusieCKCEMbimP8nkLGRhQDktMEL8yYOGIGjp0I7t\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83e133108196b9b0670c42912f4c\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"open_page\",\n        \"url\": \"https://github.com/python/cpython/blob/3.13/configure.ac?plain=1\"\n
+        \     }\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83e4a3588196a126bd6061ab8fc2\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"find_in_page\",\n        \"pattern\": \"SOABI='cpython-\",\n
+        \       \"url\": \"https://github.com/python/cpython/blob/3.13/configure.ac?plain=1\"\n
+        \     }\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83e7b8988196a40da4f88b8f7228\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPVZYCznsTThKIfmn6XQg7oXCNWNdRSDPW7Ehsq8x5h26-D0ndnDcGLjD7xXQLQrU1CN_rJPvXHKL0nqr3eimiA2cD7VcZ61kWqwbOdTMoXRG4IKdJKopqHrZwdTAZuPsdF6sfG2I-Hpm081FVl-rllDhFb62i2SkDtDZOMseJPrqjIvziPMvQoxynmRqFhrYC4or9zXxt8D-w3G-vzefKFcco33iEsVC9QoJQi0clMGbDY483Ao_vYWJwV3TcCU4EKIrZArkWGCvNoWjHZ5LGyrrK5aio7ZwGUggCyNjW_SVKIZFy1A56fd4C3v_nTPaWZPESghEXJitN1rJoAMLSo5lor1oA5p2Fqpu6jk9ADogiTkyjx_LPGxwKPp2MCmBJFgvSjwtEte1dsNUMX96c22S5_m-Iph6xWf4ExAeYb36VVdSjFZhwImGp7Fr83RhLJQSoBD7qbwGq96mPsyOY8U-TzL7-HE-hAS91tnNRCcp8uPVgUjCe3styT2iVt_pxEGIJP4_eRv9LRW_U-U2U54opjH_XjMyudDL4YhqhDEUDN1P9QFWo7544vpLmWt8uxE7fJ8X-zx3NrGmppH8_fI7tgm4fNqsH-EX1aAZhDAm0UCSlTEcvUQ0qz1ZZBADWNzkh-ttoL2DpxSZRTZe_R8BwYOmCR3--O5fz3jfPG7BsynNGaRnbJzCfvc-0pgic8ZRH-TlDVL5F8d5t2NpqtR7_YXnRzBzj4wdwhF07aTXlcQ8kImWObtugAuJOvPkfHfxbiqWy0gPxC4bCYWRy9kcB65P2kcrCM5Z-UrAdLyFjFNQ1z8_dQdKWWJV_R649u5E95cpBtiUJwbjpvjU5QGCcZUrK7cSEuSt7scpS0gu-CkYsmyK7tXvyMftelLKhv0M7lGCst-mK1aGl8ZhV21lAlONdtEKOMuMy9kTyZWarbtJPRRqkru72NMyFHD4ADuzXm8v31ozBmfpMm4Z9HjvzW4L0nDD9WbA00I-bmvHe7huR43gbegbDXkosJU0DZf1VfptIzEBBQ6N9M392Z26fct2WMblWSNnVhdqocYja1UUFk8Z-QMitVGVeFfxB-ajWDloN7ziOqqAVtIUaLkeMOPkQ0zLZJ5A5yG-nEG9ynT1Dexc3NGTyRtPhjoXWrUB1giJ-_Y58hAtt3I3xQWIdvvNRooBqrDpeOjG_HFp2WWC6RG2xgaeh9KPPgFmhAymg3KSSBFy0PZ_dctJA8mM-7E3uyJCMVMTT5bxL2UiWf8Wx0AbUjFEB1fvL5cRpw_lRhgA8CryDqS4zyl_7DK9RvpLBuq32WilC0zu-EwE_KahoCn84ig-xt-txPqM3V5vjpMLf0uDYdSf1pQJv_ZPFcD_wO3Fj3xSjBcGSyvYemjGW-bFJUR4Ml3ho79-Htol_y3NvbSi967BuURjcdbGe7IymHAVHSQsM0SVOVybqPfV6gRHWyDoJ5sW1ekUI5WO7P4V8susn0f-K2S25ESCTggscjTndPZ_othrr4pSltumgdPISLUkorvKQK-Nx2KG5W3ZsxCQ6C2vvp_LN3dutBf4fIvcuCH-XiPadWwn-GJ7x_8yxLJoC5SC4P5N9nch1PARyu1Vb5vYJw0LM3paFdzhY-Tiufa_NYLOaYT_d6XEeInM5G62FnIRA_YfBwi53dyS6fNuQMLwR_5RI2uvJUFDEv7bQWgzuvNQJZMpB9eudGv_seY6TOreI_r01HuFin9HZo3EjouBC5odn7ArNm0drbOsV6UJxeYY8v7dQIbKZe7hd02NzMye8ES3dGPdBCMpt25CfgId_RzRb65uaL7Y2a0V84z-9__LjZNSRG37tiUN5BDpcN8ynASppk1BFrprWquIOpWhFZVysJLqtm37-Rss8O7GfEUHRFE8=\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83e9b9508196a2e081fded8c67d9\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"search\",\n        \"queries\": [\n          \"site:python.org
+        \\\"cp313t\\\" Python 3.13 free-threaded\",\n          \"site:docs.python.org/3.13
+        \\\"wheels\\\" \\\"t suffix\\\" free-threaded\",\n          \"site:peps.python.org
+        \\\"cp313-cp313t\\\"\",\n          \"site:github.com/python/cpython \\\"cp313-cp313t\\\"\"\n
+        \       ],\n        \"query\": \"site:python.org \\\"cp313t\\\" Python 3.13
+        free-threaded\"\n      }\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83ed76588196ba7348d94d02b66a\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RP2Q4Nk0oy2ILTgwW6jQ6nO5aKVIdJV8u3geLggR4djU3mOOzMDF7PKnpVKAZndzcmz-13bqNqZgSYEn-9marirD8HZe7LLtqjEapoCudBoqNq8QJZ8nGmYssAsfwdq80SeFJdvv5G3d4CnyWjK0JUSMysIJxp_jFa20w7T23KS8ddXNDoV8kVR5-cyk9jEyP4-egTu5AS8n-uZucCaA5S8V8SheBLXIa55mqhCw5nMmuEucXQsXy9NamW7ZByrCDhM0_VNQiofW_qsNjpIip_zXo8poQGRWEZ5ZnKbTktXTA5bh9lePdgF-_LZhyMJK9feymT6QyJsiF_faaN3VZ4H56X7LhmK_NVxnyxSqg8numZY7bpM2isI5-pfWy_4V1_NHhAzExEkaelHAIRIgs8A8PZX73arp0ClaFuZZQbtjix4PcK-TgOrQ9re02NtpZvKw3c81Kfh0Sl8DWOEQ6i4GjlPXD21GggeEp1Mf5bmFbPLyXpgcUMhCB19KRvPNgTU_c_DEUXcKL7n6woMCvI_DEBV_CA5P_hPNzAeyUUoOt_tHc0lqmBzNQXsDCX__GD9H9IrQHXIiTJH2WpyGyQEsBYnIMdxPqONwWZK_mxSAeiIub0DNp6dRnuqS7DhPTzASd0lhWxIC8W50E98LQEGkYie9e6uGBQbKhogK7QO2ZqXEEzLzVYf8YP_sVVrcUrl9XB62GxapHZewjfi8_QMR6oDlERWdIlmUxDK8UVIPKCUsr9VQzKK1nxjOijynRtGBJBWsHJV8Khe16sqbncoDC76Nfk33DQnh7ZdqdLeTFDosQM72-Z37zzDHLHbaqvOk7j1-rPGw5pXI5zO0eFysZhOIUtBh7yHLKlJKY7s0SXJQ0sesxSUShEH14RMcFtf5b1I-f3glGV2J54tqOERgttMQ4yvgD2cQX68dfeAagCPfCZcpJ_3nPnLBvuKYivqB1NhUTAABp96d5Md1AFSEcLhy30PkMSOQn2h7vQ-shmIxkAN2lP4QpyItwAuZnPYAfKtGEP3MtB8xGMnyBBAxKfZ6JjNW6al2DEXAhEyOm5KNG8FvRUyzhCrZkTqUbhD_e_FI1IIM5QnFMpOnhKh7cYlrNAx6JrWIzLRaV8S02ph9WDmp841m-XPnY_qBtryeKyNvi9Bug52uYtHcKIc_WQv02G0eMLQdAsgyBZxY8gELMmJqBp4surzOceXdSojuzqXfpC6J_51mSfNmS8XxTDqV0sVZikIAirekmjVbQmxq7rCTAKR5VTPXPF_rZ-IIGlYrNJ0g9y_N3fUIykf1Tkxd5V0h5weRlmOKQslZXD8XOpCGwNzK1anZax9J6I_CLSWHekbcfSZG7KHd3oPIf-GN-dX9avikaVXpflvdjHhpCAD07Q_7EZ-Y2OWVlhcBnzNs0EThLqtb0Z5Tu4r0ZnvtWuPkIlmlODjQHX1ktGOFjS7J-3Qp9lNk6xKOyQn68QiRZRX5m9vEi7fDpGxNYT9PbVOeeB7DminiLybcpZn3rmocQskZvYmBP36Dmx-Y2nhzExVnr6uH2X4-fGy2_OFseZusZoFhcIGmBuprZfskpacU0lUtVt5Gqcd6YUiM8e9EXuP8hNS-aH2oHzD_WECBtdolerWoH8-bFE6LyQD-IK4dt5i_vXhoPvaIY1xYk3eQZ7Z5qtDqasrWEXg23AtWx5TYakS7LzK5fVoWZAamZoybSdB5jS_JUjETRTLo12us1jA-EvsonSCpkICJ0REptuJFdFX6RltASEaWlV9m7ksJCwH-NmuMAQOuLp1HXeGWhMLYzx3rZ2Iekj5b2VKuBaXAu_q6Hauf6-0JVOzv2HEPhBBw4bTRui-W8YAPJhaV6GuQckXHquXEZdWxtRQxsA7Q6oL9RkEW7WJSY=\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83ef26d881968d0cc05a5ac757f3\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"open_page\",\n        \"url\": \"https://peps.python.org/pep-0427/\"\n
+        \     }\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83f0c5e081969f616a3176d5fa96\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPkEgKNNlYwHbpbH96w4jJoO6cFb9PVFDyG8MK9hMvzIygUrOMDcdnrpuoWZeCuHAM9MDS-Ox-avDkqSif5wazbKjjYfFYH69qK1xWU_SNjoycSiOmHqWBISUHcsrk37pxTTpoBspqlh2aME9MXifoeGVGFfJkwnnEgDkZJRUvBHcl9E6oMsav7V2pQIwSW3KQzvpx-hCHm3cei9wwqj-ZgE9gj1zLJMsYHEcBle4BNeJiE8ZpTZ1fnHW-tXdZMzL1McT-3sD8CYwDEph1K-cqax2z7kol90YqgQYvhaVZbx-JWf9f_LrE6xDwflKgvJuk328RiL0UH0OuJCLc66ZyfE47ktoMLQCpWEU1VrDpUdPVhMq2Jn-GUGBELkze1dsVtsiml3I519BYblK1MbRjCR5s7_N-INZE-WLsZflL2n-x2dlXM_uDgMU1ZkIBHr9m6VWfI5V0pjge9cq9YPYI2uSIdR4tYhAq2MrD1ywpAlbTQ6NmcoAeQZkJYyZRwUwk4x0ep4Wzdh7rGRcZ_yGninKXXKFqm-VPBrN_oSpo3UY27OhLoadW6fMMdn3qKkNmSFcPhoDj3y-vpil2ygF7DaSsZk0dqihmvB3HKZk0nZ3K9FhIJahB0DM2k2MwUsSSMVYl1z3lr6KIEr3IMWQyYY2tLtVcyK_uLdZ4oy5Nx3NF4AOng6_qeQG-Qic2FnJopqc6iaHV2932u78z-Xk3G_iWhNRH2Sw0SHvWD1gEzs1ErEZBqZh5e_cVU1SOGF2e2TmUiMQc0P1s5sfATGKbgISNLQ_1pE7hdzJGz-wjWyWdqAAkQDzxzcASnOW0Qa4ZUMcOny7vtKWWT14fOvEqMwF2tavhsmP38sZEkncC8wW7UQFjq8sIcd3eEoX83QRFk0fAvXWVWl4b3fPh5VPUDVcL97gZxpxHE4ng97kVZHL5CnyQfx65hJmFN2tRLpZX5T8hma3E6RXlfT8kdbo5KKFlVxRfgyEqRiY8WI-eKAowaHc6SAN8QOkj3zkCmgwSKx8JUxhJH6rj1S0siWe3ll9e0x7gKAGm9-dZ6BFngar0vHfxXXbB5C-LHhM9mB745MiqM_Fpp1cEDZJN3-IlKKzSwECAPQHsb_ZUiYvn8bDlFmabw73WGBt1G-2HWJcQCR_1Kck2AfwO_3TdLoQzjPHMNxPd05aU1w73vq9ZuYsc2vAaZDMdiOoKY_s-HBFV3sNE2jHRaTuGrdbJ2_3Ex_vPIq8AMfjK1npTpYGVvQeTeUu67ojseJ6GP-0fEtdVhBn-h-ckpszTRPCLtKSXSaL1gWoii6nGlx29kQd1T9HtsQDJ4qbnt7mtPEwO3aEyYJ4RuBfd95Qjzrl7G16UFxuJAVSQiZqnuDIF-BDF2yoo6uzxQiqTAY1nI1Zge3DZrHZiF8InYRV1KPG1BnfjwIFhubj4x2Cn6WrU3Zzs5EIUCwNBWiIdbn-2PAn5EViOkI2aFlbYVo2KOc-z_vLvRISOMjZtDU6Ymf0cNbUTy6I=\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83f1e0bc819689966f37f23ecb61\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"open_page\",\n        \"url\": \"https://docs.python.org/3.13/using/cmdline.html\"\n
+        \     }\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83f488d8819683a47bb6072c9930\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"find_in_page\",\n        \"pattern\": \"PYTHON_GIL\",\n
+        \       \"url\": \"https://docs.python.org/3.13/using/cmdline.html\"\n      }\n
+        \   },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83f6c8a48196aad11aa87e2ac22b\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPFmntqmCgpQqhzgcts6c0f3g1syEASI4ynQ1NHg2LI_IVhFeBwYkB4uMMlkAqspK9cDFuNa1v6oJwqNsau4srYLV7It1sFgck0_3V-b1y2cfx7B9iE191f_BYiuy16hWPO-WEKXFZRXw4h32t6320CjDC_Ljkofu2j3e_oRUqtYs-l_6n3TNSHrP-akF91EfByOebXOikoIY0B2_W_UYP8Hkaltn9cpWU2E_xmkGHmeIru6ie8ZXnKjD7q-xTgn60IEFI8LIR8ghPZdKLusLyUMWs0HZFccIi593rrW4ghOvlz0-0TxL33Ye5XE-yGmUN-uyFHa8UJKqIUHILZ32fyBGzpUJ6Q3z4G2I95HbY83VwgQSRqDLWxu6kDuYo7HWVKfPb6fXRtFCABMbmpQ0Qt70YcoPtBZBlhZRMFPjZZd_Pguq2SjrmBCpIyOyLbWBWBBA6LlkLW1LZ4fH4mb4RH9YyXVSPoRlRDPs9txIm41k1FBMOqO8Dpc3KF9cqmk_Wi0R0_XiWeUWA-F0Kp-N_Px6PeKgyKiXGNv1UgpGQADTXUxXPwEWAL5Uk5tRy2zKqeal21yW-q5Y_jW-B6zNZlHSJTQUn-8rLB7oe6vXvVKCc4NLYwChHA_Un5DwrOm1ZTMhHbjFDsF8Sk6JMlFeTwklCvVEWICp9_xreCG7EPSjo95Sr1d_a3BT3q2h3Co3O_gmzG3Mq9i-aaBxpyeMdOvrXjbmFuBTMP_J5ihb_uWi8doaqTyiSQzyK-AvVXelLlWU4Tr2zvJFTqU074a6d-pDApnIiiYn-foPQ3ZjzYn2G4rqqf2DB9_bNZ1BkyMPCdKU8iSH35S9Mfne4s6kSTDbjzsRG6x40gaTbpSwIu7DG8GvRV2RA7udflWXjFBEtaz3QjEAEyOigCII_N6clv7RuWa3TEMUPg7ynXjF6Bb2ujO8FBweRUcSXrsBAoD5n6D6B7sRNwrvDxZ_fpXYg4bpbs2V_xeZW-7eJtfljfyLa6KWaBOZmZ5RJhOrfyj6EiVci0_4MhZCJRxzW9Fog5Uyf7Sl_-ndh6eE6DYx_ORBNqVOecPYjwujdtE2eTDxaO2EYzSO7hiOjVrbq2dkCxWb4AVL-uXeDbIuHiMup1C_l7lzw36MZpLjD998qtITueXAV3LYlBpGNSlvWofLAWbKC3LFljB6JQo2w8tlIU5Y8LrLEItTrHRZKoEYf-9Es3TPeIc_Sq387qBEavpQRZ7Fa8puxpUvvpZLRGponP6GNCgNDNlwnHXkCmO7J1ybzBrULtp0XP4-pqT2P6vfZLSV1J6zIqC0wfa7ndfUMKpQ=\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"ws_0dc3c7d60a62eff8006a7f83f70d0c8196801bdbae3294a2ff\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"open_page\",\n        \"url\": \"https://docs.python.org/3.13/using/windows.html\"\n
+        \     }\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f83fa87648196bff9d0c6a84a826d\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPAd99XmeTq16QQGpT_QsSpN5wl6Xrv05bwArFyReslv6Dz0UKQHz2QUv7SXYDV9FFvyy8B-qxZzd-pS3NizhrW3RdYHW7ew4gG3HaK8mgWVLlqfxejVTVNqRhr5UM8s6wW3m2SFiYM9ngsOUifKxTmwhSoeanfDfICk71gXSqs27EgZrPBDUjl7FBz0BjNqtyk83voneTd7w3Ytu3jtHd3zYcXk4sedvUpGzAzEqm9iLkTpI6lbtTwmcwVGUxu_yqKniXrY05B09h2U7DWIgBMrHGRxvLfhZZpTcm2h_ft21cWK2ZdY6g-vJ_Mtzgt4MaBkV0Njle08hTQgJ9qjefdaJ09qy3xsUpYe8ykJ2BYyA5zlW9Y7_kX8KGaiEH3BhiuUqnvKYpHWcBZtpFAr9XdC-YRKz7Dm8qK6A-2frNjEJLDJQz4YD9JCjQXqzI0ZYbcVsI25CGlYkVfCsFKc0qL8TR7dHSY8T3jkFaJ732I79HHv0gi4wVULpDy0c2J_9rhJdR4hnA1zuM8-xTtzqD5FYlqrL7o0WhqLymLxXcN-uUMHIXkIo1-Khr9AoLwaoCofVXiYH58r7q1mwizN3eoa-q9jIyh-pS8RPWvXLRs3O8m-4jV1evog5UonVi8qjEa_z-z8tsfZJpY0m3wvTNUb7IOLxL042XGFmR_hc8N1gzklEoM8QMQJmZH0I32nipV8T6GI26CB1XYwJB8s0XgUM62JfVFMIMn9YTri-hhGlammuUNadeHq8reUuFDkYSEcpidFeoh_GDHzH9bPDWX4eSQfVx4hQtP3W-hgjj3OBXXg3C1-EVFbSl9z-4By83rHC9b60NUx10bQyixwBVreDXaEKvzpdHxxHrJppCOAxgrtwe_bh--yKuWZDV8J7ga4CGUCUvIs4RxRbwBk1i5ZD4Tpk4cKNmMd8g0HnMiz69OBBG1aT0OZBxyIwNfk2Ql7pP6MXlfFdYQot_cT3HJlBETvd_E1RBIyrj-mTdDGxFupIZuXJ2NS8YhLHVq64akbQyIQggiuJ_7qMsWNLFRoj7Vej8HhBkHmPG3t9dTQn9FGflsuqvZxMPp7ZsJJV-P88PJHYtdrUiMHKhRXh8DjwStjvnrnpfh8RM7dDDvmnPTt4aMjo7e_yPqZ_qxO0i9hfPyZv5Uz8l_dzJNLe9jSQic3fHtQT0k5HZZU2nwNW-lesIqhmUJCOxBQ6BQoIPjIwXmagrYtNgATRsfQoMHjbsTZ5dyxUb_zg2tPI6KNA4fkYdvuLufbD3Y4cjsu_yGy-0oMkwW5-69J_62FQgaVsWOq8gX4XtYxVYc-EpZpjNvvEyWnw5SzSFdEzNFANDTifdeX0ceT4lAud5bS2osxjvNwNWP_G1h6Lpw_-CCmLGLoMl3-y-m8zFoUxiTt7hUl1RhsovEKAF5At6LvQ8OwyQ8WMmrL8N7AWqfYSmwyXrRHeOAHanLh_4G26N6bBNjQvB81iPSU-A4YLqJoqdLUUDlKWo6fFb9ZM-ZZcqFwx6A50gXmPJ8wBTyKb9yk9uGhvkpYTCUeMDIOzikpgSdzXJ5KtSunkunci85-RBytD264OovMYttX2MLhTHU7yhmGTlfdDskOnykNyli1TzdhwErCbZShG6KAyfyH9uiTRDtunmLKsSC1wpJQrn2WWSBW67Z-xa0MZok4oGNokJFBk0xiJgzIf4kgM_QG_1TH4w9PNs8XTlBaoqlAgpznxmK3_Pkyqq6-SIThOu5rsqGAQgP0Ze6hfJ-qYp-_BLHLvFc-geqCZC8JBhqIPpCy8rBPf6wjjAIQ-wCgaKo25VGkO53HVZW8HctA7x3l_4_hQtZ_CtJerBMUGVVaezpHqDmkdD6fYhDdaYQEgS54wxNkENbOs7_XY3YJGlO8on26hSc7WX16FxKiKOlu6jJ5rIW6yAj1YT_wKADYNDzX4DRVWGFOQG18vDZGxWipiHy8FqWJxK9Z3-bd9YdlpkgT5OBSQou1_OgT2EhFjlyt29ppzij2K2fc4kETf9_5MYJW8iIgkvw2303u6P_hKJVnxxN3NPPPPSAMgdJSgX04qsBWzG__l4SIsOf67QoGMKDdzJiaqRmMANirRRT_P3CYC75poUQD7QHhVoIvXewifqygi-jws5Ydod2Pi-QGpDcGTCPAdi1OPUd0sM7BrmGgXx2Ey76TSoS0wC1o8DrSEhP34UBFcUXpbTXsR5ULGpPV-msb8_iExEGr8vKsCNyJyfMW9qJFzROafjbXCZAp9C_ZoN8NjsK7O0s7pLjJb8CnjQi57nn9Y7Ss5_60nqMPgsOWtrlsK1KcPXXIIM4wqzfXeoqPcLlXeDf4mDzmti51Mtd6IIP-18cfCreiW52pYGbCxzGHBFLuFVJqcFVRa11_3sUMf_5UgYO5B54NY-q2APcMC7AJiB1z9vooFUJZRGHe_o_KmPXAReTrWtEWCXojn6oykdNf-vAomGm_g_5qNnuhDDhwRjKIn01qGNL5jStBs7lJemyW-yNxGJUovkjtCCIvbX5jgwPu6fPcJ11S3y8mBo2FEKboYhINub7c7j4M9cvkoD-M8NusyDx3hi651h0XW4jzLK-aIY5gPivLJyqGtYiV-k8b7UTrWMdht1jv1EP3U-kxk4tZ_CtS0xjUA1BNLSYyed5pIubqWmW4be1o4VzAyIEaD-tWv-DuVMbDAAKzBwRa_Bvgmoqu4xupYWhGUbi2d-NEuY3lreuK-g-384iw5rCkiL-2Wk9PRmNVjj9vcTZDWkbPtQCvJpLmMVPaRL-Qn7q-TxrXpc-MG3BxezZ1h7Kwee4EJA2BzhB7RzdupcAJukN4H4s_Cyt8SbH2-zCpiiqgTgND4I8a0somirP2INIdYQII9ezoBhSCmV3MSaE1x1aEOl7vIYY1GJ-4Ua8rNC3SZ18gTJsgstInTaMM6_T-GQrTGM-rclqlHOme32qmqPI4mYI3FY0ZRzKmY7MorqtgUwkVbzDUZc_Lq4oYuCWtbS4mOFcgd65PgIYEg8DSjdE6a34sdnMszHd_wDxX82L7ua5DEYSentP6hbnuP1kQQcImx0Uo-hOX3vSinarXeLHsPqPAQ1l8W1nKYH3xZZGFzbwF6h9h-Z6di4yPY-ZQdNa0yb8NebHFa_ya_59mKu8TocCzg0qeHY_JYmGhj-G9FhB10HRA_-NopUndHc2pd5KXjM-2UQVPP4CQUweTC85xxm_4j_-ul9GHtYKn2Plr-A9TsWeq5DdmFCqJliCb-HXKcDHMSrKfq5wqv9EoF1lo1MJhid0YP-3T_fNocLD3x8ryFkFLsGcwaj7HfY2vis_ef3oULp-D60IKwaTLUgFahmxuKEn4bZIY00Qb0TMdPTKCioWlPLAB__Rrtq405C7e6w1DOwq5YL7GTqoi3EKuFsOhO0lfj_0r4joF_pFySL7ZBU5fBZoo5sXQp_DINlZ7mF4chaxJjpEGXRyZxzWYKccMKYE6_W8Xn6gPCsl8x_VuHMA6k93AJ-R2yHJIr5dHf7-5ElkCvpDhj0z-QYEw5v7YkZ9d8B4mmG4aNusb0-aAIlZ1LOvENOSjBOkGbLxruum4rwKL6y_dP5Aa0J-b4VkIcPZVGuCb6kO3hQjiEhQY057dJoFVhCgQ9uX8pEh0-dJf2-bTiTkWc5NxCsSs9yyhP8qQwMEZGrDNtXWLpYC6Z0Zhn0K5oNw4Bm61jy5_3NBpF_TLvrWMb1pWr9B5tYC9YETmS-ZcwuR9qieXd8J1RezevoBONuXuYPDdBsqJknlmgdR4k2I8EXHg3W8Rc23ct1vbPWXowDviSF6F7SnGBzbPs4fhmoEQtz_5CxH3Dc3eMDjHrsbcB3A20MKwHwuplWZWK2ikFpouK-UQ8TFJwaiFflhUQhNZpz7NtdCSWJofgZwM0WqiOW1QpqSoIb5XrJ0r0-G_UH2TpJHP04dU_O14gWWu9ep85Wxo_SIqGCosrmwHmBI5AnZk0mVxfXgZkojJCDRzkQTBd1QJaOtrygL0hvLZvSK-Fp9NX9pvHhPkKYwqrTVyJWoCFRfhDQ4zvXMGWIBvatz5zWKiqWnnKOebc6hBtGEzMJNDrjyP0f3YhDgpkBX8liftVVwgRsJD95gQFI5H-Q2FpjiZ-4rwgBxDIDrMcsqF4qj9N2yxN4Oc9O1RCICfER0ValSwrzMGqjb0hhU3yd1qIIdwnPMKmYa5vOGsTMKZr3PpxJ4keQUOnDIH1S4eRb0n05A4XFu-7asNL60JTBRrFoL4PZJuD4MzmNOHxb5kFj-_uaZlUvUaqU0aFrcsTql6SGmPp1dKF1-fk51CUE1YC9JNf9nYzC0mQWUC3Nq8O26L0335MlA0AeRWbIbIznyE7GJkATwOLvwj2a8QO8zmD9gO6OyL_hVRlZIHaOXQ6C-wK32s1XQnJehABWd9tQ8cWRC-CyUTx2yU-my0LMYTxGOAHH1lULKVv0D9wBICGZ5PoMvyUagK8luHseW2-hlTuO51EFRvpE4FV7p7Q3afz2EUNpo7QMsBE=\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"rs_0dc3c7d60a62eff8006a7f84042ac88196b75e6f1e49e706d9\",\n
+        \     \"type\": \"reasoning\",\n      \"content\": [],\n      \"encrypted_content\":
+        \"gAAAAABqf4RPq-TYgU9sY9S1vkmLvoUj5DUmv39QorzZHgzuhQa4MewJ0hP9LxKT63PZRBpn-9Be3rT1p1GIgTfmCOgPSqgiLQJYoOxXdCjuBNQx2dNKjSDqdcAikddtTKW28z--RrfcGhLA6qTKVQ1Gk_6K3xc2JS1hIh1r8NWpZgV3mnz5Pu63gXOa0QFACnpO8a03eComsrhpu-bJKEgpSjaYVcAnhOnywenAPZBNhmStK1NYXRdXXPNIOIG0_UyilUv7lraf5zCgwj-HV_DXoREBj9RhR5PSMSiZOOaAk363lxADx3PsV5wRUEo2_sUyaf3FuWXGYEx-IqGNGeX7BJxPGJtyXQd13Uari8IXlxmX3vSDtunjo1QQc5aF8A4A6jEWTWlCzJXifY3aVcrMSrlSZpcQDaIrDwk_FUSPYYii2YxvI1Ba8pY49Zr8AVW_FtI34su6rAWlpB3NYf4FSkkm9wwZgWAK4MajUg0T-6kKXLyP5c0Gkh4-snVHjeZM71RVm6HO732difUqk5Bzrq18EEHcyM7CzmVJKA0mmZnnhTTTtRFlxWmXMoK6Yiacg5Pl9RhIkt9dwiOLw2yIJKoxHxgtwTRc-jrKDzt8esCIXNZKYFwaAtBoOPlaKiujn9KitBb4J031NXC6v0S9eu8VWMPW-J8DBEqcyBAlJ6ggu4e98shcEh-B7FJQqdjB5IDyB2PAhlsVNcI2YUrfEE0JzKb-I2sJBTReGqiN0C3dEcrUXg6mIrbXc73y4EqoicxB4rSyy-8ZAfVJSro9dOGMXDhKwEh9LnAZvMPnmxO_lTYUyTlJMAx_fCrmu-iFKEOueot-vetGh5Ovlx_Z6I6cnhUnCIqfZ2BNVm5TKOm3hnCc1d_xwzWeLXe0D3PvG-zpdOzfu4DlH_SVOkDXmeOazFQTo9KZYKNbskH2bg2eQpccORsfACnGKnunlbFI0L19mHQ2ZJo6af4nxxdjoPg4JlijLurhfr2Tl0Z-7Nrv-sxmP0IjE-sSMYFZXNJhWe9dlkCZlZ6CW0PK2qnRClHuKeGcGOhhinu721M8_HsaPAWIBdUmLlxz12VwuDZf0N3dBUcvZSfMm70hfwv7B32D_uXatouU46tlQgUaSZYI3i7uouLe5xLDLW0kNxokqEE65Om6i_5QbYAZ7AAU-YqbgbkTHa-ao9NFP8KYCCt9wN_QkXbt3Q7M2FY4hUscuGtYNbUp7nmXkyZG8HguCm0pxgzgv2oD4UWX3PIJZbKxGPIgQec6kS_Hf9u7FLxUIEKrH6cu67BaRJgfC-lJzWY1nxYQ3RsKLZEmRU5lgBE_gGes_sQXL5eYNyE2MxhGqOoBwxBoJ08fOI86RNs2C_aOoeIiw7AorqF41KDd23kWh0B0KipS_o0WjnFNDFOetpfK-g2Z5vf7BoRomWnCPWngI3PGjkS2_msARvFJbE1kwReXqZAVCo8Deb9UwFnok2lPOFrjaV134FPqJ5QrqbNZrnCcNdTaMR88HCcqRZ0IyxI8icd3q3lT5rEmqiShoahT7-mu4xCp9QD_sbFePwTD6_5aUNkzWnbogTMZ2qTIcRPQpdbMVTzuF1nlMcPLpvGFUvUx9gbTk60JC0Ey4mjqhPHhJWKSyNG7N1EiRQ00BKUU7z_7HXk4Q2O6nUlHdCFZQzSyM0jM9hSWHsz6OE80apxMdyTQSSseYxnYULn7nDmYDtoco3YZo8LHlZ7FM1X4W9svpSWw7u8rK0Rt-zs8GeOE7dwQWsrahcCJJgyBUPljnzCPcN2_xFWFST7FpYw-4hIh9HFD06iN8CJ_AxQ5CqmkcH6FXJ193d-YvMSLPzkYk62-nMznR35E8iBvKy6YXaFpWlC7EAIEbTfRpVxH5SxPUx77HqqomI6yapO3mVfaSLJZHBWemQIIZBOdeH318nt3ttB4BRkxb5IG8JgwBTr9-K_43P3cpzy-WUwFhC8qYcP3FgBTh2tabduJeA34iENs_m66oD14naRonVZSmJp4Kuq9ZV3ZGX7kY11WS9I8g1ghy9FnTHc1ZBx78KLG3labAUxknSQzZwzmnY5OgLExfADB6ssuGJeOsuluhK107SdFpUHuLnjUHTioc7T5H2a2hL1hXOEj94X-rykBIcdHxQwcL9XaRlDgrSKVHlnyT4Y9yp0d0WNRl8xzWZcSB5cWvx7MOC0FqSROghwvg15AD4eDWHeSf3I4djCrsLuilQXaixYNvdA1dyGza2391ThFW_s7X_k_j5Efl8f1u3CyxYqQevBiqjhYi3LoIF_BHiGj8_RR7yjCB540Xpzlbt7VBqOzzrZ6sjU4k6yxLHEsfGAby9nzgaC0QN-gp29Lc5Agf2Tydl3uhnFtshcBmqT4b2aokXVAfgR5U77HRRCzpetiwZirgpt1CgHVO6JzL0YYwy73kjhatHM2WU62iXvNKOFLotxAnejc4kSCcO9_A7JUy-4U_UucUzLak-iaWU_JuZjrZ5ZRioxW_Q0Q5E2w1LBSPPPNdHGVIzvabx7gcXpCSjU46ymTqA61wNFDroVD5-lNwiGfEQIHr18uIXZu4-oNXh-aG_0IVggWs360ot-k5YT42msfXeIX5uCy_Ko0zWSBjduSkBROqEfMygjtnmk_DWvNF1vc-HyLtvfj2jlSt4v7jyJgESL59fTrTAec26zYSrJDsXQjHPwW3a5ARZF-4jqhkzvSKzG75fdiNoek8Ngor7xVK8HBWKWcZOQqd89mUicj23Qr8MWZxRHEAesgwydDDPw2-gSM9d-eFOabH-U-mTf1k524FiTcLbJcCSICxdAutDcA4pRtra8SjuFTV8WIXmUy0X90axtvwqPH5mvfPkLBo-J0-VttQM4giZUtwzOkoP21FxujW8mSPd1MSMVC8SYDJi8nANhVVrjk47A1Tek1RvdR-3Ajg1F-TjySkZVH9quxpRu_kBiBVjCzvbEBZgGkP02W2EL8bvro05saDjCJcq3MbCStnPfRcPY8lDePPTNLIqwqoDjq-zGsVJHj4EU4wbAsuEwj_gRlK67CGYK3v6b9Ayd85JVp0-Zm94YMivYgwv9wOJAOitB_nEpyZFE20ET8Kqkj3n31UIVe_Ems0gEMmOEqHeZx_yYZK2NYOwwgalX8qQ0YWoWx7Ap5EZOw1meJ3jeTxgEiANXV1mRjKhAvNZb8E9uu4kn109BZzdTXU2MJ-IFV-vVqbWGj0PLQ3Cbs0Fx-OBGopgwomqazfvtY5lb3U-8vx6f31wqMx9ateuGds0CRqxYzihc-IjRwMQKlCQvllHeIljFp_Mr08uvsXjwMpiPsb12WULXMevsTP1lLoPFyfDIiw3cC-edBWtAh_ZJW8I70fRPsctF_1CJX74RIcVMDLopxRmvLwtd0GSjIgj81Jp6N5Ua5JhpFadM5YgrRXJeD3mhhoeZ8zsipJP7UmMdkZaVMN565no9fY0ceI1xBDmqwZhniweMVAd6vIqOgesHHmR4WQmJRVOVZDexbFnVSLJCstqfUmtFSJ5fFD8gKFQ5-fuQ_z8DfFZYegc297fc5CP3pGfiHGNOkQpWeQekFz9UEuRbjHsh8OzWGC8-cvV-qlWgUKz_9v5_m_9sw8cNUnu5GVG2U95Jgx6pQNsYvLiOGiE9MCVTtEJXg3q4JM4g-82zHuyWf6_ICfsX74gnNsMkBcH8A_zK1QKwxHWI5ziTb5F1y4AjQJ9eQS7I1jHSqg_8eEnqapPeDtwenflyroDcsfspz7_Hhpi4RmYT6jOHXpymEOSxQ72T6Hei908ZdhOx03NJJI6kWK3xmaM1zvWWTtHiwTkvro50fCe-dmXL_uzKLRnAsMOz_CcwSzhde6aLjayNIVhryX3xsdyHT8tBhpi6MMIKPudKGcVPOG9Bs0uGwBeJnf_XkXFiaMhzk0-u9bL2z0MRKNEqLk5YTMawWzY0W66f5Bj4FJZw4_gciZWUuWXtB9EPrr0Q2Py4tXjKDEwv1R_xU_LTeFx35d8HlQSmdm6SC1L_uxh4_r2dOwFU5C7uU54Odyz7VXMOVGC502T4Qr3hF0-BtKBgOVfj1EzUXKvCHKJk-E0El5ruVUPC4IoB6RHOt9zc0CvhQZxfwEJGGoN-AkUt-xbtiFMxoMzJI7ej4vgYOmFNbbEFDCCUD6F_uowXiWO8SvYiQpgRFpyn5xYGJcC_nzyP01pYvnRdURX00RSU5vHSV0rL13817cczLN8D3istS5I7H5Rw3MadaD1a8Z8V7nEPmIaaKnYXseB-hErsVF7A8tt6F9n3_EmjH9mcbd64nxc_s22ZX5VcoUuNeYwn6jSaEpqxbB9wKZk3ILwFTtfOcP4kqmIE5OIqG7sVth6DPX-jDY6aMUGv6nam9j9DJwOCETU07CkfWM7GUeTLR2zUDcxy4vBNWBRx0G_NDCzyWSO269VNNMi0HA1cu1thDEFex3HTtYsIBKc7l_RHFc3s2c3ZGN0E0o1Yr7uZJa4AV\",\n
+        \     \"summary\": []\n    },\n    {\n      \"id\": \"msg_0dc3c7d60a62eff8006a7f840c0074819686109d68e40ad166\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [\n            {\n              \"type\": \"url_citation\",\n              \"end_index\":
+        938,\n              \"start_index\": 856,\n              \"title\": \"Python
+        experimental support for free threading \\u2014 Python 3.13.15 documentation\",\n
+        \             \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 1392,\n              \"start_index\": 1324,\n
+        \             \"title\": \"What\\u2019s New In Python 3.13 \\u2014 Python
+        3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/whatsnew/3.13.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 1898,\n              \"start_index\": 1830,\n
+        \             \"title\": \"What\\u2019s New In Python 3.13 \\u2014 Python
+        3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/whatsnew/3.13.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 2154,\n              \"start_index\": 2072,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 2446,\n              \"start_index\": 2378,\n
+        \             \"title\": \"4. Using Python on Windows \\u2014 Python 3.13.15
+        documentation\",\n              \"url\": \"https://docs.python.org/3.13/using/windows.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 2787,\n              \"start_index\": 2733,\n
+        \             \"title\": \"PEP 703 \\u2013 Making the Global Interpreter Lock
+        Optional in CPython | peps.python.org\",\n              \"url\": \"https://peps.python.org/pep-0703/\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 3368,\n              \"start_index\": 3286,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 3782,\n              \"start_index\": 3714,\n
+        \             \"title\": \"4. Using Python on Windows \\u2014 Python 3.13.15
+        documentation\",\n              \"url\": \"https://docs.python.org/3.13/using/windows.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 4053,\n              \"start_index\": 3985,\n
+        \             \"title\": \"4. Using Python on Windows \\u2014 Python 3.13.15
+        documentation\",\n              \"url\": \"https://docs.python.org/3.13/using/windows.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 4541,\n              \"start_index\": 4453,\n
+        \             \"title\": \"3. Configure Python \\u2014 Python 3.13.14 documentation\",\n
+        \             \"url\": \"https://docs.python.org/3.13/using/configure.html?utm_source=openai\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 4940,\n              \"start_index\": 4872,\n
+        \             \"title\": \"What\\u2019s New In Python 3.13 \\u2014 Python
+        3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/whatsnew/3.13.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 5228,\n              \"start_index\": 5160,\n
+        \             \"title\": \"What\\u2019s New In Python 3.13 \\u2014 Python
+        3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/whatsnew/3.13.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 6228,\n              \"start_index\": 6146,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 6747,\n              \"start_index\": 6661,\n
+        \             \"title\": \"C API Extension Support for Free Threading \\u2014
+        Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-extensions.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 7042,\n              \"start_index\": 6954,\n
+        \             \"title\": \"3. Configure Python \\u2014 Python 3.13.14 documentation\",\n
+        \             \"url\": \"https://docs.python.org/3.13/using/configure.html?utm_source=openai\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 7752,\n              \"start_index\": 7684,\n
+        \             \"title\": \"1. Command line and environment \\u2014 Python
+        3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/using/cmdline.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 8275,\n              \"start_index\": 8189,\n
+        \             \"title\": \"C API Extension Support for Free Threading \\u2014
+        Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-extensions.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 8725,\n              \"start_index\": 8657,\n
+        \             \"title\": \"What\\u2019s New In Python 3.13 \\u2014 Python
+        3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/whatsnew/3.13.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 9387,\n              \"start_index\": 9301,\n
+        \             \"title\": \"C API Extension Support for Free Threading \\u2014
+        Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-extensions.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 9965,\n              \"start_index\": 9879,\n
+        \             \"title\": \"C API Extension Support for Free Threading \\u2014
+        Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-extensions.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 11103,\n              \"start_index\": 11017,\n
+        \             \"title\": \"C API Extension Support for Free Threading \\u2014
+        Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-extensions.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 11436,\n              \"start_index\": 11350,\n
+        \             \"title\": \"C API Extension Support for Free Threading \\u2014
+        Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-extensions.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 11910,\n              \"start_index\": 11824,\n
+        \             \"title\": \"C API Extension Support for Free Threading \\u2014
+        Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-extensions.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 12507,\n              \"start_index\": 12419,\n
+        \             \"title\": \"3. Configure Python \\u2014 Python 3.13.14 documentation\",\n
+        \             \"url\": \"https://docs.python.org/3.13/using/configure.html?utm_source=openai\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 12946,\n              \"start_index\": 12860,\n
+        \             \"title\": \"C API Extension Support for Free Threading \\u2014
+        Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-extensions.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 13430,\n              \"start_index\": 13363,\n
+        \             \"title\": \"Module Objects \\u2014 Python 3.13.15 documentation\",\n
+        \             \"url\": \"https://docs.python.org/3.13/c-api/module.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 14459,\n              \"start_index\": 14405,\n
+        \             \"title\": \"PEP 703 \\u2013 Making the Global Interpreter Lock
+        Optional in CPython | peps.python.org\",\n              \"url\": \"https://peps.python.org/pep-0703/\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 14887,\n              \"start_index\": 14833,\n
+        \             \"title\": \"PEP 425 \\u2013 Compatibility Tags for Built Distributions
+        | peps.python.org\",\n              \"url\": \"https://peps.python.org/pep-0425/\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 15465,\n              \"start_index\": 15383,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 15822,\n              \"start_index\": 15740,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 16457,\n              \"start_index\": 16375,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 16925,\n              \"start_index\": 16843,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 17243,\n              \"start_index\": 17161,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 17905,\n              \"start_index\": 17823,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 18463,\n              \"start_index\": 18381,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 19084,\n              \"start_index\": 18996,\n
+        \             \"title\": \"3. Configure Python \\u2014 Python 3.13.14 documentation\",\n
+        \             \"url\": \"https://docs.python.org/3.13/using/configure.html?utm_source=openai\"\n
+        \           },\n            {\n              \"type\": \"url_citation\",\n
+        \             \"end_index\": 20458,\n              \"start_index\": 20376,\n
+        \             \"title\": \"Python experimental support for free threading
+        \\u2014 Python 3.13.15 documentation\",\n              \"url\": \"https://docs.python.org/3.13/howto/free-threading-python.html\"\n
+        \           }\n          ],\n          \"logprobs\": [],\n          \"text\":
+        \"# Free-threaded CPython 3.13\\n\\n## Executive summary\\n\\nCPython 3.13
+        introduced a **separate, experimental free-threaded build** in which the GIL
+        is normally disabled. It is not the default CPython build, has a distinct
+        ABI, requires separately built native extensions, and can automatically re-enable
+        the GIL when an extension has not declared free-threading support. CPython
+        3.13\\u2019s documentation warns of bugs, unsafe edge cases, increased memory
+        use, and roughly **40% single-threaded overhead on `pyperformance`**.\\n\\nThe
+        feature\\u2019s acceptance was deliberately provisional: the Steering Council
+        reserved the ability to roll back disruptive parts\\u2014or even all\\u2014of
+        PEP 703.  \\nSources:  \\n<https://docs.python.org/3.13/howto/free-threading-python.html>
+        \ \\n<https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython>
+        \ \\n<https://peps.python.org/pep-0703/> ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n**Methodology
+        note:** I treated the versioned CPython 3.13 documentation as authoritative
+        for implemented behavior. The 3.13 \\u201cWhat\\u2019s New\\u201d document
+        itself warns that PEPs are usually not maintained after implementation, so
+        I use PEP 703 mainly for design intent, ABI rationale, and the Steering Council\\u2019s
+        acceptance proviso.  \\nSource: <https://docs.python.org/3.13/whatsnew/3.13.html>
+        ([docs.python.org](https://docs.python.org/3.13/whatsnew/3.13.html))\\n\\n---\\n\\n##
+        1. Maturity and experimental status\\n\\n- Python 3.13 itself is a stable
+        language release, but its free-threaded mode is explicitly **experimental**,
+        is **not enabled by default**, and uses a different executable, usually `python3.13t`
+        or `python3.13t.exe`. The documentation says to expect bugs and a substantial
+        single-threaded performance hit.  \\n  Source: <https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython>
+        ([docs.python.org](https://docs.python.org/3.13/whatsnew/3.13.html))\\n\\n-
+        The dedicated 3.13 HOWTO repeats that the mode remains experimental and that
+        work is ongoing.  \\n  Source: <https://docs.python.org/3.13/howto/free-threading-python.html>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n-
+        Windows installation behavior is also explicitly marked experimental and \\u201cshould
+        be expected to change in future releases.\\u201d  \\n  Source: <https://docs.python.org/3.13/using/windows.html#installing-free-threaded-binaries>
+        ([docs.python.org](https://docs.python.org/3.13/using/windows.html))\\n\\n-
+        PEP 703 was accepted with a gradual-rollout proviso: changes may be rolled
+        back if they prove too disruptive, potentially including all of PEP 703. This
+        is a policy-level lack of permanence, not a claim that rollback is expected.
+        \ \\n  Source: <https://peps.python.org/pep-0703/#note> ([peps.python.org](https://peps.python.org/pep-0703/))\\n\\n---\\n\\n##
+        2. Obtaining, building, and enabling it\\n\\n### Official binaries\\n\\n-
+        Official Python 3.13 installers for **macOS and Windows** optionally install
+        free-threaded binaries. They are not the ordinary/default interpreter binaries.
+        \ \\n  Sources:  \\n  <https://docs.python.org/3.13/howto/free-threading-python.html#installation>
+        \ \\n  <https://docs.python.org/3.13/using/mac.html#installing-free-threaded-binaries>
+        \ \\n  <https://docs.python.org/3.13/using/windows.html#installing-free-threaded-binaries>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n-
+        On Windows, choose **Customize installation**, then select **Download free-threaded
+        binaries**. For unattended installation, use `Include_freethreaded=1`. The
+        main executable is `python3.13t.exe`; the launcher can select it with `py.exe
+        -3.13t`.  \\n  Source: <https://docs.python.org/3.13/using/windows.html#installing-free-threaded-binaries>
+        ([docs.python.org](https://docs.python.org/3.13/using/windows.html))\\n\\n-
+        Windows NuGet packages are named `python-freethreaded`, `pythonx86-freethreaded`,
+        and `pythonarm64-freethreaded`.  \\n  Source: <https://docs.python.org/3.13/using/windows.html#free-threaded-packages>
+        ([docs.python.org](https://docs.python.org/3.13/using/windows.html))\\n\\n###
+        Building from source\\n\\nOn platforms using the normal `configure` build:\\n\\n```sh\\n./configure
+        --disable-gil\\nmake\\nmake install       # or make altinstall\\n```\\n\\n`--disable-gil`
+        defines `Py_GIL_DISABLED` and adds `t` to `sys.abiflags`.  \\nSources:  \\n<https://docs.python.org/3.13/using/configure.html#cmdoption-disable-gil>
+        \ \\n<https://docs.python.org/3.13/howto/free-threading-python.html#installation>
+        ([docs.python.org](https://docs.python.org/3.13/using/configure.html?utm_source=openai))\\n\\nThis
+        is a **build configuration**, not a switch that turns an ordinary CPython
+        3.13 binary into a free-threaded binary. The resulting interpreter has its
+        own executable and ABI.  \\nSources:  \\n<https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython>
+        \ \\n<https://peps.python.org/pep-0703/#build-configuration-changes> ([docs.python.org](https://docs.python.org/3.13/whatsnew/3.13.html))\\n\\n###
+        Installing packages\\n\\n`pip` 24.1 or newer is required to install packages
+        containing C extensions into the 3.13 free-threaded build.  \\nSource: <https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython>
+        ([docs.python.org](https://docs.python.org/3.13/whatsnew/3.13.html))\\n\\n---\\n\\n##
+        3. Runtime identification\\n\\nThese checks answer different questions:\\n\\n```python\\nimport
+        sys\\nimport sysconfig\\n\\nprint(sys.version)\\nprint(sysconfig.get_config_var(\\\"Py_GIL_DISABLED\\\"))\\nprint(sys._is_gil_enabled())\\n```\\n\\n-
+        `python -VV` and `sys.version` contain **`experimental free-threading build`**
+        when the executable supports free threading.  \\n- `sysconfig.get_config_var(\\\"Py_GIL_DISABLED\\\")
+        == 1` identifies the free-threaded **build configuration** and is the documented
+        recommended test for build-dependent decisions.  \\n- `sys._is_gil_enabled()`
+        reports the current process state: `True` if the GIL is active, `False` otherwise.
+        It is a CPython implementation detail and is not guaranteed to exist in every
+        Python implementation.  \\nSources:  \\n<https://docs.python.org/3.13/howto/free-threading-python.html#identifying-free-threaded-python>
+        \ \\n<https://docs.python.org/3.13/library/sys.html#sys._is_gil_enabled> ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\nFor
+        C compilation:\\n\\n```c\\n#ifdef Py_GIL_DISABLED\\n    /* free-threaded-build-specific
+        code */\\n#endif\\n```\\n\\nIn a free-threaded build, `Py_GIL_DISABLED` is
+        defined as `1`; in a regular build it is not defined. On Windows 3.13, extensions
+        must define it manually when compiling against the free-threaded installation.
+        \ \\nSource: <https://docs.python.org/3.13/howto/free-threading-extensions.html#identifying-the-free-threaded-build-in-c>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-extensions.html))\\n\\nOn
+        Unix/configure builds, `sys.abiflags` includes `t`.  \\nSources:  \\n<https://docs.python.org/3.13/using/configure.html#cmdoption-disable-gil>
+        \ \\n<https://docs.python.org/3.13/library/sys.html#sys.abiflags> ([docs.python.org](https://docs.python.org/3.13/using/configure.html?utm_source=openai))\\n\\n---\\n\\n##
+        4. Runtime GIL toggling and extension fallback\\n\\nA free-threaded executable
+        can still run with the GIL enabled:\\n\\n```sh\\npython3.13t -X gil=1 program.py\\nPYTHON_GIL=1
+        python3.13t program.py\\n```\\n\\nIt can be explicitly forced off with:\\n\\n```sh\\npython3.13t
+        -X gil=0 program.py\\nPYTHON_GIL=0 python3.13t program.py\\n```\\n\\n`-X gil=0,1`
+        forces the corresponding state. Forcing `0` is available only in a build configured
+        with `--disable-gil`. The command-line option takes precedence over `PYTHON_GIL`.
+        \ \\nSource: <https://docs.python.org/3.13/using/cmdline.html#cmdoption-X>
+        and <https://docs.python.org/3.13/using/cmdline.html#envvar-PYTHON_GIL> ([docs.python.org](https://docs.python.org/3.13/using/cmdline.html))\\n\\n###
+        Automatic fallback\\n\\nIf a C extension does not explicitly declare that
+        it is safe without the GIL:\\n\\n1. importing it produces a warning; and\\n2.
+        CPython enables the GIL at runtime.\\n\\nThe module declaration defaults to
+        `Py_MOD_GIL_USED` when no declaration is present.  \\nSources:  \\n<https://docs.python.org/3.13/howto/free-threading-extensions.html#module-initialization>
+        \ \\n<https://docs.python.org/3.13/c-api/module.html#c.Py_mod_gil> ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-extensions.html))\\n\\nThat
+        automatic fallback is suppressed if the user explicitly forced the GIL off
+        with `PYTHON_GIL=0` or `-X gil=0`. This permits loading the extension without
+        fallback, but it does **not** make an unsafe extension thread-safe.  \\nSources:
+        \ \\n<https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython>
+        \ \\n<https://peps.python.org/pep-0703/#pythongil-environment-variable> ([docs.python.org](https://docs.python.org/3.13/whatsnew/3.13.html))\\n\\n---\\n\\n##
+        5. Native-extension compatibility requirements\\n\\n### Declaring support\\n\\nFor
+        a multi-phase initialized extension, add:\\n\\n```c\\nstatic PyModuleDef_Slot
+        slots[] = {\\n#if PY_VERSION_HEX >= 0x030D0000\\n    {Py_mod_gil, Py_MOD_GIL_NOT_USED},\\n#endif\\n
+        \   {0, NULL}\\n};\\n```\\n\\n`Py_MOD_GIL_NOT_USED` asserts that the module
+        is safe without an active GIL. If the slot is absent, the default is `Py_MOD_GIL_USED`.
+        \ \\nSources:  \\n<https://docs.python.org/3.13/howto/free-threading-extensions.html#multi-phase-initialization>
+        \ \\n<https://docs.python.org/3.13/c-api/module.html#c.Py_mod_gil> ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-extensions.html))\\n\\nFor
+        single-phase initialization:\\n\\n```c\\n#ifdef Py_GIL_DISABLED\\n    PyUnstable_Module_SetGIL(module,
+        Py_MOD_GIL_NOT_USED);\\n#endif\\n```\\n\\n`PyUnstable_Module_SetGIL()` exists
+        only in free-threaded builds and is part of the Unstable API; its signature
+        or behavior may change without warning in minor releases.  \\nSources:  \\n<https://docs.python.org/3.13/howto/free-threading-extensions.html#single-phase-initialization>
+        \ \\n<https://docs.python.org/3.13/c-api/module.html#c.PyUnstable_Module_SetGIL>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-extensions.html))\\n\\n###
+        Being thread-safe in practice\\n\\nThe declaration is only an assertion; extension
+        authors must actually remove assumptions that the GIL protects their state.
+        Important requirements include:\\n\\n- protect global caches and mutable global/module
+        state with explicit locks or thread-local storage;\\n- do not directly access
+        concurrently mutable C-API struct fields;\\n- do not use unchecked macros
+        such as `PyList_GET_ITEM` against concurrently mutable containers;\\n- prefer
+        strong-reference APIs such as `PyList_GetItemRef()` and `PyDict_GetItemRef()`
+        where another thread could remove the underlying item;\\n- protect `PyDict_Next()`
+        iteration with a Python critical section when concurrent mutation is possible;\\n-
+        use the object-memory domain only for Python objects, and do not allocate
+        ordinary buffers with `PyObject_Malloc()`;\\n- continue using thread-state
+        APIs such as `PyGILState_Ensure()`, `PyEval_SaveThread()`, and `Py_BEGIN_ALLOW_THREADS`,
+        even when the GIL is disabled.\\n\\nSource: <https://docs.python.org/3.13/howto/free-threading-extensions.html>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-extensions.html))\\n\\nOn
+        Windows 3.13, an extension build must manually pass `Py_GIL_DISABLED=1` to
+        the compiler because the official installer does not arrange this automatically.
+        \ \\nSource: <https://docs.python.org/3.13/howto/free-threading-extensions.html#windows>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-extensions.html))\\n\\n---\\n\\n##
+        6. ABI and wheel tagging\\n\\n- The free-threaded and normal CPython 3.13
+        builds are **not ABI-compatible**. Native extensions must be rebuilt specifically
+        for the free-threaded build.  \\n  Sources:  \\n  <https://docs.python.org/3.13/howto/free-threading-extensions.html#building-extensions-for-the-free-threaded-build>
+        \ \\n  <https://peps.python.org/pep-0703/#backwards-compatibility> ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-extensions.html))\\n\\n-
+        The free-threaded ABI uses a `t` suffix. This appears in `sys.abiflags`, extension/shared-library
+        naming, executables, and wheel ABI identification. POSIX `pkg-config` files
+        are likewise named, for example, `python-3.13t.pc`.  \\n  Sources:  \\n  <https://docs.python.org/3.13/using/configure.html#cmdoption-disable-gil>
+        \ \\n  <https://docs.python.org/3.13/howto/free-threading-extensions.html#building-extensions-for-the-free-threaded-build>
+        \ \\n  <https://docs.python.org/3.13/whatsnew/3.13.html#build-changes> ([docs.python.org](https://docs.python.org/3.13/using/configure.html?utm_source=openai))\\n\\n-
+        CPython 3.13\\u2019s free-threaded build does **not** support the Limited
+        C API or Stable ABI for free-threaded native extensions. A project using `py_limited_api=True`
+        must opt out for this build, and separate free-threaded wheels are required.
+        \ \\n  Source: <https://docs.python.org/3.13/howto/free-threading-extensions.html#limited-c-api-and-stable-abi>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-extensions.html))\\n\\n-
+        `Py_mod_gil` itself is listed as part of the Stable ABI since 3.13, but that
+        does not make a CPython 3.13 `abi3` extension binary-compatible with the free-threaded
+        interpreter. The free-threaded-build limitation above still applies.  \\n
+        \ Sources:  \\n  <https://docs.python.org/3.13/c-api/module.html#c.Py_mod_gil>
+        \ \\n  <https://docs.python.org/3.13/howto/free-threading-extensions.html#limited-c-api-and-stable-abi>
+        ([docs.python.org](https://docs.python.org/3.13/c-api/module.html))\\n\\n###
+        Wheel filename \\u2014 explicit inference\\n\\n**Inference from the official
+        ABI and wheel-tag specifications:** a platform-specific CPython 3.13 free-threaded
+        wheel conventionally has compatibility tags of the form:\\n\\n```text\\ncp313-cp313t-<platform>\\n```\\n\\nFor
+        example:\\n\\n```text\\npackage-1.0-cp313-cp313t-manylinux_2_17_x86_64.whl\\n```\\n\\nReasoning:\\n\\n1.
+        CPython\\u2019s free-threaded ABI includes `t`;\\n2. CPython\\u2019s version/implementation
+        Python tag is `cp313`;\\n3. wheel filenames encode `{python tag}-{abi tag}-{platform
+        tag}`.\\n\\nThe CPython 3.13 HOWTO directly guarantees the `t`-suffixed free-threaded
+        ABI and separate wheels, but does not itself spell out this complete example
+        filename.  \\nSources:  \\n<https://peps.python.org/pep-0703/#build-configuration-changes>
+        \ \\n<https://peps.python.org/pep-0425/#overview>  \\n<https://peps.python.org/pep-0427/#file-name-convention>
+        \ \\n<https://docs.python.org/3.13/howto/free-threading-extensions.html#building-extensions-for-the-free-threaded-build>
+        ([peps.python.org](https://peps.python.org/pep-0703/))\\n\\nPure-Python wheels
+        with no ABI requirement, such as `py3-none-any`, are not subject to the native-extension
+        ABI split; the separate-build requirement specifically concerns C-API/native
+        extensions.  \\nSources:  \\n<https://peps.python.org/pep-0425/#abi-tag>  \\n<https://docs.python.org/3.13/howto/free-threading-extensions.html#building-extensions-for-the-free-threaded-build>
+        ([peps.python.org](https://peps.python.org/pep-0425/))\\n\\n---\\n\\n## 7.
+        Important limitations and performance caveats\\n\\n### Single-threaded performance\\n\\nCPython
+        3.13\\u2019s free-threaded build has approximately **40% overhead on `pyperformance`**
+        versus the normal GIL build. Programs dominated by I/O or C-extension work
+        may see less impact. The largest stated cause is that the specializing adaptive
+        interpreter is disabled in the 3.13 free-threaded build.  \\nSource: <https://docs.python.org/3.13/howto/free-threading-python.html#single-threaded-performance>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\nThis
+        40% figure from the implemented 3.13 documentation supersedes PEP 703\\u2019s
+        earlier prototype performance estimates.  \\nSources:  \\n<https://docs.python.org/3.13/howto/free-threading-python.html#single-threaded-performance>
+        \ \\n<https://peps.python.org/pep-0703/#performance> ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n###
+        Immortalization and memory growth\\n\\nAfter the first additional thread starts,
+        the 3.13 free-threaded build immortalizes several kinds of objects, including
+        module-level functions, method descriptors, code objects, modules and their
+        dictionaries, and classes. Numeric and string literals and strings returned
+        by `sys.intern()` are also immortalized. Since immortal objects are not deallocated,
+        applications creating many such objects can consume more memory.  \\nSource:
+        <https://docs.python.org/3.13/howto/free-threading-python.html#immortalization>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n###
+        Frames\\n\\nAccessing a frame object from a different thread is unsafe and
+        may crash the process. Consequently, `sys._current_frames()` is generally
+        unsafe in this build. `inspect.currentframe()` and `sys._getframe()` are generally
+        safe only while the resulting frame remains in the same thread.  \\nSource:
+        <https://docs.python.org/3.13/howto/free-threading-python.html#frame-objects>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n###
+        Iterators\\n\\nSharing one iterator object between threads is generally unsafe:
+        elements may be duplicated or omitted, and the interpreter may crash.  \\nSource:
+        <https://docs.python.org/3.13/howto/free-threading-python.html#iterators>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n###
+        Containers are protected, but not a synchronization contract\\n\\n`dict`,
+        `list`, and `set` use internal locks in the current free-threaded implementation
+        to provide behavior similar to GIL-enabled CPython under concurrent operations.
+        However, Python has never guaranteed particular results for concurrent mutation
+        of these containers, so this is explicitly an implementation description\\u2014not
+        a present or future language guarantee. Explicit `threading.Lock` synchronization
+        is recommended.  \\nSource: <https://docs.python.org/3.13/howto/free-threading-python.html#thread-safety>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n###
+        Parallelism is not automatic\\n\\nThe build permits Python threads to execute
+        in parallel on multiple cores, but the documentation expressly says that not
+        all software benefits automatically. Benefits depend on workload, thread design,
+        contention, extension behavior, and whether an imported extension causes GIL
+        fallback.  \\nSources:  \\n<https://docs.python.org/3.13/howto/free-threading-python.html>
+        \ \\n<https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython>
+        ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n---\\n\\n##
+        8. Guarantees\\u2014and what is not guaranteed\\n\\n### Reasonably firm 3.13
+        interfaces\\n\\n- `--disable-gil`, `PYTHON_GIL`, `-X gil=0,1`, `Py_GIL_DISABLED`,
+        `sys._is_gil_enabled()`, and `Py_mod_gil` were added and documented in 3.13.
+        \ \\n  Sources:  \\n  <https://docs.python.org/3.13/using/configure.html#cmdoption-disable-gil>
+        \ \\n  <https://docs.python.org/3.13/using/cmdline.html#envvar-PYTHON_GIL>
+        \ \\n  <https://docs.python.org/3.13/library/sys.html#sys._is_gil_enabled>
+        \ \\n  <https://docs.python.org/3.13/c-api/module.html#c.Py_mod_gil> ([docs.python.org](https://docs.python.org/3.13/using/configure.html?utm_source=openai))\\n\\n###
+        Explicitly not guaranteed\\n\\n- The overall mode is experimental and may
+        contain bugs or change in later releases.  \\n- Windows/macOS installation
+        layout and behavior are experimental.  \\n- Internal locking of built-in containers
+        is not a language-level concurrency guarantee.  \\n- Cross-thread frame access
+        and shared iterators are not generally safe.  \\n- `sys._is_gil_enabled()`
+        is CPython-specific, not guaranteed across Python implementations.  \\n- `PyUnstable_Module_SetGIL()`
+        may change without warning in minor releases.  \\n- A `t`-tagged extension
+        binary is not automatically thread-safe merely because it was compiled for
+        the free-threaded ABI; it must correctly synchronize its own state and accurately
+        declare its GIL requirement.  \\n- There is no guarantee that a workload will
+        become faster; substantial single-thread overhead is documented for 3.13.
+        \ \\n- PEP 703\\u2019s rollout itself retains an explicit policy escape hatch
+        for rollback.\\n\\nSources:  \\n<https://docs.python.org/3.13/howto/free-threading-python.html>
+        \ \\n<https://docs.python.org/3.13/howto/free-threading-extensions.html>  \\n<https://docs.python.org/3.13/c-api/module.html#c.PyUnstable_Module_SetGIL>
+        \ \\n<https://docs.python.org/3.13/using/windows.html#installing-free-threaded-binaries>
+        \ \\n<https://peps.python.org/pep-0703/> ([docs.python.org](https://docs.python.org/3.13/howto/free-threading-python.html))\\n\\n**Bottom
+        line:** CPython 3.13 free threading is suitable for experimentation, porting,
+        compatibility testing, and carefully controlled workloads. Its own official
+        documentation does not present it as a drop-in production replacement for
+        ordinary CPython 3.13.\"\n        }\n      ],\n      \"phase\": \"final_answer\",\n
+        \     \"role\": \"assistant\"\n    }\n  ],\n  \"parallel_tool_calls\": true,\n
+        \ \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": \"24h\",\n  \"reasoning\": {\n    \"context\":
+        \"all_turns\",\n    \"effort\": \"medium\",\n    \"mode\": \"standard\",\n
+        \   \"summary\": null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\":
+        \"default\",\n  \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n
+        \   \"format\": {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n
+        \ },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\": {\n    \"image_gen\":
+        {\n      \"input_tokens\": 0,\n      \"input_tokens_details\": {\n        \"image_tokens\":
+        0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\": 0,\n      \"output_tokens_details\":
+        {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"total_tokens\":
+        0\n    },\n    \"web_search\": {\n      \"num_requests\": 5\n    }\n  },\n
+        \ \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\":
+        \"Fetches the content of a web page at the given URL and returns it as markdown
+        or binary content.\",\n      \"name\": \"web_fetch\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"url\": {\n            \"description\":
+        \"The URL to fetch.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"url\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": true\n    },\n    {\n      \"type\":
+        \"function\",\n      \"description\": \"Read a slice of a spilled tool result.\",\n
+        \     \"name\": \"read_tool_result\",\n      \"output_schema\": null,\n      \"parameters\":
+        {\n        \"additionalProperties\": false,\n        \"properties\": {\n          \"handle\":
+        {\n            \"description\": \"The handle from the overflowed tool return.\",\n
+        \           \"type\": \"string\"\n          },\n          \"offset\": {\n
+        \           \"default\": 0,\n            \"description\": \"Number of matching
+        lines to skip from the start (or end). Must be >= 0.\",\n            \"type\":
+        \"integer\"\n          },\n          \"limit\": {\n            \"default\":
+        200,\n            \"description\": \"Maximum number of lines to return (>=
+        1; clamped to a built-in cap).\",\n            \"type\": \"integer\"\n          },\n
+        \         \"from_end\": {\n            \"default\": false,\n            \"description\":
+        \"Count `offset`/`limit` from the end of the result.\",\n            \"type\":
+        \"boolean\"\n          },\n          \"pattern\": {\n            \"default\":
+        null,\n            \"description\": \"Optional literal substring; only lines
+        containing it are returned.\",\n            \"anyOf\": [\n              {\n
+        \               \"type\": \"string\"\n              },\n              {\n
+        \               \"type\": \"null\"\n              }\n            ]\n          }\n
+        \       },\n        \"required\": [\n          \"handle\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": false\n    },\n    {\n      \"type\":
+        \"web_search\",\n      \"return_token_budget\": \"default\",\n      \"search_content_types\":
+        [\n        \"text\"\n      ],\n      \"search_context_size\": \"medium\",\n
+        \     \"user_location\": {\n        \"type\": \"approximate\",\n        \"city\":
+        null,\n        \"country\": \"US\",\n        \"region\": null,\n        \"timezone\":
+        null\n      }\n    }\n  ],\n  \"top_logprobs\": 0,\n  \"top_p\": 0.98,\n  \"truncation\":
+        \"disabled\",\n  \"usage\": {\n    \"input_tokens\": 122620,\n    \"input_tokens_details\":
+        {\n      \"cache_write_tokens\": 118,\n      \"cached_tokens\": 4594\n    },\n
+        \   \"output_tokens\": 8355,\n    \"output_tokens_details\": {\n      \"reasoning_tokens\":
+        3150\n    },\n    \"total_tokens\": 130975\n  },\n  \"user\": null,\n  \"metadata\":
+        {}\n}"
     headers:
       access-control-expose-headers:
       - X-Request-ID
@@ -767,8 +826,6 @@ interactions:
       - a2b2ef311d41a619-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-type:
       - application/json
       date:
@@ -896,46 +953,99 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: !!binary |
-        G1MbAOTedPZ3Lqd5Ov0CxAbTvKU273PG0tgokUaONAqw5WgtNSLGJS5Kp+T0zM6Iu78r8qUAPLN7
-        f90Pgmv5/lUIZIEkoPG1pABlbJX7F971Y1Tt/U9GCNE+NfsB/p4AKGtUDSpSGtuCVtt+u6xKXOzW
-        201VFGvc9NtqVZRmVW3L3Ro16u1aFz1WFa3XKzWdAKjQXZAWVYOiNVBldBnmz0GmRVE1lJvtelOV
-        26rYrlESlJyIxNA8OM6ee5GqoUeXqIguQ37noGqg/JMA1IgniqoGdRaLg2oC8LdyQmv5qFuV96QY
-        Q1Q1cHYO/wv2ka4ysT61IzE6Oakaijmtwjyidlq3krS1aojdqgY1s10M6zbd5k4wz+ACmogHywPo
-        wNrlZAOnecPvCc1+Rs6aQo6aEsxUzNPLebCP99y4HlxzALvnDb+9aPgILHg3soG55M6wgmKvEc4w
-        b/iBFYK9vb8IetSS0WGaAQ5W9oCw8FhDwcuAs3w5b/ihTWJ5yDbtSwODQa7b9Z86hRwhHBgs9xSJ
-        Nc0bbvhbyKCRwZCjAYUgkesvin4WA4LpMsHOSn5FIki5m+FALAn8YnR+/36tYLo8BwnBzeER6j3E
-        zAksg5VEQK6PlPYLXl11FDmwDeUSEch1L/B3Al9TTCg28BRSgBFTAuW/FqzAjlgCE7Pcu0brsHP0
-        nV43PINIsyUeoljD+7+HAMIKbAOzBRlaCVy3ApsO1NHF0zDIfaNEsZMzB6ql6MOk/N/s8diGLGOW
-        VsIlsbJ9EY/HVkJwrUanhq/ngyGnalDDKLPVfD1LwanSIApBqS1Wk6gaftgSWhT7gj4e0mNDWa2X
-        22dtSlOsF0ssq/V6XRYHQJTIaaSnzdS1wgOiBVAq0wcAnhSBzbwEsGJTMPwjANRVpmgpcWOKFipZ
-        odoEnebjSfaB5yEOZ8t5WUEfiWbXA8EJxvIAb0HuAU/ffPn4Bpz1VjQ0cKonPcq5HvYoiekAFawl
-        c08dylp3sm3JsqB4mZHGWeDto7ew2ezwbrY81JUal5vU530A994+AzoKcbKBwQeTHSWiY6ggVmL0
-        ftIIYg5OLXB1BWvaedXfyW/Y7FnpX7LsF9QLfVVXUKWrTa/XVb8rOtKgKr2dIYzE7YhDhQcAVI6W
-        N8+9yJjqszM1GcvZPhwknImpMAO8q3vxTjL1G1yU+r8eabfsCtMtioXZ4q48jKO3bFr7Que4zKka
-        1GMFEYbRL5teipcvmSDYdzYSbWKvk12/0nr2Q7ZFt9iUHS6wM5tdjwc+a2V2jyfGIXtiCXy2/m7U
-        NDcfDzWqblRRYlEsSpwhbpezzWK1mG1xXc3Mpiy2tCnW/WJ3ptG59uP+4uPLT+NF/94dP3yulr8+
-        XD7U1dXjedGoaaNC3yeSRtXFtFHOeiuNqstF8VeRAqjQ6ADrX3u6OV309PHdfT4+fu1fd/a79ffZ
-        fid+E6NXo+ZIaDoisbpq1OA1fyd+Yy5qxIjOkeusmiVmAhlfpESsKdCiWDlqY0gkknvAn26MwY/S
-        atR7ai/pVH4okhCr7Wa1qPoMT61sWkeQJoB4lKpBoXOt5Oj8PbWC6tNVDYoDqzf0teAOTxNkg7Fx
-        T1cpe4+RLA5DT0/Yk5zaqX2H95aCTp4eeHUrZZFKaBDgOgmRhHehkB8pouSiQik3w4LhKdeH6PF/
-        0vgB1p/4mAvUNcUuJBvqXqE8GZu9oh0DjWQfrMaQwyxBFeZywoFqnsV6HKgdyEsMV5bDmF6L6Z0M
-        qGljxun4MCzLUnMf/1VtDG2cVevS6noT10mGFciQJh2vElLC2bdZR5D8QVhupluhlRSjWd1PrNiP
-        zBRn0aj6Bx6T6H1KEVKcfCILhB4wOK044kBw+u9LB3tNDJ/evwxZwRBeHawAJvAYL004MIQInWWM
-        J3zevHJyDiMfqGt7khCNBD9i0nvyqP5AtEijLSogsv2T38YwUpQQjxNBBO6mRgCBgvsO9W+HiDZ9
-        3BPfmyQA3YIn/Ma95vAkMTiizkXrHniYMV5lG8kEo0NydAhUZEXdchhSZwMn1DlJEm1KnZeYaVLO
-        WpSNPkQPk7JW8akcJACuW8MzuY9UCEi60N9DpjT0455gs87Mem74ITzP+Hix54ZCd6Ym2CTN0zlj
-        TWsfiK/QGoXSS4cS5l+jJ1glvZD8V0uAmHkOr3IS6AgG2QDoE1PDziYhA6t6V8MPmemxgg6U+Ioi
-        OvjoTHAgpMWpLsnPcuhDBM6q076kyFUtyBP/sxYNDwZ3TkBIzup2HAEhjdatqH5tcEYl/GWbOMZi
-        AmtQrzFILV5FEDyGIVLr2T4E33dHcmRVxdDWSQ3GTrrbdtL5jNfZdxQh9OBRtHdJnGUal7omXdqR
-        epqxcSb4J0QgNv/a5K3dvgWFSh+0LDQMQhIhFiZgiCH1a38WxdMMr/BoffYwUM33xmHf85/bt6C8
-        AdqhH2X/RwKELlsnM8ugcfyXhRP6GHxLo7Lpvmz+0qktJz8ImQXOW3TT+dm5ZLxz+YujBqjnSeXb
-        JrILwRHyg0hE0xGtOofW4ZWWUDEEHSys/6CDlDt1XXcDdlsAm8F0XabL2oKRWqVnMjxUQj696R2a
-        ylTFD07eHfZh57gYLDfm7Nyjps3/SWmGztj4CeY0e7cLXa0/aUhqN9cIhnCMqPoYnx9ou2wGL6Hz
-        KSCfRj4wHK7QymmkgUNPpUkyWNPbjnyUNtlflDQxaOWcKLZnqtQ6xxzIPS8vP1qPMooU6jTMooux
-        mpoVRt66ffqwyeZIgy3ZPi4R6+lXYEJnbsywEifoj5Iwti4MYwxdZgYFwZiLr95tIbfFzNxE6rgk
-        oKRFlf9ZUr1xLJfFdjktdiVdocrXrz1EK4nX9atyMwXyTPmWarvJlFAmlrxunKqGqtiUOgngAQGB
-        oYdllbrZ8rojy2W1K1K0HnLK55/mSdCgoKrh99/JXw==
+      string: "{\n  \"id\": \"resp_0e58f8341a296874006a7f84501d548196acac86c0fa44e665\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1786741840,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1786741851,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Search broadly before drawing conclusions.\\nRead the sources that support
+        each important claim.\\nPrefer primary and authoritative sources.\\nCite every
+        factual claim with a direct source link.\\nDistinguish sourced facts from
+        your own inference.\\n\\nYou can delegate self-contained tasks to these sub-agents
+        using the `delegate_task` tool. Each runs in its own fresh context and does
+        not see this conversation, so pass everything it needs.\\n\\nAvailable sub-agents:\\n-
+        researcher: Research a focused sub-question on the web and report back with
+        findings and source links\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-5.6-sol\",\n  \"moderation\": null,\n  \"output\":
+        [\n    {\n      \"id\": \"ws_0e58f8341a296874006a7f845146388196a71d0623a1466610\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"search\",\n        \"queries\": [\n          \"site:docs.python.org/3.14
+        free-threading Python HOWTO limitations\",\n          \"site:docs.python.org/3.14
+        whatsnew 3.14 free-threaded Python officially supported\",\n          \"site:peps.python.org
+        PEP 779 free-threading 3.14 supported\",\n          \"site:docs.python.org/3.14
+        C API extension modules free threading\"\n        ],\n        \"query\": \"site:docs.python.org/3.14
+        free-threading Python HOWTO limitations\"\n      }\n    },\n    {\n      \"id\":
+        \"ws_0e58f8341a296874006a7f8453f2e48196b0e4c47fc64f90be\",\n      \"type\":
+        \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"open_page\",\n        \"url\": \"https://docs.python.org/3.14/howto/free-threading-python.html\"\n
+        \     }\n    },\n    {\n      \"id\": \"ws_0e58f8341a296874006a7f8457a21c8196ae93b0db202d8a91\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"find_in_page\",\n        \"pattern\": \"Free-threaded
+        Python is officially supported\",\n        \"url\": \"https://docs.python.org/3.14/whatsnew/3.14.html\"\n
+        \     }\n    },\n    {\n      \"id\": \"fc_0e58f8341a296874006a7f8459f5c4819680b271ba2abd79fa\",\n
+        \     \"type\": \"function_call\",\n      \"status\": \"completed\",\n      \"arguments\":
+        \"{\\\"handle\\\":\\\"01a0021a-aa83-7252-8a64-d7108e706f29/call_ThjTLUpjfRlxSV43zSkDc4qF.0\\\",\\\"offset\\\":0,\\\"limit\\\":120}\",\n
+        \     \"call_id\": \"call_H7yjfeTQBnxFNmNbiZimBniZ\",\n      \"name\": \"read_tool_result\"\n
+        \   }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n
+        \ \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
+        \"24h\",\n  \"reasoning\": {\n    \"context\": \"all_turns\",\n    \"effort\":
+        \"none\",\n    \"mode\": \"standard\",\n    \"summary\": null\n  },\n  \"safety_identifier\":
+        null,\n  \"service_tier\": \"default\",\n  \"store\": true,\n  \"temperature\":
+        1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"text\"\n    },\n
+        \   \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\":
+        {\n    \"image_gen\": {\n      \"input_tokens\": 0,\n      \"input_tokens_details\":
+        {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\":
+        0,\n      \"output_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\":
+        0\n      },\n      \"total_tokens\": 0\n    },\n    \"web_search\": {\n      \"num_requests\":
+        1\n    }\n  },\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\":
+        \"Fetches the content of a web page at the given URL and returns it as markdown
+        or binary content.\",\n      \"name\": \"web_fetch\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"url\": {\n            \"description\":
+        \"The URL to fetch.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"url\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": true\n    },\n    {\n      \"type\":
+        \"function\",\n      \"description\": \"Delegate a self-contained task to
+        a named sub-agent and return its result.\\n\\nThe sub-agent runs in its own
+        fresh context and does not see this\\nconversation, so `task` must contain
+        everything it needs.\",\n      \"name\": \"delegate_task\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"agent_name\": {\n            \"description\":
+        \"Name of the sub-agent to run. Must be one of the agents\\nlisted in the
+        instructions.\",\n            \"type\": \"string\"\n          },\n          \"task\":
+        {\n            \"description\": \"The complete, self-contained instruction
+        for the sub-agent.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"agent_name\",\n          \"task\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": true\n    },\n    {\n
+        \     \"type\": \"function\",\n      \"description\": \"Read a slice of a
+        spilled tool result.\",\n      \"name\": \"read_tool_result\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"handle\": {\n            \"description\":
+        \"The handle from the overflowed tool return.\",\n            \"type\": \"string\"\n
+        \         },\n          \"offset\": {\n            \"default\": 0,\n            \"description\":
+        \"Number of matching lines to skip from the start (or end). Must be >= 0.\",\n
+        \           \"type\": \"integer\"\n          },\n          \"limit\": {\n
+        \           \"default\": 200,\n            \"description\": \"Maximum number
+        of lines to return (>= 1; clamped to a built-in cap).\",\n            \"type\":
+        \"integer\"\n          },\n          \"from_end\": {\n            \"default\":
+        false,\n            \"description\": \"Count `offset`/`limit` from the end
+        of the result.\",\n            \"type\": \"boolean\"\n          },\n          \"pattern\":
+        {\n            \"default\": null,\n            \"description\": \"Optional
+        literal substring; only lines containing it are returned.\",\n            \"anyOf\":
+        [\n              {\n                \"type\": \"string\"\n              },\n
+        \             {\n                \"type\": \"null\"\n              }\n            ]\n
+        \         }\n        },\n        \"required\": [\n          \"handle\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": false\n    },\n
+        \   {\n      \"type\": \"web_search\",\n      \"return_token_budget\": \"default\",\n
+        \     \"search_content_types\": [\n        \"text\"\n      ],\n      \"search_context_size\":
+        \"medium\",\n      \"user_location\": {\n        \"type\": \"approximate\",\n
+        \       \"city\": null,\n        \"country\": \"US\",\n        \"region\":
+        null,\n        \"timezone\": null\n      }\n    }\n  ],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 0.98,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n
+        \   \"input_tokens\": 33083,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\":
+        517,\n      \"cached_tokens\": 4871\n    },\n    \"output_tokens\": 407,\n
+        \   \"output_tokens_details\": {\n      \"reasoning_tokens\": 340\n    },\n
+        \   \"total_tokens\": 33490\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       access-control-expose-headers:
       - X-Request-ID
@@ -949,8 +1059,6 @@ interactions:
       - a2b2f29459f2a619-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-type:
       - application/json
       date:
@@ -1166,41 +1274,84 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: !!binary |
-        G3QWAGR/qfj3XE56Ov2RNRx3zOU+IoPs0GBwQWS0L1drWfkoGxUhbPd0i6UQQs/M3tYEnsgB7d0j
-        WEAJaDyhApSxr1zOxlBp/JyiAYQDujR9Cf8OANAaLAEjp15NeVU0xWI5o/l2XWyW0+maNk2xXNX1
-        iqbFbLveLsxqVder5WJmFrppcDgAwFD/Yi1YAvLqYRs9hvkDsFEkWMJsU6w3y1mxmvUrkoQkJ2LR
-        Nx8sd8+dhyU05BI30WPIt7ZYAuefBYA9XThiCXgXi34cAFwPTsOafhQsr8sxhogl+Ozc+A/aRP6d
-        2euL6tmTkwuWMB1P24V7hGpZt2WptzYRnVgCrmwXwb5Nm9wF1hlcRxPpZH0LOnjtcrLBp3Hl3zOZ
-        84y8ago5ak6wUjEvL+fAOd7z5DrwzAF0jiv/9qHhQ/DgTvIG1pKbYoXEHge8wrjyD6wwnO39PGhI
-        SyY30hXgZGUPBBuPVRw8CjjrD+PKP7RJrG+zTftWz4wg9+36X11CjhBOHqxvOLLXPK585b+FDJo8
-        GHbckjAkds1D0V/FgFA6JDhZyW9IDCnXI2rZSwJcDHfvX0wJpcMOJAQ3hkek9xCzT2A9WEkMpJrI
-        ab/h1bKz6IF9KJWYQZ57gX8T/JFjIrHBDyEF6CklMP79wQqciCUIcZV7R7KOasff5LLyI4i8WuIA
-        xxLe/3svINiBrWd6kKMtg+dWoO7ENV+8DIM8N0pUO4E5cC1V7yfj/+6Ozipk6bMoCQf2xvZVOjor
-        CcEpTc4Mn6wLhh2WgG0vo9V4PUrBYasXlaCZLR6mDUv44UvoUYwFO9noj4W8XC2WN9arhTZbYzaL
-        zXzl8TBQm1x6/lSWvWMAy4IkluPDd4atyVgC/q1wGYh3mSssK5zOaDqdz2hEVCxGm/lqPipovRyZ
-        zWxa8Ga6bubbiSbn1Mf9r48vP/W/mvfu/OHzcvHnw+GhXv5+PJ5WOKwwNE1iqbCczafDCp3trFRY
-        zpbTKw4HAAAAqMk5ZQ0+rQs5pz7pJeVPG3v4/Ozxib9P39b1N/dweWK/zlMnentkMlMl9h/sIVHf
-        dQDwc76uoadIzrGbznaJmUnOL3JirxmKKJqECmU9hd1sI79cH0PXi9Kk96wOfGkfiCzs7aIN58v9
-        HDi4918dY5WL3RBLQHJOSY7eWPcCwD0GT8YS0AdvAmCNZVjOdKc3FKd3MqbcdRTZYqCenKhhuajF
-        L/dtLMMyL6BZrqQtxJCPBAdIiKy8ucJdz5EkNwUzvSkRlEypJsSO/k8aLIgKhMGV67FHjnVINhic
-        CTs2NncBBl2xbR+sHiFFWQI2pnKilo98NdtRy6pl/2Vb6x0dZtncKEMOdeYxLT+UyLJVvY+uB0Dn
-        t/U3tG6sY4tn7cFIpFjrxxPXCmU1JbX53Km4vHWSbvosrJJQzAhAEYofmkWAgh4Ox+BjFr0Puj5H
-        krFeIDRA8J2zp5bhFpILW3tkD5/evwR1cITHBytACTqKBxNOHkKE2nqKl/Gc8cEJHK504lo1LHrf
-        rBR/xqT33JH5A9Mi0TSYgMiHv+BtDD1HsZxSJfxtG+wJxBDnBIA5uv+2qKju457lrpMAfAuZ8HdW
-        9pmTROtbPEZ0/bdz7RdiIsrThr8DQzyA+7MTzaYfkktFJ8y5LUm0SWdaYuaBqbMVJWMP4cO0ZVX6
-        lA0SgHZ24JjsQBoEpCWI95BL7P1xz7RJ5y7br/wHf5cT8XaoFYf2XMZieXpWldfWB+oLlFNodmkx
-        wvRr6hj2ES40/80SIGY/hlc5CdQMZSgQfWaqvLNJ2MC+t7UEPTE71qg9VF/GXkOlwopDW5I/s6EJ
-        ESTbmP7lkMotMvHI+eh4UP6MIUjO6nk8A0HqrdtzeGVwTmWBUnOOxVR5aNeYpmZuIkgewYUIxhtG
-        C7mPjeToTRWTWys3mDvpYdvK531e567mCKGBjkSjS5uzniu3/dLB9tzTmmZXgn9CBPbmX588vNu3
-        YGrS/dYLt2U6acogBKTjsb/uynz66Qqv6Gy73MFFOfxeAfZ1/7l9C2Y3QDvqet3/lYCgztbJyHrQ
-        1P8rwpgmhk7x5Rbxfpnw0mot4x+E7AV2M1q3m+yKFGenf3HhGUWeWNh2IesQHJPnmh4YI/Z7LTis
-        Dl9pkwF7kYOtp/c7SLlG1aobsLF3nAYVulTIaqDIs7J9NjLkIn950wCaBjTiL2xfFhg3S5zJKAf3
-        2bmPOm/uT04TBGOFE0ycPOxCqHUHmEzzxmLIZJoY89H0MT/vU3U2LUro9RSwj0l4oNLhsyq59Jxi
-        ioNlkowbet8zn0Ul+4eLJibNnRNHdbcj3eZYAnlu0lln25GErHLUZZjBFiNcvBDqs20+fehSH7nF
-        A9OPBWI7/hM8D6deMaaKAv12EnrlQtvHUJdI0OD1tXj5tig3m2L20oR4aStwsiLWf4ZS7zzmRTFf
-        D5ttRZeP9fr+p2il8DrrfLHYroZkjqFIrxZFMXB1Q2V3XCxhvWm0csCXCMSq3Exl3dC8KLaLCm07
-        OZXz9+pYyJAQlvD3OrgC
+      string: "{\n  \"id\": \"resp_0e58f8341a296874006a7f845bb5a0819693d55bb5431d3cff\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1786741851,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1786741854,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Search broadly before drawing conclusions.\\nRead the sources that support
+        each important claim.\\nPrefer primary and authoritative sources.\\nCite every
+        factual claim with a direct source link.\\nDistinguish sourced facts from
+        your own inference.\\n\\nYou can delegate self-contained tasks to these sub-agents
+        using the `delegate_task` tool. Each runs in its own fresh context and does
+        not see this conversation, so pass everything it needs.\\n\\nAvailable sub-agents:\\n-
+        researcher: Research a focused sub-question on the web and report back with
+        findings and source links\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-5.6-sol\",\n  \"moderation\": null,\n  \"output\":
+        [\n    {\n      \"id\": \"fc_0e58f8341a296874006a7f845e4534819693c53cd9dd73725e\",\n
+        \     \"type\": \"function_call\",\n      \"status\": \"completed\",\n      \"arguments\":
+        \"{\\\"handle\\\":\\\"01a0021a-aa83-7252-8a64-d7108e706f29/call_ThjTLUpjfRlxSV43zSkDc4qF.0\\\",\\\"offset\\\":120,\\\"limit\\\":140}\",\n
+        \     \"call_id\": \"call_Uc4auU7ikVIFweZ0PbbYlD4w\",\n      \"name\": \"read_tool_result\"\n
+        \   }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n
+        \ \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
+        \"24h\",\n  \"reasoning\": {\n    \"context\": \"all_turns\",\n    \"effort\":
+        \"none\",\n    \"mode\": \"standard\",\n    \"summary\": null\n  },\n  \"safety_identifier\":
+        null,\n  \"service_tier\": \"default\",\n  \"store\": true,\n  \"temperature\":
+        1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"text\"\n    },\n
+        \   \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\":
+        {\n    \"image_gen\": {\n      \"input_tokens\": 0,\n      \"input_tokens_details\":
+        {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\":
+        0,\n      \"output_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\":
+        0\n      },\n      \"total_tokens\": 0\n    },\n    \"web_search\": {\n      \"num_requests\":
+        0\n    }\n  },\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\":
+        \"Fetches the content of a web page at the given URL and returns it as markdown
+        or binary content.\",\n      \"name\": \"web_fetch\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"url\": {\n            \"description\":
+        \"The URL to fetch.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"url\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": true\n    },\n    {\n      \"type\":
+        \"function\",\n      \"description\": \"Delegate a self-contained task to
+        a named sub-agent and return its result.\\n\\nThe sub-agent runs in its own
+        fresh context and does not see this\\nconversation, so `task` must contain
+        everything it needs.\",\n      \"name\": \"delegate_task\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"agent_name\": {\n            \"description\":
+        \"Name of the sub-agent to run. Must be one of the agents\\nlisted in the
+        instructions.\",\n            \"type\": \"string\"\n          },\n          \"task\":
+        {\n            \"description\": \"The complete, self-contained instruction
+        for the sub-agent.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"agent_name\",\n          \"task\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": true\n    },\n    {\n
+        \     \"type\": \"function\",\n      \"description\": \"Read a slice of a
+        spilled tool result.\",\n      \"name\": \"read_tool_result\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"handle\": {\n            \"description\":
+        \"The handle from the overflowed tool return.\",\n            \"type\": \"string\"\n
+        \         },\n          \"offset\": {\n            \"default\": 0,\n            \"description\":
+        \"Number of matching lines to skip from the start (or end). Must be >= 0.\",\n
+        \           \"type\": \"integer\"\n          },\n          \"limit\": {\n
+        \           \"default\": 200,\n            \"description\": \"Maximum number
+        of lines to return (>= 1; clamped to a built-in cap).\",\n            \"type\":
+        \"integer\"\n          },\n          \"from_end\": {\n            \"default\":
+        false,\n            \"description\": \"Count `offset`/`limit` from the end
+        of the result.\",\n            \"type\": \"boolean\"\n          },\n          \"pattern\":
+        {\n            \"default\": null,\n            \"description\": \"Optional
+        literal substring; only lines containing it are returned.\",\n            \"anyOf\":
+        [\n              {\n                \"type\": \"string\"\n              },\n
+        \             {\n                \"type\": \"null\"\n              }\n            ]\n
+        \         }\n        },\n        \"required\": [\n          \"handle\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": false\n    },\n
+        \   {\n      \"type\": \"web_search\",\n      \"return_token_budget\": \"default\",\n
+        \     \"search_content_types\": [\n        \"text\"\n      ],\n      \"search_context_size\":
+        \"medium\",\n      \"user_location\": {\n        \"type\": \"approximate\",\n
+        \       \"city\": null,\n        \"country\": \"US\",\n        \"region\":
+        null,\n        \"timezone\": null\n      }\n    }\n  ],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 0.98,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n
+        \   \"input_tokens\": 28826,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\":
+        23395,\n      \"cached_tokens\": 5388\n    },\n    \"output_tokens\": 67,\n
+        \   \"output_tokens_details\": {\n      \"reasoning_tokens\": 0\n    },\n
+        \   \"total_tokens\": 28893\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       access-control-expose-headers:
       - X-Request-ID
@@ -1214,8 +1365,6 @@ interactions:
       - a2b2f2dc9e82a619-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-type:
       - application/json
       date:
@@ -1513,41 +1662,84 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: !!binary |
-        G3MWAGSz5fv3XE4anf6SpJDsdFk33vgJEMSNkaktZ2knV2tl+XfuhbDd0y2WnoiSdM/sXk2QHNDe
-        BcECSkDjoz+vAiRjY1zk32M0W/WncYDkSm+f4N8RANoGC8DAcTAZLzftZr7IabZdbdaLLFvRut0s
-        lu28bepNvl1RPltslpzPVjzPF1mN4xEA+uoX14oFIKwBptF7mL8EN4YUC8jXm9V6kW+Wy3KVopKm
-        SCCGzdbx8tw1WEBLLnISvYd8T4cFQL4uABzozAELwJdYjOEI4DJxqtZ2rVg/kEPwAQuQ5Fz9L9sG
-        /p1Y6rMZWMjpGQvIplm6EI/YdOu2XSytGmIAC8Ce7RIYt2mnO0M/g3+xCXS00kHtpXYpWi9xWsoH
-        pmY+I+8ZfQo1R+ipmLuX82Ae77lxPfjkAAampbx7a/gYJHiApIG+5BZZJbWHCu8yLeWhVYa5vV8D
-        LdWayNV0Fzha3QHBwGMNBK8Dzsp+WsojG9VKl2zcpQZNDXLcrv/U2acA/ihgpeXAUvO0lFK++wQ1
-        CTTsuCNliOzat6K/RwNKcR9hZiW/IDLEVE2oY9EIejG+3nycUYr7a1Dv3RQeU72DkCSCFbAaAci1
-        geNuwKu1J6UDy1AuMoN+9gJ/xsuBQyS1XsYQPQwUIzD/iWAVZsQSkLjH/QNZR5WDb2FRygQC95Y4
-        zqGAD38fAwQjsA2aEiRo28FnK9B65Aou7oZBzhslkp2UOUAtSR9G5v/qnk7GJx2SGvV7FmbbkJ5O
-        Rr13pibHhm/X+4YdFoDdoJPldDWJ3mFqEIig2BYn04sF/JQllCjWBYfW1rtKq2y15cULN7PlYl3T
-        dl1tt8zb7QIq6tXzwPvaJIIBIIssqQQfLqy2FmIB+LfEbiD+H1xiUWKWU5bNcpoQbeaT9Ww5m2xo
-        tZg06zzb8DpbtbPtjZqcM592vz69+jz8aj+408cvi/mfj/tH9eL3k2lW4rhE37aRtcRitsrGJTrb
-        Wy2xWOcXWKAu1IxQ7R/7+vRdenz6oPffubXPPi9+vJcX9kwZ9K1CPeZ9galpKTH84AAzjV5GAFfN
-        dR8DBXKOXWv2aUic5cYCR5aaNREZk9goWQSSWeSHG4LvBzU11Ts2ez6njwdWFrboxdli1wQeDv1X
-        q1gjYQ/FApCcM5qC8OoxADjE4K2wABQvnNLa+4YSZF/ouiCmvqcAFuvphZFa1rPp+/L41rJW5v4z
-        64yuY7T4mOEk9YGJt1q5HziQpqQop5tBweCUa33o6X+SXyEvHKILNrMPHCofrS24Gvbc2NTbF5TE
-        3p23dQ05SuoxMZcidTzle9meOjYdy3F/K3J+0Gy8lhaHCnOdjqtBWaaaTXJhbZR956R16uY6iw/t
-        wZqJqN135MooWUWkXkm9Mcv7Ri2mW2EnUYlZ9U+C6MdNH0DRoA1n4RPWemdzQzYks0XBt0Dau+RA
-        HcMTJLfs7IEFPn94pdNBEN4crAJF6CnsG38U8AEqKxTO9XnTiZNy2MAjV6ZlrXfYJFeN9Y57Yn8A
-        WviZFhYQ7vBnvAt+4KCWo6eE3/fDIYOo4roAMAX3bweJWj/tGO9W9QC3wAm/MbGvHjVY6XAayeVv
-        71IuRj+Umw2/AUBcgX9ViFoz9L6lySfYuTdqsD5nXkPiUbpdvrPxQ/zIa9kp7YtBPdDADrzGOZAM
-        AV4J6ntwJY79tOO8hXZdDlzKNrx2iXg01AZCtysj0CTO005VWXMfkC8yQqH40sGE+TfUMwwjXFD+
-        i9VDSDKF1ykqVAxRKGRaZyzF2ajcwLC3lX9eMD5WuQMkXyagg0/KBCOFHY55Sd6KofUBMNuc8uUR
-        yR048T/LUfAg+plFEJ2t2/EqBHGwbsjhDd4JldCX6XwsBrAM+Rq91OwsgtkTuA/B+rxogff50RSE
-        VdG3dUKDvpM22044X/Am9RUH8C30pLV26XVWOHA7Ie7tAD11aXY3+McHYGn+lckzu3MbMpYes6Lc
-        RekEiQUJ8MZTnw5nlu3v8ppOtk893JPDG6OwH/jPnduQ34TaUT/Q/rcEBFWyTidWoKbhXxRmtcH3
-        hu+2SPdl05fOlpj70CdRuG7R1usb1zGKd01/cd/ZDkFQ8BeWw5tZee+YBGp6X4zUG2Ucdg4nGmPA
-        MeRg5OljDmKq2LXxJozrHZvBmC5jstopcKscmBscSpGc37YKTYWq4ierHId82DHOUsupJTm307D5
-        V5AWUBkbPcGZC692wdTu8sjZkc40ARYi66N/Pmqq1HRaQsdTAD464ZFxh69p9DxwtCkehknSWdNl
-        r35SE+0fDpo4a+kUOZhXHWmeYwzkrEkXnWxParLqsA7DLLyYYN+FEJ/t9/ljkbbAnSzZrluo7fmP
-        F67OLNGmigD9SeoH43w3BF+FSJAQDLF43XYTbnaGJNjEeGcrQLJDjP8soV7/PNtuw71MuxDj9ROP
-        wWrgVTzLV4txLr/JkN+sN/ORO2yJ7C6IBazWiU4I+B6BVJGbLaybnOfZch2hHSDFcP55PSs1pIQF
-        /L2MLg==
+      string: "{\n  \"id\": \"resp_0e58f8341a296874006a7f845f3fdc8196a12485e126e3140c\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1786741855,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1786741857,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Search broadly before drawing conclusions.\\nRead the sources that support
+        each important claim.\\nPrefer primary and authoritative sources.\\nCite every
+        factual claim with a direct source link.\\nDistinguish sourced facts from
+        your own inference.\\n\\nYou can delegate self-contained tasks to these sub-agents
+        using the `delegate_task` tool. Each runs in its own fresh context and does
+        not see this conversation, so pass everything it needs.\\n\\nAvailable sub-agents:\\n-
+        researcher: Research a focused sub-question on the web and report back with
+        findings and source links\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-5.6-sol\",\n  \"moderation\": null,\n  \"output\":
+        [\n    {\n      \"id\": \"fc_0e58f8341a296874006a7f846069e4819682547ca97b99ee99\",\n
+        \     \"type\": \"function_call\",\n      \"status\": \"completed\",\n      \"arguments\":
+        \"{\\\"handle\\\":\\\"01a0021a-aa83-7252-8a64-d7108e706f29/call_ThjTLUpjfRlxSV43zSkDc4qF.0\\\",\\\"offset\\\":260,\\\"limit\\\":71}\",\n
+        \     \"call_id\": \"call_WGPuExRtAPl7o0U4ZQnJiya0\",\n      \"name\": \"read_tool_result\"\n
+        \   }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n
+        \ \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
+        \"24h\",\n  \"reasoning\": {\n    \"context\": \"all_turns\",\n    \"effort\":
+        \"none\",\n    \"mode\": \"standard\",\n    \"summary\": null\n  },\n  \"safety_identifier\":
+        null,\n  \"service_tier\": \"default\",\n  \"store\": true,\n  \"temperature\":
+        1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"text\"\n    },\n
+        \   \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\":
+        {\n    \"image_gen\": {\n      \"input_tokens\": 0,\n      \"input_tokens_details\":
+        {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\":
+        0,\n      \"output_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\":
+        0\n      },\n      \"total_tokens\": 0\n    },\n    \"web_search\": {\n      \"num_requests\":
+        0\n    }\n  },\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\":
+        \"Fetches the content of a web page at the given URL and returns it as markdown
+        or binary content.\",\n      \"name\": \"web_fetch\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"url\": {\n            \"description\":
+        \"The URL to fetch.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"url\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": true\n    },\n    {\n      \"type\":
+        \"function\",\n      \"description\": \"Delegate a self-contained task to
+        a named sub-agent and return its result.\\n\\nThe sub-agent runs in its own
+        fresh context and does not see this\\nconversation, so `task` must contain
+        everything it needs.\",\n      \"name\": \"delegate_task\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"agent_name\": {\n            \"description\":
+        \"Name of the sub-agent to run. Must be one of the agents\\nlisted in the
+        instructions.\",\n            \"type\": \"string\"\n          },\n          \"task\":
+        {\n            \"description\": \"The complete, self-contained instruction
+        for the sub-agent.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"agent_name\",\n          \"task\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": true\n    },\n    {\n
+        \     \"type\": \"function\",\n      \"description\": \"Read a slice of a
+        spilled tool result.\",\n      \"name\": \"read_tool_result\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"handle\": {\n            \"description\":
+        \"The handle from the overflowed tool return.\",\n            \"type\": \"string\"\n
+        \         },\n          \"offset\": {\n            \"default\": 0,\n            \"description\":
+        \"Number of matching lines to skip from the start (or end). Must be >= 0.\",\n
+        \           \"type\": \"integer\"\n          },\n          \"limit\": {\n
+        \           \"default\": 200,\n            \"description\": \"Maximum number
+        of lines to return (>= 1; clamped to a built-in cap).\",\n            \"type\":
+        \"integer\"\n          },\n          \"from_end\": {\n            \"default\":
+        false,\n            \"description\": \"Count `offset`/`limit` from the end
+        of the result.\",\n            \"type\": \"boolean\"\n          },\n          \"pattern\":
+        {\n            \"default\": null,\n            \"description\": \"Optional
+        literal substring; only lines containing it are returned.\",\n            \"anyOf\":
+        [\n              {\n                \"type\": \"string\"\n              },\n
+        \             {\n                \"type\": \"null\"\n              }\n            ]\n
+        \         }\n        },\n        \"required\": [\n          \"handle\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": false\n    },\n
+        \   {\n      \"type\": \"web_search\",\n      \"return_token_budget\": \"default\",\n
+        \     \"search_content_types\": [\n        \"text\"\n      ],\n      \"search_context_size\":
+        \"medium\",\n      \"user_location\": {\n        \"type\": \"approximate\",\n
+        \       \"city\": null,\n        \"country\": \"US\",\n        \"region\":
+        null,\n        \"timezone\": null\n      }\n    }\n  ],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 0.98,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n
+        \   \"input_tokens\": 30990,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\":
+        2164,\n      \"cached_tokens\": 28783\n    },\n    \"output_tokens\": 67,\n
+        \   \"output_tokens_details\": {\n      \"reasoning_tokens\": 0\n    },\n
+        \   \"total_tokens\": 31057\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       access-control-expose-headers:
       - X-Request-ID
@@ -1561,8 +1753,6 @@ interactions:
       - a2b2f2f29ba2a619-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-type:
       - application/json
       date:
@@ -1929,42 +2119,87 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: !!binary |
-        G0kXAORaav79ee3wSnORq6yU2pzRrWAlkYNFgcUlN75v7dWIGBcZpSPdzO6IoxBBYWb3cm9/gfD+
-        VwG2BZJERlanVYCytq5GNrLHclrdXmLYidYgeQ+vRgDKGlWBipSGekarsi0XywLn23W5Wc5ma9y0
-        5XJdbGZLXRbbddls9XK22q7KQm/aWaNujQBUaP6SFlWBgtVTZfo1zB+DTI2iKig25XqzLMrVpl2B
-        JCg5aRB9c7U8PXcHVUGLLlGRfg35lk5VAPmWANSAJ4qqAvUUiz41AjgPrrs1fOStt7ekGENUFXB2
-        rv/HbSP9y8T6VA/E6OSkKphNZuVMPcJ6WreM1FowokNVoGa2i2Ddpo3uBPMM/kYT8WC5Ax1Yu5xs
-        4DTZ8SdCs52RG6aQo6YEMxXT9HIObOM9MdeBPQfQMdnxh5eGD0GDO5ANzCU3yQqK3Xe4zmTHj60Q
-        bO39DtCiloyup3XgYKUHhIXHKgieBpzly8mOn9gklrtsU1/qmR74ul3/qFPIEcKBwXJLkVjTZMc7
-        /hkyaGQw5KhDIUjk2pei38CAYLpMsLGSn5AIUm7G2BFLArsYXlxerxZMlxcgIbgJPEXdQ8ycwDJY
-        SQCk2kipX/Bq6VHoQDqUSkQg+17g1wTeU0woNvAtSAEGTAmE/1KwAhtiCUhs8HCP1mHj4JtY7XgM
-        kWZL7KdYwae/TwGEFdh6poVWtAzYtwK1B2rgomkY+LZRItm1MQeoOen9JPyf7fFYhyxDllrCJbGw
-        fRSPx1pCcLVGJ4bP54MhpypQ3SDj1WQ9TsGpUi8SQYgtDtOqKvitS6hRZAuO8ZDe8nFe4vKRuG0X
-        i9WiKNer9VqvlwfoqFVOA73XUVMTD4BmlWKpPlSgSRFIzTOg13u2lk1tuR6wo1ZgCh5ThCKrCtQb
-        662Qgcfw8MNL0cj8PP1J+8NHL9U43nk8/zysCf9CtjpfN9tZ+VW2TbltCrMyVM71at0e6GlXyb2N
-        jl32xGIU/4arncrR7VS1U73IkKrp1ASdJsNJ+sCTELvpYlIsp304SJi2kWi8dwtuYyx3YzoKsZmZ
-        rxfvduo8Up9G52qbD3/+auOfvv3+a/vk6d/izfDo4X4+e/zok1vi1cjoedrXkuielr3nEcAfCdzE
-        gBGdIyegbRIzVVlapESsybhq/xjWfgOhI6n/5oYY/CC1Rt1TfUmn8v5IQizprWq+7HF21GqGpddQ
-        RuO2qgKFztWSI6vfKQBq1cQTVQWKAwsZ6FepqvjXwQajuE5UKXuPESxyPRMTtiSnejrP01tLjoam
-        BC2rpSxUQQxWuExCJOLNFvIDRZRcFBR0UygonFJtiB7/xxUG6gJyStpnqT3FJiTLhfmUJ2Ozd5nI
-        v9Y+WI1xCrMEVZjKCTsaeQPrsaO6I109XVk2XUed3TpzJ6obU5+WD4UyL1UDRmeDgubM1t5Q+m+N
-        zfZDhLGSeuPmT3CnlbOvI41DkzSTXNhLsstGs8JsaWimNQoGAz9KPSPRfRjhk28czQKhBXRIOQfs
-        CB7zObuze2L4+umN65QzR71DAiuACTzGSxMODCFCYxnjqT9nYsQtVoGKFUvmTbonj+IPRGChs4EV
-        LML/gA8xDBTFUgr+8NthaqjAulgUgMrR/dtCotovPeFdKwEsGcMJv5GnmT9JtNypDqMzHO4ZJB1a
-        E9vwJwBE/3P/4KC56YdwWRUycW5NEm0YnZaYaTRkwvIQPgnE9orv2SABcK0Kjol3uEBAoMVWzw3R
-        0alfeqqbdDR25B1f/YsojxZ4rSC0R2cWyZNxIquyDaUPyBfUbnLfr4Qw/Q49wcrIGeU/WQLEzBN4
-        m5NAQ5BYA2u2mHbsbBIysJJvkXIwvcRvFC3Z5FjU9hT55gS098WYYPKzx1uyxD+zoQ0RMEsMNkKC
-        QxlPvxwkuRgFcaLetqPiQUI3CiE5q5k9D0IarFtFeUVwSmUR6rZIaOInrPY/K7nWc6/tP4kIVo/g
-        ZhHjQ70Z3jdHcmRRXWJo20SiXRg7SbdthfMR77JvKEJowaNo69LqLFMuekm6tAP0epa29eBaiEBs
-        ruvktd27CzMc+iwLdTc86G8GJK7dWW8vxzOfva/zFo/WZw83TtFFGexbXrt3F4rboB36Qd5+SoDQ
-        ZOtkbBk0DtdRGNXG4Gu6JSbel0m2rNIy9nHILHDB0dqL6QVlnAvJYTcHmhUFQSMbspxNCI6QoWbp
-        YDyyC0XaO8Csl01wCjpYTHufg5Qb61V5G5Yqj2xQrku5rHqMFE8dmQzVcyGf3rfBgvDu7FtcM27m
-        0Vx6uTJn597k/9w/NRI0xspO0AjJm10QH3dUwWx3eTBNXWDQipF7b91k01kJmU8B3bFtUIewC9Zy
-        Giih4qg0iSMh285/lDrZ/5Q0UdXcOVGsn0gllYQklm9tddbRehSXVaZ0GmaQxUhNxwj52WFfPzep
-        i9SNYvrYSayn/4EpyVS4oE9lCfq9JAy1C90QQ5MiQYE35OJl2zL/aIyZsQnV7ccA+B5V/mdI9Zaw
-        WBTl+laxLenyVS5/6SFaSbxOKZbbvA2yfcdkZfMuZtvlZiQle1Q531mL5arUCgLdJMB7OK0oRiOY
-        MrvBxWKxKJK0I+SU0T/Mk6BBQVXB1Xl0Bg==
+      string: "{\n  \"id\": \"resp_0e58f8341a296874006a7f8461704c81968b9c4059581c7f0b\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1786741857,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1786741869,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Search broadly before drawing conclusions.\\nRead the sources that support
+        each important claim.\\nPrefer primary and authoritative sources.\\nCite every
+        factual claim with a direct source link.\\nDistinguish sourced facts from
+        your own inference.\\n\\nYou can delegate self-contained tasks to these sub-agents
+        using the `delegate_task` tool. Each runs in its own fresh context and does
+        not see this conversation, so pass everything it needs.\\n\\nAvailable sub-agents:\\n-
+        researcher: Research a focused sub-question on the web and report back with
+        findings and source links\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-5.6-sol\",\n  \"moderation\": null,\n  \"output\":
+        [\n    {\n      \"id\": \"ws_0e58f8341a296874006a7f846a28a48196a9f3353186566c64\",\n
+        \     \"type\": \"web_search_call\",\n      \"status\": \"completed\",\n      \"action\":
+        {\n        \"type\": \"find_in_page\",\n        \"pattern\": \"Limited C API
+        and Stable ABI\"\n      }\n    },\n    {\n      \"id\": \"fc_0e58f8341a296874006a7f846cb90881969b89b1d5de82c56f\",\n
+        \     \"type\": \"function_call\",\n      \"status\": \"completed\",\n      \"arguments\":
+        \"{\\\"url\\\":\\\"https://docs.python.org/3.14/howto/free-threading-extensions.html\\\"}\",\n
+        \     \"call_id\": \"call_dmEMWZ9DEj1LpBAv20CBRl4f\",\n      \"name\": \"web_fetch\"\n
+        \   }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n
+        \ \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
+        \"24h\",\n  \"reasoning\": {\n    \"context\": \"all_turns\",\n    \"effort\":
+        \"none\",\n    \"mode\": \"standard\",\n    \"summary\": null\n  },\n  \"safety_identifier\":
+        null,\n  \"service_tier\": \"default\",\n  \"store\": true,\n  \"temperature\":
+        1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"text\"\n    },\n
+        \   \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\":
+        {\n    \"image_gen\": {\n      \"input_tokens\": 0,\n      \"input_tokens_details\":
+        {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\":
+        0,\n      \"output_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\":
+        0\n      },\n      \"total_tokens\": 0\n    },\n    \"web_search\": {\n      \"num_requests\":
+        0\n    }\n  },\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\":
+        \"Fetches the content of a web page at the given URL and returns it as markdown
+        or binary content.\",\n      \"name\": \"web_fetch\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"url\": {\n            \"description\":
+        \"The URL to fetch.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"url\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": true\n    },\n    {\n      \"type\":
+        \"function\",\n      \"description\": \"Delegate a self-contained task to
+        a named sub-agent and return its result.\\n\\nThe sub-agent runs in its own
+        fresh context and does not see this\\nconversation, so `task` must contain
+        everything it needs.\",\n      \"name\": \"delegate_task\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"agent_name\": {\n            \"description\":
+        \"Name of the sub-agent to run. Must be one of the agents\\nlisted in the
+        instructions.\",\n            \"type\": \"string\"\n          },\n          \"task\":
+        {\n            \"description\": \"The complete, self-contained instruction
+        for the sub-agent.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"agent_name\",\n          \"task\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": true\n    },\n    {\n
+        \     \"type\": \"function\",\n      \"description\": \"Read a slice of a
+        spilled tool result.\",\n      \"name\": \"read_tool_result\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"handle\": {\n            \"description\":
+        \"The handle from the overflowed tool return.\",\n            \"type\": \"string\"\n
+        \         },\n          \"offset\": {\n            \"default\": 0,\n            \"description\":
+        \"Number of matching lines to skip from the start (or end). Must be >= 0.\",\n
+        \           \"type\": \"integer\"\n          },\n          \"limit\": {\n
+        \           \"default\": 200,\n            \"description\": \"Maximum number
+        of lines to return (>= 1; clamped to a built-in cap).\",\n            \"type\":
+        \"integer\"\n          },\n          \"from_end\": {\n            \"default\":
+        false,\n            \"description\": \"Count `offset`/`limit` from the end
+        of the result.\",\n            \"type\": \"boolean\"\n          },\n          \"pattern\":
+        {\n            \"default\": null,\n            \"description\": \"Optional
+        literal substring; only lines containing it are returned.\",\n            \"anyOf\":
+        [\n              {\n                \"type\": \"string\"\n              },\n
+        \             {\n                \"type\": \"null\"\n              }\n            ]\n
+        \         }\n        },\n        \"required\": [\n          \"handle\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": false\n    },\n
+        \   {\n      \"type\": \"web_search\",\n      \"return_token_budget\": \"default\",\n
+        \     \"search_content_types\": [\n        \"text\"\n      ],\n      \"search_context_size\":
+        \"medium\",\n      \"user_location\": {\n        \"type\": \"approximate\",\n
+        \       \"city\": null,\n        \"country\": \"US\",\n        \"region\":
+        null,\n        \"timezone\": null\n      }\n    }\n  ],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 0.98,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n
+        \   \"input_tokens\": 33186,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\":
+        1490,\n      \"cached_tokens\": 30947\n    },\n    \"output_tokens\": 145,\n
+        \   \"output_tokens_details\": {\n      \"reasoning_tokens\": 111\n    },\n
+        \   \"total_tokens\": 33331\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       access-control-expose-headers:
       - X-Request-ID
@@ -1978,8 +2213,6 @@ interactions:
       - a2b2f3005de6a619-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-type:
       - application/json
       date:
@@ -2638,41 +2871,85 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: !!binary |
-        G34WAGQzNfv788LgdcV25NKUUpsyXEiCZGZJUEeCLpfxPWv9Xic1IiHUsbCGqczMyjNMm9jepS9e
-        EYuipZM/PyEWqaTG5Y6N8e6rP6eKKHBCS18f4Z8RANoWS8DIaTAFr7bddrGc0Xy33m6WRbGmTbdd
-        rnm+qovtbLfeLlfLdVHPtsWymfOqwPEIAEP9mxvFEpDXANP4OsxfgFtDiiXMNtv1ZjnbbopyMyQl
-        zYlZDNuHlIvnHoUldOQSJ/F1yK/usQTOJwWAA505Ygl4EYutOAK4VM5kvY9p8/tyjCFiCZKdo/+S
-        XeT/MktzNgMLOT1jCcWUV2UesZnWrZJKG0GsxxJwZrsE1m26wp1hnsE/2EY6WumhCdK4nGyQNK3k
-        A1O7nZHjppBjwwlmKpbp5Uqwjfci3BLccgDrp5W8u2r4GCx4PUkLc8kdYJXUHgiOMa3koVWGrb0/
-        CjpqNJOjNAYcre6BYOGxxMGrgLNyPa3kkU1qpc827VODloJet+tfdQ45QjgKWOk4sjQ8raSS7yFD
-        QwItO+5JGRK77qrox2lBKV0n2FjJz0gMKdcT6lk0AS7GV/cfZpTS9RVoCG4Kj6nZQ8ySwApYTQy0
-        ushpv+DVOSftB7GhVmIGve0Ffk+QA8dEaoOMIQUYKCVQ/uvBKmyIJTRinPsHso5qx9/+ZSUTiDxb
-        4jaOJXz4+yogWIFt0JZgQ6vAbSuw5Mg1XzINg942Sux2BnPgWnd9mJT/iz2dTMg6ZDUarlmUbUo8
-        nYyG4ExDTg3fzIeWHZaA/aCT1XQ9ScFhahA7wagtVrMGS/hpS2hRggUX2TWP0ztaz7bPrdvNmott
-        vSuWq82uWeyA0Bo9D/w0J4thAMsqSybDh3eBrf2xBPxT4TQQ/wWusKywmFFRzGc0IdouJpv5aj7Z
-        0no5aTezYsubYt3Ndzcacs60/vHrrz92jx7/nr0aHtw/zIuHDz64ZTctKhxXOJAqR6mwrPCjUu0Y
-        7j94XuG4Qme91QrLVXHB8QgAAAAbcs6gJFTx23bvn/7nHr7dHb76/e788sns4WZRvKJ3LVki5Hth
-        bWRqpaaWIhxgU7dcRgC/RDeBgSI5x06yazVmzjK4yImlYVTigSU2gBsYJkVdvrshBj+oaajZs7nm
-        c/q2yMqiImtwvtyLo4TLALZwS9b2QCwByTmjOYreXgWAyw0+DktACcIpS3xoe4LHGv7YL2XvKbIl
-        mL1/oo71bObBvLazjNAyl+Zco3cxjv6Y4QYNkTvvSGU/cCTNSdGs36gJ1KZWF6Kn/2ndhbyQEF24
-        3vPAsQ7JSqEv9Nza7McalN+afbANhRZlDZjYyol6rnk866ln07O8nGvF5i9YjO/06MOFhWbKBzVZ
-        p1JLk4u5IQ6kVm1T/603dQM+uJnocSseuTaAa6SzRrI3Q/TZSYtZKTQkQHOxSCFN3M4HFAwJR5SA
-        T1ib/fgb8qCypyiEDgjJuw7UM5xZ8tjeHljg84dX+A6G8PpgFSiBp3jdhqNAiFBboXimV5pCHIPD
-        FB65Nh1rs0eR9JmaPXsyWcigfE5HFMo1/oR3MQwc1XLymvDbOTjcKRIDAsAc3b9TumjJpz23e4kG
-        4Fu1CQuK8fSdNFrpkWByIV6+sMQ+qYgNvwFD8lz+VYgrCYOfSRwrdV6TNFr/s60x86jKgvUhfuTB
-        NNJTJ2gAWuRBqXUUtEKAh4J4D27F1Z/2nLdoN+b8lTyEV+6RrIyaOEx3a1I0zzpYSjF7UPugWyLD
-        Xg4lbL8hz7CkcNWjn60BYpYpvM5JoWaISKHLJ5kqcTYpt7AEbuOrF6bHJneA3ZeL6eATmGDUUDvW
-        Jf3ZCV2I0LLCeJP7U73Yl+5yUwu2SUj0ouFBJLQHQXK2EXYfBGmwbvnh84MzqhQo9X0sydWDeo0e
-        a34VwewJHJ/gnkdatfveaI6iqoMMXZdYrQt9Jztsp/L5nDfZ1xwhdOBJG3RZ46xwEHddurYD9zy9
-        2VjwV4jA0v5tk7d35zYUprbVinIfsfM3pxHgjWd+vZR58TTGazpZnz0cqyP3BNj3/evObZjdhMaR
-        H/r+lwQEdbZOJ1agoeHvJuzRxeANH4WR7cvTrVRt2fthyKJwJdElVzeuYpTSVf+r49F8QyGijG1D
-        WYfgmOSBIqPMTBtDaoZXXm/AVeRgFepbHaRco9eCm7DGdxQDASINWcso8hB6fm7b0I3k/LYDNBO2
-        qm9ZYdyXUR4qN5fs3KMVVvmX6AoEY8IJ+XfxsAuwVB5V6+OudqaZsRA7GiOGLabObY8SNp6CvHiM
-        R2Tc4X6NngdOTdFhkh43bNm+T2qS/Z+DJsnaPSeO5hJI1gGQkVhvpnTHyXrSIWsuNmGYo4sJzmMI
-        8dk5nz8WWRq5103v4xi1nv8PwqlUB4pSBeiP0zAYF/ohhjpEgoRgiMXn7raB5YqYpTUxHvEKjNdi
-        /OeEeoNYLIrNZpycFnSFGK9ff4xWA755qx0JzlRqg8E+F/PlYjOydD/ku+B6m5jKgBwhoAg4gZsX
-        1e1YLGbLVWh/npyi+Wd5VmpJCUv4cxldAA==
+      string: "{\n  \"id\": \"resp_0e58f8341a296874006a7f846e25b08196845460b1804c2e50\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1786741870,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1786741872,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Search broadly before drawing conclusions.\\nRead the sources that support
+        each important claim.\\nPrefer primary and authoritative sources.\\nCite every
+        factual claim with a direct source link.\\nDistinguish sourced facts from
+        your own inference.\\n\\nYou can delegate self-contained tasks to these sub-agents
+        using the `delegate_task` tool. Each runs in its own fresh context and does
+        not see this conversation, so pass everything it needs.\\n\\nAvailable sub-agents:\\n-
+        researcher: Research a focused sub-question on the web and report back with
+        findings and source links\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-5.6-sol\",\n  \"moderation\": null,\n  \"output\":
+        [\n    {\n      \"id\": \"fc_0e58f8341a296874006a7f846fa6188196bd76e08b904579c3\",\n
+        \     \"type\": \"function_call\",\n      \"status\": \"completed\",\n      \"arguments\":
+        \"{\\\"handle\\\":\\\"01a0021a-aa83-7252-8a64-d7108e706f29/call_dmEMWZ9DEj1LpBAv20CBRl4f.0\\\",\\\"pattern\\\":\\\"Stable
+        ABI\\\",\\\"limit\\\":50}\",\n      \"call_id\": \"call_9QGqlCO9vWmh9yKF1C730LaP\",\n
+        \     \"name\": \"read_tool_result\"\n    }\n  ],\n  \"parallel_tool_calls\":
+        true,\n  \"presence_penalty\": 0.0,\n  \"previous_response_id\": null,\n  \"prompt_cache_key\":
+        null,\n  \"prompt_cache_retention\": \"24h\",\n  \"reasoning\": {\n    \"context\":
+        \"all_turns\",\n    \"effort\": \"none\",\n    \"mode\": \"standard\",\n    \"summary\":
+        null\n  },\n  \"safety_identifier\": null,\n  \"service_tier\": \"default\",\n
+        \ \"store\": true,\n  \"temperature\": 1.0,\n  \"text\": {\n    \"format\":
+        {\n      \"type\": \"text\"\n    },\n    \"verbosity\": \"medium\"\n  },\n
+        \ \"tool_choice\": \"auto\",\n  \"tool_usage\": {\n    \"image_gen\": {\n
+        \     \"input_tokens\": 0,\n      \"input_tokens_details\": {\n        \"image_tokens\":
+        0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\": 0,\n      \"output_tokens_details\":
+        {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"total_tokens\":
+        0\n    },\n    \"web_search\": {\n      \"num_requests\": 0\n    }\n  },\n
+        \ \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\":
+        \"Fetches the content of a web page at the given URL and returns it as markdown
+        or binary content.\",\n      \"name\": \"web_fetch\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"url\": {\n            \"description\":
+        \"The URL to fetch.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"url\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": true\n    },\n    {\n      \"type\":
+        \"function\",\n      \"description\": \"Delegate a self-contained task to
+        a named sub-agent and return its result.\\n\\nThe sub-agent runs in its own
+        fresh context and does not see this\\nconversation, so `task` must contain
+        everything it needs.\",\n      \"name\": \"delegate_task\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"agent_name\": {\n            \"description\":
+        \"Name of the sub-agent to run. Must be one of the agents\\nlisted in the
+        instructions.\",\n            \"type\": \"string\"\n          },\n          \"task\":
+        {\n            \"description\": \"The complete, self-contained instruction
+        for the sub-agent.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"agent_name\",\n          \"task\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": true\n    },\n    {\n
+        \     \"type\": \"function\",\n      \"description\": \"Read a slice of a
+        spilled tool result.\",\n      \"name\": \"read_tool_result\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"handle\": {\n            \"description\":
+        \"The handle from the overflowed tool return.\",\n            \"type\": \"string\"\n
+        \         },\n          \"offset\": {\n            \"default\": 0,\n            \"description\":
+        \"Number of matching lines to skip from the start (or end). Must be >= 0.\",\n
+        \           \"type\": \"integer\"\n          },\n          \"limit\": {\n
+        \           \"default\": 200,\n            \"description\": \"Maximum number
+        of lines to return (>= 1; clamped to a built-in cap).\",\n            \"type\":
+        \"integer\"\n          },\n          \"from_end\": {\n            \"default\":
+        false,\n            \"description\": \"Count `offset`/`limit` from the end
+        of the result.\",\n            \"type\": \"boolean\"\n          },\n          \"pattern\":
+        {\n            \"default\": null,\n            \"description\": \"Optional
+        literal substring; only lines containing it are returned.\",\n            \"anyOf\":
+        [\n              {\n                \"type\": \"string\"\n              },\n
+        \             {\n                \"type\": \"null\"\n              }\n            ]\n
+        \         }\n        },\n        \"required\": [\n          \"handle\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": false\n    },\n
+        \   {\n      \"type\": \"web_search\",\n      \"return_token_budget\": \"default\",\n
+        \     \"search_content_types\": [\n        \"text\"\n      ],\n      \"search_context_size\":
+        \"medium\",\n      \"user_location\": {\n        \"type\": \"approximate\",\n
+        \       \"city\": null,\n        \"country\": \"US\",\n        \"region\":
+        null,\n        \"timezone\": null\n      }\n    }\n  ],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 0.98,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n
+        \   \"input_tokens\": 33077,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\":
+        597,\n      \"cached_tokens\": 32437\n    },\n    \"output_tokens\": 68,\n
+        \   \"output_tokens_details\": {\n      \"reasoning_tokens\": 0\n    },\n
+        \   \"total_tokens\": 33145\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       access-control-expose-headers:
       - X-Request-ID
@@ -2686,8 +2963,6 @@ interactions:
       - a2b2f34c8bf5a619-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-type:
       - application/json
       date:
@@ -3412,105 +3687,210 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: !!binary |
-        i/8PAMSvXjX798/XK9BJKAIil1Tixd3MjSpLznCRTUwDaGvQA08PRMHH87+W6vDgoMAAFgCD+vAw
-        /P7+BXc+AxX380xOlmZydtrJpe+uXE6pkpHi9OZSsZRSKoHBclBs5DAHBjExaFvionepRAiy0GlJ
-        7hf831dAJi7bIItsw27BF9fN9Wq9pGc3l9dX68Xikq6a6/XVor6s19fLm0ta1c9qt1xdcl3fNNeU
-        zb8CsnD4k+uUbZC11cr28TPM34HdjlK2wfLq+vJqvby+enbeFpYojcZNtN3HDLfn9sk2aMgb7+Jn
-        yO9tsw1aXhaQDTRxzDbIbrFozb4C/l85F6v/3HSzWBblGEPMNtDR+/LftYn818haT7uBlXyasg0W
-        5WK/Ih7OLq1blp2tDUQy2yDLbFeNeZs2+wl5BtfQRTqKtqiD1n40CWplpT8wuXVGLmphjDUbMhXL
-        9HIhrPFeDm4IrxxAsqz09tHwDiQ4SeqQS66TJEryWOACZaUvJTFWe98HDdVpJF/SAjhK6kCYeKxo
-        wYfAiz6Ulb4SS6LtKNbttVwJ6rxd/6spjBHhqBBtOLLWXFZa6a9hRE0Kx55bSgxj3zyKfhGHRPZg
-        WKzkHxjDxkNBLWsy6EVn/+HbdonsYY8Ugi/xmuoOcVSDKCRZA25oIls34dXIU6KDlKEbjBnptRdY
-        naCPHI2SBJ3DAgYyA/NfCElYiCU6scjzRxJPB9++jptKC0TOltjGcYMf/l8AwgxsLXcGC1oWXluB
-        hiMf2iXTMKhroySyszJHq1XS28b8y+7paRfGNIxpl8IDK7P9lp6edikEv6vJs+Gn9cGxzzbI2iEV
-        F+VlYcFne61IBI1tqRov2+B3WSKJkrrgDHtrP2xeNuuLZ17z5Wp1dbO4Wl1dLWh9/QYleWka+PME
-        bEYt7xySzOMADGdIG6Y1Ti+aOnBgl/gpFY+DFO05qWUb/P7HAdPzoR1iOHxBYf9sg2w2w93Y9xSn
-        SivN85e3U+qCYlUuV5jF7QLs0ERmvJQEizjRFmRYeMdDB47Ssybyc+hvBxkYckt8/uk1+vDIDpKQ
-        Am5f3+JqscLQkTG22w3sT9xPqqCGXUaSKVgS75EpPEqeibBZ1ggRTaaOcXPcrfB2+7F45kyVa85D
-        8hzV+GyxrO8qwCbXQVroMampJatWXT6btCpjNz+/3RqytS81qInjyA6WW0am2nxqEyKCtkG0xWj8
-        jzeQzGCea0h5XgGpORMhJxaDhiPa788xqkjwqns/oSFLHOcIEXXoB0py8JM9Jg33EH5KrCZBcSul
-        V+L730fP+7mj1M93vDF85uMf33cpDbY5P3ehtnIYnHcoQ2zPV+VydX7sKJnycYthLh5psyYyF2Oe
-        YFfUZ3lnc/xOsxGrYvv1hrV3NsfvnJBzdXP+ngMPf2vgoVhcXd2cn51VWukJzyMTTrx1hNWmwWuc
-        Kj0VRfH3sis94ROlMUqacMJrpjXxYg5O97ZuxfgNNUXxatiIzdpwwufwDxwQF0vGAxXpnnDHsPae
-        mJ1W5XKV9qdnOmSb9cBKT7gTbf2grCnCI8eOyeGE54cwJqwX3yAo9sMEdYrvccIPYWw7P2E5YpdZ
-        XX8zv3GGcVIKokilS1LhuVCPwk29OFDpCa857tTnL7Ytj6T95hUgdTh2zN5wwp2kZjwOnYM89Tv/
-        KL0kdqXX/KgjABHTGVLhfKWq8HgSitZKUSSFcWMJnPCJJhwpCnosstIohbfbjzjhjnpuorbClQGQ
-        vg8xEdRGEZ5OCAjQwZ2l5QkbTvgULPkJeLfpH/D9S0sBdXDaJJFIk0nk21t9B0vRTqLutjeRej4o
-        mDhSCrHHD+QoYTTUMZiJaDqMGk5TVWQMLsQJH7fIpD6kU9X11gYR2VIUBAdN9CqKMRw54lRppbOZ
-        2NCm7JnYZW9Uf3qlld53LJBTi+yZjBkIxtuo//Ly3ICk8nyOyV1LB6QaWjw0KUgwWW+KahiNI7bq
-        z08D1wmHEWH4BBsPJL5JyMNEp5AdJKQKqFfO55pvGM41uFJZWDLuBHTwPMf0o8fzfpLi/BA3ruuS
-        n3iviO0zusfEjKg+JwZA4wvFT3B2ID8qqQkVqobjUSEm0XYOrkOuarY1JcRLmnAM8YHyReqgKQbv
-        2e3o4AM5K5Uo9zNAdc1DInBH8hYQGQm7HSMxM5XthwYxeDYEFANOLI4Dkp9woJgMUyknW9xS4vvf
-        axuWwdi4WJkYd8z1BlswqvAqrbQr7tUNvEqTzuGy9qeAPLcD8TwHEENAMGE4njpW8kvcd0w9ML3S
-        1QDEYGNxz2RNfkIjSl7+Zjf3ASQaiYwGQQgOEYs+hNShGdMYOXwC3EICQuqH836DtJziG+0Yb3V9
-        Ne6cfIskAwPpakheGuCSR84xT/iPrMLjTbB/HE/1ZH4INnH8YP8hMj14O7DaKmM3iLYgS47ySEEC
-        59YgP0sM/DR4qSX5Cc6Vi9YJGrLVvsS2xBsdRHoRSFYCTLK5aaQOHTlWomtLdAjRiVKc3gsmc0s8
-        H4ALbl/fYpbmkQM7WvTN6+mB8a+CVEey25UBvgCn3DzferKNmzwf2wIxxMGgPfjpCRdIULwWICkJ
-        itmWE4qYiLUWNkTEOJZEZIRTKNSFg0gRA3bYrmIDRfKevVjPcjExxD+hhgRCsEbVUjcXR3H8rqEJ
-        sUInDBOsamCInDi6uSVmM2zVEnlvk1KkDtGhwZVW+iKkDhMBgHlBB4oZ9YwDmdTwNjttKq20gIkB
-        9FR/uZNEjjzaUlMDR4sLsJqJ+2mvCcwEDqIUJWzRWODONQbuo4a8bF+e10EbacfIKIrnW/hFK35/
-        lj61ExM6YquFRpD/1BhH9cSjqcM4bF0pClFqf/vr/bsvn3dvtx9NWnPxC6pJ7G2ydrSWLafdf396
-        90jx+yq7nXZvtx93r7Z3z198fP2qys7wr39huUdS/0gjJlU1Y0HRtqhp8J8Ab2U1/cud2K4VvzP8
-        ie/P9ggk5BoCkeiBLwaqzYU6yXuGrkp+QBQc2/b2jTxVxoCINbF8qy9giEHju6It+AcVA9xLAoFF
-        KlD7LVolTf7dvPvy8/0XQz+FLhxTOK+1qlB07BxBJIdZ4G6u4Tv1vu9GmyOO2g2DlyEjSDLMTPE4
-        GG2iqdSW5bzdfiyayLwBaQFrIlXRFKVtOaIh7yM/SoQfaE1T0rEmhP1oSKcQmqbE60NEoKogNE0j
-        oUYXJ8WoRg2P64DI5AqjxgOuAAKWPUsdF60PB/KFVlm48KF+KESLs2PshpGIDgxd5M8QIf0Qw6Om
-        OsIGjmqfWiutdAuvrTlp9NI1jdYMMd8swi4OsyrDEMOT9JTYT8jz9eIb2IufEs/zyJzRMWy1URIj
-        kWBPorCkt8kAFECMC+SaDTzy8rcwNTkaRE9pVMuRDLrJdjIZoyTfFSMZR5ph+W0LZvRjZh+WFcpE
-        9MiRWnai0yNpK9oiBiNFraVjTbq+6PPnse4u10gB17tW6On6srhc46Po+JTnrrU0fgQo1lN0R4os
-        OlyyRMWGNJexaHTNOZJTuMgjz6hZuD4l/LkXWonP/MgxdezZbB7MbqTIzMRkjdgcNIVJm1zchIgr
-        QFl4HFNTiVsI0Ac2MLtxgJykXRKGoKFuW0PZkqjkFjTOoYH/pjo4CMy2QqqnQcIGz/SorCW3HmMp
-        qcKtT/fScJIeaHP62+opgECwwpqFoMqqtNKfO1aQ4oodgxzOgRux+dFqHKGZDVfflPiB8d5RgTY6
-        98GNnosFTMirbxGb7/Y4dYEgnFs5GuIuhBgoMiGORTEUS6AiQ3iYV0z4xJB/TWPwf7QtJrV/cUMU
-        bbG0Btsfz3EKRwIXCPHDjNPmhu/P9pcWkndj3bUGDKMtFK43HJP3oaYQb54FphB+RtBNSr3UyImu
-        pIWxtHjRm/CcGIiNUgfIYCOoALdkUB00iY48gDIlcwUpJlNkiA0AuCO01uxjr+cxJOBtisLASRDw
-        0hAhUpmCx8aZf3FJ3dRUIs10JSk1Dp5Ha+f/0BZ6kelr433HF++M3EqYOSc0I8A0J6dTsCVMgVxl
-        Bi78aWu+ZytQCSovM8HtTwOcNxrmHXhgdNJ2HJ30I+GRQOpi/uMR825RVuRRYKEXHBe9pFInMSiQ
-        ZFHMZ3dMg83x1yhsNWsqjGd1kX1bsFogcu2pJx1ppmcehIzdHI4bjpEd4zYNHG28hQubB1hrLham
-        AQyarDvu3W5xfTGHJvGBAq0c8vbVOjIZu0Jg2orRqLWt3myGz9o2VKAuNdgoPSi2GBxNU0AaR+oY
-        5AnoLZGGjLZLkJmFXO1CNtI+jT5JEfBircae2ov3t9OuD27Xit/DfEhqKXA77T59eeWl9Pn85X73
-        493rV27NvjvR1htxAQJAVlOr/3xehLY0O31Lbb89yLRMx0Jk0SCpyXgO+b818/l6UWcq3CexJHZT
-        2rsSHdOfWegkKeRSVkegCGyBpW99rUjcCVkbYz3fP+/dytAQYRhfRz0qsbv5Mf/NoErsvy4b7n+T
-        vf/4pat8tobvNpAco1KVouYkLpZE6GQn5i7KEkdXogQVjTydeEG1LR5ArIVTv4AkmiOGDErb6UXb
-        gcJYrkLMjXEU4bkK2poK7QzRlJLnL2qiHnNPFdnDmZOwUTAYY1r0xm8AS4tDDwRz14vnHLvEvlx6
-        AOLtQQ4Pr6S5qGGv65c/PgJ9YXoRgj5S6qwm4QocZWBhi1lgfOIFONo9SBwOwJW5Ydwyin6lqzs1
-        SwOj5I5qwnm/AuJkyUDJRQ5jwXr2YIKokKmfaskN8rvmx/wmBvPf6MJu3mrSA4DNILuhI0j07Pj1
-        REHOHm5phhGnImBJuljqjmMAwr/vjZStXjyAEkiA1gotHsouNz0T25AB1aG5uFhsoUpT+RI0UDn8
-        2jvmVC9hHu7wcBwkRfzey1cfUQlIKYDpSKzRzMrFwsgpiTH1QokquRebuCXQ4orBq9gCsDOsZ4Fo
-        0RTUOadcZk6YO8gDGwhyXzNew8sfH4ElJ3YPXr76yN9IhP0oucaidCYzf5/gTNBgG7cNkhTPoKmO
-        ImEwSpsNxVg2CHdu1TBB9S2H8Ex1z1LbQLEzNFTLmqxSxeGRD+FdcsDFnDQN8wh482OGm+JhCNGv
-        tKVGfaUaozFmEgXS4y+aLgZrKmhSVGvchK5GyZoxDT3ry5hMTeMCLvuK8xDmYNqlQWI71PRFBVQ0
-        TCiLaB84eOEojVlwtnBN2UwwvOhr6Ps7alC4mgrAJqXFuxZfOByQQ7lzHxnqZ4POOQzC2ek1EiJR
-        FyxPKRNniDl00QZMjaYaoVXgNf+K4gFa9N/YfAtssxUP3lPyexgOA0xESi7XMjhxLoJGHnJbg0eW
-        F0dHfjXlCAitMBTGUU00cx/FFtXa5u9VbOqntLegPH7cxb0gqMbciXhTK4VLVP9zpE2vigaHFRLn
-        IZBoGYLzOi4R53xmDniJ0nFR/1LQNxyyEQ9yMCogdMjPSo5HZhFEhaQw+wwNuWvRKxVc/heEx4E/
-        5J4vfXm9easpwlnI4++QQAaxAJ7DeNGWsXcfye01xf/JoveJAyZt4GrMQkz7Q6oMfOsP8x4uBNGs
-        VjsoA8gT1O3bQv3QUjxHMJ96xWY8QoqZDnp8+zaRoent2yQ2BxjCIVzCSIWODtx2dE5CIC6jiEEV
-        PdsAAadKRipPyPC20P5D8dMwwSHzMXfGnetJOBM8NA8vgHAi+YWdzjNL9hLzNFXFIZTb8tK3tGUR
-        XwOoVRUw2JDmboM9IKqxMDWOgOiuPROO5JI4ciQl03G6hJQT448MGuTLmVDMdDVL6tmrEgKSQ4CY
-        HfgfdQuZx1XCIYGB6LItV0Fmz8dwqow71SJgaEjgrGXM1IWVEdYjIVsYf9mJJG3o6KwCils6QSiP
-        38gy/iFEabIB1POuAtPtX3COIxA2nIZbvjKZkViMRzR3c6wGTLRwJM7gRDAVXqfnYtq77hE45sBO
-        HrMeSYioqXCikt5F1UhAwvIqp7NyQpeQtfBt75kUWmV/Qko5EFcc+ssDLupp8J4n1wuJ95+bhMfJ
-        fMAwkD/QvLwiBPkOdY/AbXZDDXyXmzBJ8MSBhjoNT8lbkcwmfg/A3QTaLPcIXOZMS9KROyYtzwDg
-        n77SX0lkYdLjWB75ZKbJm5crnEu8LQscQ8l3KywxFmq81GhMN3tlUbBuN6oC1Ql6pPp/mvkL64K4
-        wUnqoeckLWtk6+/kRupiGWcAIFf67sAxlLAJi7FbCNCO2vNpccQ9+T3lrx/EPDGxX7mqFuo5Abyx
-        lFnbflKV9VL6EJ12wATnjF2bS1vru3qsYtaVSLRud6TW0+CNRrqby+gnTjSqbWYehTpKM+djyrBp
-        5KofdDA+qX7PO7IwoEeUA+kC7gH59T0T7gnyc1P38Zwy/P31ZSwxL4QJKHQfQYUR5dDx0SJRhEjl
-        OYudpxlHRTnpSK3vycIgFzU8gJEudmcQWs0EsqiAcjX/4ofwRGKRdC4L/jHPTSuoIvYE4Iqk/53R
-        ROmfgeqdGoPcqk74lzQ2QuCuWyE6/bdz2i5wAEh1R8IngaQA97+NhJOPs39oPaXOiOyT+XTPVF20
-        qBx9CN/MK6mLn7eCMeCltzrd9A2tEABgq5sBFKBfrVv25JLm//JHv5m0AjgJRbzZk00yNM+c9tLW
-        2gfNF/hOUUAJvW/eADIUVct/whik5AV8LYCRnicIK43WfzlFtTz5PIIZVKqF8A8xGFl6bKztueYr
-        JDQkx2kuV81Kl7QoIVCppGalySb/Xbh/Odjkxl6wTlJyO3Y8mJ82BEFTDMexC0GnyH19YMypU2WY
-        0ntC2M1Vwn7X1hYVIuHnJxXB1ZmehwSJRX3iY703xopkVd0n972SSYO+k+kuZMo55FsZW5JUZIoW
-        rMvdFDNRwBfpIU7SQ9L9JLjJApS7W31ydc+ewkqlu2M22s+j5Jay9DXg8Oeuw5tsVp9P+IoXcSwj
-        zLWVD2SwP3nz2VNYP4aQcJzCChfBxAXC6VYVhvTCo6eJpfl+2+xlprYMf80lGzRHNG2WTcs4Tfur
-        2c32joJ/iNSXsmVOhJnPXJb7gzE41IdvfBWolzGRGDDaHSMx7x/DnVfiYSCgloYsD1PY6t447XXY
-        DvP8vTdo1jl7+H/zmnF7jYuUsnwuKX0yP7j/FViiMSY7ISuXb3ZhqHXPbDIfNylGO9NSBKo+ut9d
-        vi3d3kqY8RSUg/NQA+8O7+ptnkjHFMeFSXrcMLfd+cK8xksKmmQXvUVJfGbd1DmpgabZaaVIXAjD
-        LLrouUQ+xJQfuL+/N+kQ2tsD288ZFke65EzF0VsM8VWAvth48tM5o9UCb4rFk4cPws2bUnJtQkfN
-        A0lquvjPEurtY7faPHhYLc4KunwXry8+SrTAa+v9zXpTreV0K+y43a62u7Oubons9usewWa3ub84
-        UwbBBHLFbrbArm+3ub++FyU3KRrQ/2gkww4N3SP4/3R2Ag==
+      string: "{\n  \"id\": \"resp_0e58f8341a296874006a7f8470c6c48196a3c2cd136ecc9f8a\",\n
+        \ \"object\": \"response\",\n  \"created_at\": 1786741872,\n  \"status\":
+        \"completed\",\n  \"background\": false,\n  \"billing\": {\n    \"payer\":
+        \"developer\"\n  },\n  \"completed_at\": 1786741901,\n  \"error\": null,\n
+        \ \"frequency_penalty\": 0.0,\n  \"incomplete_details\": null,\n  \"instructions\":
+        \"Search broadly before drawing conclusions.\\nRead the sources that support
+        each important claim.\\nPrefer primary and authoritative sources.\\nCite every
+        factual claim with a direct source link.\\nDistinguish sourced facts from
+        your own inference.\\n\\nYou can delegate self-contained tasks to these sub-agents
+        using the `delegate_task` tool. Each runs in its own fresh context and does
+        not see this conversation, so pass everything it needs.\\n\\nAvailable sub-agents:\\n-
+        researcher: Research a focused sub-question on the web and report back with
+        findings and source links\",\n  \"max_output_tokens\": null,\n  \"max_tool_calls\":
+        null,\n  \"model\": \"gpt-5.6-sol\",\n  \"moderation\": null,\n  \"output\":
+        [\n    {\n      \"id\": \"msg_0e58f8341a296874006a7f8471f45481968e63379073770a48\",\n
+        \     \"type\": \"message\",\n      \"status\": \"completed\",\n      \"content\":
+        [\n        {\n          \"type\": \"output_text\",\n          \"annotations\":
+        [],\n          \"logprobs\": [],\n          \"text\": \"## Summary\\n\\n**CPython
+        3.13 introduced free threading as an experimental, separate build. CPython
+        3.14 moved it to PEP 703 phase II: officially supported, but still optional
+        and still separate from the default GIL-enabled build.** \\u201cSupported\\u201d
+        in 3.14 means the core design and APIs are considered stable enough for ongoing
+        use; it does **not** mean that free threading is now the default, universally
+        faster, or compatible with every extension package. ([3.13 What\\u2019s New](https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython),
+        [3.14 What\\u2019s New](https://docs.python.org/3.14/whatsnew/3.14.html),
+        [PEP 779](https://peps.python.org/pep-0779/))\\n\\n| Area | CPython 3.13 |
+        CPython 3.14 |\\n|---|---|---|\\n| Maturity | Experimental, PEP 703 phase
+        I | Officially supported, PEP 703 phase II |\\n| Default build | No | No |\\n|
+        Distribution | Separate `python3.13t` build | Separate `python3.14t` build
+        |\\n| Single-thread overhead | About 40% on `pyperformance` | Roughly 1\\u20138%,
+        depending on platform in current 3.14 documentation |\\n| Extension ABI |
+        Separate `t` ABI and wheels | Still separate `t` ABI and wheels |\\n| Stable/Limited
+        ABI | Unsupported for free-threaded extensions | Still unsupported |\\n| Unsupported
+        extension behavior | May warn and re-enable GIL | Same |\\n| Broad immortalization
+        | Many object categories | Mostly eliminated; limited to code constants and
+        interned strings |\\n| Frames and iterators | Serious cross-thread safety
+        limitations | Limitations remain, but frame restriction is narrower |\\n\\n##
+        Maturity\\n\\n### CPython 3.13: experimental\\n\\nThe 3.13 release documentation
+        calls free threading **experimental**, says it is not enabled by default,
+        and warns users to expect bugs and a substantial single-threaded performance
+        penalty. It requires a different executable, generally `python3.13t` or `python3.13t.exe`.
+        ([3.13 What\\u2019s New](https://docs.python.org/3.13/whatsnew/3.13.html#free-threaded-cpython))\\n\\nThis
+        phase was primarily appropriate for experimentation, extension porting, ecosystem
+        compatibility work, and controlled workloads. PEP 703\\u2019s acceptance also
+        retained the possibility of rolling back disruptive parts of the design. ([PEP
+        703](https://peps.python.org/pep-0703/))\\n\\n### CPython 3.14: supported,
+        but optional\\n\\nPEP 779 advanced free-threaded CPython to **phase II** in
+        3.14: officially supported rather than experimental. The PEP says the design
+        is sufficiently finalized, its APIs are usable and stable, and future changes
+        are expected to follow the normal PEP 387 compatibility policy. It also notes
+        that 3.14 added convenience and replacement APIs without breaking the 3.13
+        free-threading APIs. ([PEP 779](https://peps.python.org/pep-0779/))\\n\\nPhase
+        II is explicitly distinct from phase III. Free threading remains an optional
+        build and has not replaced ordinary GIL-enabled CPython. A future PEP would
+        be needed to make it the default. ([PEP 779](https://peps.python.org/pep-0779/),
+        [3.14 What\\u2019s New](https://docs.python.org/3.14/whatsnew/3.14.html))\\n\\n**Inference:**
+        3.14 is reasonable for production adoption when dependencies have been validated
+        and the workload benefits from thread parallelism. It is still not a transparent,
+        ecosystem-wide replacement for the ordinary interpreter.\\n\\n## Installation
+        and operation\\n\\nBoth versions use the same basic model:\\n\\n- Official
+        macOS and Windows installers can optionally install free-threaded binaries.\\n-
+        Source builds use `./configure --disable-gil`.\\n- The free-threaded executable
+        can still run with the GIL enabled using `PYTHON_GIL` or `-X gil`.\\n- `sysconfig.get_config_var(\\\"Py_GIL_DISABLED\\\")
+        == 1` identifies a free-threading-capable build.\\n- `sys._is_gil_enabled()`
+        reports whether the GIL is active in the current process.\\n- Importing an
+        extension that has not declared free-threading support can emit a warning
+        and re-enable the GIL. ([3.13 HOWTO](https://docs.python.org/3.13/howto/free-threading-python.html),
+        [3.14 HOWTO](https://docs.python.org/3.14/howto/free-threading-python.html))\\n\\nThus,
+        running `python3.14t` does not guarantee that the process remains GIL-free:
+        a dependency can trigger fallback unless the user explicitly forces the GIL
+        off. Explicitly forcing it off does not make an unsafe extension thread-safe.
+        ([3.14 HOWTO](https://docs.python.org/3.14/howto/free-threading-python.html#the-global-interpreter-lock-in-free-threaded-python))\\n\\n##
+        Major improvement: single-thread performance\\n\\nIn 3.13, the free-threaded
+        interpreter is documented as approximately **40% slower** on the `pyperformance`
+        suite. The main stated reason is that the specializing adaptive interpreter
+        was disabled in that build. ([3.13 HOWTO](https://docs.python.org/3.13/howto/free-threading-python.html#single-threaded-performance))\\n\\nThe
+        current 3.14 documentation reports average overhead ranging from approximately
+        **1% on macOS AArch64 to 8% on x86-64 Linux**, depending on workload and hardware.
+        ([3.14 HOWTO](https://docs.python.org/3.14/howto/free-threading-python.html#single-threaded-performance))\\n\\nThis
+        is the most substantial practical improvement between the releases. Nevertheless,
+        these are suite averages, not a guarantee for an individual application. Parallel
+        speedup also depends on contention, workload design, native code, and whether
+        dependencies leave the GIL disabled.\\n\\n## Major improvement: object lifetime
+        and memory behavior\\n\\n### 3.13\\n\\nWhen an additional thread starts, 3.13
+        immortalizes numerous categories, including:\\n\\n- module-level functions,\\n-
+        method descriptors,\\n- code objects,\\n- modules and module dictionaries,\\n-
+        classes,\\n- numeric and string literals,\\n- strings interned with `sys.intern()`.\\n\\nSuch
+        objects are never deallocated, so applications that dynamically create many
+        modules, functions, or classes can experience continued memory growth. ([3.13
+        HOWTO](https://docs.python.org/3.13/howto/free-threading-python.html#immortalization))\\n\\n###
+        3.14\\n\\nIn 3.14, immortalization is restricted to:\\n\\n- code constants,
+        including numeric, string and qualifying tuple literals;\\n- strings interned
+        through `sys.intern()`.\\n\\nThe broad 3.13 immortalization of modules, classes
+        and functions was therefore removed. ([3.14 HOWTO](https://docs.python.org/3.14/howto/free-threading-python.html#immortalization))\\n\\nMemory
+        use can still be higher in 3.14 because of larger headers for some objects,
+        mimalloc and its separate heaps, quiescent-state-based memory reclamation,
+        and biased, deferred, or per-thread reference-counting schemes that can delay
+        deallocation. ([3.14 HOWTO](https://docs.python.org/3.14/howto/free-threading-python.html#increased-memory-usage))\\n\\n##
+        Native-extension limitations\\n\\nBoth releases require extensions to explicitly
+        declare that they support GIL-free execution:\\n\\n- Multi-phase modules use
+        the `Py_mod_gil` slot with `Py_MOD_GIL_NOT_USED`.\\n- Single-phase modules
+        use `PyUnstable_Module_SetGIL()`.\\n- Otherwise, importing the module warns
+        and enables the GIL. ([3.13 extension HOWTO](https://docs.python.org/3.13/howto/free-threading-extensions.html#module-initialization),
+        [3.14 extension HOWTO](https://docs.python.org/3.14/howto/free-threading-extensions.html#module-initialization))\\n\\nDeclaring
+        support is not sufficient by itself. Extensions may need to:\\n\\n- protect
+        mutable global or module state;\\n- avoid direct access to concurrently mutable
+        C-API structure fields;\\n- replace unsafe accessor macros with locking APIs;\\n-
+        replace borrowed-reference access with strong-reference APIs where concurrent
+        removal is possible;\\n- protect `PyDict_Next()` iteration with a critical
+        section;\\n- obey stricter allocator-domain requirements;\\n- continue using
+        thread-state APIs even though the GIL is disabled. ([3.14 extension HOWTO](https://docs.python.org/3.14/howto/free-threading-extensions.html))\\n\\nThe
+        free-threaded build still has a separate ABI identified by the `t` suffix.
+        Native extensions and wheels must be built specifically for it. The 3.14 free-threaded
+        build still does **not** support the Limited C API or Stable ABI, so projects
+        cannot yet use one `abi3` binary across ordinary and free-threaded CPython
+        builds. ([3.13 extension HOWTO](https://docs.python.org/3.13/howto/free-threading-extensions.html#building-extensions-for-the-free-threaded-build),
+        [3.14 extension HOWTO](https://docs.python.org/3.14/howto/free-threading-extensions.html#building-extensions-for-the-free-threaded-build))\\n\\n##
+        Python-level concurrency limitations\\n\\nIn both versions, built-in containers
+        such as `dict`, `list`, and `set` use internal locking. However, CPython explicitly
+        describes this as current implementation behavior, not a language guarantee
+        for concurrent mutation. Programs should use `threading.Lock` or other explicit
+        synchronization rather than depending upon incidental container locking. ([3.13
+        HOWTO](https://docs.python.org/3.13/howto/free-threading-python.html#thread-safety),
+        [3.14 HOWTO](https://docs.python.org/3.14/howto/free-threading-python.html#thread-safety))\\n\\nSharing
+        a single iterator concurrently remains unsafe in 3.14: threads may observe
+        duplicate or missing elements. The 3.13 documentation additionally warns that
+        this may crash the interpreter. ([3.13 HOWTO](https://docs.python.org/3.13/howto/free-threading-python.html#iterators),
+        [3.14 HOWTO](https://docs.python.org/3.14/howto/free-threading-python.html#iterators))\\n\\nFrame
+        handling improved but remains hazardous:\\n\\n- In 3.13, accessing frame objects
+        from another thread is generally unsafe and may crash, making `sys._current_frames()`
+        generally unsafe.\\n- In 3.14, the documented restriction is narrower: accessing
+        `frame.f_locals` while that frame is executing in another thread may crash
+        the interpreter. ([3.13 HOWTO](https://docs.python.org/3.13/howto/free-threading-python.html#frame-objects),
+        [3.14 HOWTO](https://docs.python.org/3.14/howto/free-threading-python.html#frame-objects))\\n\\n##
+        Bottom line\\n\\n- **3.13:** an experimental technology preview with severe
+        single-thread overhead, broad immortalization, distinct extension requirements,
+        and several known crash-prone edge cases.\\n- **3.14:** a supported optional
+        configuration with much better single-thread performance, substantially improved
+        object-lifetime behavior, and stabilized APIs.\\n- **Still unresolved in 3.14:**
+        incomplete package compatibility, GIL fallback caused by unsupported extensions,
+        separate native wheels, no free-threaded Stable ABI, greater memory consumption,
+        unsafe concurrent iterator/frame operations, and the need to redesign or synchronize
+        code rather than assuming existing threaded programs will automatically scale.\"\n
+        \       }\n      ],\n      \"phase\": \"final_answer\",\n      \"role\": \"assistant\"\n
+        \   }\n  ],\n  \"parallel_tool_calls\": true,\n  \"presence_penalty\": 0.0,\n
+        \ \"previous_response_id\": null,\n  \"prompt_cache_key\": null,\n  \"prompt_cache_retention\":
+        \"24h\",\n  \"reasoning\": {\n    \"context\": \"all_turns\",\n    \"effort\":
+        \"none\",\n    \"mode\": \"standard\",\n    \"summary\": null\n  },\n  \"safety_identifier\":
+        null,\n  \"service_tier\": \"default\",\n  \"store\": true,\n  \"temperature\":
+        1.0,\n  \"text\": {\n    \"format\": {\n      \"type\": \"text\"\n    },\n
+        \   \"verbosity\": \"medium\"\n  },\n  \"tool_choice\": \"auto\",\n  \"tool_usage\":
+        {\n    \"image_gen\": {\n      \"input_tokens\": 0,\n      \"input_tokens_details\":
+        {\n        \"image_tokens\": 0,\n        \"text_tokens\": 0\n      },\n      \"output_tokens\":
+        0,\n      \"output_tokens_details\": {\n        \"image_tokens\": 0,\n        \"text_tokens\":
+        0\n      },\n      \"total_tokens\": 0\n    },\n    \"web_search\": {\n      \"num_requests\":
+        0\n    }\n  },\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"description\":
+        \"Fetches the content of a web page at the given URL and returns it as markdown
+        or binary content.\",\n      \"name\": \"web_fetch\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"url\": {\n            \"description\":
+        \"The URL to fetch.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"url\"\n        ],\n        \"type\":
+        \"object\"\n      },\n      \"strict\": true\n    },\n    {\n      \"type\":
+        \"function\",\n      \"description\": \"Delegate a self-contained task to
+        a named sub-agent and return its result.\\n\\nThe sub-agent runs in its own
+        fresh context and does not see this\\nconversation, so `task` must contain
+        everything it needs.\",\n      \"name\": \"delegate_task\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"agent_name\": {\n            \"description\":
+        \"Name of the sub-agent to run. Must be one of the agents\\nlisted in the
+        instructions.\",\n            \"type\": \"string\"\n          },\n          \"task\":
+        {\n            \"description\": \"The complete, self-contained instruction
+        for the sub-agent.\",\n            \"type\": \"string\"\n          }\n        },\n
+        \       \"required\": [\n          \"agent_name\",\n          \"task\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": true\n    },\n    {\n
+        \     \"type\": \"function\",\n      \"description\": \"Read a slice of a
+        spilled tool result.\",\n      \"name\": \"read_tool_result\",\n      \"output_schema\":
+        null,\n      \"parameters\": {\n        \"additionalProperties\": false,\n
+        \       \"properties\": {\n          \"handle\": {\n            \"description\":
+        \"The handle from the overflowed tool return.\",\n            \"type\": \"string\"\n
+        \         },\n          \"offset\": {\n            \"default\": 0,\n            \"description\":
+        \"Number of matching lines to skip from the start (or end). Must be >= 0.\",\n
+        \           \"type\": \"integer\"\n          },\n          \"limit\": {\n
+        \           \"default\": 200,\n            \"description\": \"Maximum number
+        of lines to return (>= 1; clamped to a built-in cap).\",\n            \"type\":
+        \"integer\"\n          },\n          \"from_end\": {\n            \"default\":
+        false,\n            \"description\": \"Count `offset`/`limit` from the end
+        of the result.\",\n            \"type\": \"boolean\"\n          },\n          \"pattern\":
+        {\n            \"default\": null,\n            \"description\": \"Optional
+        literal substring; only lines containing it are returned.\",\n            \"anyOf\":
+        [\n              {\n                \"type\": \"string\"\n              },\n
+        \             {\n                \"type\": \"null\"\n              }\n            ]\n
+        \         }\n        },\n        \"required\": [\n          \"handle\"\n        ],\n
+        \       \"type\": \"object\"\n      },\n      \"strict\": false\n    },\n
+        \   {\n      \"type\": \"web_search\",\n      \"return_token_budget\": \"default\",\n
+        \     \"search_content_types\": [\n        \"text\"\n      ],\n      \"search_context_size\":
+        \"medium\",\n      \"user_location\": {\n        \"type\": \"approximate\",\n
+        \       \"city\": null,\n        \"country\": \"US\",\n        \"region\":
+        null,\n        \"timezone\": null\n      }\n    }\n  ],\n  \"top_logprobs\":
+        0,\n  \"top_p\": 0.98,\n  \"truncation\": \"disabled\",\n  \"usage\": {\n
+        \   \"input_tokens\": 40289,\n    \"input_tokens_details\": {\n      \"cache_write_tokens\":
+        7212,\n      \"cached_tokens\": 33034\n    },\n    \"output_tokens\": 2427,\n
+        \   \"output_tokens_details\": {\n      \"reasoning_tokens\": 0\n    },\n
+        \   \"total_tokens\": 42716\n  },\n  \"user\": null,\n  \"metadata\": {}\n}"
     headers:
       access-control-expose-headers:
       - X-Request-ID
@@ -3524,8 +3904,6 @@ interactions:
       - a2b2f3600b25a619-DFW
       connection:
       - keep-alive
-      content-encoding:
-      - br
       content-type:
       - application/json
       date:

--- a/tests/test_cassettes.py
+++ b/tests/test_cassettes.py
@@ -24,8 +24,26 @@ from vcr.serializers import yamlserializer  # pyright: ignore[reportMissingTypeS
 
 _ROOT = Path(__file__).parent.parent
 
-# What httpx decodes from the standard library alone; everything else needs a package.
+# `httpx._decoders.SUPPORTED_DECODERS` minus the two entries it pops when their
+# optional package is absent: `br` needs `brotli`/`brotlicffi`, `zstd` needs
+# `zstandard`. An encoding it cannot look up falls through to `IdentityDecoder`,
+# which is what leaves a compressed body sitting in `Response.content`.
 _STDLIB_ENCODINGS = frozenset({'gzip', 'deflate', 'identity'})
+
+
+def _optional_encodings(header_value: str) -> list[str]:
+    """The encodings in one `Content-Encoding` value that httpx cannot decode from the stdlib.
+
+    Normalizes the way httpx does -- it reads the header with `split_commas=True`
+    and then `.strip().lower()` -- so `gzip, deflate` is two stdlib decoders rather
+    than one unrecognized encoding.
+    """
+    optional: list[str] = []
+    for part in header_value.split(','):
+        encoding = part.strip().lower()
+        if encoding and encoding not in _STDLIB_ENCODINGS:
+            optional.append(encoding)
+    return optional
 
 
 class _Request(BaseModel):
@@ -64,11 +82,19 @@ def test_cassette_replays_without_an_optional_decompressor(path: Path) -> None:
     needs = [
         f'{interaction.request.uri} responds `Content-Encoding: {encoding}`'
         for interaction in cassette.interactions
-        for encoding in interaction.response.headers.get('content-encoding', [])
-        if encoding.lower() not in _STDLIB_ENCODINGS
+        for value in interaction.response.headers.get('content-encoding', [])
+        for encoding in _optional_encodings(value)
     ]
     assert not needs, (
         '\n'.join(needs) + f'\nDecode the body in {path.name} and drop the header, or re-record it '
         'without that encoding. Relying on an optional decompressor makes the cassette depend on '
         'whichever extra a transitive dependency happens to pull in.'
     )
+
+
+def test_optional_encodings_normalizes_like_httpx() -> None:
+    assert _optional_encodings('gzip') == []
+    assert _optional_encodings(' GZIP , deflate ') == []  # a list value, and httpx lowercases
+    assert _optional_encodings('') == []  # no encoding declared is not an unknown one
+    assert _optional_encodings('br') == ['br']
+    assert _optional_encodings('gzip, zstd') == ['zstd']

--- a/tests/test_cassettes.py
+++ b/tests/test_cassettes.py
@@ -1,0 +1,74 @@
+"""Recorded responses must replay without an optional decompressor.
+
+A cassette body stored under `Content-Encoding: br` or `zstd` only decodes when
+`brotli`/`brotlicffi` or `zstandard` happens to be importable. Nothing in this
+repo asks for either: they arrive through an extra of a transitive dependency,
+so an upstream that drops that extra silently takes the decoder away. That is
+what #709 was -- `ddgs` 9.16.0 dropped `httpx[brotli, ...]`, and the two agent
+integration cassettes stopped decoding on every leg that resolves without the
+lock, while the locked matrix stayed green.
+
+`gzip`, `deflate` and `identity` come from the standard library, so a cassette
+may keep those.
+"""
+
+from __future__ import annotations as _annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import pytest
+from _pytest.mark import ParameterSet
+from pydantic import BaseModel
+from vcr.serializers import yamlserializer  # pyright: ignore[reportMissingTypeStubs]
+
+_ROOT = Path(__file__).parent.parent
+
+# What httpx decodes from the standard library alone; everything else needs a package.
+_STDLIB_ENCODINGS = frozenset({'gzip', 'deflate', 'identity'})
+
+
+class _Request(BaseModel):
+    uri: str
+
+
+class _Response(BaseModel):
+    headers: dict[str, list[str]]
+
+
+class _Interaction(BaseModel):
+    request: _Request
+    response: _Response
+
+
+class _Cassette(BaseModel):
+    interactions: list[_Interaction]
+
+
+def _cassettes() -> Iterable[ParameterSet]:
+    for directory in ('tests', 'integration_tests'):
+        for path in sorted((_ROOT / directory).glob('**/cassettes/**/*.yaml')):
+            yield pytest.param(path, id=str(path.relative_to(_ROOT)))
+
+
+def test_cassettes_discovered() -> None:
+    # Guard against a discovery break silently making the check vacuous.
+    assert sum(1 for _ in _cassettes()) >= 7
+
+
+@pytest.mark.parametrize('path', _cassettes())
+def test_cassette_replays_without_an_optional_decompressor(path: Path) -> None:
+    # `vcr`'s own loader, because a cassette can carry tags `yaml.safe_load` rejects.
+    document = yamlserializer.deserialize(path.read_text())  # pyright: ignore[reportUnknownMemberType]
+    cassette = _Cassette.model_validate(document)
+    needs = [
+        f'{interaction.request.uri} responds `Content-Encoding: {encoding}`'
+        for interaction in cassette.interactions
+        for encoding in interaction.response.headers.get('content-encoding', [])
+        if encoding.lower() not in _STDLIB_ENCODINGS
+    ]
+    assert not needs, (
+        '\n'.join(needs) + f'\nDecode the body in {path.name} and drop the header, or re-record it '
+        'without that encoding. Relying on an optional decompressor makes the cassette depend on '
+        'whichever extra a transitive dependency happens to pull in.'
+    )


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Closes #709

## What broke

`ddgs` 9.16.0, published 2026-08-26T21:52:32Z, dropped `httpx[brotli,http2,socks]` from its
requirements. That edge was the only thing in the dependency graph reaching `brotli`, so `test-floor`
-- which resolves without the lock, on purpose -- stopped installing a brotli decoder. httpx binds
`brotli` at module scope in `_decoders.py` and falls back to `None` when neither it nor `brotlicffi`
imports, so a recorded `Content-Encoding: br` body replays as raw brotli and `Response.json()` raises
`UnicodeDecodeError`.

Repo-wide, not branch-specific: `main` and every open PR hit it on their next `test-floor` run. The
locked `test` matrix is unaffected, because `uv.lock` still pins `ddgs` 9.14.4. Full evidence in
#709.

## The fix

Decode the 25 brotli bodies in place and drop the header, rather than declaring the decoder.

Which optional extras a transitive dependency happens to pull in is not something these tests should
rest on, and adding `brotli` to the `dev` group would leave them one upstream change away from the
same break. The bodies are all `application/json`, so they now store as readable text instead of
`!!binary` blobs. The one remaining encoded response in either cassette is `gzip`, which the standard
library decodes.

`tests/test_cassettes.py` stops it recurring. Every recorded response must declare an encoding the
standard library handles -- `gzip`, `deflate`, `identity` -- so re-recording against a server that
negotiates `br` or `zstd` fails at the gate instead of passing until a resolver changes its mind.

No `pyproject.toml` or `uv.lock` change, so no `dependencies:approved`.

## Verification

The failure was reproduced locally before being fixed, by uninstalling `brotli` from the worktree
venv -- the same condition `test-floor` now resolves into:

| | cassettes as recorded | cassettes decoded |
|---|---|---|
| `brotli` uninstalled | **2 failed** (`UnicodeDecodeError`, both tests) | 2 passed |
| `brotli` installed | 2 passed | 2 passed |

- Mutation check on the new gate: run against the pre-fix cassettes it fails on exactly the two that
  carried brotli and passes on the other five.
- `tests/coder`, `tests/researcher`, `tests/media` and `tests/test_cassettes.py`: 122 passed, 1
  skipped.
- `ruff format --check .` and `ruff check .` repo-wide; `pyright tests/test_cassettes.py`.
- Focused branch coverage on `tests/test_cassettes.py`: 100%, no partial branches.

## Checklist

- [x] Linked issue exists and is referenced above.
- [x] Tests added or updated.
- [x] No changes to `pyproject.toml` or `uv.lock`.
