### PR TITLE
Require `youdotcom>=3.1.2` and pass attribution kwargs to `You()` so outbound requests carry an `X-Client-Info` header

### DIFF
--- a/pydantic_ai_harness/youdotcom/_toolset.py
+++ b/pydantic_ai_harness/youdotcom/_toolset.py
@@ -165,14 +165,35 @@ class YouClient(Protocol):
         ...  # pragma: no cover
 
 
+def _harness_version() -> str:
+    """Resolve the installed `pydantic-ai-harness` version for the attribution header."""
+    from importlib.metadata import version as _pkg_version
+
+    try:
+        return _pkg_version('pydantic-ai-harness')
+    except Exception:  # pragma: no cover
+        return 'unknown'
+
+
 def default_client(timeout_ms: int) -> YouClient:
-    """Build a `youdotcom.You` client from the `YDC_API_KEY` environment variable."""
+    """Build a `youdotcom.You` client from the `YDC_API_KEY` environment variable.
+
+    The client carries an `X-Client-Info` attribution header (SDK 3.1.2+)
+    so You.com analytics can distinguish harness traffic from other SDK callers.
+    """
     if not (os.environ.get('YDC_API_KEY') or os.environ.get('YOU_API_KEY_AUTH')):
         raise UserError(
             'The You.com capabilities need an API key: set the YDC_API_KEY environment variable, '
             'or pass a configured client, e.g. YouSearch(client=You(api_key_auth=...)).'
         )
-    return You(api_key_auth=None, timeout_ms=timeout_ms)
+    return You(
+        api_key_auth=None,
+        timeout_ms=timeout_ms,
+        app_name='pydantic-ai-harness',
+        app_version=_harness_version(),
+        app_title='Pydantic AI Harness',
+        app_url='https://github.com/pydantic/pydantic-ai-harness',
+    )
 
 
 def recoverable(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ exa = [
     "exa-py>=2.16.0",
 ]
 youdotcom = [
-    "youdotcom>=3.1.1,<4",
+    "youdotcom>=3.1.2,<4",
 ]
 mongodb = [
     "pymongo>=4.17.0",

--- a/tests/youdotcom/test_youdotcom.py
+++ b/tests/youdotcom/test_youdotcom.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -30,6 +31,7 @@ from pydantic_ai_harness.youdotcom import (
     YouSearch,
     YouSearchToolset,
 )
+from pydantic_ai_harness.youdotcom._toolset import default_client
 
 
 @pytest.fixture
@@ -596,6 +598,19 @@ class TestYouSearchCapability:
         monkeypatch.setenv('YOU_API_KEY_AUTH', 'legacy-key')
         toolset = YouSearch[None]().get_toolset()
         assert isinstance(toolset, YouSearchToolset)
+
+    def test_default_client_sets_attribution_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """default_client() passes app_name/app_version/app_title/app_url to You()."""
+        monkeypatch.setenv('YDC_API_KEY', 'test-key')
+        with patch('pydantic_ai_harness.youdotcom._toolset.You') as you_cls:
+            default_client(timeout_ms=60_000)
+        kwargs = you_cls.call_args.kwargs
+        assert kwargs['app_name'] == 'pydantic-ai-harness'
+        assert kwargs['app_title'] == 'Pydantic AI Harness'
+        assert kwargs['app_url'] == 'https://github.com/pydantic/pydantic-ai-harness'
+        assert isinstance(kwargs['app_version'], str) and kwargs['app_version']
+        assert kwargs['api_key_auth'] is None
+        assert kwargs['timeout_ms'] == 60_000
 
     @pytest.mark.parametrize('num_results', [0, 21])
     def test_num_results_out_of_bounds_rejected(self, num_results: int) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3996,7 +3996,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'skills'", specifier = ">=6.0.2" },
     { name = "stackone-defender", marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender'", specifier = ">=0.7.3,<0.8" },
     { name = "stackone-defender", extras = ["onnx"], marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender-ml'", specifier = ">=0.7.3,<0.8" },
-    { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.1,<4" },
+    { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.2,<4" },
 ]
 provides-extras = ["acp", "anthropic", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
 
@@ -9393,7 +9393,7 @@ wheels = [
 
 [[package]]
 name = "youdotcom"
-version = "3.1.1"
+version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpcore" },
@@ -9401,9 +9401,9 @@ dependencies = [
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/e495bf7682785e56d5687a409e23757aae1395cca3e54a8e1daa38fe1d25/youdotcom-3.1.1.tar.gz", hash = "sha256:f2008847a881a41c84016baa7ec6f3224969908fb81132398e8c1428418a9602", size = 116688, upload-time = "2026-08-12T18:23:22.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/99/77c5b7246ca4ffbb0ae0fc98757836b2a6cd114e2454e2bc73cd52c2bef0/youdotcom-3.1.2.tar.gz", hash = "sha256:73b4801203b6fca15f0531c5c34ae1dc680d2d41edf83748f572023c6137916d", size = 141929, upload-time = "2026-08-21T06:46:55.788Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/18/4a35e8ee8e37f18290a49ead01d7a5f23b8023dd328b3879a30a1d323602/youdotcom-3.1.1-py3-none-any.whl", hash = "sha256:d46e8657d4906218817c7850c6bdf2a36cda4efd75abca8c92190149193d9e1f", size = 105118, upload-time = "2026-08-12T18:23:21.462Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/bb/258571903378fc865b87b3749c460dad7a8534bbccf8c4a3873203359536/youdotcom-3.1.2-py3-none-any.whl", hash = "sha256:1ef5c66871e0fe3320d5fa0869ba59420511560648e9fb793f9c7f1e0e7d641c", size = 114867, upload-time = "2026-08-21T06:46:54.5Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bump the `youdotcom` extra floor from `>=3.1.1` to `>=3.1.2` and pass attribution kwargs (`app_name`, `app_version`, `app_title`, `app_url`) to `You()` in `default_client()`, so every outbound request from a Pydantic AI agent carries an `X-Client-Info` header that identifies the harness as the caller.

The `youdotcom` SDK shipped v3.1.2 on 2026-08-20, which added the `X-Client-Info` attribution header via `You(app_name=..., app_version=..., app_title=..., app_url=...)` constructor kwargs. The header lets the You.com analytics layer distinguish traffic by integration (SDK, MCP server, harness, etc.) without parsing `User-Agent`. Currently `default_client()` constructs `You(api_key_auth=None, timeout_ms=timeout_ms)` with no attribution, so harness traffic is indistinguishable from direct SDK calls.

Closes #723.

## What changes

1. **`pyproject.toml`**: `youdotcom>=3.1.1,<4` → `youdotcom>=3.1.2,<4` (the attribution kwargs are new in 3.1.2).
2. **`pydantic_ai_harness/youdotcom/_toolset.py`**: `default_client()` now passes `app_name='pydantic-ai-harness'`, `app_version=<resolved package version>` (via `importlib.metadata`), `app_title='Pydantic AI Harness'`, `app_url='https://github.com/pydantic/pydantic-ai-harness'` to `You()`.
3. **`tests/youdotcom/test_youdotcom.py`**: new `test_default_client_sets_attribution_header` that patches `You` and asserts the kwargs are passed.

### Wire format after this change

```
X-Client-Info: sdk; client=pydantic-ai-harness/0.26.0; title=Pydantic AI Harness; url=https://github.com/pydantic/pydantic-ai-harness; ua=python/3.11 httpx/0.28
```

The SDK validates all values at construction time: printable ASCII, no `;`, no `/` in `app_name`/`app_version`.

## Verification

- `uv run pytest tests/youdotcom/` — 70 passed
- `uv run ruff check` — all checks passed
- `uv run ruff format --check` — 2 files already formatted
- `uv run coverage run -m pytest` + `coverage report` — 100% on `_toolset.py` (154 stmts, 0 miss, 38 branches, 0 miss)
- `uv run pyright pydantic_ai_harness/youdotcom/_toolset.py` — 0 errors, 0 warnings

## Notes

- `app_version` resolves via `importlib.metadata.version('pydantic-ai-harness')` at call time, falling back to `'unknown'` if the package metadata is unavailable (editable installs, etc.).
- The `YouClient` protocol and all capability/toolset classes are unchanged — only `default_client()` is affected.
- Users who pass `client=You(...)` explicitly are unaffected; attribution is only set on the default client path.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `make lint && make typecheck && make test` passes locally
- [ ] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)
