### PR TITLE
Support `AdvisorTool.provider_settings` across Pydantic AI versions

### DIFF
--- a/pydantic_ai_harness/advisor/_capability.py
+++ b/pydantic_ai_harness/advisor/_capability.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Literal
 
+import pydantic_ai.native_tools as native_tools
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import ModelSelection, NativeOrLocalTool
 from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior, UserError
@@ -215,7 +216,7 @@ class Advisor(NativeOrLocalTool[AgentDepsT]):
             max_tokens=self.max_tokens,
         )
         if self.caching is not None:
-            if hasattr(tool, 'provider_settings'):  # pragma: no cover - exercised with unreleased Pydantic AI
+            if hasattr(native_tools, 'AnthropicAdvisorToolSettings'):  # pragma: no cover - unreleased Pydantic AI
                 setattr(tool, 'provider_settings', {'anthropic': {'caching': self.caching}})
             else:
                 tool.caching = self.caching

--- a/pydantic_ai_harness/advisor/_capability.py
+++ b/pydantic_ai_harness/advisor/_capability.py
@@ -216,9 +216,8 @@ class Advisor(NativeOrLocalTool[AgentDepsT]):
         )
         if self.caching is not None:
             if hasattr(tool, 'provider_settings'):
-                # Compatibility with Pydantic AI versions before provider-specific native-tool settings.
                 setattr(tool, 'provider_settings', {'anthropic': {'caching': self.caching}})
-            else:
+            else:  # pragma: no cover - exercised only with older Pydantic AI versions
                 tool.caching = self.caching
         return tool
 

--- a/pydantic_ai_harness/advisor/_capability.py
+++ b/pydantic_ai_harness/advisor/_capability.py
@@ -216,9 +216,9 @@ class Advisor(NativeOrLocalTool[AgentDepsT]):
             max_tokens=self.max_tokens,
         )
         if self.caching is not None:
-            if hasattr(native_tools, 'AnthropicAdvisorToolSettings'):  # pragma: no cover - unreleased Pydantic AI
+            if hasattr(native_tools, 'AnthropicAdvisorToolSettings'):  # pragma: no cover - new-version path
                 setattr(tool, 'provider_settings', {'anthropic': {'caching': self.caching}})
-            else:
+            else:  # pragma: no cover - old-version path
                 tool.caching = self.caching
         return tool
 

--- a/pydantic_ai_harness/advisor/_capability.py
+++ b/pydantic_ai_harness/advisor/_capability.py
@@ -215,9 +215,9 @@ class Advisor(NativeOrLocalTool[AgentDepsT]):
             max_tokens=self.max_tokens,
         )
         if self.caching is not None:
-            if hasattr(tool, 'provider_settings'):
+            if hasattr(tool, 'provider_settings'):  # pragma: no cover - exercised with unreleased Pydantic AI
                 setattr(tool, 'provider_settings', {'anthropic': {'caching': self.caching}})
-            else:  # pragma: no cover - exercised only with older Pydantic AI versions
+            else:
                 tool.caching = self.caching
         return tool
 

--- a/pydantic_ai_harness/advisor/_capability.py
+++ b/pydantic_ai_harness/advisor/_capability.py
@@ -209,12 +209,18 @@ class Advisor(NativeOrLocalTool[AgentDepsT]):
         return self._advisor_tool(native_model_name)
 
     def _advisor_tool(self, model_name: str) -> AdvisorTool:
-        return AdvisorTool(
+        tool = AdvisorTool(
             model=model_name,
             max_uses=self.max_uses,
             max_tokens=self.max_tokens,
-            caching=self.caching,
         )
+        if self.caching is not None:
+            if hasattr(tool, 'provider_settings'):
+                # Compatibility with Pydantic AI versions before provider-specific native-tool settings.
+                setattr(tool, 'provider_settings', {'anthropic': {'caching': self.caching}})
+            else:
+                tool.caching = self.caching
+        return tool
 
     @staticmethod
     def _parse_native_model(

--- a/tests/advisor/test_advisor.py
+++ b/tests/advisor/test_advisor.py
@@ -79,7 +79,16 @@ class TestAdvisor:
         await agent.run('Review this plan.')
 
         assert seen[0].function_tools == []
-        assert seen[0].native_tools == [AdvisorTool(model='claude-opus-4-8', max_tokens=2048, caching='5m')]
+        assert len(seen[0].native_tools) == 1
+        tool = seen[0].native_tools[0]
+        assert isinstance(tool, AdvisorTool)
+        assert tool.model == 'claude-opus-4-8'
+        assert tool.max_tokens == 2048
+        if hasattr(tool, 'provider_settings'):
+            assert getattr(tool, 'provider_settings') == {'anthropic': {'caching': '5m'}}
+            assert tool.caching is None
+        else:
+            assert tool.caching == '5m'
 
     async def test_model_instance_uses_local_advisor_and_preserves_identity(self) -> None:
         advisor_prompts: list[str] = []

--- a/tests/advisor/test_advisor.py
+++ b/tests/advisor/test_advisor.py
@@ -85,10 +85,10 @@ class TestAdvisor:
         assert isinstance(tool, AdvisorTool)
         assert tool.model == 'claude-opus-4-8'
         assert tool.max_tokens == 2048
-        if hasattr(native_tools, 'AnthropicAdvisorToolSettings'):  # pragma: no cover - unreleased Pydantic AI
+        if hasattr(native_tools, 'AnthropicAdvisorToolSettings'):  # pragma: no cover - new-version path
             assert getattr(tool, 'provider_settings') == {'anthropic': {'caching': '5m'}}
             assert tool.caching is None
-        else:
+        else:  # pragma: no cover - old-version path
             assert tool.caching == '5m'
 
     async def test_model_instance_uses_local_advisor_and_preserves_identity(self) -> None:

--- a/tests/advisor/test_advisor.py
+++ b/tests/advisor/test_advisor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Sequence
 
+import pydantic_ai.native_tools as native_tools
 import pytest
 from inline_snapshot import snapshot
 from pydantic_ai import AdvisorTool, Agent
@@ -84,7 +85,7 @@ class TestAdvisor:
         assert isinstance(tool, AdvisorTool)
         assert tool.model == 'claude-opus-4-8'
         assert tool.max_tokens == 2048
-        if hasattr(tool, 'provider_settings'):  # pragma: no cover - exercised with unreleased Pydantic AI
+        if hasattr(native_tools, 'AnthropicAdvisorToolSettings'):  # pragma: no cover - unreleased Pydantic AI
             assert getattr(tool, 'provider_settings') == {'anthropic': {'caching': '5m'}}
             assert tool.caching is None
         else:

--- a/tests/advisor/test_advisor.py
+++ b/tests/advisor/test_advisor.py
@@ -84,7 +84,7 @@ class TestAdvisor:
         assert isinstance(tool, AdvisorTool)
         assert tool.model == 'claude-opus-4-8'
         assert tool.max_tokens == 2048
-        if hasattr(tool, 'provider_settings'):
+        if hasattr(tool, 'provider_settings'):  # pragma: no cover - exercised with unreleased Pydantic AI
             assert getattr(tool, 'provider_settings') == {'anthropic': {'caching': '5m'}}
             assert tool.caching is None
         else:


### PR DESCRIPTION
## Summary

Translate the existing `Advisor(caching=...)` convenience option to `AdvisorTool.provider_settings['anthropic']` when the installed Pydantic AI version supports it. Fall back to the legacy `AdvisorTool.caching` field on currently supported releases.

This is the coordinated harness migration for pydantic/pydantic-ai#7807. The harness API and user-facing behavior do not change.

## Linked Issue

Fixes #717

## Verification

- the full advisor test module passes against the released Pydantic AI 2.33.0 floor
- the native-advisor test passes against pydantic/pydantic-ai#7807
- repository-wide Ruff and focused Pyright pass

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] Focused lint, typecheck, and tests pass locally
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)
