### PR TITLE
Route Harness intake to Mike through the shared owner workflow

### DIFF
--- a/.github/workflows/maintainer-attention.yml
+++ b/.github/workflows/maintainer-attention.yml
@@ -32,7 +32,7 @@ jobs:
       issues: write
       pull-requests: write
     # Pin merged upstream history: GitHub cannot resolve a reusable workflow from a deleted PR-head ref.
-    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@252922e206ba0064eb8a96ab1e37616ba016b06a
+    uses: pydantic/pydantic-ai/.github/workflows/pydantic-ai-owner-routing.yml@22b3d6a4dc9e409c5a581e4657311b0dfff16256
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -49,7 +49,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@252922e206ba0064eb8a96ab1e37616ba016b06a
+    uses: pydantic/pydantic-ai/.github/workflows/issue-pr-attention-monitor.yml@22b3d6a4dc9e409c5a581e4657311b0dfff16256
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}
 
@@ -59,6 +59,6 @@ jobs:
       contents: read
       issues: read
       pull-requests: read
-    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@252922e206ba0064eb8a96ab1e37616ba016b06a
+    uses: pydantic/pydantic-ai/.github/workflows/weekly-maintainer-digest.yml@22b3d6a4dc9e409c5a581e4657311b0dfff16256
     secrets:
       PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL: ${{ secrets.PYDANTIC_AI_TRIAGE_SLACK_WEBHOOK_URL }}

--- a/tests/test_maintainer_attention_workflow.py
+++ b/tests/test_maintainer_attention_workflow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-UPSTREAM_SHA = '252922e206ba0064eb8a96ab1e37616ba016b06a'
+UPSTREAM_SHA = '22b3d6a4dc9e409c5a581e4657311b0dfff16256'
 
 
 def test_maintainer_attention_uses_merged_upstream_workflows():


### PR DESCRIPTION
## Summary

Update all three shared maintainer-workflow pins from the August 25 snapshot to merged pydantic-ai commit `22b3d6a4`, which contains the Harness-wide `mpfaffenberger` default owner. This keeps owner routing, attention reconciliation, and the weekly digest on one compatible source revision.

Boundary notes: this changes only the immutable refs used by reusable GitHub workflows. The referenced owner router blanket-routes ungated `pydantic-ai-harness` intake to `mpfaffenberger`; the three referenced reusable workflows were verified to exist at the pinned commit.

## Linked Issue

Fixes #732

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior (pin-level router assertion performed; no repository test seam for a remote reusable-workflow ref)
- [ ] `make lint && make typecheck && make test` passes locally (workflow-only immutable-ref update)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)