### PR TITLE
Connect ChannelHost to the Slack Events API

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -86,7 +86,7 @@ For GovSlack, pass `api_base_url='https://slack-gov.com/api'` to `SlackChannel`.
 
 The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
-Run one host process for each Slack app installation. Terminate TLS and limit
+Route each Slack app installation to exactly one live host process. Terminate TLS and limit
 request body size in the ASGI server or reverse proxy.
 
 ## How channels fit Pydantic AI

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -82,7 +82,7 @@ Save this as `app.py`, run `uvicorn app:app`, and point Slack's Events API URL
 at `/slack/events`.
 For GovSlack, pass `api_base_url='https://slack-gov.com/api'` to `SlackChannel`.
 
-The task group owns the channel service and waits for its turns during shutdown.
+The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
 Multi-worker deployments need external ingress routing and storage.
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -35,9 +35,11 @@ control. Replace `U0123456789` below with your Slack member id from
 **Profile > Copy member ID**.
 
 ```python
-import asyncio
 import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
+import anyio
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
@@ -51,25 +53,28 @@ channel = SlackChannel(
 host = ChannelHost(agent, channel, allowed_senders={'U0123456789'})
 
 
-def receive_slack(method: str, headers: dict[str, str], body: bytes) -> WebhookResponse:
+async def receive_slack(method: str, headers: dict[str, str], body: bytes) -> WebhookResponse:
     request = WebhookRequest(method=method, headers=headers, query={}, body=body)
     return channel.handle_webhook(request)
 
 
-def start_channel() -> asyncio.Task[None]:
-    return asyncio.create_task(host.serve())
+@asynccontextmanager
+async def channel_lifespan() -> AsyncIterator[None]:
+    async with anyio.create_task_group() as tasks:
+        tasks.start_soon(host.serve)
+        yield
+        tasks.cancel_scope.cancel()
 ```
 
-Connect the two functions to your web app:
+Connect the lifespan and route to your web app:
 
-1. Call `start_channel()` when the app starts.
+1. Enter `channel_lifespan()` for the app's lifespan.
 2. Forward the Events API route to `receive_slack()` and return its status code
    and body.
-3. On shutdown, cancel the channel task, then await it while suppressing
-   `asyncio.CancelledError`.
 
-The lifespan and route must use the same process and event loop. Multi-worker
-deployments need external ingress routing and storage.
+The task group owns the channel service and waits for its turns during shutdown.
+The lifespan and route must use the same process and async event-loop thread.
+Multi-worker deployments need external ingress routing and storage.
 
 ## How channels fit Pydantic AI
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -32,7 +32,8 @@ Create a Slack app with `chat:write`, `app_mentions:read`, and `im:history` bot
 scopes. Subscribe it to `app_mention` and `message.im`. Set `SLACK_BOT_TOKEN`
 and `SLACK_SIGNING_SECRET` from the app settings, keeping both outside source
 control. Replace `U0123456789` below with your Slack member id from
-**Profile > Copy member ID**.
+**Profile > Copy member ID**, and `C0123456789` with a channel where the bot may
+answer mentions.
 
 ```python
 import os
@@ -53,12 +54,13 @@ agent = Agent('anthropic:claude-fable-5')
 channel = SlackChannel(
     os.environ['SLACK_BOT_TOKEN'],
     os.environ['SLACK_SIGNING_SECRET'],
+    allowed_channel_ids={'C0123456789'},
 )
 host = ChannelHost(agent, channel, allowed_senders={'U0123456789'})
 
 
 async def receive_slack(request: Request) -> PlainTextResponse:
-    result = channel.handle_webhook(
+    result = await channel.handle_webhook(
         WebhookRequest(request.method, request.headers, request.query_params, await request.body())
     )
     return PlainTextResponse(result.body, status_code=result.status_code)
@@ -84,7 +86,8 @@ For GovSlack, pass `api_base_url='https://slack-gov.com/api'` to `SlackChannel`.
 
 The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
-Multi-worker deployments need external ingress routing and storage.
+Run one host process for each Slack app installation. Terminate TLS and limit
+request body size in the ASGI server or reverse proxy.
 
 ## How channels fit Pydantic AI
 
@@ -130,8 +133,10 @@ History remains saved after a successful run even when delivery cannot be
 confirmed.
 
 `SlackChannel` retries one `chat.postMessage` call after an HTTP 429 with a
-valid non-negative `Retry-After`. It does not retry timeouts or other
-ambiguous failures because Slack may already have accepted the message.
+valid non-negative `Retry-After` of at most 60 seconds. Longer delays fail the
+delivery instead of holding that conversation's turn slot. It does not retry
+timeouts or other ambiguous failures because Slack may already have accepted
+the message. If a later text chunk fails, earlier chunks remain visible.
 
 The webhook handler verifies and enqueues a request before returning HTTP 200.
 It returns HTTP 503 while the channel is opening or when its bounded queue is
@@ -154,10 +159,10 @@ Slack signatures are checked over the exact request bytes with the app signing
 secret. Requests more than five minutes from the local clock are rejected.
 Replies disable link and media unfurling so Slack does not fetch URLs generated
 by the agent.
-`SlackChannel` validates one workspace and drops events from other workspaces,
+Slack direct messages are enabled by default. App mentions are accepted only
+from `allowed_channel_ids`. The adapter also drops events from other workspaces,
 bot-authored messages, edits, messages with a subtype (including file shares),
-and unaddressed channel messages. These filters
-also prevent the bot from responding to its own replies.
+and unaddressed channel messages.
 
 ## Adapters and stores
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -102,8 +102,9 @@ an integration, not an `AbstractCapability`.
   ids are dropped before the history store or agent is called.
 - Turns in one conversation run in arrival order. Different conversations may
   run concurrently.
-- At most 100 accepted turns may be running or waiting by default. Set
-  `max_pending_turns` to tune this backpressure limit.
+- At most 100 turns may be running or waiting inside the host by default. Set
+  `max_pending_turns` to tune this limit. Webhook adapters separately buffer up
+  to `max_queued_messages` verified messages before the host accepts them.
 - `/new` waits for earlier turns in the conversation, then deletes its stored
   Pydantic AI message history. It does not cancel an active turn.
 - `InMemoryConversationStore` is the default. It keeps history only for the

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -20,7 +20,7 @@ This quickstart uses Anthropic. Install the provider extra and set
 `ANTHROPIC_API_KEY` before running it:
 
 ```bash
-uv add "pydantic-ai-harness[anthropic]"
+uv add "pydantic-ai-harness[anthropic]" starlette uvicorn
 ```
 
 ## Slack: DMs and app mentions
@@ -41,8 +41,12 @@ from contextlib import asynccontextmanager
 
 import anyio
 from pydantic_ai import Agent
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
 
-from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
+from pydantic_ai_harness.channels import ChannelHost, WebhookRequest
 from pydantic_ai_harness.channels.slack import SlackChannel
 
 agent = Agent('anthropic:claude-fable-5')
@@ -53,24 +57,30 @@ channel = SlackChannel(
 host = ChannelHost(agent, channel, allowed_senders={'U0123456789'})
 
 
-async def receive_slack(method: str, headers: dict[str, str], body: bytes) -> WebhookResponse:
-    request = WebhookRequest(method=method, headers=headers, query={}, body=body)
-    return channel.handle_webhook(request)
+async def receive_slack(request: Request) -> PlainTextResponse:
+    result = channel.handle_webhook(
+        WebhookRequest(request.method, request.headers, request.query_params, await request.body())
+    )
+    return PlainTextResponse(result.body, status_code=result.status_code)
 
 
 @asynccontextmanager
-async def channel_lifespan() -> AsyncIterator[None]:
+async def channel_lifespan(_app: Starlette) -> AsyncIterator[None]:
     async with anyio.create_task_group() as tasks:
         tasks.start_soon(host.serve)
         yield
         tasks.cancel_scope.cancel()
+
+
+app = Starlette(
+    routes=[Route('/slack/events', receive_slack, methods=['POST'])],
+    lifespan=channel_lifespan,
+)
 ```
 
-Connect the lifespan and route to your web app:
-
-1. Enter `channel_lifespan()` for the app's lifespan.
-2. Forward the Events API route to `receive_slack()` and return its status code
-   and body.
+Save this as `app.py`, run `uvicorn app:app`, and point Slack's Events API URL
+at `/slack/events`.
+For GovSlack, pass `api_base_url='https://slack-gov.com/api'` to `SlackChannel`.
 
 The task group owns the channel service and waits for its turns during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
@@ -119,7 +129,7 @@ History remains saved after a successful run even when delivery cannot be
 confirmed.
 
 `SlackChannel` retries one `chat.postMessage` call after an HTTP 429 with a
-valid `Retry-After` of at most 60 seconds. It does not retry timeouts or other
+valid non-negative `Retry-After`. It does not retry timeouts or other
 ambiguous failures because Slack may already have accepted the message.
 
 The webhook handler verifies and enqueues a request before returning HTTP 200.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -12,26 +12,64 @@ Channels are useful for:
 - a support agent in team messages
 - an internal agent that can use the same tools and capabilities as your app
 
-The agent-side integration is the same for every provider:
-
-```python
-from pydantic_ai import Agent
-
-from pydantic_ai_harness.channels import ChannelAdapter, ChannelHost
-
-
-async def serve(channel: ChannelAdapter) -> None:
-    agent = Agent('anthropic:claude-fable-5', instructions='Be concise and helpful.')
-    host = ChannelHost(agent, channel, allowed_senders={'provider-user-id'})
-    await host.serve()
-```
-
-The provider adapter supplies real sender ids and delivers each reply. Replace
-`provider-user-id` with an id from that provider.
-
 [Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
 
 > While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
+
+This quickstart uses Anthropic. Install the provider extra and set
+`ANTHROPIC_API_KEY` before running it:
+
+```bash
+uv add "pydantic-ai-harness[anthropic]"
+```
+
+## Slack: DMs and app mentions
+
+Use Slack to answer direct messages or respond when somebody mentions the agent
+in a channel.
+
+Create a Slack app with `chat:write`, `app_mentions:read`, and `im:history` bot
+scopes. Subscribe it to `app_mention` and `message.im`. Set `SLACK_BOT_TOKEN`
+and `SLACK_SIGNING_SECRET` from the app settings, keeping both outside source
+control. Replace `U0123456789` below with your Slack member id from
+**Profile > Copy member ID**.
+
+```python
+import asyncio
+import os
+
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
+from pydantic_ai_harness.channels.slack import SlackChannel
+
+agent = Agent('anthropic:claude-fable-5')
+channel = SlackChannel(
+    os.environ['SLACK_BOT_TOKEN'],
+    os.environ['SLACK_SIGNING_SECRET'],
+)
+host = ChannelHost(agent, channel, allowed_senders={'U0123456789'})
+
+
+def receive_slack(method: str, headers: dict[str, str], body: bytes) -> WebhookResponse:
+    request = WebhookRequest(method=method, headers=headers, query={}, body=body)
+    return channel.handle_webhook(request)
+
+
+def start_channel() -> asyncio.Task[None]:
+    return asyncio.create_task(host.serve())
+```
+
+Connect the two functions to your web app:
+
+1. Call `start_channel()` when the app starts.
+2. Forward the Events API route to `receive_slack()` and return its status code
+   and body.
+3. On shutdown, cancel the channel task, then await it while suppressing
+   `asyncio.CancelledError`.
+
+The lifespan and route must use the same process and event loop. Multi-worker
+deployments need external ingress routing and storage.
 
 ## How channels fit Pydantic AI
 
@@ -75,6 +113,17 @@ chat. If sending a reply fails, the host logs the failure and continues serving.
 History remains saved after a successful run even when delivery cannot be
 confirmed.
 
+`SlackChannel` retries one `chat.postMessage` call after an HTTP 429 with a
+valid `Retry-After` of at most 60 seconds. It does not retry timeouts or other
+ambiguous failures because Slack may already have accepted the message.
+
+The webhook handler verifies and enqueues a request before returning HTTP 200.
+It returns HTTP 503 while the channel is opening or when its bounded queue is
+full, allowing Slack to retry the event. Duplicate suppression covers the
+10,000 most recently accepted `event_id` values. The queue and duplicate window
+are process-local. A restart can reprocess a redelivered event, and can lose an
+acknowledged event that was still waiting in the queue.
+
 `serve()` runs until it is cancelled or the adapter ends. It owns every turn in
 an AnyIO task group, so no turn task outlives it. Cancellation closes the
 message iterator, cancels in-flight turns, and then closes the adapter.
@@ -84,6 +133,15 @@ message iterator, cancels in-flight turns, and then closes the adapter.
 Anyone allowed to message the agent can supply model input to an agent that may
 have access to tools, credentials, files, and network services. Use a narrow
 sender allowlist and apply normal Pydantic AI guardrails to the connected agent.
+
+Slack signatures are checked over the exact request bytes with the app signing
+secret. Requests more than five minutes from the local clock are rejected.
+Replies disable link and media unfurling so Slack does not fetch URLs generated
+by the agent.
+`SlackChannel` validates one workspace and drops events from other workspaces,
+bot-authored messages, edits, messages with a subtype (including file shares),
+and unaddressed channel messages. These filters
+also prevent the bot from responding to its own replies.
 
 ## Adapters and stores
 
@@ -103,6 +161,10 @@ multiple live hosts safe without external per-conversation serialization.
 
 ## Not included
 
+The Slack adapter does not include Socket Mode, multi-workspace OAuth routing,
+files, reactions, message edits, or messages in channels that do not mention
+the bot. Socket Mode requires a WebSocket client and can be added separately.
+
 The host does not define media, reactions, typing indicators, streaming edits,
 tool approvals, or provider authentication. Adapters add only the provider
 behavior they document.
@@ -120,3 +182,9 @@ behavior they document.
 ::: pydantic_ai_harness.channels.ConversationStore
 
 ::: pydantic_ai_harness.channels.InMemoryConversationStore
+
+::: pydantic_ai_harness.channels.WebhookRequest
+
+::: pydantic_ai_harness.channels.WebhookResponse
+
+::: pydantic_ai_harness.channels.slack.SlackChannel

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -97,8 +97,9 @@ an integration, not an `AbstractCapability`.
   ids are dropped before the history store or agent is called.
 - Turns in one conversation run in arrival order. Different conversations may
   run concurrently.
-- At most 100 accepted turns may be running or waiting by default. Set
-  `max_pending_turns` to tune this backpressure limit.
+- At most 100 turns may be running or waiting inside the host by default. Set
+  `max_pending_turns` to tune this limit. Webhook adapters separately buffer up
+  to `max_queued_messages` verified messages before the host accepts them.
 - `/new` waits for earlier turns in the conversation, then deletes its stored
   Pydantic AI message history. It does not cancel an active turn.
 - `InMemoryConversationStore` is the default. It keeps history only for the

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -27,7 +27,8 @@ Create a Slack app with `chat:write`, `app_mentions:read`, and `im:history` bot
 scopes. Subscribe it to `app_mention` and `message.im`. Set `SLACK_BOT_TOKEN`
 and `SLACK_SIGNING_SECRET` from the app settings, keeping both outside source
 control. Replace `U0123456789` below with your Slack member id from
-**Profile > Copy member ID**.
+**Profile > Copy member ID**, and `C0123456789` with a channel where the bot may
+answer mentions.
 
 ```python
 import os
@@ -48,12 +49,13 @@ agent = Agent('anthropic:claude-fable-5')
 channel = SlackChannel(
     os.environ['SLACK_BOT_TOKEN'],
     os.environ['SLACK_SIGNING_SECRET'],
+    allowed_channel_ids={'C0123456789'},
 )
 host = ChannelHost(agent, channel, allowed_senders={'U0123456789'})
 
 
 async def receive_slack(request: Request) -> PlainTextResponse:
-    result = channel.handle_webhook(
+    result = await channel.handle_webhook(
         WebhookRequest(request.method, request.headers, request.query_params, await request.body())
     )
     return PlainTextResponse(result.body, status_code=result.status_code)
@@ -79,7 +81,8 @@ For GovSlack, pass `api_base_url='https://slack-gov.com/api'` to `SlackChannel`.
 
 The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
-Multi-worker deployments need external ingress routing and storage.
+Run one host process for each Slack app installation. Terminate TLS and limit
+request body size in the ASGI server or reverse proxy.
 
 ## How channels fit Pydantic AI
 
@@ -125,8 +128,10 @@ History remains saved after a successful run even when delivery cannot be
 confirmed.
 
 `SlackChannel` retries one `chat.postMessage` call after an HTTP 429 with a
-valid non-negative `Retry-After`. It does not retry timeouts or other
-ambiguous failures because Slack may already have accepted the message.
+valid non-negative `Retry-After` of at most 60 seconds. Longer delays fail the
+delivery instead of holding that conversation's turn slot. It does not retry
+timeouts or other ambiguous failures because Slack may already have accepted
+the message. If a later text chunk fails, earlier chunks remain visible.
 
 The webhook handler verifies and enqueues a request before returning HTTP 200.
 It returns HTTP 503 while the channel is opening or when its bounded queue is
@@ -149,10 +154,10 @@ Slack signatures are checked over the exact request bytes with the app signing
 secret. Requests more than five minutes from the local clock are rejected.
 Replies disable link and media unfurling so Slack does not fetch URLs generated
 by the agent.
-`SlackChannel` validates one workspace and drops events from other workspaces,
+Slack direct messages are enabled by default. App mentions are accepted only
+from `allowed_channel_ids`. The adapter also drops events from other workspaces,
 bot-authored messages, edits, messages with a subtype (including file shares),
-and unaddressed channel messages. These filters
-also prevent the bot from responding to its own replies.
+and unaddressed channel messages.
 
 ## Adapters and stores
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -15,7 +15,7 @@ This quickstart uses Anthropic. Install the provider extra and set
 `ANTHROPIC_API_KEY` before running it:
 
 ```bash
-uv add "pydantic-ai-harness[anthropic]"
+uv add "pydantic-ai-harness[anthropic]" starlette uvicorn
 ```
 
 ## Slack: DMs and app mentions
@@ -36,8 +36,12 @@ from contextlib import asynccontextmanager
 
 import anyio
 from pydantic_ai import Agent
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
 
-from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
+from pydantic_ai_harness.channels import ChannelHost, WebhookRequest
 from pydantic_ai_harness.channels.slack import SlackChannel
 
 agent = Agent('anthropic:claude-fable-5')
@@ -48,24 +52,30 @@ channel = SlackChannel(
 host = ChannelHost(agent, channel, allowed_senders={'U0123456789'})
 
 
-async def receive_slack(method: str, headers: dict[str, str], body: bytes) -> WebhookResponse:
-    request = WebhookRequest(method=method, headers=headers, query={}, body=body)
-    return channel.handle_webhook(request)
+async def receive_slack(request: Request) -> PlainTextResponse:
+    result = channel.handle_webhook(
+        WebhookRequest(request.method, request.headers, request.query_params, await request.body())
+    )
+    return PlainTextResponse(result.body, status_code=result.status_code)
 
 
 @asynccontextmanager
-async def channel_lifespan() -> AsyncIterator[None]:
+async def channel_lifespan(_app: Starlette) -> AsyncIterator[None]:
     async with anyio.create_task_group() as tasks:
         tasks.start_soon(host.serve)
         yield
         tasks.cancel_scope.cancel()
+
+
+app = Starlette(
+    routes=[Route('/slack/events', receive_slack, methods=['POST'])],
+    lifespan=channel_lifespan,
+)
 ```
 
-Connect the lifespan and route to your web app:
-
-1. Enter `channel_lifespan()` for the app's lifespan.
-2. Forward the Events API route to `receive_slack()` and return its status code
-   and body.
+Save this as `app.py`, run `uvicorn app:app`, and point Slack's Events API URL
+at `/slack/events`.
+For GovSlack, pass `api_base_url='https://slack-gov.com/api'` to `SlackChannel`.
 
 The task group owns the channel service and waits for its turns during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
@@ -114,7 +124,7 @@ History remains saved after a successful run even when delivery cannot be
 confirmed.
 
 `SlackChannel` retries one `chat.postMessage` call after an HTTP 429 with a
-valid `Retry-After` of at most 60 seconds. It does not retry timeouts or other
+valid non-negative `Retry-After`. It does not retry timeouts or other
 ambiguous failures because Slack may already have accepted the message.
 
 The webhook handler verifies and enqueues a request before returning HTTP 200.

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -77,7 +77,7 @@ Save this as `app.py`, run `uvicorn app:app`, and point Slack's Events API URL
 at `/slack/events`.
 For GovSlack, pass `api_base_url='https://slack-gov.com/api'` to `SlackChannel`.
 
-The task group owns the channel service and waits for its turns during shutdown.
+The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
 Multi-worker deployments need external ingress routing and storage.
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -30,9 +30,11 @@ control. Replace `U0123456789` below with your Slack member id from
 **Profile > Copy member ID**.
 
 ```python
-import asyncio
 import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
+import anyio
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
@@ -46,25 +48,28 @@ channel = SlackChannel(
 host = ChannelHost(agent, channel, allowed_senders={'U0123456789'})
 
 
-def receive_slack(method: str, headers: dict[str, str], body: bytes) -> WebhookResponse:
+async def receive_slack(method: str, headers: dict[str, str], body: bytes) -> WebhookResponse:
     request = WebhookRequest(method=method, headers=headers, query={}, body=body)
     return channel.handle_webhook(request)
 
 
-def start_channel() -> asyncio.Task[None]:
-    return asyncio.create_task(host.serve())
+@asynccontextmanager
+async def channel_lifespan() -> AsyncIterator[None]:
+    async with anyio.create_task_group() as tasks:
+        tasks.start_soon(host.serve)
+        yield
+        tasks.cancel_scope.cancel()
 ```
 
-Connect the two functions to your web app:
+Connect the lifespan and route to your web app:
 
-1. Call `start_channel()` when the app starts.
+1. Enter `channel_lifespan()` for the app's lifespan.
 2. Forward the Events API route to `receive_slack()` and return its status code
    and body.
-3. On shutdown, cancel the channel task, then await it while suppressing
-   `asyncio.CancelledError`.
 
-The lifespan and route must use the same process and event loop. Multi-worker
-deployments need external ingress routing and storage.
+The task group owns the channel service and waits for its turns during shutdown.
+The lifespan and route must use the same process and async event-loop thread.
+Multi-worker deployments need external ingress routing and storage.
 
 ## How channels fit Pydantic AI
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -81,7 +81,7 @@ For GovSlack, pass `api_base_url='https://slack-gov.com/api'` to `SlackChannel`.
 
 The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
-Run one host process for each Slack app installation. Terminate TLS and limit
+Route each Slack app installation to exactly one live host process. Terminate TLS and limit
 request body size in the ASGI server or reverse proxy.
 
 ## How channels fit Pydantic AI

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -7,26 +7,64 @@ Channels are useful for:
 - a support agent in team messages
 - an internal agent that can use the same tools and capabilities as your app
 
-The agent-side integration is the same for every provider:
-
-```python
-from pydantic_ai import Agent
-
-from pydantic_ai_harness.channels import ChannelAdapter, ChannelHost
-
-
-async def serve(channel: ChannelAdapter) -> None:
-    agent = Agent('anthropic:claude-fable-5', instructions='Be concise and helpful.')
-    host = ChannelHost(agent, channel, allowed_senders={'provider-user-id'})
-    await host.serve()
-```
-
-The provider adapter supplies real sender ids and delivers each reply. Replace
-`provider-user-id` with an id from that provider.
-
 [Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
 
 > While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](../../docs/index.md#version-policy).
+
+This quickstart uses Anthropic. Install the provider extra and set
+`ANTHROPIC_API_KEY` before running it:
+
+```bash
+uv add "pydantic-ai-harness[anthropic]"
+```
+
+## Slack: DMs and app mentions
+
+Use Slack to answer direct messages or respond when somebody mentions the agent
+in a channel.
+
+Create a Slack app with `chat:write`, `app_mentions:read`, and `im:history` bot
+scopes. Subscribe it to `app_mention` and `message.im`. Set `SLACK_BOT_TOKEN`
+and `SLACK_SIGNING_SECRET` from the app settings, keeping both outside source
+control. Replace `U0123456789` below with your Slack member id from
+**Profile > Copy member ID**.
+
+```python
+import asyncio
+import os
+
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
+from pydantic_ai_harness.channels.slack import SlackChannel
+
+agent = Agent('anthropic:claude-fable-5')
+channel = SlackChannel(
+    os.environ['SLACK_BOT_TOKEN'],
+    os.environ['SLACK_SIGNING_SECRET'],
+)
+host = ChannelHost(agent, channel, allowed_senders={'U0123456789'})
+
+
+def receive_slack(method: str, headers: dict[str, str], body: bytes) -> WebhookResponse:
+    request = WebhookRequest(method=method, headers=headers, query={}, body=body)
+    return channel.handle_webhook(request)
+
+
+def start_channel() -> asyncio.Task[None]:
+    return asyncio.create_task(host.serve())
+```
+
+Connect the two functions to your web app:
+
+1. Call `start_channel()` when the app starts.
+2. Forward the Events API route to `receive_slack()` and return its status code
+   and body.
+3. On shutdown, cancel the channel task, then await it while suppressing
+   `asyncio.CancelledError`.
+
+The lifespan and route must use the same process and event loop. Multi-worker
+deployments need external ingress routing and storage.
 
 ## How channels fit Pydantic AI
 
@@ -70,6 +108,17 @@ chat. If sending a reply fails, the host logs the failure and continues serving.
 History remains saved after a successful run even when delivery cannot be
 confirmed.
 
+`SlackChannel` retries one `chat.postMessage` call after an HTTP 429 with a
+valid `Retry-After` of at most 60 seconds. It does not retry timeouts or other
+ambiguous failures because Slack may already have accepted the message.
+
+The webhook handler verifies and enqueues a request before returning HTTP 200.
+It returns HTTP 503 while the channel is opening or when its bounded queue is
+full, allowing Slack to retry the event. Duplicate suppression covers the
+10,000 most recently accepted `event_id` values. The queue and duplicate window
+are process-local. A restart can reprocess a redelivered event, and can lose an
+acknowledged event that was still waiting in the queue.
+
 `serve()` runs until it is cancelled or the adapter ends. It owns every turn in
 an AnyIO task group, so no turn task outlives it. Cancellation closes the
 message iterator, cancels in-flight turns, and then closes the adapter.
@@ -79,6 +128,15 @@ message iterator, cancels in-flight turns, and then closes the adapter.
 Anyone allowed to message the agent can supply model input to an agent that may
 have access to tools, credentials, files, and network services. Use a narrow
 sender allowlist and apply normal Pydantic AI guardrails to the connected agent.
+
+Slack signatures are checked over the exact request bytes with the app signing
+secret. Requests more than five minutes from the local clock are rejected.
+Replies disable link and media unfurling so Slack does not fetch URLs generated
+by the agent.
+`SlackChannel` validates one workspace and drops events from other workspaces,
+bot-authored messages, edits, messages with a subtype (including file shares),
+and unaddressed channel messages. These filters
+also prevent the bot from responding to its own replies.
 
 ## Adapters and stores
 
@@ -98,6 +156,10 @@ multiple live hosts safe without external per-conversation serialization.
 
 ## Not included
 
+The Slack adapter does not include Socket Mode, multi-workspace OAuth routing,
+files, reactions, message edits, or messages in channels that do not mention
+the bot. Socket Mode requires a WebSocket client and can be added separately.
+
 The host does not define media, reactions, typing indicators, streaming edits,
 tool approvals, or provider authentication. Adapters add only the provider
 behavior they document.
@@ -110,3 +172,6 @@ behavior they document.
 - [`InboundMessage`][pydantic_ai_harness.channels.InboundMessage]
 - [`ConversationStore`][pydantic_ai_harness.channels.ConversationStore]
 - [`InMemoryConversationStore`][pydantic_ai_harness.channels.InMemoryConversationStore]
+- [`WebhookRequest`][pydantic_ai_harness.channels.WebhookRequest]
+- [`WebhookResponse`][pydantic_ai_harness.channels.WebhookResponse]
+- [`SlackChannel`][pydantic_ai_harness.channels.slack.SlackChannel]

--- a/pydantic_ai_harness/channels/__init__.py
+++ b/pydantic_ai_harness/channels/__init__.py
@@ -12,6 +12,8 @@ from pydantic_ai_harness.channels._types import (
     ConversationStore,
     InboundMessage,
     InMemoryConversationStore,
+    WebhookRequest,
+    WebhookResponse,
 )
 
 __all__ = [
@@ -21,4 +23,6 @@ __all__ = [
     'ConversationStore',
     'InboundMessage',
     'InMemoryConversationStore',
+    'WebhookRequest',
+    'WebhookResponse',
 ]

--- a/pydantic_ai_harness/channels/_types.py
+++ b/pydantic_ai_harness/channels/_types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
 from types import TracebackType
 from typing import Protocol
@@ -27,6 +27,29 @@ class InboundMessage:
     sender_id: str
     message_id: str
     text: str
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookRequest:
+    """A framework-neutral HTTP request passed to a webhook adapter.
+
+    `body` must contain the exact request bytes used for signature verification.
+    `query` carries verification parameters for providers that use a GET
+    handshake.
+    """
+
+    method: str
+    headers: Mapping[str, str]
+    query: Mapping[str, str]
+    body: bytes
+
+
+@dataclass(frozen=True, slots=True)
+class WebhookResponse:
+    """An HTTP response returned by a webhook adapter."""
+
+    status_code: int
+    body: str = ''
 
 
 class ChannelAdapter(Protocol):

--- a/pydantic_ai_harness/channels/_webhook.py
+++ b/pydantic_ai_harness/channels/_webhook.py
@@ -19,17 +19,19 @@ class WebhookInbox:
         self._closed = True
 
     def open(self) -> None:
-        if self._closed:
-            self._send_stream, self._receive_stream = anyio.create_memory_object_stream[InboundMessage](
-                self._max_queued_messages
-            )
-            self._receive_claimed = False
-            self._closed = False
+        if not self._closed:  # pragma: no cover
+            return
+        self._send_stream, self._receive_stream = anyio.create_memory_object_stream[InboundMessage](
+            self._max_queued_messages
+        )
+        self._receive_claimed = False
+        self._closed = False
 
     def put(self, message: InboundMessage) -> bool:
         send_stream = self._send_stream
-        if self._closed or send_stream is None:
+        if self._closed:  # pragma: no cover
             return False
+        assert send_stream is not None
         try:
             send_stream.send_nowait(message)
         except (anyio.WouldBlock, anyio.BrokenResourceError, anyio.ClosedResourceError):
@@ -37,21 +39,21 @@ class WebhookInbox:
         return True
 
     def close(self) -> None:
-        if self._closed:
+        if self._closed:  # pragma: no cover
             return
         self._closed = True
         send_stream = self._send_stream
-        if send_stream is not None:
-            send_stream.close()
+        assert send_stream is not None
+        send_stream.close()
         receive_stream = self._receive_stream
-        if receive_stream is not None:
-            statistics = receive_stream.statistics()
-            if not self._receive_claimed and statistics.current_buffer_used == 0:
-                receive_stream.close()
+        assert receive_stream is not None
+        statistics = receive_stream.statistics()
+        if not self._receive_claimed and statistics.current_buffer_used == 0:
+            receive_stream.close()
 
     async def messages(self) -> AsyncGenerator[InboundMessage, None]:
         receive_stream = self._receive_stream
-        if receive_stream is None:
+        if receive_stream is None:  # pragma: no cover
             return
         self._receive_claimed = True
         try:

--- a/pydantic_ai_harness/channels/_webhook.py
+++ b/pydantic_ai_harness/channels/_webhook.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
+
+import anyio
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 
 from pydantic_ai_harness.channels._types import InboundMessage
 
@@ -11,33 +13,54 @@ from pydantic_ai_harness.channels._types import InboundMessage
 class WebhookInbox:
     def __init__(self, max_queued_messages: int) -> None:
         self._max_queued_messages = max_queued_messages
-        self._queue: asyncio.Queue[InboundMessage | None] = asyncio.Queue(max_queued_messages)
-        self._closed = False
+        self._send_stream: MemoryObjectSendStream[InboundMessage] | None = None
+        self._receive_stream: MemoryObjectReceiveStream[InboundMessage] | None = None
+        self._receive_claimed = False
+        self._closed = True
 
     def open(self) -> None:
         if self._closed:
-            self._queue = asyncio.Queue(self._max_queued_messages)
+            self._send_stream, self._receive_stream = anyio.create_memory_object_stream[InboundMessage](
+                self._max_queued_messages
+            )
+            self._receive_claimed = False
             self._closed = False
 
     def put(self, message: InboundMessage) -> bool:
-        if self._closed:  # pragma: no cover
+        send_stream = self._send_stream
+        if self._closed or send_stream is None:
             return False
         try:
-            self._queue.put_nowait(message)
-        except asyncio.QueueFull:
+            send_stream.send_nowait(message)
+        except (anyio.WouldBlock, anyio.BrokenResourceError, anyio.ClosedResourceError):
             return False
         return True
 
     def close(self) -> None:
+        if self._closed:
+            return
         self._closed = True
-        if self._queue.full():
-            self._queue.get_nowait()
-        self._queue.put_nowait(None)
+        send_stream = self._send_stream
+        if send_stream is not None:
+            send_stream.close()
+        receive_stream = self._receive_stream
+        if receive_stream is not None:
+            statistics = receive_stream.statistics()
+            if not self._receive_claimed and statistics.current_buffer_used == 0:
+                receive_stream.close()
 
-    async def messages(self) -> AsyncIterator[InboundMessage]:
-        queue = self._queue
-        while True:
-            message = await queue.get()
-            if message is None:
+    async def messages(self) -> AsyncGenerator[InboundMessage, None]:
+        receive_stream = self._receive_stream
+        if receive_stream is None:
+            return
+        self._receive_claimed = True
+        try:
+            try:
+                async with receive_stream:
+                    async for message in receive_stream:
+                        yield message
+            except anyio.ClosedResourceError:
                 return
-            yield message
+        finally:
+            if receive_stream is self._receive_stream:
+                self._receive_claimed = False

--- a/pydantic_ai_harness/channels/_webhook.py
+++ b/pydantic_ai_harness/channels/_webhook.py
@@ -1,0 +1,43 @@
+"""Private queue bridge for webhook channel adapters."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+from pydantic_ai_harness.channels._types import InboundMessage
+
+
+class WebhookInbox:
+    def __init__(self, max_queued_messages: int) -> None:
+        self._max_queued_messages = max_queued_messages
+        self._queue: asyncio.Queue[InboundMessage | None] = asyncio.Queue(max_queued_messages)
+        self._closed = False
+
+    def open(self) -> None:
+        if self._closed:
+            self._queue = asyncio.Queue(self._max_queued_messages)
+            self._closed = False
+
+    def put(self, message: InboundMessage) -> bool:
+        if self._closed:  # pragma: no cover
+            return False
+        try:
+            self._queue.put_nowait(message)
+        except asyncio.QueueFull:
+            return False
+        return True
+
+    def close(self) -> None:
+        self._closed = True
+        if self._queue.full():
+            self._queue.get_nowait()
+        self._queue.put_nowait(None)
+
+    async def messages(self) -> AsyncIterator[InboundMessage]:
+        queue = self._queue
+        while True:
+            message = await queue.get()
+            if message is None:
+                return
+            yield message

--- a/pydantic_ai_harness/channels/_webhook.py
+++ b/pydantic_ai_harness/channels/_webhook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from collections.abc import AsyncGenerator
 
 import anyio
@@ -15,23 +16,16 @@ class WebhookInbox:
         self._max_queued_messages = max_queued_messages
         self._send_stream: MemoryObjectSendStream[InboundMessage] | None = None
         self._receive_stream: MemoryObjectReceiveStream[InboundMessage] | None = None
-        self._receive_claimed = False
-        self._closed = True
 
     def open(self) -> None:
-        if not self._closed:  # pragma: no cover
-            return
         self._send_stream, self._receive_stream = anyio.create_memory_object_stream[InboundMessage](
             self._max_queued_messages
         )
-        self._receive_claimed = False
-        self._closed = False
 
     def put(self, message: InboundMessage) -> bool:
         send_stream = self._send_stream
-        if self._closed:  # pragma: no cover
+        if send_stream is None:  # pragma: no cover
             return False
-        assert send_stream is not None
         try:
             send_stream.send_nowait(message)
         except (anyio.WouldBlock, anyio.BrokenResourceError, anyio.ClosedResourceError):
@@ -39,30 +33,38 @@ class WebhookInbox:
         return True
 
     def close(self) -> None:
-        if self._closed:  # pragma: no cover
-            return
-        self._closed = True
         send_stream = self._send_stream
-        assert send_stream is not None
-        send_stream.close()
         receive_stream = self._receive_stream
-        assert receive_stream is not None
-        statistics = receive_stream.statistics()
-        if not self._receive_claimed and statistics.current_buffer_used == 0:
-            receive_stream.close()
+        self._send_stream = None
+        self._receive_stream = None
+        assert send_stream is not None and receive_stream is not None
+        send_stream.close()
+        receive_stream.close()
 
     async def messages(self) -> AsyncGenerator[InboundMessage, None]:
         receive_stream = self._receive_stream
         if receive_stream is None:  # pragma: no cover
             return
-        self._receive_claimed = True
         try:
-            try:
-                async with receive_stream:
-                    async for message in receive_stream:
-                        yield message
-            except anyio.ClosedResourceError:
-                return
-        finally:
-            if receive_stream is self._receive_stream:
-                self._receive_claimed = False
+            async with receive_stream:
+                async for message in receive_stream:
+                    yield message
+        except anyio.ClosedResourceError:
+            return
+
+
+class RecentMessageIds:
+    def __init__(self, max_size: int) -> None:
+        self._max_size = max_size
+        self._ids: OrderedDict[str, None] = OrderedDict()
+
+    def __contains__(self, message_id: str) -> bool:
+        return message_id in self._ids
+
+    def add(self, message_id: str) -> None:
+        self._ids[message_id] = None
+        if len(self._ids) > self._max_size:
+            self._ids.popitem(last=False)
+
+    def clear(self) -> None:
+        self._ids.clear()

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -14,15 +14,16 @@ before changing authentication, acknowledgement, deduplication, or delivery.
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import hmac
 import math
 import time
 from collections import OrderedDict
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncGenerator, Mapping
+from contextlib import aclosing
 from types import TracebackType
 
+import anyio
 import httpx
 from pydantic import TypeAdapter, ValidationError
 from typing_extensions import Self
@@ -127,8 +128,8 @@ class SlackChannel:
     def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
         """Authenticate and enqueue one Slack Events API request.
 
-        This method performs no agent work and is safe to call from an HTTP
-        request handler that must acknowledge Slack promptly.
+        This method performs no agent work and acknowledges Slack promptly. Call
+        it on the same async event-loop thread that runs `messages()`.
         """
         if request.method.upper() != 'POST':
             return WebhookResponse(405)
@@ -232,9 +233,11 @@ class SlackChannel:
             text=text,
         )
 
-    def messages(self) -> AsyncIterator[InboundMessage]:
+    async def messages(self) -> AsyncGenerator[InboundMessage, None]:
         """Yield verified direct messages and app mentions until cancelled."""
-        return self._inbox.messages()
+        async with aclosing(self._inbox.messages()) as messages:
+            async for message in messages:
+                yield message
 
     async def send_text(self, conversation_id: str, text: str) -> None:
         """Post text in ordered chunks no longer than Slack's recommended limit."""
@@ -253,7 +256,7 @@ class SlackChannel:
             try:
                 await self._call('chat.postMessage', params)
             except _RateLimited as exc:
-                await asyncio.sleep(exc.retry_after)
+                await anyio.sleep(exc.retry_after)
                 await self._call('chat.postMessage', params)
 
     async def _call(self, method: str, params: Mapping[str, object] | None = None) -> dict[str, object]:

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -39,7 +39,6 @@ from pydantic_ai_harness.channels._webhook import WebhookInbox
 _API_BASE = 'https://slack.com/api'
 _MAX_TEXT_CHARS = 4000
 _MAX_SEEN_EVENTS = 10_000
-_MAX_RETRY_AFTER = 60.0
 _REQUEST_TIMEOUT = 10.0
 _SIGNATURE_TOLERANCE_SECONDS = 300
 _MAPPING_ADAPTER = TypeAdapter(dict[str, object])
@@ -54,6 +53,7 @@ class SlackChannel:
         signing_secret: str,
         *,
         http_client: httpx.AsyncClient | None = None,
+        api_base_url: str = _API_BASE,
         max_queued_messages: int = 100,
     ) -> None:
         """Configure the Slack adapter without opening it.
@@ -62,6 +62,7 @@ class SlackChannel:
             bot_token: Bot token with `chat:write` and subscribed-event scopes.
             signing_secret: Secret used to authenticate Events API requests.
             http_client: Optional client whose lifecycle remains owned by the caller.
+            api_base_url: Slack Web API root. Use `https://slack-gov.com/api` for GovSlack.
             max_queued_messages: Maximum verified messages waiting for the host.
 
         Raises:
@@ -71,12 +72,15 @@ class SlackChannel:
             raise ValueError('bot_token must not be empty')
         if not signing_secret:
             raise ValueError('signing_secret must not be empty')
+        if not api_base_url:
+            raise ValueError('api_base_url must not be empty')
         if type(max_queued_messages) is not int or max_queued_messages <= 0:
             raise ValueError('max_queued_messages must be a positive integer')
 
         self._bot_token = bot_token
         self._signing_secret = signing_secret.encode()
         self._provided_client = http_client
+        self._api_base_url = api_base_url.rstrip('/')
         self._client: httpx.AsyncClient | None = None
         self._owns_client = False
         self._inbox = WebhookInbox(max_queued_messages)
@@ -267,7 +271,7 @@ class SlackChannel:
             raise RuntimeError('SlackChannel must be opened before use')
         try:
             response = await client.post(
-                f'{_API_BASE}/{method}',
+                f'{self._api_base_url}/{method}',
                 headers={'Authorization': f'Bearer {self._bot_token}'},
                 json=dict(params or {}),
                 timeout=_REQUEST_TIMEOUT,
@@ -313,7 +317,7 @@ def _retry_after(headers: httpx.Headers) -> float | None:
         seconds = float(value)
     except ValueError:
         return None
-    if not math.isfinite(seconds) or not 0 <= seconds <= _MAX_RETRY_AFTER:
+    if not math.isfinite(seconds) or seconds < 0:
         return None
     return seconds
 

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -216,7 +216,7 @@ class SlackChannel:
             )
         elif event_type == 'app_mention':
             thread_timestamp = event.get('thread_ts')
-            if not isinstance(thread_timestamp, str):
+            if not isinstance(thread_timestamp, str) or not thread_timestamp:
                 thread_timestamp = timestamp
             conversation_id = f'thread:{channel_id}:{thread_timestamp}'
             text = text.replace(f'<@{bot_user_id}>', '').strip()

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -18,9 +18,7 @@ import hashlib
 import hmac
 import math
 import time
-from collections import OrderedDict
 from collections.abc import AsyncGenerator, Mapping
-from contextlib import aclosing
 from types import TracebackType
 
 import anyio
@@ -34,7 +32,7 @@ from pydantic_ai_harness.channels._types import (
     WebhookRequest,
     WebhookResponse,
 )
-from pydantic_ai_harness.channels._webhook import WebhookInbox
+from pydantic_ai_harness.channels._webhook import RecentMessageIds, WebhookInbox
 
 _API_BASE = 'https://slack.com/api'
 _MAX_TEXT_CHARS = 4000
@@ -82,9 +80,8 @@ class SlackChannel:
         self._provided_client = http_client
         self._api_base_url = api_base_url.rstrip('/')
         self._client: httpx.AsyncClient | None = None
-        self._owns_client = False
         self._inbox = WebhookInbox(max_queued_messages)
-        self._seen_events: OrderedDict[str, None] = OrderedDict()
+        self._seen_events = RecentMessageIds(_MAX_SEEN_EVENTS)
         self._team_id: str | None = None
         self._bot_user_id: str | None = None
 
@@ -94,7 +91,6 @@ class SlackChannel:
             raise RuntimeError('SlackChannel is already open')
         self._inbox.open()
         self._client = self._provided_client or httpx.AsyncClient()
-        self._owns_client = self._provided_client is None
         try:
             identity = await self._call('auth.test')
             team_id = identity.get('team_id')
@@ -115,20 +111,20 @@ class SlackChannel:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         traceback: TracebackType | None,
-    ) -> bool | None:
+    ) -> None:
         """Close the internally created HTTP client, if any."""
         self._inbox.close()
+        # Events still queued at shutdown were acknowledged but not handled.
+        self._seen_events.clear()
         await self._close_owned_client()
         self._client = None
         self._team_id = None
         self._bot_user_id = None
-        return None
 
     async def _close_owned_client(self) -> None:
-        if self._owns_client and self._client is not None:
+        if self._provided_client is None and self._client is not None:
             with anyio.CancelScope(shield=True):
                 await self._client.aclose()
-        self._owns_client = False
 
     def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
         """Authenticate and enqueue one Slack Events API request.
@@ -172,9 +168,7 @@ class SlackChannel:
         if not self._inbox.put(message):
             return WebhookResponse(503)
 
-        self._seen_events[event_id] = None
-        if len(self._seen_events) > _MAX_SEEN_EVENTS:
-            self._seen_events.popitem(last=False)
+        self._seen_events.add(event_id)
         return WebhookResponse(200)
 
     def _valid_signature(self, request: WebhookRequest) -> bool:
@@ -238,11 +232,9 @@ class SlackChannel:
             text=text,
         )
 
-    async def messages(self) -> AsyncGenerator[InboundMessage, None]:
+    def messages(self) -> AsyncGenerator[InboundMessage, None]:
         """Yield verified direct messages and app mentions until cancelled."""
-        async with aclosing(self._inbox.messages()) as messages:
-            async for message in messages:
-                yield message
+        return self._inbox.messages()
 
     async def send_text(self, conversation_id: str, text: str) -> None:
         """Post text in ordered chunks no longer than Slack's recommended limit."""

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -122,7 +122,8 @@ class SlackChannel:
 
     async def _close_owned_client(self) -> None:
         if self._owns_client and self._client is not None:
-            await self._client.aclose()
+            with anyio.CancelScope(shield=True):
+                await self._client.aclose()
         self._owns_client = False
 
     def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
@@ -248,6 +249,7 @@ class SlackChannel:
             params: dict[str, object] = {
                 'channel': channel_id,
                 'text': text[start : start + _MAX_TEXT_CHARS],
+                'mrkdwn': False,
                 'unfurl_links': False,
                 'unfurl_media': False,
             }

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -1,0 +1,326 @@
+"""Slack Events API channel adapter.
+
+External assumptions verified 2026-08-31:
+
+* Events API requests are signed as HMAC-SHA256 over the raw request body and
+  must be acknowledged within three seconds.
+* `event_id` is globally unique and Slack retries failed deliveries.
+* `chat.postMessage` recommends text no longer than 4000 characters and
+  returns HTTP 429 with `Retry-After` when rate limited.
+
+Re-check these assumptions against https://docs.slack.dev/apis/events-api/
+before changing authentication, acknowledgement, deduplication, or delivery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import math
+import time
+from collections import OrderedDict
+from collections.abc import AsyncIterator, Mapping
+from types import TracebackType
+
+import httpx
+from pydantic import TypeAdapter, ValidationError
+from typing_extensions import Self
+
+from pydantic_ai_harness.channels._types import (
+    ChannelError,
+    InboundMessage,
+    WebhookRequest,
+    WebhookResponse,
+)
+from pydantic_ai_harness.channels._webhook import WebhookInbox
+
+_API_BASE = 'https://slack.com/api'
+_MAX_TEXT_CHARS = 4000
+_MAX_SEEN_EVENTS = 10_000
+_MAX_RETRY_AFTER = 60.0
+_REQUEST_TIMEOUT = 10.0
+_SIGNATURE_TOLERANCE_SECONDS = 300
+_MAPPING_ADAPTER = TypeAdapter(dict[str, object])
+
+
+class SlackChannel:
+    """Connect one Slack app installation through the HTTP Events API."""
+
+    def __init__(
+        self,
+        bot_token: str,
+        signing_secret: str,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        max_queued_messages: int = 100,
+    ) -> None:
+        """Configure the Slack adapter without opening it.
+
+        Args:
+            bot_token: Bot token with `chat:write` and subscribed-event scopes.
+            signing_secret: Secret used to authenticate Events API requests.
+            http_client: Optional client whose lifecycle remains owned by the caller.
+            max_queued_messages: Maximum verified messages waiting for the host.
+
+        Raises:
+            ValueError: If a credential is empty or the queue limit is not positive.
+        """
+        if not bot_token:
+            raise ValueError('bot_token must not be empty')
+        if not signing_secret:
+            raise ValueError('signing_secret must not be empty')
+        if type(max_queued_messages) is not int or max_queued_messages <= 0:
+            raise ValueError('max_queued_messages must be a positive integer')
+
+        self._bot_token = bot_token
+        self._signing_secret = signing_secret.encode()
+        self._provided_client = http_client
+        self._client: httpx.AsyncClient | None = None
+        self._owns_client = False
+        self._inbox = WebhookInbox(max_queued_messages)
+        self._seen_events: OrderedDict[str, None] = OrderedDict()
+        self._team_id: str | None = None
+        self._bot_user_id: str | None = None
+
+    async def __aenter__(self) -> Self:
+        """Open the HTTP client and validate the bot token with `auth.test`."""
+        if self._client is not None:
+            raise RuntimeError('SlackChannel is already open')
+        self._inbox.open()
+        self._client = self._provided_client or httpx.AsyncClient()
+        self._owns_client = self._provided_client is None
+        try:
+            identity = await self._call('auth.test')
+            team_id = identity.get('team_id')
+            user_id = identity.get('user_id')
+            if not isinstance(team_id, str) or not isinstance(user_id, str):
+                raise ChannelError('Slack auth.test returned an invalid identity')
+            self._team_id = team_id
+            self._bot_user_id = user_id
+        except BaseException:
+            self._inbox.close()
+            await self._close_owned_client()
+            self._client = None
+            raise
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Close the internally created HTTP client, if any."""
+        self._inbox.close()
+        await self._close_owned_client()
+        self._client = None
+        self._team_id = None
+        self._bot_user_id = None
+        return None
+
+    async def _close_owned_client(self) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+        self._owns_client = False
+
+    def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
+        """Authenticate and enqueue one Slack Events API request.
+
+        This method performs no agent work and is safe to call from an HTTP
+        request handler that must acknowledge Slack promptly.
+        """
+        if request.method.upper() != 'POST':
+            return WebhookResponse(405)
+        if not self._valid_signature(request):
+            return WebhookResponse(401)
+
+        try:
+            payload = _MAPPING_ADAPTER.validate_json(request.body)
+        except ValidationError:
+            return WebhookResponse(400)
+
+        payload_type = payload.get('type')
+        if payload_type == 'url_verification':
+            challenge = payload.get('challenge')
+            return WebhookResponse(200, challenge) if isinstance(challenge, str) else WebhookResponse(400)
+        if payload_type != 'event_callback':
+            return WebhookResponse(200)
+
+        team_id = self._team_id
+        bot_user_id = self._bot_user_id
+        if team_id is None or bot_user_id is None:
+            return WebhookResponse(503)
+        if payload.get('team_id') != team_id:
+            return WebhookResponse(200)
+
+        event_id = payload.get('event_id')
+        if not isinstance(event_id, str):
+            return WebhookResponse(400)
+        if event_id in self._seen_events:
+            return WebhookResponse(200)
+
+        message = self._parse_event(payload.get('event'), event_id, bot_user_id)
+        if message is None:
+            return WebhookResponse(200)
+        if not self._inbox.put(message):
+            return WebhookResponse(503)
+
+        self._seen_events[event_id] = None
+        if len(self._seen_events) > _MAX_SEEN_EVENTS:
+            self._seen_events.popitem(last=False)
+        return WebhookResponse(200)
+
+    def _valid_signature(self, request: WebhookRequest) -> bool:
+        headers = {name.lower(): value for name, value in request.headers.items()}
+        timestamp = headers.get('x-slack-request-timestamp')
+        signature = headers.get('x-slack-signature')
+        if timestamp is None or signature is None:
+            return False
+        try:
+            request_time = int(timestamp)
+        except ValueError:
+            return False
+        now = int(time.time())
+        if request_time < now - _SIGNATURE_TOLERANCE_SECONDS or request_time > now + _SIGNATURE_TOLERANCE_SECONDS:
+            return False
+        base = b'v0:' + timestamp.encode() + b':' + request.body
+        expected = 'v0=' + hmac.new(self._signing_secret, base, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected.encode(), signature.encode('utf-8', 'replace'))
+
+    def _parse_event(self, value: object, event_id: str, bot_user_id: str) -> InboundMessage | None:
+        event = _mapping(value)
+        if event is None or event.get('subtype') is not None or event.get('bot_id') is not None:
+            return None
+
+        event_type = event.get('type')
+        user_id = event.get('user')
+        channel_id = event.get('channel')
+        text = event.get('text')
+        timestamp = event.get('ts')
+        if (
+            not isinstance(user_id, str)
+            or user_id == bot_user_id
+            or not isinstance(channel_id, str)
+            or not isinstance(text, str)
+            or not isinstance(timestamp, str)
+        ):
+            return None
+
+        if event_type == 'message' and event.get('channel_type') == 'im':
+            thread_timestamp = event.get('thread_ts')
+            conversation_id = (
+                f'thread:{channel_id}:{thread_timestamp}'
+                if isinstance(thread_timestamp, str) and thread_timestamp
+                else f'dm:{channel_id}'
+            )
+        elif event_type == 'app_mention':
+            thread_timestamp = event.get('thread_ts')
+            if not isinstance(thread_timestamp, str):
+                thread_timestamp = timestamp
+            conversation_id = f'thread:{channel_id}:{thread_timestamp}'
+            text = text.replace(f'<@{bot_user_id}>', '').strip()
+        else:
+            return None
+
+        if not text:
+            return None
+        return InboundMessage(
+            conversation_id=conversation_id,
+            sender_id=user_id,
+            message_id=event_id,
+            text=text,
+        )
+
+    def messages(self) -> AsyncIterator[InboundMessage]:
+        """Yield verified direct messages and app mentions until cancelled."""
+        return self._inbox.messages()
+
+    async def send_text(self, conversation_id: str, text: str) -> None:
+        """Post text in ordered chunks no longer than Slack's recommended limit."""
+        if not text:
+            raise ValueError('text must not be empty')
+        channel_id, thread_timestamp = _decode_conversation_id(conversation_id)
+        for start in range(0, len(text), _MAX_TEXT_CHARS):
+            params: dict[str, object] = {
+                'channel': channel_id,
+                'text': text[start : start + _MAX_TEXT_CHARS],
+                'unfurl_links': False,
+                'unfurl_media': False,
+            }
+            if thread_timestamp is not None:
+                params['thread_ts'] = thread_timestamp
+            try:
+                await self._call('chat.postMessage', params)
+            except _RateLimited as exc:
+                await asyncio.sleep(exc.retry_after)
+                await self._call('chat.postMessage', params)
+
+    async def _call(self, method: str, params: Mapping[str, object] | None = None) -> dict[str, object]:
+        client = self._client
+        if client is None:
+            raise RuntimeError('SlackChannel must be opened before use')
+        try:
+            response = await client.post(
+                f'{_API_BASE}/{method}',
+                headers={'Authorization': f'Bearer {self._bot_token}'},
+                json=dict(params or {}),
+                timeout=_REQUEST_TIMEOUT,
+            )
+        except httpx.RequestError:
+            raise ChannelError(f'Slack Web API request failed: {method}') from None
+
+        if response.status_code == 429:
+            retry_after = _retry_after(response.headers)
+            if retry_after is not None:
+                raise _RateLimited('Slack Web API rate limited the request', retry_after=retry_after)
+
+        try:
+            envelope = _MAPPING_ADAPTER.validate_json(response.content)
+        except ValidationError:
+            raise ChannelError(f'Slack Web API returned an invalid response: {method}') from None
+        if envelope.get('ok') is True:
+            return envelope
+
+        error = envelope.get('error')
+        message = error if isinstance(error, str) else 'unknown Slack Web API error'
+        raise ChannelError(message)
+
+
+class _RateLimited(ChannelError):
+    def __init__(self, message: str, *, retry_after: float) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+def _mapping(value: object) -> dict[str, object] | None:
+    try:
+        return _MAPPING_ADAPTER.validate_python(value)
+    except ValidationError:
+        return None
+
+
+def _retry_after(headers: httpx.Headers) -> float | None:
+    value = headers.get('Retry-After')
+    if value is None:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        return None
+    if not math.isfinite(seconds) or not 0 <= seconds <= _MAX_RETRY_AFTER:
+        return None
+    return seconds
+
+
+def _decode_conversation_id(conversation_id: str) -> tuple[str, str | None]:
+    kind, separator, route = conversation_id.partition(':')
+    if not separator:
+        raise ChannelError('invalid Slack conversation id')
+    if kind == 'dm' and route:
+        return route, None
+    if kind == 'thread':
+        channel_id, thread_separator, thread_timestamp = route.partition(':')
+        if channel_id and thread_separator and thread_timestamp:
+            return channel_id, thread_timestamp
+    raise ChannelError('invalid Slack conversation id')

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -18,7 +18,7 @@ import hashlib
 import hmac
 import math
 import time
-from collections.abc import AsyncGenerator, Mapping
+from collections.abc import AsyncGenerator, Collection, Mapping
 from types import TracebackType
 
 import anyio
@@ -37,6 +37,7 @@ from pydantic_ai_harness.channels._webhook import RecentMessageIds, WebhookInbox
 _API_BASE = 'https://slack.com/api'
 _MAX_TEXT_CHARS = 4000
 _MAX_SEEN_EVENTS = 10_000
+_MAX_INLINE_RETRY_DELAY = 60.0
 _REQUEST_TIMEOUT = 10.0
 _SIGNATURE_TOLERANCE_SECONDS = 300
 _MAPPING_ADAPTER = TypeAdapter(dict[str, object])
@@ -50,6 +51,7 @@ class SlackChannel:
         bot_token: str,
         signing_secret: str,
         *,
+        allowed_channel_ids: Collection[str] = (),
         http_client: httpx.AsyncClient | None = None,
         api_base_url: str = _API_BASE,
         max_queued_messages: int = 100,
@@ -59,11 +61,14 @@ class SlackChannel:
         Args:
             bot_token: Bot token with `chat:write` and subscribed-event scopes.
             signing_secret: Secret used to authenticate Events API requests.
+            allowed_channel_ids: Channel ids where app mentions may invoke the agent.
+                Direct messages remain enabled when this is empty.
             http_client: Optional client whose lifecycle remains owned by the caller.
             api_base_url: Slack Web API root. Use `https://slack-gov.com/api` for GovSlack.
             max_queued_messages: Maximum verified messages waiting for the host.
 
         Raises:
+            TypeError: If `allowed_channel_ids` is a string instead of a collection of ids.
             ValueError: If a credential is empty or the queue limit is not positive.
         """
         if not bot_token:
@@ -72,11 +77,14 @@ class SlackChannel:
             raise ValueError('signing_secret must not be empty')
         if not api_base_url:
             raise ValueError('api_base_url must not be empty')
+        if isinstance(allowed_channel_ids, str):
+            raise TypeError('allowed_channel_ids must be a collection of channel ids, not a string')
         if type(max_queued_messages) is not int or max_queued_messages <= 0:
             raise ValueError('max_queued_messages must be a positive integer')
 
         self._bot_token = bot_token
         self._signing_secret = signing_secret.encode()
+        self._allowed_channel_ids = frozenset(allowed_channel_ids)
         self._provided_client = http_client
         self._api_base_url = api_base_url.rstrip('/')
         self._client: httpx.AsyncClient | None = None
@@ -126,7 +134,7 @@ class SlackChannel:
             with anyio.CancelScope(shield=True):
                 await self._client.aclose()
 
-    def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
+    async def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
         """Authenticate and enqueue one Slack Events API request.
 
         This method performs no agent work and acknowledges Slack promptly. Call
@@ -214,7 +222,7 @@ class SlackChannel:
                 if isinstance(thread_timestamp, str) and thread_timestamp
                 else f'dm:{channel_id}'
             )
-        elif event_type == 'app_mention':
+        elif event_type == 'app_mention' and channel_id in self._allowed_channel_ids:
             thread_timestamp = event.get('thread_ts')
             if not isinstance(thread_timestamp, str) or not thread_timestamp:
                 thread_timestamp = timestamp
@@ -254,6 +262,8 @@ class SlackChannel:
             try:
                 await self._call('chat.postMessage', params)
             except _RateLimited as exc:
+                if exc.retry_after > _MAX_INLINE_RETRY_DELAY:
+                    raise
                 await anyio.sleep(exc.retry_after)
                 await self._call('chat.postMessage', params)
 

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -97,8 +97,8 @@ class TestSlackChannel:
         async with channel:
             async with aclosing(channel.messages()) as messages:
                 request = event_request('Ev1', direct_message())
-                assert channel.handle_webhook(request).status_code == 200
-                assert channel.handle_webhook(request).status_code == 200
+                assert (await channel.handle_webhook(request)).status_code == 200
+                assert (await channel.handle_webhook(request)).status_code == 200
                 message = await anext(messages)
 
         assert (message.conversation_id, message.sender_id, message.message_id, message.text) == (
@@ -113,10 +113,10 @@ class TestSlackChannel:
     async def test_handles_challenge_and_rejects_invalid_requests(self) -> None:
         channel = SlackChannel('xoxb-token', _SIGNING_SECRET)
         challenge = signed_request({'type': 'url_verification', 'challenge': 'verify-me'})
-        assert channel.handle_webhook(challenge).body == 'verify-me'
-        assert channel.handle_webhook(signed_request({'type': 'url_verification'})).status_code == 400
-        assert channel.handle_webhook(signed_request({'type': 'other'})).status_code == 200
-        assert channel.handle_webhook(signed_request({}, method='GET')).status_code == 405
+        assert (await channel.handle_webhook(challenge)).body == 'verify-me'
+        assert (await channel.handle_webhook(signed_request({'type': 'url_verification'}))).status_code == 400
+        assert (await channel.handle_webhook(signed_request({'type': 'other'}))).status_code == 200
+        assert (await channel.handle_webhook(signed_request({}, method='GET'))).status_code == 405
 
         bad_signature = WebhookRequest(
             method='POST',
@@ -127,7 +127,7 @@ class TestSlackChannel:
             query={},
             body=b'{}',
         )
-        assert channel.handle_webhook(bad_signature).status_code == 401
+        assert (await channel.handle_webhook(bad_signature)).status_code == 401
         non_ascii_signature = WebhookRequest(
             method='POST',
             headers={
@@ -137,10 +137,10 @@ class TestSlackChannel:
             query={},
             body=b'{}',
         )
-        assert channel.handle_webhook(non_ascii_signature).status_code == 401
-        assert channel.handle_webhook(WebhookRequest('POST', {}, {}, b'{}')).status_code == 401
+        assert (await channel.handle_webhook(non_ascii_signature)).status_code == 401
+        assert (await channel.handle_webhook(WebhookRequest('POST', {}, {}, b'{}'))).status_code == 401
         assert (
-            channel.handle_webhook(
+            await channel.handle_webhook(
                 WebhookRequest(
                     'POST',
                     {
@@ -150,10 +150,9 @@ class TestSlackChannel:
                     {},
                     b'{}',
                 )
-            ).status_code
-            == 401
-        )
-        assert channel.handle_webhook(signed_request({}, timestamp=int(time.time()) - 301)).status_code == 401
+            )
+        ).status_code == 401
+        assert (await channel.handle_webhook(signed_request({}, timestamp=int(time.time()) - 301))).status_code == 401
         oversized_timestamp = WebhookRequest(
             'POST',
             {
@@ -163,22 +162,24 @@ class TestSlackChannel:
             {},
             b'{}',
         )
-        assert channel.handle_webhook(oversized_timestamp).status_code == 401
+        assert (await channel.handle_webhook(oversized_timestamp)).status_code == 401
 
-        assert channel.handle_webhook(signed_body(b'not json')).status_code == 400
+        assert (await channel.handle_webhook(signed_body(b'not json'))).status_code == 400
 
     async def test_requires_open_channel_for_events(self) -> None:
         channel = SlackChannel('xoxb-token', _SIGNING_SECRET)
-        assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 503
+        assert (await channel.handle_webhook(event_request('Ev1', direct_message()))).status_code == 503
 
     async def test_filters_unaddressed_and_bot_authored_events(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
         channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
 
         async with channel:
-            assert channel.handle_webhook(event_request('Ev0', direct_message(), team_id='other')).status_code == 200
             assert (
-                channel.handle_webhook(
+                await channel.handle_webhook(event_request('Ev0', direct_message(), team_id='other'))
+            ).status_code == 200
+            assert (
+                await channel.handle_webhook(
                     signed_request(
                         {
                             'type': 'event_callback',
@@ -186,20 +187,26 @@ class TestSlackChannel:
                             'event': direct_message(),
                         }
                     )
-                ).status_code
-                == 400
-            )
+                )
+            ).status_code == 400
             ignored = [
                 {**direct_message(user='UBOT')},
                 {**direct_message(), 'bot_id': 'B1'},
                 {**direct_message(), 'subtype': 'message_changed'},
                 {**direct_message(), 'channel_type': 'channel'},
+                {
+                    'type': 'app_mention',
+                    'channel': 'C2',
+                    'user': 'U1',
+                    'text': '<@UBOT> hello',
+                    'ts': '123.45',
+                },
                 {**direct_message(), 'text': ''},
                 {'type': 'reaction_added'},
                 123,
             ]
             for index, event in enumerate(ignored):
-                assert channel.handle_webhook(event_request(f'Ev{index + 1}', event)).status_code == 200
+                assert (await channel.handle_webhook(event_request(f'Ev{index + 1}', event))).status_code == 200
 
         await client.aclose()
 
@@ -216,10 +223,10 @@ class TestSlackChannel:
             async with aclosing(channel.messages()) as messages:
                 first = event_request('Ev1', direct_message(text='first'))
                 second = event_request('Ev2', direct_message(text='second'))
-                assert channel.handle_webhook(first).status_code == 200
-                assert channel.handle_webhook(second).status_code == 503
+                assert (await channel.handle_webhook(first)).status_code == 200
+                assert (await channel.handle_webhook(second)).status_code == 503
                 assert (await anext(messages)).text == 'first'
-                assert channel.handle_webhook(second).status_code == 200
+                assert (await channel.handle_webhook(second)).status_code == 200
                 assert (await anext(messages)).text == 'second'
 
         await client.aclose()
@@ -237,10 +244,10 @@ class TestSlackChannel:
             async with aclosing(channel.messages()) as messages:
                 for index in range(10_001):
                     request = event_request(f'Ev{index}', direct_message(text=str(index)))
-                    assert channel.handle_webhook(request).status_code == 200
+                    assert (await channel.handle_webhook(request)).status_code == 200
                     await anext(messages)
                 first = event_request('Ev0', direct_message(text='first again'))
-                assert channel.handle_webhook(first).status_code == 200
+                assert (await channel.handle_webhook(first)).status_code == 200
                 assert (await anext(messages)).text == 'first again'
 
         await client.aclose()
@@ -255,7 +262,12 @@ class TestSlackChannel:
             return response({'ok': True, 'ts': '124.00'})
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
-        channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
+        channel = SlackChannel(
+            'xoxb-token',
+            _SIGNING_SECRET,
+            allowed_channel_ids={'C1'},
+            http_client=client,
+        )
         mention = {
             'type': 'app_mention',
             'channel': 'C1',
@@ -266,17 +278,17 @@ class TestSlackChannel:
 
         async with channel:
             async with aclosing(channel.messages()) as messages:
-                assert channel.handle_webhook(event_request('Ev1', mention)).status_code == 200
+                assert (await channel.handle_webhook(event_request('Ev1', mention))).status_code == 200
                 message = await anext(messages)
                 await channel.send_text(message.conversation_id, 'reply')
                 continued = {**mention, 'thread_ts': '100.00'}
-                assert channel.handle_webhook(event_request('Ev2', continued)).status_code == 200
+                assert (await channel.handle_webhook(event_request('Ev2', continued))).status_code == 200
                 continued_message = await anext(messages)
                 empty_thread = {**mention, 'thread_ts': ''}
-                assert channel.handle_webhook(event_request('Ev3', empty_thread)).status_code == 200
+                assert (await channel.handle_webhook(event_request('Ev3', empty_thread))).status_code == 200
                 empty_thread_message = await anext(messages)
                 threaded_dm = {**direct_message(), 'thread_ts': '110.00'}
-                assert channel.handle_webhook(event_request('Ev4', threaded_dm)).status_code == 200
+                assert (await channel.handle_webhook(event_request('Ev4', threaded_dm))).status_code == 200
                 dm_message = await anext(messages)
                 await channel.send_text(dm_message.conversation_id, 'dm reply')
 
@@ -326,7 +338,7 @@ class TestSlackChannel:
             task_group.start_soon(host.serve)
             with anyio.fail_after(1):
                 await opened.wait()
-            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+            assert (await channel.handle_webhook(event_request('Ev1', direct_message()))).status_code == 200
             with anyio.fail_after(1):
                 await posted.wait()
             task_group.cancel_scope.cancel()
@@ -359,7 +371,7 @@ class TestSlackChannel:
                 return response(
                     {'ok': False, 'error': 'ratelimited'},
                     status_code=429,
-                    headers={'Retry-After': '61'},
+                    headers={'Retry-After': '60'},
                 )
             return response({'ok': True, 'ts': str(len(posts))})
 
@@ -374,7 +386,24 @@ class TestSlackChannel:
             {'channel': 'D1', 'text': 'a' * 4000, 'mrkdwn': False, 'unfurl_links': False, 'unfurl_media': False},
             {'channel': 'D1', 'text': 'a', 'mrkdwn': False, 'unfurl_links': False, 'unfurl_media': False},
         ]
-        assert delays == [61]
+        assert delays == [60]
+        await client.aclose()
+
+    async def test_does_not_hold_conversation_lane_for_long_rate_limit(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith('/auth.test'):
+                return auth_response()
+            return response(
+                {'ok': False, 'error': 'ratelimited'},
+                status_code=429,
+                headers={'Retry-After': '61'},
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
+        async with channel:
+            with pytest.raises(ChannelError, match='rate limited'):
+                await channel.send_text('dm:D1', 'hello')
         await client.aclose()
 
     async def test_uses_configured_api_root(self) -> None:
@@ -511,7 +540,7 @@ class TestSlackChannel:
 
         async with channel:
             async with aclosing(channel.messages()) as messages:
-                assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+                assert (await channel.handle_webhook(event_request('Ev1', direct_message()))).status_code == 200
                 assert (await anext(messages)).message_id == 'Ev1'
         await client.aclose()
 
@@ -520,11 +549,11 @@ class TestSlackChannel:
         channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
         async with channel:
             messages = channel.messages()
-            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+            assert (await channel.handle_webhook(event_request('Ev1', direct_message()))).status_code == 200
             assert (await anext(messages)).message_id == 'Ev1'
             await messages.aclose()
 
-            assert channel.handle_webhook(event_request('Ev2', direct_message())).status_code == 503
+            assert (await channel.handle_webhook(event_request('Ev2', direct_message()))).status_code == 503
         await client.aclose()
 
     async def test_old_message_iterator_ends_after_channel_reopens(self) -> None:
@@ -532,14 +561,14 @@ class TestSlackChannel:
         channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
         messages = channel.messages()
         async with channel:
-            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+            assert (await channel.handle_webhook(event_request('Ev1', direct_message()))).status_code == 200
             assert (await anext(messages)).message_id == 'Ev1'
 
         async with channel:
             with pytest.raises(StopAsyncIteration):
                 await anext(messages)
             async with aclosing(channel.messages()) as reopened_messages:
-                assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+                assert (await channel.handle_webhook(event_request('Ev1', direct_message()))).status_code == 200
                 assert (await anext(reopened_messages)).message_id == 'Ev1'
         await client.aclose()
 
@@ -561,6 +590,8 @@ class TestSlackChannel:
             SlackChannel('token', '')
         with pytest.raises(ValueError, match='api_base_url'):
             SlackChannel('token', _SIGNING_SECRET, api_base_url='')
+        with pytest.raises(TypeError, match='allowed_channel_ids'):
+            SlackChannel('token', _SIGNING_SECRET, allowed_channel_ids='C1')
         for value in (0, True):
             with pytest.raises(ValueError, match='max_queued_messages'):
                 SlackChannel('token', _SIGNING_SECRET, max_queued_messages=value)

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -153,6 +153,7 @@ class TestSlackChannel:
             )
         ).status_code == 401
         assert (await channel.handle_webhook(signed_request({}, timestamp=int(time.time()) - 301))).status_code == 401
+        assert (await channel.handle_webhook(signed_request({}, timestamp=int(time.time()) + 301))).status_code == 401
         oversized_timestamp = WebhookRequest(
             'POST',
             {

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -515,18 +515,6 @@ class TestSlackChannel:
                 assert (await anext(messages)).message_id == 'Ev1'
         await client.aclose()
 
-    async def test_closing_full_inbox_drains_accepted_message(self) -> None:
-        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
-        channel = SlackChannel('token', _SIGNING_SECRET, http_client=client, max_queued_messages=1)
-        messages = channel.messages()
-        async with channel:
-            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
-
-        assert (await anext(messages)).message_id == 'Ev1'
-        with pytest.raises(StopAsyncIteration):
-            await anext(messages)
-        await client.aclose()
-
     async def test_closed_message_iterator_rejects_new_webhooks(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
         channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
@@ -550,6 +538,9 @@ class TestSlackChannel:
         async with channel:
             with pytest.raises(StopAsyncIteration):
                 await anext(messages)
+            async with aclosing(channel.messages()) as reopened_messages:
+                assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+                assert (await anext(reopened_messages)).message_id == 'Ev1'
         await client.aclose()
 
     async def test_open_failure_ends_pending_message_iterator(self) -> None:

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -267,14 +267,18 @@ class TestSlackChannel:
             continued = {**mention, 'thread_ts': '100.00'}
             assert channel.handle_webhook(event_request('Ev2', continued)).status_code == 200
             continued_message = await anext(channel.messages())
+            empty_thread = {**mention, 'thread_ts': ''}
+            assert channel.handle_webhook(event_request('Ev3', empty_thread)).status_code == 200
+            empty_thread_message = await anext(channel.messages())
             threaded_dm = {**direct_message(), 'thread_ts': '110.00'}
-            assert channel.handle_webhook(event_request('Ev3', threaded_dm)).status_code == 200
+            assert channel.handle_webhook(event_request('Ev4', threaded_dm)).status_code == 200
             dm_message = await anext(channel.messages())
             await channel.send_text(dm_message.conversation_id, 'dm reply')
 
         assert message.conversation_id == 'thread:C1:123.45'
         assert message.text == 'explain this'
         assert continued_message.conversation_id == 'thread:C1:100.00'
+        assert empty_thread_message.conversation_id == 'thread:C1:123.45'
         assert dm_message.conversation_id == 'thread:D1:110.00'
         assert posts == [
             {

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import hmac
 import json
 import time
-from collections.abc import Mapping
+from collections.abc import AsyncGenerator, Mapping
+from contextlib import aclosing
 
+import anyio
 import httpx
 import pytest
 from pydantic import TypeAdapter
 from pydantic_ai import Agent
 
-from pydantic_ai_harness.channels import ChannelError, ChannelHost, WebhookRequest
+from pydantic_ai_harness.channels import ChannelError, ChannelHost, InboundMessage, WebhookRequest
 from pydantic_ai_harness.channels.slack import SlackChannel
 
 _BODY_ADAPTER = TypeAdapter(dict[str, object])
@@ -94,10 +95,11 @@ class TestSlackChannel:
         channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
 
         async with channel:
-            request = event_request('Ev1', direct_message())
-            assert channel.handle_webhook(request).status_code == 200
-            assert channel.handle_webhook(request).status_code == 200
-            message = await anext(channel.messages())
+            async with aclosing(channel.messages()) as messages:
+                request = event_request('Ev1', direct_message())
+                assert channel.handle_webhook(request).status_code == 200
+                assert channel.handle_webhook(request).status_code == 200
+                message = await anext(messages)
 
         assert (message.conversation_id, message.sender_id, message.message_id, message.text) == (
             'dm:D1',
@@ -211,13 +213,14 @@ class TestSlackChannel:
         )
 
         async with channel:
-            first = event_request('Ev1', direct_message(text='first'))
-            second = event_request('Ev2', direct_message(text='second'))
-            assert channel.handle_webhook(first).status_code == 200
-            assert channel.handle_webhook(second).status_code == 503
-            assert (await anext(channel.messages())).text == 'first'
-            assert channel.handle_webhook(second).status_code == 200
-            assert (await anext(channel.messages())).text == 'second'
+            async with aclosing(channel.messages()) as messages:
+                first = event_request('Ev1', direct_message(text='first'))
+                second = event_request('Ev2', direct_message(text='second'))
+                assert channel.handle_webhook(first).status_code == 200
+                assert channel.handle_webhook(second).status_code == 503
+                assert (await anext(messages)).text == 'first'
+                assert channel.handle_webhook(second).status_code == 200
+                assert (await anext(messages)).text == 'second'
 
         await client.aclose()
 
@@ -231,13 +234,14 @@ class TestSlackChannel:
         )
 
         async with channel:
-            for index in range(10_001):
-                request = event_request(f'Ev{index}', direct_message(text=str(index)))
-                assert channel.handle_webhook(request).status_code == 200
-                await anext(channel.messages())
-            first = event_request('Ev0', direct_message(text='first again'))
-            assert channel.handle_webhook(first).status_code == 200
-            assert (await anext(channel.messages())).text == 'first again'
+            async with aclosing(channel.messages()) as messages:
+                for index in range(10_001):
+                    request = event_request(f'Ev{index}', direct_message(text=str(index)))
+                    assert channel.handle_webhook(request).status_code == 200
+                    await anext(messages)
+                first = event_request('Ev0', direct_message(text='first again'))
+                assert channel.handle_webhook(first).status_code == 200
+                assert (await anext(messages)).text == 'first again'
 
         await client.aclose()
 
@@ -261,19 +265,20 @@ class TestSlackChannel:
         }
 
         async with channel:
-            assert channel.handle_webhook(event_request('Ev1', mention)).status_code == 200
-            message = await anext(channel.messages())
-            await channel.send_text(message.conversation_id, 'reply')
-            continued = {**mention, 'thread_ts': '100.00'}
-            assert channel.handle_webhook(event_request('Ev2', continued)).status_code == 200
-            continued_message = await anext(channel.messages())
-            empty_thread = {**mention, 'thread_ts': ''}
-            assert channel.handle_webhook(event_request('Ev3', empty_thread)).status_code == 200
-            empty_thread_message = await anext(channel.messages())
-            threaded_dm = {**direct_message(), 'thread_ts': '110.00'}
-            assert channel.handle_webhook(event_request('Ev4', threaded_dm)).status_code == 200
-            dm_message = await anext(channel.messages())
-            await channel.send_text(dm_message.conversation_id, 'dm reply')
+            async with aclosing(channel.messages()) as messages:
+                assert channel.handle_webhook(event_request('Ev1', mention)).status_code == 200
+                message = await anext(messages)
+                await channel.send_text(message.conversation_id, 'reply')
+                continued = {**mention, 'thread_ts': '100.00'}
+                assert channel.handle_webhook(event_request('Ev2', continued)).status_code == 200
+                continued_message = await anext(messages)
+                empty_thread = {**mention, 'thread_ts': ''}
+                assert channel.handle_webhook(event_request('Ev3', empty_thread)).status_code == 200
+                empty_thread_message = await anext(messages)
+                threaded_dm = {**direct_message(), 'thread_ts': '110.00'}
+                assert channel.handle_webhook(event_request('Ev4', threaded_dm)).status_code == 200
+                dm_message = await anext(messages)
+                await channel.send_text(dm_message.conversation_id, 'dm reply')
 
         assert message.conversation_id == 'thread:C1:123.45'
         assert message.text == 'explain this'
@@ -298,9 +303,10 @@ class TestSlackChannel:
         ]
         await client.aclose()
 
-    async def test_webhook_runs_agent_and_posts_reply(self) -> None:
-        opened = asyncio.Event()
-        posted = asyncio.Event()
+    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
+    async def test_webhook_runs_agent_and_posts_reply(self, anyio_backend: str) -> None:
+        opened = anyio.Event()
+        posted = anyio.Event()
         posts: list[dict[str, object]] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -314,16 +320,15 @@ class TestSlackChannel:
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
         host = ChannelHost(Agent('test'), channel, allowed_senders={'U1'})
-        task = asyncio.create_task(host.serve())
-
-        try:
-            await asyncio.wait_for(opened.wait(), timeout=1)
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(host.serve)
+            with anyio.fail_after(1):
+                await opened.wait()
             assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
-            await asyncio.wait_for(posted.wait(), timeout=1)
-        finally:
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
-            await client.aclose()
+            with anyio.fail_after(1):
+                await posted.wait()
+            task_group.cancel_scope.cancel()
+        await client.aclose()
 
         assert posts == [
             {
@@ -460,26 +465,49 @@ class TestSlackChannel:
     async def test_closing_channel_ends_pending_message_iterator(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
         channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
-        async with channel:
-            pending_message = asyncio.ensure_future(anext(channel.messages()))
-            await asyncio.sleep(0)
+        iterator_stopped = anyio.Event()
 
-        with pytest.raises(StopAsyncIteration):
-            await pending_message
+        async def wait_for_message(messages: AsyncGenerator[InboundMessage, None]) -> None:
+            with pytest.raises(StopAsyncIteration):
+                await anext(messages)
+            iterator_stopped.set()
+
+        async with anyio.create_task_group() as task_group:
+            async with channel:
+                messages = channel.messages()
+                task_group.start_soon(wait_for_message, messages)
+                await anyio.sleep(0)
+            with anyio.fail_after(1):
+                await iterator_stopped.wait()
 
         async with channel:
-            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
-            assert (await anext(channel.messages())).message_id == 'Ev1'
+            async with aclosing(channel.messages()) as messages:
+                assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+                assert (await anext(messages)).message_id == 'Ev1'
         await client.aclose()
 
-    async def test_closing_full_inbox_discards_one_message_to_end_iterator(self) -> None:
+    async def test_closing_full_inbox_drains_accepted_message(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
         channel = SlackChannel('token', _SIGNING_SECRET, http_client=client, max_queued_messages=1)
+        messages = channel.messages()
         async with channel:
             assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
 
+        assert (await anext(messages)).message_id == 'Ev1'
         with pytest.raises(StopAsyncIteration):
-            await anext(channel.messages())
+            await anext(messages)
+        await client.aclose()
+
+    async def test_closed_message_iterator_rejects_new_webhooks(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
+        async with channel:
+            messages = channel.messages()
+            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+            assert (await anext(messages)).message_id == 'Ev1'
+            await messages.aclose()
+
+            assert channel.handle_webhook(event_request('Ev2', direct_message())).status_code == 503
         await client.aclose()
 
     async def test_old_message_iterator_ends_after_channel_reopens(self) -> None:
@@ -500,13 +528,10 @@ class TestSlackChannel:
             transport=httpx.MockTransport(lambda request: response({'ok': True, 'team_id': 'T1'}))
         )
         channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
-        pending_message = asyncio.ensure_future(anext(channel.messages()))
-        await asyncio.sleep(0)
-
         with pytest.raises(ChannelError, match='invalid identity'):
             await channel.__aenter__()
         with pytest.raises(StopAsyncIteration):
-            await pending_message
+            await anext(channel.messages())
         await client.aclose()
 
     async def test_rejects_invalid_configuration_and_double_open(self) -> None:

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+from collections.abc import Mapping
+
+import httpx
+import pytest
+from pydantic import TypeAdapter
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelError, ChannelHost, WebhookRequest
+from pydantic_ai_harness.channels.slack import SlackChannel
+
+_BODY_ADAPTER = TypeAdapter(dict[str, object])
+_SIGNING_SECRET = 'signing-secret'
+
+
+def response(payload: object, *, status_code: int = 200, headers: Mapping[str, str] | None = None) -> httpx.Response:
+    return httpx.Response(status_code, json=payload, headers=headers)
+
+
+def signed_request(
+    payload: object,
+    *,
+    secret: str = _SIGNING_SECRET,
+    timestamp: int | None = None,
+    method: str = 'POST',
+) -> WebhookRequest:
+    body = json.dumps(payload, separators=(',', ':')).encode()
+    return signed_body(body, secret=secret, timestamp=timestamp, method=method)
+
+
+def signed_body(
+    body: bytes,
+    *,
+    secret: str = _SIGNING_SECRET,
+    timestamp: int | None = None,
+    method: str = 'POST',
+) -> WebhookRequest:
+    timestamp_text = str(int(time.time()) if timestamp is None else timestamp)
+    signature = (
+        'v0='
+        + hmac.new(
+            secret.encode(),
+            b'v0:' + timestamp_text.encode() + b':' + body,
+            hashlib.sha256,
+        ).hexdigest()
+    )
+    return WebhookRequest(
+        method=method,
+        headers={
+            'X-Slack-Request-Timestamp': timestamp_text,
+            'X-Slack-Signature': signature,
+        },
+        query={},
+        body=body,
+    )
+
+
+def event_request(event_id: str, event: object, *, team_id: str = 'T1') -> WebhookRequest:
+    return signed_request(
+        {
+            'type': 'event_callback',
+            'team_id': team_id,
+            'event_id': event_id,
+            'event': event,
+        }
+    )
+
+
+def direct_message(*, text: str = 'hello', user: str = 'U1') -> dict[str, object]:
+    return {
+        'type': 'message',
+        'channel_type': 'im',
+        'channel': 'D1',
+        'user': user,
+        'text': text,
+        'ts': '123.45',
+    }
+
+
+def auth_response() -> httpx.Response:
+    return response({'ok': True, 'team_id': 'T1', 'user_id': 'UBOT'})
+
+
+@pytest.mark.anyio
+class TestSlackChannel:
+    async def test_normalizes_direct_messages_and_suppresses_duplicate_events(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
+
+        async with channel:
+            request = event_request('Ev1', direct_message())
+            assert channel.handle_webhook(request).status_code == 200
+            assert channel.handle_webhook(request).status_code == 200
+            message = await anext(channel.messages())
+
+        assert (message.conversation_id, message.sender_id, message.message_id, message.text) == (
+            'dm:D1',
+            'U1',
+            'Ev1',
+            'hello',
+        )
+        assert client.is_closed is False
+        await client.aclose()
+
+    async def test_handles_challenge_and_rejects_invalid_requests(self) -> None:
+        channel = SlackChannel('xoxb-token', _SIGNING_SECRET)
+        challenge = signed_request({'type': 'url_verification', 'challenge': 'verify-me'})
+        assert channel.handle_webhook(challenge).body == 'verify-me'
+        assert channel.handle_webhook(signed_request({'type': 'url_verification'})).status_code == 400
+        assert channel.handle_webhook(signed_request({'type': 'other'})).status_code == 200
+        assert channel.handle_webhook(signed_request({}, method='GET')).status_code == 405
+
+        bad_signature = WebhookRequest(
+            method='POST',
+            headers={
+                'x-slack-request-timestamp': str(int(time.time())),
+                'x-slack-signature': 'v0=wrong',
+            },
+            query={},
+            body=b'{}',
+        )
+        assert channel.handle_webhook(bad_signature).status_code == 401
+        non_ascii_signature = WebhookRequest(
+            method='POST',
+            headers={
+                'x-slack-request-timestamp': str(int(time.time())),
+                'x-slack-signature': 'v0=é',
+            },
+            query={},
+            body=b'{}',
+        )
+        assert channel.handle_webhook(non_ascii_signature).status_code == 401
+        assert channel.handle_webhook(WebhookRequest('POST', {}, {}, b'{}')).status_code == 401
+        assert (
+            channel.handle_webhook(
+                WebhookRequest(
+                    'POST',
+                    {
+                        'x-slack-request-timestamp': 'invalid',
+                        'x-slack-signature': 'v0=wrong',
+                    },
+                    {},
+                    b'{}',
+                )
+            ).status_code
+            == 401
+        )
+        assert channel.handle_webhook(signed_request({}, timestamp=int(time.time()) - 301)).status_code == 401
+        oversized_timestamp = WebhookRequest(
+            'POST',
+            {
+                'x-slack-request-timestamp': '9' * 1000,
+                'x-slack-signature': 'v0=wrong',
+            },
+            {},
+            b'{}',
+        )
+        assert channel.handle_webhook(oversized_timestamp).status_code == 401
+
+        assert channel.handle_webhook(signed_body(b'not json')).status_code == 400
+
+    async def test_requires_open_channel_for_events(self) -> None:
+        channel = SlackChannel('xoxb-token', _SIGNING_SECRET)
+        assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 503
+
+    async def test_filters_unaddressed_and_bot_authored_events(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
+
+        async with channel:
+            assert channel.handle_webhook(event_request('Ev0', direct_message(), team_id='other')).status_code == 200
+            assert (
+                channel.handle_webhook(
+                    signed_request(
+                        {
+                            'type': 'event_callback',
+                            'team_id': 'T1',
+                            'event': direct_message(),
+                        }
+                    )
+                ).status_code
+                == 400
+            )
+            ignored = [
+                {**direct_message(user='UBOT')},
+                {**direct_message(), 'bot_id': 'B1'},
+                {**direct_message(), 'subtype': 'message_changed'},
+                {**direct_message(), 'channel_type': 'channel'},
+                {**direct_message(), 'text': ''},
+                {'type': 'reaction_added'},
+                123,
+            ]
+            for index, event in enumerate(ignored):
+                assert channel.handle_webhook(event_request(f'Ev{index + 1}', event)).status_code == 200
+
+        await client.aclose()
+
+    async def test_queue_full_is_retryable_and_not_recorded_as_seen(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel(
+            'xoxb-token',
+            _SIGNING_SECRET,
+            http_client=client,
+            max_queued_messages=1,
+        )
+
+        async with channel:
+            first = event_request('Ev1', direct_message(text='first'))
+            second = event_request('Ev2', direct_message(text='second'))
+            assert channel.handle_webhook(first).status_code == 200
+            assert channel.handle_webhook(second).status_code == 503
+            assert (await anext(channel.messages())).text == 'first'
+            assert channel.handle_webhook(second).status_code == 200
+            assert (await anext(channel.messages())).text == 'second'
+
+        await client.aclose()
+
+    async def test_bounds_recent_event_deduplication(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel(
+            'xoxb-token',
+            _SIGNING_SECRET,
+            http_client=client,
+            max_queued_messages=1,
+        )
+
+        async with channel:
+            for index in range(10_001):
+                request = event_request(f'Ev{index}', direct_message(text=str(index)))
+                assert channel.handle_webhook(request).status_code == 200
+                await anext(channel.messages())
+            first = event_request('Ev0', direct_message(text='first again'))
+            assert channel.handle_webhook(first).status_code == 200
+            assert (await anext(channel.messages())).text == 'first again'
+
+        await client.aclose()
+
+    async def test_mentions_start_or_continue_threads_and_strip_bot_mention(self) -> None:
+        posts: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith('/auth.test'):
+                return auth_response()
+            posts.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            return response({'ok': True, 'ts': '124.00'})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
+        mention = {
+            'type': 'app_mention',
+            'channel': 'C1',
+            'user': 'U1',
+            'text': '<@UBOT> explain this',
+            'ts': '123.45',
+        }
+
+        async with channel:
+            assert channel.handle_webhook(event_request('Ev1', mention)).status_code == 200
+            message = await anext(channel.messages())
+            await channel.send_text(message.conversation_id, 'reply')
+            continued = {**mention, 'thread_ts': '100.00'}
+            assert channel.handle_webhook(event_request('Ev2', continued)).status_code == 200
+            continued_message = await anext(channel.messages())
+            threaded_dm = {**direct_message(), 'thread_ts': '110.00'}
+            assert channel.handle_webhook(event_request('Ev3', threaded_dm)).status_code == 200
+            dm_message = await anext(channel.messages())
+            await channel.send_text(dm_message.conversation_id, 'dm reply')
+
+        assert message.conversation_id == 'thread:C1:123.45'
+        assert message.text == 'explain this'
+        assert continued_message.conversation_id == 'thread:C1:100.00'
+        assert dm_message.conversation_id == 'thread:D1:110.00'
+        assert posts == [
+            {
+                'channel': 'C1',
+                'text': 'reply',
+                'unfurl_links': False,
+                'unfurl_media': False,
+                'thread_ts': '123.45',
+            },
+            {
+                'channel': 'D1',
+                'text': 'dm reply',
+                'unfurl_links': False,
+                'unfurl_media': False,
+                'thread_ts': '110.00',
+            },
+        ]
+        await client.aclose()
+
+    async def test_webhook_runs_agent_and_posts_reply(self) -> None:
+        opened = asyncio.Event()
+        posted = asyncio.Event()
+        posts: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith('/auth.test'):
+                opened.set()
+                return auth_response()
+            posts.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            posted.set()
+            return response({'ok': True, 'ts': '124.00'})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
+        host = ChannelHost(Agent('test'), channel, allowed_senders={'U1'})
+        task = asyncio.create_task(host.serve())
+
+        try:
+            await asyncio.wait_for(opened.wait(), timeout=1)
+            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+            await asyncio.wait_for(posted.wait(), timeout=1)
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            await client.aclose()
+
+        assert posts == [
+            {
+                'channel': 'D1',
+                'text': 'success (no tool calls)',
+                'unfurl_links': False,
+                'unfurl_media': False,
+            }
+        ]
+
+    async def test_chunks_messages_and_retries_one_explicit_rate_limit(self) -> None:
+        posts: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith('/auth.test'):
+                return auth_response()
+            posts.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            if len(posts) == 1:
+                return response(
+                    {'ok': False, 'error': 'ratelimited'},
+                    status_code=429,
+                    headers={'Retry-After': '0'},
+                )
+            return response({'ok': True, 'ts': str(len(posts))})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = SlackChannel('xoxb-token', _SIGNING_SECRET, http_client=client)
+
+        async with channel:
+            await channel.send_text('dm:D1', 'a' * 4001)
+
+        assert posts == [
+            {'channel': 'D1', 'text': 'a' * 4000, 'unfurl_links': False, 'unfurl_media': False},
+            {'channel': 'D1', 'text': 'a' * 4000, 'unfurl_links': False, 'unfurl_media': False},
+            {'channel': 'D1', 'text': 'a', 'unfurl_links': False, 'unfurl_media': False},
+        ]
+        await client.aclose()
+
+    async def test_surfaces_api_and_transport_errors_without_credentials(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return auth_response()
+            if calls == 2:
+                return httpx.Response(500, content=b'not json')
+            if calls == 3:
+                return response({'ok': False, 'error': 'channel_not_found'})
+            if calls == 4:
+                return response(
+                    {'ok': False, 'error': 'ratelimited'},
+                    status_code=429,
+                    headers={'Retry-After': 'invalid'},
+                )
+            if calls == 5:
+                return response({'ok': False, 'error': 'ratelimited'}, status_code=429)
+            if calls == 6:
+                return response(
+                    {'ok': False, 'error': 'ratelimited'},
+                    status_code=429,
+                    headers={'Retry-After': '-1'},
+                )
+            if calls == 7:
+                return response(
+                    {'ok': False, 'error': 'ratelimited'},
+                    status_code=429,
+                    headers={'Retry-After': 'inf'},
+                )
+            if calls == 8:
+                return response({'ok': False})
+            raise httpx.ConnectError('offline', request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = SlackChannel('secret-token', _SIGNING_SECRET, http_client=client)
+
+        async with channel:
+            with pytest.raises(ChannelError, match='invalid response'):
+                await channel.send_text('dm:D1', 'first')
+            with pytest.raises(ChannelError, match='channel_not_found'):
+                await channel.send_text('dm:D1', 'second')
+            with pytest.raises(ChannelError, match='ratelimited'):
+                await channel.send_text('dm:D1', 'third')
+            with pytest.raises(ChannelError, match='ratelimited'):
+                await channel.send_text('dm:D1', 'fourth')
+            with pytest.raises(ChannelError, match='ratelimited'):
+                await channel.send_text('dm:D1', 'fifth')
+            with pytest.raises(ChannelError, match='ratelimited'):
+                await channel.send_text('dm:D1', 'sixth')
+            with pytest.raises(ChannelError, match='unknown Slack Web API error'):
+                await channel.send_text('dm:D1', 'seventh')
+            with pytest.raises(ChannelError, match='request failed') as exc_info:
+                await channel.send_text('dm:D1', 'eighth')
+
+        assert exc_info.value.__suppress_context__ is True
+        assert 'secret-token' not in str(exc_info.value)
+        await client.aclose()
+
+    async def test_owned_client_closes_on_success_and_invalid_identity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client_class = httpx.AsyncClient
+        client = client_class(transport=httpx.MockTransport(lambda request: auth_response()))
+        monkeypatch.setattr(httpx, 'AsyncClient', lambda: client)
+
+        async with SlackChannel('token', _SIGNING_SECRET):
+            pass
+        assert client.is_closed
+
+        rejected = client_class(transport=httpx.MockTransport(lambda request: response({'ok': True, 'team_id': 'T1'})))
+        monkeypatch.setattr(httpx, 'AsyncClient', lambda: rejected)
+        with pytest.raises(ChannelError, match='invalid identity'):
+            async with SlackChannel('token', _SIGNING_SECRET):
+                pass  # pragma: no cover
+        assert rejected.is_closed
+
+    async def test_requires_open_channel_and_valid_output(self) -> None:
+        channel = SlackChannel('token', _SIGNING_SECRET)
+        with pytest.raises(RuntimeError, match='opened'):
+            await channel.send_text('dm:D1', 'hello')
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
+        async with channel:
+            with pytest.raises(ValueError, match='text'):
+                await channel.send_text('dm:D1', '')
+            with pytest.raises(ChannelError, match='invalid Slack conversation id'):
+                await channel.send_text('invalid', 'hello')
+            with pytest.raises(ChannelError, match='invalid Slack conversation id'):
+                await channel.send_text('thread:C1', 'hello')
+            with pytest.raises(ChannelError, match='invalid Slack conversation id'):
+                await channel.send_text('other:route', 'hello')
+        await client.aclose()
+
+    async def test_closing_channel_ends_pending_message_iterator(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
+        async with channel:
+            pending_message = asyncio.ensure_future(anext(channel.messages()))
+            await asyncio.sleep(0)
+
+        with pytest.raises(StopAsyncIteration):
+            await pending_message
+
+        async with channel:
+            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+            assert (await anext(channel.messages())).message_id == 'Ev1'
+        await client.aclose()
+
+    async def test_closing_full_inbox_discards_one_message_to_end_iterator(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel('token', _SIGNING_SECRET, http_client=client, max_queued_messages=1)
+        async with channel:
+            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+
+        with pytest.raises(StopAsyncIteration):
+            await anext(channel.messages())
+        await client.aclose()
+
+    async def test_old_message_iterator_ends_after_channel_reopens(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
+        messages = channel.messages()
+        async with channel:
+            assert channel.handle_webhook(event_request('Ev1', direct_message())).status_code == 200
+            assert (await anext(messages)).message_id == 'Ev1'
+
+        async with channel:
+            with pytest.raises(StopAsyncIteration):
+                await anext(messages)
+        await client.aclose()
+
+    async def test_open_failure_ends_pending_message_iterator(self) -> None:
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: response({'ok': True, 'team_id': 'T1'}))
+        )
+        channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
+        pending_message = asyncio.ensure_future(anext(channel.messages()))
+        await asyncio.sleep(0)
+
+        with pytest.raises(ChannelError, match='invalid identity'):
+            await channel.__aenter__()
+        with pytest.raises(StopAsyncIteration):
+            await pending_message
+        await client.aclose()
+
+    async def test_rejects_invalid_configuration_and_double_open(self) -> None:
+        with pytest.raises(ValueError, match='bot_token'):
+            SlackChannel('', _SIGNING_SECRET)
+        with pytest.raises(ValueError, match='signing_secret'):
+            SlackChannel('token', '')
+        for value in (0, True):
+            with pytest.raises(ValueError, match='max_queued_messages'):
+                SlackChannel('token', _SIGNING_SECRET, max_queued_messages=value)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: auth_response()))
+        channel = SlackChannel('token', _SIGNING_SECRET, http_client=client)
+        async with channel:
+            with pytest.raises(RuntimeError, match='already open'):
+                await channel.__aenter__()
+        await client.aclose()

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -318,8 +318,7 @@ class TestSlackChannel:
         ]
         await client.aclose()
 
-    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
-    async def test_webhook_runs_agent_and_posts_reply(self, anyio_backend: str) -> None:
+    async def test_webhook_runs_agent_and_posts_reply(self) -> None:
         opened = anyio.Event()
         posted = anyio.Event()
         posts: list[dict[str, object]] = []

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -342,8 +342,14 @@ class TestSlackChannel:
             }
         ]
 
-    async def test_chunks_messages_and_retries_one_explicit_rate_limit(self) -> None:
+    async def test_chunks_messages_and_retries_one_explicit_rate_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
         posts: list[dict[str, object]] = []
+        delays: list[float] = []
+
+        async def sleep(delay: float) -> None:
+            delays.append(delay)
+
+        monkeypatch.setattr(anyio, 'sleep', sleep)
 
         def handler(request: httpx.Request) -> httpx.Response:
             if request.url.path.endswith('/auth.test'):
@@ -353,7 +359,7 @@ class TestSlackChannel:
                 return response(
                     {'ok': False, 'error': 'ratelimited'},
                     status_code=429,
-                    headers={'Retry-After': '0'},
+                    headers={'Retry-After': '61'},
                 )
             return response({'ok': True, 'ts': str(len(posts))})
 
@@ -368,6 +374,26 @@ class TestSlackChannel:
             {'channel': 'D1', 'text': 'a' * 4000, 'mrkdwn': False, 'unfurl_links': False, 'unfurl_media': False},
             {'channel': 'D1', 'text': 'a', 'mrkdwn': False, 'unfurl_links': False, 'unfurl_media': False},
         ]
+        assert delays == [61]
+        await client.aclose()
+
+    async def test_uses_configured_api_root(self) -> None:
+        urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            urls.append(str(request.url))
+            return auth_response()
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        async with SlackChannel(
+            'token',
+            _SIGNING_SECRET,
+            http_client=client,
+            api_base_url='https://slack-gov.com/api/',
+        ):
+            pass
+
+        assert urls == ['https://slack-gov.com/api/auth.test']
         await client.aclose()
 
     async def test_surfaces_api_and_transport_errors_without_credentials(self) -> None:
@@ -542,6 +568,8 @@ class TestSlackChannel:
             SlackChannel('', _SIGNING_SECRET)
         with pytest.raises(ValueError, match='signing_secret'):
             SlackChannel('token', '')
+        with pytest.raises(ValueError, match='api_base_url'):
+            SlackChannel('token', _SIGNING_SECRET, api_base_url='')
         for value in (0, True):
             with pytest.raises(ValueError, match='max_queued_messages'):
                 SlackChannel('token', _SIGNING_SECRET, max_queued_messages=value)

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -289,6 +289,7 @@ class TestSlackChannel:
             {
                 'channel': 'C1',
                 'text': 'reply',
+                'mrkdwn': False,
                 'unfurl_links': False,
                 'unfurl_media': False,
                 'thread_ts': '123.45',
@@ -296,6 +297,7 @@ class TestSlackChannel:
             {
                 'channel': 'D1',
                 'text': 'dm reply',
+                'mrkdwn': False,
                 'unfurl_links': False,
                 'unfurl_media': False,
                 'thread_ts': '110.00',
@@ -334,6 +336,7 @@ class TestSlackChannel:
             {
                 'channel': 'D1',
                 'text': 'success (no tool calls)',
+                'mrkdwn': False,
                 'unfurl_links': False,
                 'unfurl_media': False,
             }
@@ -361,9 +364,9 @@ class TestSlackChannel:
             await channel.send_text('dm:D1', 'a' * 4001)
 
         assert posts == [
-            {'channel': 'D1', 'text': 'a' * 4000, 'unfurl_links': False, 'unfurl_media': False},
-            {'channel': 'D1', 'text': 'a' * 4000, 'unfurl_links': False, 'unfurl_media': False},
-            {'channel': 'D1', 'text': 'a', 'unfurl_links': False, 'unfurl_media': False},
+            {'channel': 'D1', 'text': 'a' * 4000, 'mrkdwn': False, 'unfurl_links': False, 'unfurl_media': False},
+            {'channel': 'D1', 'text': 'a' * 4000, 'mrkdwn': False, 'unfurl_links': False, 'unfurl_media': False},
+            {'channel': 'D1', 'text': 'a', 'mrkdwn': False, 'unfurl_links': False, 'unfurl_media': False},
         ]
         await client.aclose()
 


### PR DESCRIPTION
Part of #737. Stacked on #738. WhatsApp #741 reuses this webhook ingress seam.

## Summary
- add a signed Slack Events API adapter for DMs and explicitly allowed mention channels
- expose awaitable webhook admission through a bounded AnyIO memory stream
- preserve thread routing and suppress recent duplicate events
- bound unambiguous 429 retries and avoid retrying ambiguous sends
- show a complete Starlette app with an AnyIO-owned lifespan

## Review order
1. _webhook.py is the shared bounded queue and deduplication module.
2. slack.py keeps authentication, admission, routing, and send policy local.
3. test_slack.py follows webhook, send, failure, then lifecycle behavior.

## Verification
- asyncio adapter and host integration tests
- Ruff, strict Pyright, full test suite, and 100% branch coverage
- Fable adversarial review of ownership, races, public API, security, and docs
