### PR TITLE
Re-export `MCPToolsetClient` from `pydantic_ai_harness.stackone._toolset` so CI lint passes again

### DIFF
--- a/pydantic_ai_harness/stackone/_toolset.py
+++ b/pydantic_ai_harness/stackone/_toolset.py
@@ -39,9 +39,13 @@ except ImportError as _import_error:  # pragma: no cover
         'MCP support is required for the StackOne capability. Install it with: uv add "pydantic-ai-harness[stackone]"'
     ) from _import_error
 
+# `MCPToolsetClient` is re-exported for `_capability`, which must not import `pydantic_ai.mcp`
+# directly: this module's guarded import is what turns a missing `mcp` extra into the
+# install-hint `ImportError`.
 __all__ = (
     'STACKONE_API_KEY_ENV',
     'STACKONE_BASE_URL',
+    'MCPToolsetClient',
     'StackOneToolset',
     'ToolMode',
 )


### PR DESCRIPTION
CI's lint job runs the pre-commit pyright hook against the latest pydantic-ai rather than the lockfile, and it now flags `stackone/_capability.py`'s import of `MCPToolsetClient` from `_toolset` as `reportPrivateImportUsage`. That fails lint on every PR (first seen on #724; main at `6daf761` was green before the drift).

Declaring `MCPToolsetClient` in `_toolset.__all__` makes the re-export explicit, which satisfies pyright under both the old and new pydantic-ai. `_capability` keeps importing it from `_toolset`, so the guarded import there still turns a missing `mcp` extra into the install-hint `ImportError`.

No behavior change; one line plus a comment.