### PR TITLE
Connect ChannelHost to the Telegram Bot API

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -99,7 +99,9 @@ History remains saved after a successful run even when delivery cannot be
 confirmed.
 
 The Telegram adapter retries one send when the Bot API returns an explicit
-`retry_after`. Its poll loop retries transient transport and response failures.
+`retry_after` of at most 60 seconds. Longer send delays fail the delivery instead
+of holding that conversation's turn slot. Its poll loop honors provider delays
+while retrying transient transport and response failures.
 Bot API errors 401, 404, and 409 stop polling because they indicate invalid
 credentials, a missing bot, or a conflicting webhook. After a week without a
 valid update, the adapter clears its offset because Telegram may randomize the

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -33,9 +33,9 @@ Set `TELEGRAM_BOT_TOKEN` to the bot token and keep it outside source control.
 Replace `123456789` below with the `from.id` value.
 
 ```python
-import asyncio
 import os
 
+import anyio
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelHost
@@ -53,7 +53,7 @@ async def main() -> None:
     await host.serve()
 
 
-asyncio.run(main())
+anyio.run(main)
 ```
 
 ## How channels fit Pydantic AI

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -12,26 +12,49 @@ Channels are useful for:
 - a support agent in team messages
 - an internal agent that can use the same tools and capabilities as your app
 
-The agent-side integration is the same for every provider:
-
-```python
-from pydantic_ai import Agent
-
-from pydantic_ai_harness.channels import ChannelAdapter, ChannelHost
-
-
-async def serve(channel: ChannelAdapter) -> None:
-    agent = Agent('anthropic:claude-fable-5', instructions='Be concise and helpful.')
-    host = ChannelHost(agent, channel, allowed_senders={'provider-user-id'})
-    await host.serve()
-```
-
-The provider adapter supplies real sender ids and delivers each reply. Replace
-`provider-user-id` with an id from that provider.
-
 [Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
 
 > While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
+
+This quickstart uses Anthropic. Install the provider extra and set
+`ANTHROPIC_API_KEY` before running it:
+
+```bash
+uv add "pydantic-ai-harness[anthropic]"
+```
+
+## Telegram: a personal assistant
+
+Telegram uses long polling, so you can run this example without a web server.
+
+Create a bot with [BotFather](https://core.telegram.org/bots/features#botfather),
+send it one message, then read `from.id` from a Bot API `getUpdates` response.
+Set `TELEGRAM_BOT_TOKEN` to the bot token and keep it outside source control.
+Replace `123456789` below with the `from.id` value.
+
+```python
+import asyncio
+import os
+
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelHost
+from pydantic_ai_harness.channels.telegram import TelegramChannel
+
+agent = Agent(
+    'anthropic:claude-fable-5',
+    instructions='You are a personal assistant reachable over Telegram.',
+)
+
+
+async def main() -> None:
+    channel = TelegramChannel(os.environ['TELEGRAM_BOT_TOKEN'])
+    host = ChannelHost(agent, channel, allowed_senders={'123456789'})
+    await host.serve()
+
+
+asyncio.run(main())
+```
 
 ## How channels fit Pydantic AI
 
@@ -75,6 +98,13 @@ chat. If sending a reply fails, the host logs the failure and continues serving.
 History remains saved after a successful run even when delivery cannot be
 confirmed.
 
+The Telegram adapter retries one send when the Bot API returns an explicit
+`retry_after`. Its poll loop retries transient transport and response failures.
+Bot API errors 401, 404, and 409 stop polling because they indicate invalid
+credentials, a missing bot, or a conflicting webhook. After a week without a
+valid update, the adapter clears its offset because Telegram may randomize the
+next update id.
+
 `serve()` runs until it is cancelled or the adapter ends. It owns every turn in
 an AnyIO task group, so no turn task outlives it. Cancellation closes the
 message iterator, cancels in-flight turns, and then closes the adapter.
@@ -84,6 +114,11 @@ message iterator, cancels in-flight turns, and then closes the adapter.
 Anyone allowed to message the agent can supply model input to an agent that may
 have access to tools, credentials, files, and network services. Use a narrow
 sender allowlist and apply normal Pydantic AI guardrails to the connected agent.
+
+`TelegramChannel` accepts private text chats only. It drops group messages and
+non-text updates. Transport errors suppress their httpx exception chain because
+Telegram embeds the bot token in request URLs. The adapter also redacts those
+tokens from HTTPX completed-request logs.
 
 ## Adapters and stores
 
@@ -103,9 +138,13 @@ multiple live hosts safe without external per-conversation serialization.
 
 ## Not included
 
-The host does not define media, reactions, typing indicators, streaming edits,
-tool approvals, or provider authentication. Adapters add only the provider
-behavior they document.
+The Telegram adapter does not include media, group chats, reactions, typing
+indicators, streaming edits, tool approvals, or durable update offsets. Its
+offset and the default history store are process-local, so a process failure can
+redeliver or lose an in-flight update.
+
+The host does not define provider authentication or provider-specific message
+features. Adapters add only the behavior they document.
 
 ## API reference
 
@@ -120,3 +159,5 @@ behavior they document.
 ::: pydantic_ai_harness.channels.ConversationStore
 
 ::: pydantic_ai_harness.channels.InMemoryConversationStore
+
+::: pydantic_ai_harness.channels.telegram.TelegramChannel

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -28,9 +28,9 @@ Set `TELEGRAM_BOT_TOKEN` to the bot token and keep it outside source control.
 Replace `123456789` below with the `from.id` value.
 
 ```python
-import asyncio
 import os
 
+import anyio
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelHost
@@ -48,7 +48,7 @@ async def main() -> None:
     await host.serve()
 
 
-asyncio.run(main())
+anyio.run(main)
 ```
 
 ## How channels fit Pydantic AI

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -94,7 +94,9 @@ History remains saved after a successful run even when delivery cannot be
 confirmed.
 
 The Telegram adapter retries one send when the Bot API returns an explicit
-`retry_after`. Its poll loop retries transient transport and response failures.
+`retry_after` of at most 60 seconds. Longer send delays fail the delivery instead
+of holding that conversation's turn slot. Its poll loop honors provider delays
+while retrying transient transport and response failures.
 Bot API errors 401, 404, and 409 stop polling because they indicate invalid
 credentials, a missing bot, or a conflicting webhook. After a week without a
 valid update, the adapter clears its offset because Telegram may randomize the

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -7,26 +7,49 @@ Channels are useful for:
 - a support agent in team messages
 - an internal agent that can use the same tools and capabilities as your app
 
-The agent-side integration is the same for every provider:
-
-```python
-from pydantic_ai import Agent
-
-from pydantic_ai_harness.channels import ChannelAdapter, ChannelHost
-
-
-async def serve(channel: ChannelAdapter) -> None:
-    agent = Agent('anthropic:claude-fable-5', instructions='Be concise and helpful.')
-    host = ChannelHost(agent, channel, allowed_senders={'provider-user-id'})
-    await host.serve()
-```
-
-The provider adapter supplies real sender ids and delivers each reply. Replace
-`provider-user-id` with an id from that provider.
-
 [Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
 
 > While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](../../docs/index.md#version-policy).
+
+This quickstart uses Anthropic. Install the provider extra and set
+`ANTHROPIC_API_KEY` before running it:
+
+```bash
+uv add "pydantic-ai-harness[anthropic]"
+```
+
+## Telegram: a personal assistant
+
+Telegram uses long polling, so you can run this example without a web server.
+
+Create a bot with [BotFather](https://core.telegram.org/bots/features#botfather),
+send it one message, then read `from.id` from a Bot API `getUpdates` response.
+Set `TELEGRAM_BOT_TOKEN` to the bot token and keep it outside source control.
+Replace `123456789` below with the `from.id` value.
+
+```python
+import asyncio
+import os
+
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelHost
+from pydantic_ai_harness.channels.telegram import TelegramChannel
+
+agent = Agent(
+    'anthropic:claude-fable-5',
+    instructions='You are a personal assistant reachable over Telegram.',
+)
+
+
+async def main() -> None:
+    channel = TelegramChannel(os.environ['TELEGRAM_BOT_TOKEN'])
+    host = ChannelHost(agent, channel, allowed_senders={'123456789'})
+    await host.serve()
+
+
+asyncio.run(main())
+```
 
 ## How channels fit Pydantic AI
 
@@ -70,6 +93,13 @@ chat. If sending a reply fails, the host logs the failure and continues serving.
 History remains saved after a successful run even when delivery cannot be
 confirmed.
 
+The Telegram adapter retries one send when the Bot API returns an explicit
+`retry_after`. Its poll loop retries transient transport and response failures.
+Bot API errors 401, 404, and 409 stop polling because they indicate invalid
+credentials, a missing bot, or a conflicting webhook. After a week without a
+valid update, the adapter clears its offset because Telegram may randomize the
+next update id.
+
 `serve()` runs until it is cancelled or the adapter ends. It owns every turn in
 an AnyIO task group, so no turn task outlives it. Cancellation closes the
 message iterator, cancels in-flight turns, and then closes the adapter.
@@ -79,6 +109,11 @@ message iterator, cancels in-flight turns, and then closes the adapter.
 Anyone allowed to message the agent can supply model input to an agent that may
 have access to tools, credentials, files, and network services. Use a narrow
 sender allowlist and apply normal Pydantic AI guardrails to the connected agent.
+
+`TelegramChannel` accepts private text chats only. It drops group messages and
+non-text updates. Transport errors suppress their httpx exception chain because
+Telegram embeds the bot token in request URLs. The adapter also redacts those
+tokens from HTTPX completed-request logs.
 
 ## Adapters and stores
 
@@ -98,9 +133,13 @@ multiple live hosts safe without external per-conversation serialization.
 
 ## Not included
 
-The host does not define media, reactions, typing indicators, streaming edits,
-tool approvals, or provider authentication. Adapters add only the provider
-behavior they document.
+The Telegram adapter does not include media, group chats, reactions, typing
+indicators, streaming edits, tool approvals, or durable update offsets. Its
+offset and the default history store are process-local, so a process failure can
+redeliver or lose an in-flight update.
+
+The host does not define provider authentication or provider-specific message
+features. Adapters add only the behavior they document.
 
 ## API reference
 
@@ -110,3 +149,4 @@ behavior they document.
 - [`InboundMessage`][pydantic_ai_harness.channels.InboundMessage]
 - [`ConversationStore`][pydantic_ai_harness.channels.ConversationStore]
 - [`InMemoryConversationStore`][pydantic_ai_harness.channels.InMemoryConversationStore]
+- [`TelegramChannel`][pydantic_ai_harness.channels.telegram.TelegramChannel]

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -5,6 +5,8 @@ External assumptions verified 2026-08-31:
 * The Bot API base is `https://api.telegram.org/bot<token>/METHOD`.
 * `getUpdates` is the long-polling transport, confirms updates through the next
   offset, and cannot run while a webhook is configured.
+* After at least a week without updates, Telegram may choose a random next
+  `update_id`, so a stale local offset must be discarded.
 * `sendMessage` text is limited to 4096 Unicode characters. UTF-16 units apply
   to message entity offsets, not the text limit.
 
@@ -86,7 +88,6 @@ class TelegramChannel:
         self._token = token
         self._provided_client = http_client
         self._client: httpx.AsyncClient | None = None
-        self._owns_client = False
         self._poll_timeout = poll_timeout
         self._retry_delay = retry_delay
         self._offset: int | None = None
@@ -100,7 +101,6 @@ class TelegramChannel:
         if _TOKEN_FILTER not in httpx_logger.filters:
             httpx_logger.addFilter(_TOKEN_FILTER)
         self._client = self._provided_client or httpx.AsyncClient()
-        self._owns_client = self._provided_client is None
         try:
             await self._call('getMe')
         except BaseException:
@@ -114,17 +114,15 @@ class TelegramChannel:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         traceback: TracebackType | None,
-    ) -> bool | None:
+    ) -> None:
         """Close the internally created HTTP client, if any."""
         await self._close_owned_client()
         self._client = None
-        return None
 
     async def _close_owned_client(self) -> None:
-        if self._owns_client and self._client is not None:
+        if self._provided_client is None and self._client is not None:
             with anyio.CancelScope(shield=True):
                 await self._client.aclose()
-        self._owns_client = False
 
     async def send_text(self, conversation_id: str, text: str) -> None:
         """Send text in ordered chunks no longer than Telegram's limit."""
@@ -155,7 +153,7 @@ class TelegramChannel:
             if self._offset is not None:
                 params['offset'] = self._offset
             try:
-                payload = await self._call('getUpdates', params)
+                payload = await self._call('getUpdates', params, timeout=self._poll_timeout + 5)
                 updates = _LIST_ADAPTER.validate_python(payload)
             except _FatalTelegramError:
                 raise
@@ -194,7 +192,13 @@ class TelegramChannel:
                 )
                 await anyio.sleep(self._retry_delay)
 
-    async def _call(self, method: str, params: Mapping[str, object] | None = None) -> object:
+    async def _call(
+        self,
+        method: str,
+        params: Mapping[str, object] | None = None,
+        *,
+        timeout: float = _REQUEST_TIMEOUT,
+    ) -> object:
         client = self._client
         if client is None:
             raise RuntimeError('TelegramChannel must be opened before use')
@@ -202,7 +206,7 @@ class TelegramChannel:
             response = await client.post(
                 f'{_API_BASE}/bot{self._token}/{method}',
                 json=dict(params or {}),
-                timeout=self._poll_timeout + 5 if method == 'getUpdates' else _REQUEST_TIMEOUT,
+                timeout=timeout,
             )
         except httpx.RequestError:
             # httpx exceptions include the request URL, whose path contains the

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -14,13 +14,13 @@ changing authentication, polling, or text delivery.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import math
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncGenerator, Mapping
 from time import monotonic
 from types import TracebackType
 
+import anyio
 import httpx
 from pydantic import TypeAdapter, ValidationError
 from typing_extensions import Self
@@ -134,10 +134,10 @@ class TelegramChannel:
             try:
                 await self._call('sendMessage', params)
             except _RateLimited as exc:
-                await asyncio.sleep(exc.retry_after)
+                await anyio.sleep(exc.retry_after)
                 await self._call('sendMessage', params)
 
-    async def messages(self) -> AsyncIterator[InboundMessage]:
+    async def messages(self) -> AsyncGenerator[InboundMessage, None]:
         """Yield private text messages from `getUpdates` until cancelled."""
         while True:
             if (
@@ -160,17 +160,17 @@ class TelegramChannel:
                 raise
             except _RateLimited as exc:
                 logger.warning('Telegram polling rate limited; retrying in %s seconds', exc.retry_after)
-                await asyncio.sleep(exc.retry_after)
+                await anyio.sleep(exc.retry_after)
                 continue
             except ChannelError as exc:
                 logger.warning('Telegram polling failed: %s; retrying in %s seconds', exc, self._retry_delay)
-                await asyncio.sleep(self._retry_delay)
+                await anyio.sleep(self._retry_delay)
                 continue
             except ValidationError:
                 logger.warning(
                     'Telegram getUpdates returned an invalid result; retrying in %s seconds', self._retry_delay
                 )
-                await asyncio.sleep(self._retry_delay)
+                await anyio.sleep(self._retry_delay)
                 continue
 
             advanced_offset = False
@@ -191,7 +191,7 @@ class TelegramChannel:
                 logger.warning(
                     'Telegram returned updates without usable ids; retrying in %s seconds', self._retry_delay
                 )
-                await asyncio.sleep(self._retry_delay)
+                await anyio.sleep(self._retry_delay)
 
     async def _call(self, method: str, params: Mapping[str, object] | None = None) -> object:
         client = self._client

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -31,6 +31,7 @@ from pydantic_ai_harness.channels._types import ChannelError, InboundMessage
 
 _API_BASE = 'https://api.telegram.org'
 _MAX_TEXT_CHARS = 4096
+_MAX_INLINE_RETRY_DELAY = 60.0
 _REQUEST_TIMEOUT = 10.0
 _UPDATE_ID_RESET_SECONDS = 7 * 24 * 60 * 60
 _MAPPING_ADAPTER = TypeAdapter(dict[str, object])
@@ -134,6 +135,8 @@ class TelegramChannel:
             try:
                 await self._call('sendMessage', params)
             except _RateLimited as exc:
+                if exc.retry_after > _MAX_INLINE_RETRY_DELAY:
+                    raise
                 await anyio.sleep(exc.retry_after)
                 await self._call('sendMessage', params)
 

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -1,0 +1,296 @@
+"""Telegram Bot API channel adapter.
+
+External assumptions verified 2026-08-31:
+
+* The Bot API base is `https://api.telegram.org/bot<token>/METHOD`.
+* `getUpdates` is the long-polling transport, confirms updates through the next
+  offset, and cannot run while a webhook is configured.
+* `sendMessage` text is limited to 4096 Unicode characters. UTF-16 units apply
+  to message entity offsets, not the text limit.
+
+Re-check these assumptions against https://core.telegram.org/bots/api before
+changing authentication, polling, or text delivery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from collections.abc import AsyncIterator, Mapping
+from time import monotonic
+from types import TracebackType
+
+import httpx
+from pydantic import TypeAdapter, ValidationError
+from typing_extensions import Self
+
+from pydantic_ai_harness.channels._types import ChannelError, InboundMessage
+
+_API_BASE = 'https://api.telegram.org'
+_MAX_TEXT_CHARS = 4096
+_REQUEST_TIMEOUT = 10.0
+_UPDATE_ID_RESET_SECONDS = 7 * 24 * 60 * 60
+_MAPPING_ADAPTER = TypeAdapter(dict[str, object])
+_LIST_ADAPTER = TypeAdapter(list[object])
+_JSON_ADAPTER = TypeAdapter(object)
+_FATAL_ERROR_CODES = frozenset({401, 404, 409})
+
+logger = logging.getLogger(__name__)
+
+
+class _TelegramTokenFilter(logging.Filter):
+    """Redact Bot API credentials from HTTPX's completed-request log."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        redacted = _redact_telegram_url(message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+_TOKEN_FILTER = _TelegramTokenFilter()
+
+
+class TelegramChannel:
+    """Connect a Telegram bot through the official Bot API's long-polling transport."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        poll_timeout: int = 30,
+        retry_delay: float = 1.0,
+    ) -> None:
+        """Configure the Telegram adapter without opening it.
+
+        Args:
+            token: Bot token issued by BotFather.
+            http_client: Optional client whose lifecycle remains owned by the caller.
+            poll_timeout: Long-poll timeout sent to `getUpdates`, in seconds.
+            retry_delay: Delay after a transient polling error, in seconds.
+
+        Raises:
+            ValueError: If the token is empty, `poll_timeout` is not positive,
+                or `retry_delay` is not positive or non-finite.
+        """
+        if not token:
+            raise ValueError('token must not be empty')
+        if type(poll_timeout) is not int or poll_timeout <= 0:
+            raise ValueError('poll_timeout must be a positive integer')
+        if retry_delay <= 0 or not math.isfinite(retry_delay):
+            raise ValueError('retry_delay must be finite and positive')
+        self._token = token
+        self._provided_client = http_client
+        self._client: httpx.AsyncClient | None = None
+        self._owns_client = False
+        self._poll_timeout = poll_timeout
+        self._retry_delay = retry_delay
+        self._offset: int | None = None
+        self._last_update_at: float | None = None
+
+    async def __aenter__(self) -> Self:
+        """Open the HTTP client and validate the bot token with `getMe`."""
+        if self._client is not None:
+            raise RuntimeError('TelegramChannel is already open')
+        httpx_logger = logging.getLogger('httpx')
+        if _TOKEN_FILTER not in httpx_logger.filters:
+            httpx_logger.addFilter(_TOKEN_FILTER)
+        self._client = self._provided_client or httpx.AsyncClient()
+        self._owns_client = self._provided_client is None
+        try:
+            await self._call('getMe')
+        except BaseException:
+            await self._close_owned_client()
+            self._client = None
+            raise
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Close the internally created HTTP client, if any."""
+        await self._close_owned_client()
+        self._client = None
+        return None
+
+    async def _close_owned_client(self) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+        self._owns_client = False
+
+    async def send_text(self, conversation_id: str, text: str) -> None:
+        """Send text in ordered chunks no longer than Telegram's limit."""
+        if not text:
+            raise ValueError('text must not be empty')
+        for start in range(0, len(text), _MAX_TEXT_CHARS):
+            params = {'chat_id': conversation_id, 'text': text[start : start + _MAX_TEXT_CHARS]}
+            try:
+                await self._call('sendMessage', params)
+            except _RateLimited as exc:
+                await asyncio.sleep(exc.retry_after)
+                await self._call('sendMessage', params)
+
+    async def messages(self) -> AsyncIterator[InboundMessage]:
+        """Yield private text messages from `getUpdates` until cancelled."""
+        while True:
+            if (
+                self._offset is not None
+                and self._last_update_at is not None
+                and monotonic() - self._last_update_at >= _UPDATE_ID_RESET_SECONDS
+            ):
+                self._offset = None
+                self._last_update_at = None
+            params: dict[str, object] = {
+                'timeout': self._poll_timeout,
+                'allowed_updates': ['message'],
+            }
+            if self._offset is not None:
+                params['offset'] = self._offset
+            try:
+                payload = await self._call('getUpdates', params)
+                updates = _LIST_ADAPTER.validate_python(payload)
+            except _FatalTelegramError:
+                raise
+            except _RateLimited as exc:
+                logger.warning('Telegram polling rate limited; retrying in %s seconds', exc.retry_after)
+                await asyncio.sleep(exc.retry_after)
+                continue
+            except ChannelError as exc:
+                logger.warning('Telegram polling failed: %s; retrying in %s seconds', exc, self._retry_delay)
+                await asyncio.sleep(self._retry_delay)
+                continue
+            except ValidationError:
+                logger.warning(
+                    'Telegram getUpdates returned an invalid result; retrying in %s seconds', self._retry_delay
+                )
+                await asyncio.sleep(self._retry_delay)
+                continue
+
+            advanced_offset = False
+            for raw_update in updates:
+                update = _mapping(raw_update)
+                if update is None:
+                    continue
+                update_id = update.get('update_id')
+                if not isinstance(update_id, int):
+                    continue
+                self._offset = update_id + 1
+                self._last_update_at = monotonic()
+                advanced_offset = True
+                message = _parse_message(update.get('message'))
+                if message is not None:
+                    yield message
+            if updates and not advanced_offset:
+                logger.warning(
+                    'Telegram returned updates without usable ids; retrying in %s seconds', self._retry_delay
+                )
+                await asyncio.sleep(self._retry_delay)
+
+    async def _call(self, method: str, params: Mapping[str, object] | None = None) -> object:
+        client = self._client
+        if client is None:
+            raise RuntimeError('TelegramChannel must be opened before use')
+        try:
+            response = await client.post(
+                f'{_API_BASE}/bot{self._token}/{method}',
+                json=dict(params or {}),
+                timeout=self._poll_timeout + 5 if method == 'getUpdates' else _REQUEST_TIMEOUT,
+            )
+        except httpx.RequestError:
+            # httpx exceptions include the request URL, whose path contains the
+            # bot token. Suppress the exception chain as well as replacing the
+            # message so logging this error cannot expose credentials.
+            raise ChannelError(f'Telegram Bot API request failed: {method}') from None
+        try:
+            payload = _JSON_ADAPTER.validate_json(response.content)
+        except ValidationError:
+            if response.status_code in _FATAL_ERROR_CODES:
+                raise _FatalTelegramError(
+                    f'Telegram Bot API rejected {method} with HTTP {response.status_code}'
+                ) from None
+            raise ChannelError(f'Telegram Bot API returned an invalid response: {method}') from None
+
+        envelope = _mapping(payload)
+        if envelope is None:
+            raise ChannelError(f'Telegram Bot API returned an invalid response: {method}')
+        if envelope.get('ok') is True:
+            return envelope.get('result')
+
+        description = envelope.get('description')
+        message = description if isinstance(description, str) else 'unknown Telegram Bot API error'
+        error_code = envelope.get('error_code')
+        if isinstance(error_code, int) and error_code in _FATAL_ERROR_CODES:
+            raise _FatalTelegramError(message)
+        retry_after = _retry_after(envelope)
+        if retry_after is not None:
+            raise _RateLimited(message, retry_after=retry_after)
+        raise ChannelError(message)
+
+
+class _RateLimited(ChannelError):
+    def __init__(self, message: str, *, retry_after: float) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class _FatalTelegramError(ChannelError):
+    """A Telegram configuration or credential error that retrying cannot fix."""
+
+
+def _redact_telegram_url(message: str) -> str:
+    prefix = f'{_API_BASE}/bot'
+    before, separator, token_and_suffix = message.partition(prefix)
+    if not separator:
+        return message
+    _, separator, suffix = token_and_suffix.partition('/')
+    if not separator:  # pragma: no cover - HTTPX logs the method path used by `_call`
+        return f'{before}{prefix}<redacted>'
+    return f'{before}{prefix}<redacted>/{suffix}'
+
+
+def _mapping(value: object) -> dict[str, object] | None:
+    try:
+        return _MAPPING_ADAPTER.validate_python(value)
+    except ValidationError:
+        return None
+
+
+def _retry_after(envelope: Mapping[str, object]) -> float | None:
+    parameters = _mapping(envelope.get('parameters'))
+    if parameters is None:
+        return None
+    retry_after = parameters.get('retry_after')
+    if isinstance(retry_after, int | float) and retry_after >= 0 and math.isfinite(retry_after):
+        return float(retry_after)
+    return None
+
+
+def _parse_message(value: object) -> InboundMessage | None:
+    message = _mapping(value)
+    if message is None:
+        return None
+    chat = _mapping(message.get('chat'))
+    sender = _mapping(message.get('from'))
+    text = message.get('text')
+    message_id = message.get('message_id')
+    if chat is None or sender is None or not isinstance(text, str) or not isinstance(message_id, int):
+        return None
+    if chat.get('type') != 'private':
+        return None
+    conversation_id = chat.get('id')
+    sender_id = sender.get('id')
+    if not isinstance(conversation_id, int | str) or not isinstance(sender_id, int | str):
+        return None
+    return InboundMessage(
+        conversation_id=str(conversation_id),
+        sender_id=str(sender_id),
+        message_id=str(message_id),
+        text=text,
+    )

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -98,6 +98,7 @@ class TelegramChannel:
         if self._client is not None:
             raise RuntimeError('TelegramChannel is already open')
         httpx_logger = logging.getLogger('httpx')
+        # Keep the singleton installed because HTTPX's logger is process-wide and adapters may overlap.
         if _TOKEN_FILTER not in httpx_logger.filters:
             httpx_logger.addFilter(_TOKEN_FILTER)
         self._client = self._provided_client or httpx.AsyncClient()

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -182,7 +182,7 @@ class TelegramChannel:
                 if update is None:
                     continue
                 update_id = update.get('update_id')
-                if not isinstance(update_id, int):
+                if isinstance(update_id, bool) or not isinstance(update_id, int):
                     continue
                 self._offset = update_id + 1
                 self._last_update_at = monotonic()
@@ -227,13 +227,23 @@ class TelegramChannel:
             raise ChannelError(f'Telegram Bot API returned an invalid response: {method}') from None
 
         envelope = _mapping(payload)
+        if response.status_code in _FATAL_ERROR_CODES:
+            description = envelope.get('description') if envelope is not None else None
+            message = (
+                _redact_telegram_url(description)
+                if isinstance(description, str)
+                else f'Telegram Bot API rejected {method} with HTTP {response.status_code}'
+            )
+            raise _FatalTelegramError(message)
         if envelope is None:
             raise ChannelError(f'Telegram Bot API returned an invalid response: {method}')
         if envelope.get('ok') is True:
             return envelope.get('result')
 
         description = envelope.get('description')
-        message = description if isinstance(description, str) else 'unknown Telegram Bot API error'
+        message = (
+            _redact_telegram_url(description) if isinstance(description, str) else 'unknown Telegram Bot API error'
+        )
         error_code = envelope.get('error_code')
         if isinstance(error_code, int) and error_code in _FATAL_ERROR_CODES:
             raise _FatalTelegramError(message)
@@ -276,7 +286,12 @@ def _retry_after(envelope: Mapping[str, object]) -> float | None:
     if parameters is None:
         return None
     retry_after = parameters.get('retry_after')
-    if isinstance(retry_after, int | float) and retry_after >= 0 and math.isfinite(retry_after):
+    if (
+        isinstance(retry_after, int | float)
+        and not isinstance(retry_after, bool)
+        and retry_after >= 0
+        and math.isfinite(retry_after)
+    ):
         return float(retry_after)
     return None
 

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -122,7 +122,8 @@ class TelegramChannel:
 
     async def _close_owned_client(self) -> None:
         if self._owns_client and self._client is not None:
-            await self._client.aclose()
+            with anyio.CancelScope(shield=True):
+                await self._client.aclose()
         self._owns_client = False
 
     async def send_text(self, conversation_id: str, text: str) -> None:

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -150,7 +150,12 @@ class TestTelegramChannel:
             calls += 1
             if calls == 1:
                 return response({'ok': True, 'result': {}})
-            return response({'ok': False, 'description': 'chat not found'})
+            return response(
+                {
+                    'ok': False,
+                    'description': 'chat not found: https://api.telegram.org/botsecret-token/sendMessage',
+                }
+            )
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = TelegramChannel('secret-token', http_client=client)
@@ -159,6 +164,7 @@ class TestTelegramChannel:
                 await channel.send_text('chat', 'hello')
 
         assert 'secret-token' not in str(exc_info.value)
+        assert '/bot<redacted>/' in str(exc_info.value)
         await client.aclose()
 
     async def test_transport_error_suppresses_token_bearing_exception(self) -> None:
@@ -294,7 +300,7 @@ class TestTelegramChannel:
                     },
                     status_code=429,
                 )
-            return response({'ok': False, 'error_code': 409, 'description': 'webhook is active'}, status_code=409)
+            return response({'ok': False, 'error_code': 409, 'description': 'webhook is active'})
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = TelegramChannel('token', http_client=client)
@@ -325,7 +331,7 @@ class TestTelegramChannel:
             if poll_count == 1:
                 return response({'ok': True, 'result': 'not a list'})
             if poll_count == 2:
-                return response({'ok': True, 'result': [123, {'update_id': 'unknown'}]})
+                return response({'ok': True, 'result': [123, {'update_id': 'unknown'}, {'update_id': True}]})
             return response(
                 {
                     'ok': True,
@@ -402,6 +408,14 @@ class TestTelegramChannel:
                     200,
                     content=b'{"ok":false,"description":"non-finite error","parameters":{"retry_after":Infinity}}',
                 )
+            if calls == 6:
+                return response(
+                    {
+                        'ok': False,
+                        'description': 'boolean delay',
+                        'parameters': {'retry_after': False},
+                    }
+                )
             return response({'ok': False})
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
@@ -415,8 +429,10 @@ class TestTelegramChannel:
                 await channel.send_text('chat', 'third')
             with pytest.raises(ChannelError, match='non-finite error'):
                 await channel.send_text('chat', 'fourth')
-            with pytest.raises(ChannelError, match='unknown Telegram Bot API error'):
+            with pytest.raises(ChannelError, match='boolean delay'):
                 await channel.send_text('chat', 'fifth')
+            with pytest.raises(ChannelError, match='unknown Telegram Bot API error'):
+                await channel.send_text('chat', 'sixth')
         await client.aclose()
 
     async def test_owned_client_closes_on_success_and_open_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -444,13 +460,14 @@ class TestTelegramChannel:
                 pass  # pragma: no cover
         assert rejected.is_closed
 
-    async def test_non_json_fatal_response_does_not_retry(self) -> None:
+    @pytest.mark.parametrize('body', [b'Unauthorized', b'{}'])
+    async def test_fatal_http_response_does_not_retry(self, body: bytes) -> None:
         calls = 0
 
         def handler(request: httpx.Request) -> httpx.Response:
             nonlocal calls
             calls += 1
-            return httpx.Response(401, content=b'Unauthorized')
+            return httpx.Response(401, content=body)
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         with pytest.raises(ChannelError, match='HTTP 401'):

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -1,0 +1,463 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+import pytest
+from pydantic import TypeAdapter
+
+from pydantic_ai_harness.channels import ChannelAdapter, ChannelError
+from pydantic_ai_harness.channels.telegram import TelegramChannel
+
+_BODY_ADAPTER = TypeAdapter(dict[str, object])
+
+
+def response(payload: object, *, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=payload)
+
+
+@pytest.mark.anyio
+class TestTelegramChannel:
+    async def test_polls_private_text_and_advances_offset(self) -> None:
+        poll_bodies: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            method = request.url.path.rsplit('/', 1)[-1]
+            if method == 'getMe':
+                return response({'ok': True, 'result': {'id': 42}})
+            body = _BODY_ADAPTER.validate_python(json.loads(request.content))
+            poll_bodies.append(body)
+            if len(poll_bodies) == 1:
+                return response(
+                    {
+                        'ok': True,
+                        'result': [
+                            {
+                                'update_id': 10,
+                                'message': {
+                                    'message_id': 20,
+                                    'from': {'id': 30},
+                                    'chat': {'id': 40, 'type': 'group'},
+                                    'text': 'group',
+                                },
+                            },
+                            {'update_id': 11, 'message': {'message_id': 21}},
+                            {
+                                'update_id': 12,
+                                'message': {
+                                    'message_id': 22,
+                                    'from': {'id': 30},
+                                    'chat': {'id': 40, 'type': 'private'},
+                                    'text': 'hello',
+                                },
+                            },
+                        ],
+                    }
+                )
+            return response(
+                {
+                    'ok': True,
+                    'result': [
+                        {
+                            'update_id': 13,
+                            'message': {
+                                'message_id': 23,
+                                'from': {'id': '30'},
+                                'chat': {'id': '40', 'type': 'private'},
+                                'text': 'again',
+                            },
+                        }
+                    ],
+                }
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel: ChannelAdapter = TelegramChannel('token', http_client=client, poll_timeout=7)
+        async with channel:
+            messages = channel.messages()
+            first = await anext(messages)
+            second = await anext(messages)
+
+        assert (first.conversation_id, first.sender_id, first.message_id, first.text) == ('40', '30', '22', 'hello')
+        assert second.text == 'again'
+        assert poll_bodies == [
+            {'timeout': 7, 'allowed_updates': ['message']},
+            {'timeout': 7, 'allowed_updates': ['message'], 'offset': 13},
+        ]
+        assert client.is_closed is False
+        await client.aclose()
+
+    async def test_chunks_text_by_unicode_characters_and_retries_one_rate_limit(self) -> None:
+        texts: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            method = request.url.path.rsplit('/', 1)[-1]
+            if method == 'getMe':
+                return response({'ok': True, 'result': {}})
+            body = _BODY_ADAPTER.validate_python(json.loads(request.content))
+            text = body.get('text')
+            assert isinstance(text, str)
+            texts.append(text)
+            if len(texts) == 1:
+                return response(
+                    {
+                        'ok': False,
+                        'description': 'Too Many Requests',
+                        'parameters': {'retry_after': 0},
+                    },
+                    status_code=429,
+                )
+            return response({'ok': True, 'result': {'message_id': len(texts)}})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('token', http_client=client)
+        async with channel:
+            await channel.send_text('chat', 'a' * 4097)
+            await channel.send_text('chat', '😀' * 2049)
+            with pytest.raises(ValueError, match='text must not be empty'):
+                await channel.send_text('chat', '')
+
+        assert texts == ['a' * 4096, 'a' * 4096, 'a', '😀' * 2049]
+        await client.aclose()
+
+    async def test_provider_error_does_not_expose_token(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return response({'ok': True, 'result': {}})
+            return response({'ok': False, 'description': 'chat not found'})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('secret-token', http_client=client)
+        async with channel:
+            with pytest.raises(ChannelError, match='chat not found') as exc_info:
+                await channel.send_text('chat', 'hello')
+
+        assert 'secret-token' not in str(exc_info.value)
+        await client.aclose()
+
+    async def test_transport_error_suppresses_token_bearing_exception(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return response({'ok': True, 'result': {}})
+            raise httpx.ConnectError('offline', request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('secret-token', http_client=client)
+        async with channel:
+            with pytest.raises(ChannelError, match='request failed: sendMessage') as exc_info:
+                await channel.send_text('chat', 'hello')
+
+        assert exc_info.value.__cause__ is None
+        assert exc_info.value.__suppress_context__ is True
+        assert 'secret-token' not in str(exc_info.value)
+        await client.aclose()
+
+    async def test_httpx_request_log_redacts_token(self, caplog: pytest.LogCaptureFixture) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({'ok': True, 'result': {}})))
+        channel = TelegramChannel('secret-token', http_client=client)
+
+        with caplog.at_level('INFO', logger='httpx'):
+            async with channel:
+                await channel.send_text('chat', 'hello')
+            logging.getLogger('httpx').info('unrelated request')
+
+        assert 'secret-token' not in caplog.text
+        assert '/bot<redacted>/' in caplog.text
+        assert 'unrelated request' in caplog.text
+        await client.aclose()
+
+    async def test_poll_recovers_from_transport_error(self) -> None:
+        poll_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal poll_count
+            method = request.url.path.rsplit('/', 1)[-1]
+            if method == 'getMe':
+                return response({'ok': True, 'result': {}})
+            poll_count += 1
+            if poll_count == 1:
+                raise httpx.ConnectError('offline', request=request)
+            return response(
+                {
+                    'ok': True,
+                    'result': [
+                        {
+                            'update_id': 1,
+                            'message': {
+                                'message_id': 2,
+                                'from': {'id': 3},
+                                'chat': {'id': 4, 'type': 'private'},
+                                'text': 'recovered',
+                            },
+                        }
+                    ],
+                }
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('token', http_client=client, retry_delay=0.001)
+        async with channel:
+            message = await anext(channel.messages())
+
+        assert message.text == 'recovered'
+        assert poll_count == 2
+        await client.aclose()
+
+    async def test_resets_offset_after_one_week_without_updates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        poll_bodies: list[dict[str, object]] = []
+        update_ids = iter((10, 5))
+        clock = iter((0.0, 604_801.0, 604_801.0))
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith('/getMe'):
+                return response({'ok': True, 'result': {}})
+            poll_bodies.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            update_id = next(update_ids)
+            return response(
+                {
+                    'ok': True,
+                    'result': [
+                        {
+                            'update_id': update_id,
+                            'message': {
+                                'message_id': update_id,
+                                'from': {'id': 3},
+                                'chat': {'id': 4, 'type': 'private'},
+                                'text': str(update_id),
+                            },
+                        }
+                    ],
+                }
+            )
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.monotonic', lambda: next(clock))
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('token', http_client=client)
+        async with channel:
+            messages = channel.messages()
+            assert (await anext(messages)).text == '10'
+            assert (await anext(messages)).text == '5'
+
+        assert poll_bodies == [
+            {'timeout': 30, 'allowed_updates': ['message']},
+            {'timeout': 30, 'allowed_updates': ['message']},
+        ]
+        await client.aclose()
+
+    async def test_poll_honors_rate_limit_and_rejects_permanent_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        poll_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal poll_count
+            method = request.url.path.rsplit('/', 1)[-1]
+            if method == 'getMe':
+                return response({'ok': True, 'result': {}})
+            poll_count += 1
+            if poll_count == 1:
+                return response(
+                    {
+                        'ok': False,
+                        'error_code': 429,
+                        'description': 'Too Many Requests',
+                        'parameters': {'retry_after': 0},
+                    },
+                    status_code=429,
+                )
+            return response({'ok': False, 'error_code': 409, 'description': 'webhook is active'}, status_code=409)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('token', http_client=client)
+        async with channel:
+            with pytest.raises(ChannelError, match='webhook is active'):
+                await anext(channel.messages())
+
+        assert poll_count == 2
+        assert 'polling rate limited' in caplog.text
+        await client.aclose()
+
+    async def test_poll_recovers_from_invalid_results_and_skips_malformed_updates(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        poll_count = 0
+        invalid_sender: list[object] = []
+        sleeps: list[float] = []
+
+        async def sleep(delay: float) -> None:
+            sleeps.append(delay)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal poll_count
+            method = request.url.path.rsplit('/', 1)[-1]
+            if method == 'getMe':
+                return response({'ok': True, 'result': {}})
+            poll_count += 1
+            if poll_count == 1:
+                return response({'ok': True, 'result': 'not a list'})
+            if poll_count == 2:
+                return response({'ok': True, 'result': [123, {'update_id': 'unknown'}]})
+            return response(
+                {
+                    'ok': True,
+                    'result': [
+                        123,
+                        {'update_id': 'unknown', 'message': 123},
+                        {'update_id': 1, 'message': 123},
+                        {
+                            'update_id': 2,
+                            'message': {
+                                'message_id': 2,
+                                'from': {'id': invalid_sender},
+                                'chat': {'id': 4, 'type': 'private'},
+                                'text': 'invalid sender',
+                            },
+                        },
+                        {
+                            'update_id': 'unknown',
+                            'message': {
+                                'message_id': 3,
+                                'from': {'id': 5},
+                                'chat': {'id': 4, 'type': 'private'},
+                                'text': 'valid',
+                            },
+                        },
+                        {
+                            'update_id': 4,
+                            'message': {
+                                'message_id': 4,
+                                'from': {'id': 5},
+                                'chat': {'id': 4, 'type': 'private'},
+                                'text': 'valid update',
+                            },
+                        },
+                    ],
+                }
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('token', http_client=client, retry_delay=0.25)
+        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.asyncio.sleep', sleep)
+        async with channel:
+            message = await anext(channel.messages())
+
+        assert message.text == 'valid update'
+        assert 'invalid result' in caplog.text
+        assert 'without usable ids' in caplog.text
+        assert sleeps == [0.25, 0.25]
+        await client.aclose()
+
+    async def test_invalid_response_is_safe_and_not_rate_limited(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return response({'ok': True, 'result': {}})
+            if calls == 2:
+                return response(['invalid envelope'])
+            if calls == 3:
+                return httpx.Response(500, content=b'upstream unavailable')
+            if calls == 4:
+                return response(
+                    {
+                        'ok': False,
+                        'description': 'ordinary error',
+                        'parameters': {'retry_after': -1},
+                    }
+                )
+            if calls == 5:
+                return httpx.Response(
+                    200,
+                    content=b'{"ok":false,"description":"non-finite error","parameters":{"retry_after":Infinity}}',
+                )
+            return response({'ok': False})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('token', http_client=client)
+        async with channel:
+            with pytest.raises(ChannelError, match='invalid response'):
+                await channel.send_text('chat', 'first')
+            with pytest.raises(ChannelError, match='invalid response'):
+                await channel.send_text('chat', 'second')
+            with pytest.raises(ChannelError, match='ordinary error'):
+                await channel.send_text('chat', 'third')
+            with pytest.raises(ChannelError, match='non-finite error'):
+                await channel.send_text('chat', 'fourth')
+            with pytest.raises(ChannelError, match='unknown Telegram Bot API error'):
+                await channel.send_text('chat', 'fifth')
+        await client.aclose()
+
+    async def test_owned_client_closes_on_success_and_open_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client_class = httpx.AsyncClient
+        client = client_class(transport=httpx.MockTransport(lambda request: response({'ok': True, 'result': {}})))
+        monkeypatch.setattr(httpx, 'AsyncClient', lambda: client)
+        channel = TelegramChannel('token')
+
+        async with channel:
+            with pytest.raises(RuntimeError, match='already open'):
+                await channel.__aenter__()
+
+        assert client.is_closed
+
+        rejected = client_class(
+            transport=httpx.MockTransport(
+                lambda request: response(
+                    {'ok': False, 'error_code': 401, 'description': 'unauthorized'}, status_code=401
+                )
+            )
+        )
+        monkeypatch.setattr(httpx, 'AsyncClient', lambda: rejected)
+        with pytest.raises(ChannelError, match='unauthorized'):
+            async with TelegramChannel('token'):
+                pass  # pragma: no cover
+        assert rejected.is_closed
+
+    async def test_non_json_fatal_response_does_not_retry(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            return httpx.Response(401, content=b'Unauthorized')
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with pytest.raises(ChannelError, match='HTTP 401'):
+            async with TelegramChannel('token', http_client=client):
+                pass  # pragma: no cover
+        assert calls == 1
+        await client.aclose()
+
+    async def test_requires_open_channel(self) -> None:
+        channel = TelegramChannel('token')
+        with pytest.raises(RuntimeError, match='opened'):
+            await channel.send_text('chat', 'hello')
+
+    @pytest.mark.parametrize(
+        ('token', 'poll_timeout', 'retry_delay', 'message'),
+        [
+            ('', 30, 1.0, 'token'),
+            ('x', 0, 1.0, 'poll_timeout'),
+            ('x', True, 1.0, 'poll_timeout'),
+            ('x', 30, 0, 'retry_delay'),
+            ('x', 30, -1.0, 'retry_delay'),
+            ('x', 30, float('nan'), 'retry_delay'),
+        ],
+    )
+    def test_validates_configuration(
+        self,
+        token: str,
+        poll_timeout: int,
+        retry_delay: float,
+        message: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=message):
+            TelegramChannel(token, poll_timeout=poll_timeout, retry_delay=retry_delay)

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import aclosing
 
 import httpx
 import pytest
@@ -75,9 +76,9 @@ class TestTelegramChannel:
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel: ChannelAdapter = TelegramChannel('token', http_client=client, poll_timeout=7)
         async with channel:
-            messages = channel.messages()
-            first = await anext(messages)
-            second = await anext(messages)
+            async with aclosing(channel.messages()) as messages:
+                first = await anext(messages)
+                second = await anext(messages)
 
         assert (first.conversation_id, first.sender_id, first.message_id, first.text) == ('40', '30', '22', 'hello')
         assert second.text == 'again'
@@ -206,7 +207,8 @@ class TestTelegramChannel:
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = TelegramChannel('token', http_client=client, retry_delay=0.001)
         async with channel:
-            message = await anext(channel.messages())
+            async with aclosing(channel.messages()) as messages:
+                message = await anext(messages)
 
         assert message.text == 'recovered'
         assert poll_count == 2
@@ -243,9 +245,9 @@ class TestTelegramChannel:
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = TelegramChannel('token', http_client=client)
         async with channel:
-            messages = channel.messages()
-            assert (await anext(messages)).text == '10'
-            assert (await anext(messages)).text == '5'
+            async with aclosing(channel.messages()) as messages:
+                assert (await anext(messages)).text == '10'
+                assert (await anext(messages)).text == '5'
 
         assert poll_bodies == [
             {'timeout': 30, 'allowed_updates': ['message']},
@@ -344,9 +346,10 @@ class TestTelegramChannel:
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = TelegramChannel('token', http_client=client, retry_delay=0.25)
-        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.asyncio.sleep', sleep)
+        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.anyio.sleep', sleep)
         async with channel:
-            message = await anext(channel.messages())
+            async with aclosing(channel.messages()) as messages:
+                message = await anext(messages)
 
         assert message.text == 'valid update'
         assert 'invalid result' in caplog.text

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -122,6 +122,26 @@ class TestTelegramChannel:
         assert texts == ['a' * 4096, 'a' * 4096, 'a', '😀' * 2049]
         await client.aclose()
 
+    async def test_does_not_hold_conversation_lane_for_long_rate_limit(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith('/getMe'):
+                return response({'ok': True, 'result': {}})
+            return response(
+                {
+                    'ok': False,
+                    'description': 'Too Many Requests',
+                    'parameters': {'retry_after': 61},
+                },
+                status_code=429,
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel('token', http_client=client)
+        async with channel:
+            with pytest.raises(ChannelError, match='Too Many Requests'):
+                await channel.send_text('chat', 'hello')
+        await client.aclose()
+
     async def test_provider_error_does_not_expose_token(self) -> None:
         calls = 0
 


### PR DESCRIPTION
Part of #737. Stacked on #738. Slack is sibling #740; WhatsApp is #741 on Slack.

## Summary
- add the official Telegram Bot API long-polling adapter
- keep offset, chunking, redaction, and retry policy inside the adapter
- use AnyIO primitives without asyncio coupling
- cap inline outbound throttle waits while honoring polling delays
- lead with a runnable personal-assistant example

## Verification
- asyncio adapter and host integration tests
- Ruff, strict Pyright, full test suite, and 100% branch coverage
- malformed response, retry, lifecycle, and token-redaction coverage
