### PR TITLE
Give `ToolOutputLimits` summaries a stream seam

### DIFF
--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -240,6 +240,32 @@ instance to `Summarize(model=...)` to override, or a `summarize` callable to byp
 built-in prompt entirely. The `summary_prompt` template on the capability must contain both
 `{tool_name}` and `{output}` placeholders.
 
+## Summary streaming
+
+The summary request is non-streaming unless `event_stream_handler` is set on the `Summarize`
+action. Supply a handler to watch the summary as it is written, or pass `drain_summary_events`
+to take the streaming request path without handling the events -- which is what a summarizer
+endpoint that rejects non-streaming requests needs:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.tool_output_limits import Band, Summarize, ToolOutputLimits, drain_summary_events
+
+agent = Agent(
+    'openai:gpt-4o',
+    capabilities=[
+        ToolOutputLimits(
+            bands=[Band(over=20_000, action=Summarize(event_stream_handler=drain_summary_events))],
+        )
+    ],
+)
+```
+
+Neither transport works everywhere, which is why this is a choice rather than a default: some
+endpoints reject non-streaming requests and others reject streaming ones. The handler receives
+the summary run's own `RunContext` and event stream; the outer `Agent.run(...)` handler is not
+inherited and never sees the summary token deltas.
+
 ## Edge cases
 
 - Binary returns spill verbatim and are never stringify-truncated; `Truncate` / `Summarize`

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -207,6 +207,32 @@ instance to `Summarize(model=...)` to override, or a `summarize` callable to byp
 built-in prompt entirely. The `summary_prompt` template on the capability must contain both
 `{tool_name}` and `{output}` placeholders.
 
+## Summary streaming
+
+The summary request is non-streaming unless `event_stream_handler` is set on the `Summarize`
+action. Supply a handler to watch the summary as it is written, or pass `drain_summary_events`
+to take the streaming request path without handling the events -- which is what a summarizer
+endpoint that rejects non-streaming requests needs:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness.tool_output_limits import Band, Summarize, ToolOutputLimits, drain_summary_events
+
+agent = Agent(
+    'openai:gpt-4o',
+    capabilities=[
+        ToolOutputLimits(
+            bands=[Band(over=20_000, action=Summarize(event_stream_handler=drain_summary_events))],
+        )
+    ],
+)
+```
+
+Neither transport works everywhere, which is why this is a choice rather than a default: some
+endpoints reject non-streaming requests and others reject streaming ones. The handler receives
+the summary run's own `RunContext` and event stream; the outer `Agent.run(...)` handler is not
+inherited and never sees the summary token deltas.
+
 ## Edge cases
 
 - Binary returns spill verbatim and are never stringify-truncated; `Truncate` / `Summarize`

--- a/pydantic_ai_harness/tool_output_limits/__init__.py
+++ b/pydantic_ai_harness/tool_output_limits/__init__.py
@@ -18,6 +18,7 @@ from pydantic_ai_harness.tool_output_limits._bands import (
     Summarize,
     SummarizeFunc,
     Truncate,
+    drain_summary_events,
 )
 from pydantic_ai_harness.tool_output_limits._capability import READ_TOOL_NAME, ToolOutputLimits
 from pydantic_ai_harness.tool_output_limits._payload import (
@@ -42,6 +43,7 @@ __all__ = [
     'SummarizeFunc',
     'Truncate',
     'TruncationStrategy',
+    'drain_summary_events',
     'indented_json',
     'json_lines',
 ]

--- a/pydantic_ai_harness/tool_output_limits/_bands.py
+++ b/pydantic_ai_harness/tool_output_limits/_bands.py
@@ -19,7 +19,12 @@ from typing import TYPE_CHECKING
 from pydantic_ai_harness.tool_output_limits._payload import TruncationStrategy
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterable
+
+    from pydantic_ai.agent import EventStreamHandler
+    from pydantic_ai.messages import AgentStreamEvent
     from pydantic_ai.models import Model
+    from pydantic_ai.tools import RunContext
 
 _DEFAULT_TRUNCATE_CHARS = 4_000
 _DEFAULT_PREVIEW_CHARS = 1_000
@@ -69,11 +74,25 @@ class Summarize:
     the built-in agent receives the parent usage limits and reserves one request from a finite
     request limit for the pending parent request. Falls back to `then` on a binary payload or a
     failed call.
+
+    The summary request is non-streaming unless `event_stream_handler` is set. Supplying any
+    handler selects the streaming request path, which is what a summarizer endpoint that
+    rejects non-streaming requests needs; pass `drain_summary_events` to take that path
+    without handling the events.
     """
 
     model: str | Model | None = None
     summarize: SummarizeFunc | None = None
     then: Action | None = None
+    event_stream_handler: EventStreamHandler[object] | None = None
+    """If set, this handler is passed to the nested summary run, so the summarizer's own
+    model-streaming events surface to the caller.
+
+    Setting it also selects the streaming request path for the summary request. Left `None`,
+    the request is non-streaming, which is what an endpoint that rejects streaming requests
+    needs. The handler receives the summary run's own `RunContext`, never the outer run's,
+    and the outer `Agent.run(...)` handler is not inherited. Ignored when `summarize` is set,
+    since a custom callable performs no model request."""
 
 
 Action = Passthrough | Truncate | Spill | Summarize
@@ -85,3 +104,17 @@ class Band:
 
     over: int
     action: Action
+
+
+async def drain_summary_events(
+    _ctx: RunContext[object],
+    events: AsyncIterable[AgentStreamEvent],
+) -> None:
+    """An `event_stream_handler` that consumes summary events and discards them.
+
+    Pass this as `Summarize(event_stream_handler=drain_summary_events)` when the summary
+    endpoint requires a streaming request but the events themselves are not wanted. Supplying
+    any handler selects the streaming request path; this one just discards what it receives.
+    """
+    async for _ in events:
+        pass

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -458,8 +458,13 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         agent: Agent[None, str] = Agent(
             cast('Model[Any] | str', model), instructions='You summarize oversized tool output.'
         )
-        run = await agent.run(prompt, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
-        return run.output.strip()
+        result = await agent.run(
+            prompt,
+            usage=ctx.usage,
+            usage_limits=reserved_usage_limits(ctx.usage_limits),
+            event_stream_handler=action.event_stream_handler,
+        )
+        return result.output.strip()
 
 
 def _ensure_text(rendered: object) -> str:

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import os
 import time
+from collections.abc import AsyncIterable, AsyncIterator
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -14,10 +15,15 @@ import pytest
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import ModelRetry, UserError
 from pydantic_ai.messages import (
+    AgentStreamEvent,
     BinaryContent,
     ModelMessage,
+    ModelRequest,
     ModelResponse,
+    PartDeltaEvent,
+    PartStartEvent,
     TextPart,
+    TextPartDelta,
     ToolCallPart,
     ToolReturn,
     ToolReturnPart,
@@ -25,7 +31,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import AbstractModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
-from pydantic_ai.tools import ToolDefinition
+from pydantic_ai.tools import RunContext, ToolDefinition
 from pydantic_ai.usage import RunUsage, UsageLimits
 from pydantic_core import to_json
 
@@ -38,6 +44,7 @@ from pydantic_ai_harness.tool_output_limits import (
     ToolOutputLimits,
     Truncate,
     TruncationStrategy,
+    drain_summary_events,
     indented_json,
     json_lines,
 )
@@ -99,6 +106,21 @@ def _fixed_model(text: str) -> FunctionModel:
         return ModelResponse(parts=[TextPart(content=text)])
 
     return FunctionModel(respond)
+
+
+def _stream_only_summarizer(chunks: list[str] | None = None) -> FunctionModel:
+    """A summarizer that only accepts streaming requests (#687).
+
+    No `function` is provided, so a non-streaming request fails outright -- mirroring an
+    endpoint that returns HTTP 400 on `stream:false`.
+    """
+    parts = chunks if chunks is not None else ['STREAMED ', 'SUMMARY']
+
+    async def stream_fn(messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+        for part in parts:
+            yield part
+
+    return FunctionModel(stream_function=stream_fn)
 
 
 def _call(tool_name: str = 'big_tool', tool_call_id: str = 'call-1') -> ToolCallPart:
@@ -667,6 +689,7 @@ class TestSummarize:
 
         assert out == 'THE SUMMARY'
         assert mock_agent.run.call_args.kwargs['usage_limits'] == UsageLimits(request_limit=4, tool_calls_limit=2)
+        assert mock_agent.run.call_args.kwargs['event_stream_handler'] is None
 
     async def test_explicit_model_overrides_ctx(self):
         ctx = _make_ctx(model=_fixed_model('FROM CTX MODEL'))
@@ -712,6 +735,82 @@ class TestSummarize:
         )
         out = await _run(cap, 'a' * 100)
         assert isinstance(out, str) and 'truncated' in out
+
+    async def test_stream_only_summarizer_without_a_handler_falls_back(self):
+        # No handler means the nested run takes the non-streaming request path, which this
+        # summarizer rejects; the failure degrades to the `then` fallback (#687).
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=5, action=Summarize(model=_stream_only_summarizer(), then=Truncate(max_chars=10)))]
+        )
+        out = await _run(cap, 'x' * 100)
+        assert isinstance(out, str) and 'truncated' in out
+
+    async def test_stream_only_summarizer_completes_with_drain_handler(self):
+        # `drain_summary_events` selects the streaming request path and discards the events,
+        # which is what a summarizer endpoint that rejects non-streaming requests needs.
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[
+                Band(
+                    over=5,
+                    action=Summarize(model=_stream_only_summarizer(), event_stream_handler=drain_summary_events),
+                )
+            ]
+        )
+        out = await _run(cap, 'x' * 100)
+        assert out == 'STREAMED SUMMARY'
+
+    async def test_summary_events_reach_a_caller_supplied_handler(self):
+        deltas: list[str] = []
+
+        async def collect(ctx: RunContext[object], events: AsyncIterable[AgentStreamEvent]) -> None:
+            # The opening chunk of a part arrives as `PartStartEvent`; the rest are deltas.
+            async for event in events:
+                if isinstance(event, PartStartEvent) and isinstance(event.part, TextPart):
+                    deltas.append(event.part.content)
+                elif isinstance(event, PartDeltaEvent) and isinstance(event.delta, TextPartDelta):
+                    deltas.append(event.delta.content_delta)
+
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[
+                Band(
+                    over=5,
+                    action=Summarize(
+                        model=_stream_only_summarizer(['STREA', 'MED SU', 'MMARY']),
+                        event_stream_handler=collect,
+                    ),
+                )
+            ]
+        )
+        out = await _run(cap, 'x' * 100)
+        assert out == 'STREAMED SUMMARY'
+        assert ''.join(deltas) == 'STREAMED SUMMARY'
+
+    async def test_stream_only_summarizer_completes_the_parent_run(self):
+        # Through the public surface: an oversized tool return is summarized over the
+        # streaming path inside a full agent run (#687).
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[
+                Band(
+                    over=100,
+                    action=Summarize(model=_stream_only_summarizer(), event_stream_handler=drain_summary_events),
+                )
+            ]
+        )
+        agent = Agent(TestModel(), capabilities=[cap])
+
+        @agent.tool_plain
+        def read_log() -> str:
+            return 'log line\n' * 100
+
+        result = await agent.run('go')
+        returns = [
+            part.content
+            for message in result.all_messages()
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+            if isinstance(part, ToolReturnPart) and part.tool_name == 'read_log'
+        ]
+        assert returns == ['STREAMED SUMMARY']
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #687.

`ToolOutputLimits` summarizes oversized tool returns through a nested `Agent.run(...)`. That call never received an `event_stream_handler`, so the summary request always took the non-streaming request path, and there was no supported way to change that: `ModelSettings` carries no `stream` key and the nested `Agent` accepts no `capabilities=`. On a summarizer endpoint that rejects non-streaming requests (for example the Codex endpoint's HTTP 400 `Stream must be set to true`), `_summarize_action` catches the provider error and degrades to the `then` fallback, so the output is truncated on every call with nothing surfaced.

This is the same defect class as #619, which #620 fixes for `SummarizingCompaction`. This PR applies the same API decisions to the second nested-summarizer site:

- `Summarize` gains `event_stream_handler: EventStreamHandler[object] | None = None`, threaded into the nested `agent.run(...)`. The `object` parameter follows #620's resolution: the handler receives the summary run's own `RunContext`, which carries no caller deps. Supplying any handler selects the streaming request path; left `None` the request stays non-streaming, which is what endpoints that reject streaming requests need. The transport remains a caller's choice, not a new default.
- `drain_summary_events` ships as the ready-made handler for callers who need the streaming transport but not the events, exported from `pydantic_ai_harness.tool_output_limits`. Naming follows #620's helper.
- Ignored when a `summarize` callable is set, since a custom callable performs no model request.

The silent-fallback half of #687 (whether a permanent provider rejection should surface rather than truncate) is deliberately left unchanged: the issue flags it as a separate decision, and the fallback is intentional for transient summarizer failures.

## Tests

- A stream-only `FunctionModel` (no `function`, so a non-streaming request fails outright) falls back through `then` without a handler, and produces the summary with `drain_summary_events`.
- A caller-supplied handler observes the summary deltas as they stream.
- An end-to-end run through `Agent(..., capabilities=[ToolOutputLimits(...)])` on `TestModel`: an oversized tool return is summarized over the streaming path inside the parent run.
- The existing usage-limits test now also asserts the nested run receives `event_stream_handler=None` by default.

## Docs

`pydantic_ai_harness/tool_output_limits/README.md` and `docs/tool-output-limits.md` both gain a "Summary streaming" section, kept in parity.

## Coordination with #620

#620 is still open and this PR is independent of it. Both add a `drain_summary_events` to their own package (this one in `pydantic_ai_harness.tool_output_limits`, #620's in `pydantic_ai_harness.compaction`). If #620 lands first and a single shared home is preferred, happy to consolidate.