### PR TITLE
Connect ChannelHost to the WhatsApp Cloud API

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -151,7 +151,7 @@ and the verification token in Meta. Subscribe the route to `messages`.
 
 The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
-Run one host process for each WhatsApp phone number. Terminate TLS and limit
+Route each WhatsApp phone number to exactly one live host process. Terminate TLS and limit
 request body size in the ASGI server or reverse proxy.
 The default Graph API version is `v26.0`; pass `api_version` for another
 supported version.
@@ -211,7 +211,7 @@ delivery instead of holding that conversation's turn slot. It does not retry
 timeouts or other ambiguous failures because Slack may already have accepted
 the message. If a later text chunk fails, earlier chunks remain visible.
 
-The WhatsApp adapter limits outbound free-form text to the 24-hour customer
+WhatsApp Cloud API limits outbound free-form text to the 24-hour customer
 service window. It surfaces error 131047 when that window is closed; it does not
 substitute an approved template. It retries one response carrying an explicit
 Cloud API throttling code after `retry_delay`, but does not retry network

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -101,9 +101,11 @@ Replace `15551234567` below with the sender's international phone number
 without `+`, matching the webhook `from` value.
 
 ```python
-import asyncio
 import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
+import anyio
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
@@ -119,7 +121,7 @@ whatsapp = WhatsAppChannel(
 whatsapp_host = ChannelHost(agent, whatsapp, allowed_senders={'15551234567'})
 
 
-def receive_whatsapp(
+async def receive_whatsapp(
     method: str,
     headers: dict[str, str],
     query: dict[str, str],
@@ -129,22 +131,26 @@ def receive_whatsapp(
     return whatsapp.handle_webhook(request)
 
 
-def start_whatsapp() -> asyncio.Task[None]:
-    return asyncio.create_task(whatsapp_host.serve())
+@asynccontextmanager
+async def whatsapp_lifespan() -> AsyncIterator[None]:
+    async with anyio.create_task_group() as tasks:
+        tasks.start_soon(whatsapp_host.serve)
+        yield
+        tasks.cancel_scope.cancel()
 ```
 
-Connect the two functions to your web app:
+Connect the lifespan and route to your web app:
 
-1. Call `start_whatsapp()` when the app starts.
+1. Enter `whatsapp_lifespan()` for the app's lifespan.
 2. Forward both GET and POST webhook requests to `receive_whatsapp()` and
    return its status code and body.
 3. Register that public route and the verification token in Meta, then subscribe
    it to `messages`.
-4. On shutdown, cancel the channel task, then await it while suppressing
-   `asyncio.CancelledError`.
 
-The lifespan and route must use the same process and event loop. The default
-Graph API version is `v26.0`; pass `api_version` for another supported version.
+The task group owns the channel service and waits for its turns during shutdown.
+The lifespan and route must use the same process and async event-loop thread.
+The default Graph API version is `v26.0`; pass `api_version` for another
+supported version.
 
 ## How channels fit Pydantic AI
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -16,8 +16,8 @@ Channels are useful for:
 
 > While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
 
-This quickstart uses Anthropic. Install the provider extra and set
-`ANTHROPIC_API_KEY` before running it:
+These examples use Anthropic. Install the provider extra and set
+`ANTHROPIC_API_KEY` before running them:
 
 ```bash
 uv add "pydantic-ai-harness[anthropic]" starlette uvicorn
@@ -89,6 +89,63 @@ The lifespan and route must use the same process and async event-loop thread.
 Route each Slack app installation to exactly one live host process. Terminate TLS and limit
 request body size in the ASGI server or reverse proxy.
 
+## WhatsApp: messages to a business number
+
+Use WhatsApp when customers or teammates should reach the agent through a
+WhatsApp Business phone number.
+
+Create a Meta app and WhatsApp Business phone number, then set a System User
+access token, phone number id, app secret, and a private webhook verification
+token. The access token needs `whatsapp_business_messaging` for the phone number.
+Replace `15551234567` below with the sender's international phone number
+without `+`, matching the webhook `from` value.
+
+```python
+import asyncio
+import os
+
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
+from pydantic_ai_harness.channels.whatsapp import WhatsAppChannel
+
+agent = Agent('anthropic:claude-fable-5')
+whatsapp = WhatsAppChannel(
+    os.environ['WHATSAPP_ACCESS_TOKEN'],
+    os.environ['WHATSAPP_PHONE_NUMBER_ID'],
+    os.environ['META_APP_SECRET'],
+    os.environ['WHATSAPP_VERIFY_TOKEN'],
+)
+whatsapp_host = ChannelHost(agent, whatsapp, allowed_senders={'15551234567'})
+
+
+def receive_whatsapp(
+    method: str,
+    headers: dict[str, str],
+    query: dict[str, str],
+    body: bytes,
+) -> WebhookResponse:
+    request = WebhookRequest(method=method, headers=headers, query=query, body=body)
+    return whatsapp.handle_webhook(request)
+
+
+def start_whatsapp() -> asyncio.Task[None]:
+    return asyncio.create_task(whatsapp_host.serve())
+```
+
+Connect the two functions to your web app:
+
+1. Call `start_whatsapp()` when the app starts.
+2. Forward both GET and POST webhook requests to `receive_whatsapp()` and
+   return its status code and body.
+3. Register that public route and the verification token in Meta, then subscribe
+   it to `messages`.
+4. On shutdown, cancel the channel task, then await it while suppressing
+   `asyncio.CancelledError`.
+
+The lifespan and route must use the same process and event loop. The default
+Graph API version is `v26.0`; pass `api_version` for another supported version.
+
 ## How channels fit Pydantic AI
 
 Each inbound message starts an ordinary `Agent.run()`. The agent keeps its
@@ -132,18 +189,24 @@ chat. If sending a reply fails, the host logs the failure and continues serving.
 History remains saved after a successful run even when delivery cannot be
 confirmed.
 
+For message-bearing requests, both webhook adapters authenticate and enqueue
+before returning HTTP 200. They return HTTP 503 when not open or when their
+bounded queue is full, so the provider can retry. Each queue and its 10,000-id
+duplicate window are process-local. A restart can reprocess a redelivery or lose
+an acknowledged message that was still queued.
+
 `SlackChannel` retries one `chat.postMessage` call after an HTTP 429 with a
 valid non-negative `Retry-After` of at most 60 seconds. Longer delays fail the
 delivery instead of holding that conversation's turn slot. It does not retry
 timeouts or other ambiguous failures because Slack may already have accepted
 the message. If a later text chunk fails, earlier chunks remain visible.
 
-The webhook handler verifies and enqueues a request before returning HTTP 200.
-It returns HTTP 503 while the channel is opening or when its bounded queue is
-full, allowing Slack to retry the event. Duplicate suppression covers the
-10,000 most recently accepted `event_id` values. The queue and duplicate window
-are process-local. A restart can reprocess a redelivered event, and can lose an
-acknowledged event that was still waiting in the queue.
+The WhatsApp adapter limits outbound free-form text to the 24-hour customer
+service window. It surfaces error 131047 when that window is closed; it does not
+substitute an approved template. It retries one response carrying an explicit
+Cloud API throttling code after `retry_delay`, but does not retry network
+timeouts. Meta may batch messages and retry failed webhook deliveries for up to
+seven days.
 
 `serve()` runs until it is cancelled or the adapter ends. It owns every turn in
 an AnyIO task group, so no turn task outlives it. Cancellation closes the
@@ -163,6 +226,11 @@ Slack direct messages are enabled by default. App mentions are accepted only
 from `allowed_channel_ids`. The adapter also drops events from other workspaces,
 bot-authored messages, edits, messages with a subtype (including file shares),
 and unaddressed channel messages.
+
+WhatsApp POST signatures are checked over the exact request bytes with the Meta
+app secret. The GET handshake uses the separate verification token. The adapter
+accepts text for its configured phone number and drops delivery statuses,
+non-text messages, and updates for other numbers.
 
 ## Adapters and stores
 
@@ -185,6 +253,10 @@ multiple live hosts safe without external per-conversation serialization.
 The Slack adapter does not include Socket Mode, multi-workspace OAuth routing,
 files, reactions, message edits, or messages in channels that do not mention
 the bot. Socket Mode requires a WebSocket client and can be added separately.
+
+The WhatsApp adapter uses the official Cloud API. It does not include media,
+message templates, delivery-status callbacks, embedded signup, or the unofficial
+browser automation used by `whatsapp-web.js`.
 
 The host does not define media, reactions, typing indicators, streaming edits,
 tool approvals, or provider authentication. Adapters add only the provider
@@ -209,3 +281,5 @@ behavior they document.
 ::: pydantic_ai_harness.channels.WebhookResponse
 
 ::: pydantic_ai_harness.channels.slack.SlackChannel
+
+::: pydantic_ai_harness.channels.whatsapp.WhatsAppChannel

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -107,8 +107,12 @@ from contextlib import asynccontextmanager
 
 import anyio
 from pydantic_ai import Agent
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
 
-from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
+from pydantic_ai_harness.channels import ChannelHost, WebhookRequest
 from pydantic_ai_harness.channels.whatsapp import WhatsAppChannel
 
 agent = Agent('anthropic:claude-fable-5')
@@ -121,33 +125,31 @@ whatsapp = WhatsAppChannel(
 whatsapp_host = ChannelHost(agent, whatsapp, allowed_senders={'15551234567'})
 
 
-async def receive_whatsapp(
-    method: str,
-    headers: dict[str, str],
-    query: dict[str, str],
-    body: bytes,
-) -> WebhookResponse:
-    request = WebhookRequest(method=method, headers=headers, query=query, body=body)
-    return whatsapp.handle_webhook(request)
+async def receive_whatsapp(request: Request) -> PlainTextResponse:
+    result = whatsapp.handle_webhook(
+        WebhookRequest(request.method, request.headers, request.query_params, await request.body())
+    )
+    return PlainTextResponse(result.body, status_code=result.status_code)
 
 
 @asynccontextmanager
-async def whatsapp_lifespan() -> AsyncIterator[None]:
+async def whatsapp_lifespan(_app: Starlette) -> AsyncIterator[None]:
     async with anyio.create_task_group() as tasks:
         tasks.start_soon(whatsapp_host.serve)
         yield
         tasks.cancel_scope.cancel()
+
+
+app = Starlette(
+    routes=[Route('/whatsapp/webhook', receive_whatsapp, methods=['GET', 'POST'])],
+    lifespan=whatsapp_lifespan,
+)
 ```
 
-Connect the lifespan and route to your web app:
+Save this as `app.py`, run `uvicorn app:app`, and register `/whatsapp/webhook`
+and the verification token in Meta. Subscribe the route to `messages`.
 
-1. Enter `whatsapp_lifespan()` for the app's lifespan.
-2. Forward both GET and POST webhook requests to `receive_whatsapp()` and
-   return its status code and body.
-3. Register that public route and the verification token in Meta, then subscribe
-   it to `messages`.
-
-The task group owns the channel service and waits for its turns during shutdown.
+The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
 The default Graph API version is `v26.0`; pass `api_version` for another
 supported version.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -126,7 +126,7 @@ whatsapp_host = ChannelHost(agent, whatsapp, allowed_senders={'15551234567'})
 
 
 async def receive_whatsapp(request: Request) -> PlainTextResponse:
-    result = whatsapp.handle_webhook(
+    result = await whatsapp.handle_webhook(
         WebhookRequest(request.method, request.headers, request.query_params, await request.body())
     )
     return PlainTextResponse(result.body, status_code=result.status_code)
@@ -151,6 +151,8 @@ and the verification token in Meta. Subscribe the route to `messages`.
 
 The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
+Run one host process for each WhatsApp phone number. Terminate TLS and limit
+request body size in the ASGI server or reverse proxy.
 The default Graph API version is `v26.0`; pass `api_version` for another
 supported version.
 
@@ -213,8 +215,8 @@ The WhatsApp adapter limits outbound free-form text to the 24-hour customer
 service window. It surfaces error 131047 when that window is closed; it does not
 substitute an approved template. It retries one response carrying an explicit
 Cloud API throttling code after `retry_delay`, but does not retry network
-timeouts. Meta may batch messages and retry failed webhook deliveries for up to
-seven days.
+timeouts. If a later text chunk fails, earlier chunks remain visible. Meta may
+batch messages and retry failed webhook deliveries for up to seven days.
 
 `serve()` runs until it is cancelled or the adapter ends. It owns every turn in
 an AnyIO task group, so no turn task outlives it. Cancellation closes the

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -96,9 +96,11 @@ Replace `15551234567` below with the sender's international phone number
 without `+`, matching the webhook `from` value.
 
 ```python
-import asyncio
 import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
+import anyio
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
@@ -114,7 +116,7 @@ whatsapp = WhatsAppChannel(
 whatsapp_host = ChannelHost(agent, whatsapp, allowed_senders={'15551234567'})
 
 
-def receive_whatsapp(
+async def receive_whatsapp(
     method: str,
     headers: dict[str, str],
     query: dict[str, str],
@@ -124,22 +126,26 @@ def receive_whatsapp(
     return whatsapp.handle_webhook(request)
 
 
-def start_whatsapp() -> asyncio.Task[None]:
-    return asyncio.create_task(whatsapp_host.serve())
+@asynccontextmanager
+async def whatsapp_lifespan() -> AsyncIterator[None]:
+    async with anyio.create_task_group() as tasks:
+        tasks.start_soon(whatsapp_host.serve)
+        yield
+        tasks.cancel_scope.cancel()
 ```
 
-Connect the two functions to your web app:
+Connect the lifespan and route to your web app:
 
-1. Call `start_whatsapp()` when the app starts.
+1. Enter `whatsapp_lifespan()` for the app's lifespan.
 2. Forward both GET and POST webhook requests to `receive_whatsapp()` and
    return its status code and body.
 3. Register that public route and the verification token in Meta, then subscribe
    it to `messages`.
-4. On shutdown, cancel the channel task, then await it while suppressing
-   `asyncio.CancelledError`.
 
-The lifespan and route must use the same process and event loop. The default
-Graph API version is `v26.0`; pass `api_version` for another supported version.
+The task group owns the channel service and waits for its turns during shutdown.
+The lifespan and route must use the same process and async event-loop thread.
+The default Graph API version is `v26.0`; pass `api_version` for another
+supported version.
 
 ## How channels fit Pydantic AI
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -11,8 +11,8 @@ Channels are useful for:
 
 > While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](../../docs/index.md#version-policy).
 
-This quickstart uses Anthropic. Install the provider extra and set
-`ANTHROPIC_API_KEY` before running it:
+These examples use Anthropic. Install the provider extra and set
+`ANTHROPIC_API_KEY` before running them:
 
 ```bash
 uv add "pydantic-ai-harness[anthropic]" starlette uvicorn
@@ -84,6 +84,63 @@ The lifespan and route must use the same process and async event-loop thread.
 Route each Slack app installation to exactly one live host process. Terminate TLS and limit
 request body size in the ASGI server or reverse proxy.
 
+## WhatsApp: messages to a business number
+
+Use WhatsApp when customers or teammates should reach the agent through a
+WhatsApp Business phone number.
+
+Create a Meta app and WhatsApp Business phone number, then set a System User
+access token, phone number id, app secret, and a private webhook verification
+token. The access token needs `whatsapp_business_messaging` for the phone number.
+Replace `15551234567` below with the sender's international phone number
+without `+`, matching the webhook `from` value.
+
+```python
+import asyncio
+import os
+
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
+from pydantic_ai_harness.channels.whatsapp import WhatsAppChannel
+
+agent = Agent('anthropic:claude-fable-5')
+whatsapp = WhatsAppChannel(
+    os.environ['WHATSAPP_ACCESS_TOKEN'],
+    os.environ['WHATSAPP_PHONE_NUMBER_ID'],
+    os.environ['META_APP_SECRET'],
+    os.environ['WHATSAPP_VERIFY_TOKEN'],
+)
+whatsapp_host = ChannelHost(agent, whatsapp, allowed_senders={'15551234567'})
+
+
+def receive_whatsapp(
+    method: str,
+    headers: dict[str, str],
+    query: dict[str, str],
+    body: bytes,
+) -> WebhookResponse:
+    request = WebhookRequest(method=method, headers=headers, query=query, body=body)
+    return whatsapp.handle_webhook(request)
+
+
+def start_whatsapp() -> asyncio.Task[None]:
+    return asyncio.create_task(whatsapp_host.serve())
+```
+
+Connect the two functions to your web app:
+
+1. Call `start_whatsapp()` when the app starts.
+2. Forward both GET and POST webhook requests to `receive_whatsapp()` and
+   return its status code and body.
+3. Register that public route and the verification token in Meta, then subscribe
+   it to `messages`.
+4. On shutdown, cancel the channel task, then await it while suppressing
+   `asyncio.CancelledError`.
+
+The lifespan and route must use the same process and event loop. The default
+Graph API version is `v26.0`; pass `api_version` for another supported version.
+
 ## How channels fit Pydantic AI
 
 Each inbound message starts an ordinary `Agent.run()`. The agent keeps its
@@ -127,18 +184,24 @@ chat. If sending a reply fails, the host logs the failure and continues serving.
 History remains saved after a successful run even when delivery cannot be
 confirmed.
 
+For message-bearing requests, both webhook adapters authenticate and enqueue
+before returning HTTP 200. They return HTTP 503 when not open or when their
+bounded queue is full, so the provider can retry. Each queue and its 10,000-id
+duplicate window are process-local. A restart can reprocess a redelivery or lose
+an acknowledged message that was still queued.
+
 `SlackChannel` retries one `chat.postMessage` call after an HTTP 429 with a
 valid non-negative `Retry-After` of at most 60 seconds. Longer delays fail the
 delivery instead of holding that conversation's turn slot. It does not retry
 timeouts or other ambiguous failures because Slack may already have accepted
 the message. If a later text chunk fails, earlier chunks remain visible.
 
-The webhook handler verifies and enqueues a request before returning HTTP 200.
-It returns HTTP 503 while the channel is opening or when its bounded queue is
-full, allowing Slack to retry the event. Duplicate suppression covers the
-10,000 most recently accepted `event_id` values. The queue and duplicate window
-are process-local. A restart can reprocess a redelivered event, and can lose an
-acknowledged event that was still waiting in the queue.
+The WhatsApp adapter limits outbound free-form text to the 24-hour customer
+service window. It surfaces error 131047 when that window is closed; it does not
+substitute an approved template. It retries one response carrying an explicit
+Cloud API throttling code after `retry_delay`, but does not retry network
+timeouts. Meta may batch messages and retry failed webhook deliveries for up to
+seven days.
 
 `serve()` runs until it is cancelled or the adapter ends. It owns every turn in
 an AnyIO task group, so no turn task outlives it. Cancellation closes the
@@ -158,6 +221,11 @@ Slack direct messages are enabled by default. App mentions are accepted only
 from `allowed_channel_ids`. The adapter also drops events from other workspaces,
 bot-authored messages, edits, messages with a subtype (including file shares),
 and unaddressed channel messages.
+
+WhatsApp POST signatures are checked over the exact request bytes with the Meta
+app secret. The GET handshake uses the separate verification token. The adapter
+accepts text for its configured phone number and drops delivery statuses,
+non-text messages, and updates for other numbers.
 
 ## Adapters and stores
 
@@ -181,6 +249,10 @@ The Slack adapter does not include Socket Mode, multi-workspace OAuth routing,
 files, reactions, message edits, or messages in channels that do not mention
 the bot. Socket Mode requires a WebSocket client and can be added separately.
 
+The WhatsApp adapter uses the official Cloud API. It does not include media,
+message templates, delivery-status callbacks, embedded signup, or the unofficial
+browser automation used by `whatsapp-web.js`.
+
 The host does not define media, reactions, typing indicators, streaming edits,
 tool approvals, or provider authentication. Adapters add only the provider
 behavior they document.
@@ -196,3 +268,4 @@ behavior they document.
 - [`WebhookRequest`][pydantic_ai_harness.channels.WebhookRequest]
 - [`WebhookResponse`][pydantic_ai_harness.channels.WebhookResponse]
 - [`SlackChannel`][pydantic_ai_harness.channels.slack.SlackChannel]
+- [`WhatsAppChannel`][pydantic_ai_harness.channels.whatsapp.WhatsAppChannel]

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -102,8 +102,12 @@ from contextlib import asynccontextmanager
 
 import anyio
 from pydantic_ai import Agent
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
 
-from pydantic_ai_harness.channels import ChannelHost, WebhookRequest, WebhookResponse
+from pydantic_ai_harness.channels import ChannelHost, WebhookRequest
 from pydantic_ai_harness.channels.whatsapp import WhatsAppChannel
 
 agent = Agent('anthropic:claude-fable-5')
@@ -116,33 +120,31 @@ whatsapp = WhatsAppChannel(
 whatsapp_host = ChannelHost(agent, whatsapp, allowed_senders={'15551234567'})
 
 
-async def receive_whatsapp(
-    method: str,
-    headers: dict[str, str],
-    query: dict[str, str],
-    body: bytes,
-) -> WebhookResponse:
-    request = WebhookRequest(method=method, headers=headers, query=query, body=body)
-    return whatsapp.handle_webhook(request)
+async def receive_whatsapp(request: Request) -> PlainTextResponse:
+    result = whatsapp.handle_webhook(
+        WebhookRequest(request.method, request.headers, request.query_params, await request.body())
+    )
+    return PlainTextResponse(result.body, status_code=result.status_code)
 
 
 @asynccontextmanager
-async def whatsapp_lifespan() -> AsyncIterator[None]:
+async def whatsapp_lifespan(_app: Starlette) -> AsyncIterator[None]:
     async with anyio.create_task_group() as tasks:
         tasks.start_soon(whatsapp_host.serve)
         yield
         tasks.cancel_scope.cancel()
+
+
+app = Starlette(
+    routes=[Route('/whatsapp/webhook', receive_whatsapp, methods=['GET', 'POST'])],
+    lifespan=whatsapp_lifespan,
+)
 ```
 
-Connect the lifespan and route to your web app:
+Save this as `app.py`, run `uvicorn app:app`, and register `/whatsapp/webhook`
+and the verification token in Meta. Subscribe the route to `messages`.
 
-1. Enter `whatsapp_lifespan()` for the app's lifespan.
-2. Forward both GET and POST webhook requests to `receive_whatsapp()` and
-   return its status code and body.
-3. Register that public route and the verification token in Meta, then subscribe
-   it to `messages`.
-
-The task group owns the channel service and waits for its turns during shutdown.
+The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
 The default Graph API version is `v26.0`; pass `api_version` for another
 supported version.

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -121,7 +121,7 @@ whatsapp_host = ChannelHost(agent, whatsapp, allowed_senders={'15551234567'})
 
 
 async def receive_whatsapp(request: Request) -> PlainTextResponse:
-    result = whatsapp.handle_webhook(
+    result = await whatsapp.handle_webhook(
         WebhookRequest(request.method, request.headers, request.query_params, await request.body())
     )
     return PlainTextResponse(result.body, status_code=result.status_code)
@@ -146,6 +146,8 @@ and the verification token in Meta. Subscribe the route to `messages`.
 
 The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
+Run one host process for each WhatsApp phone number. Terminate TLS and limit
+request body size in the ASGI server or reverse proxy.
 The default Graph API version is `v26.0`; pass `api_version` for another
 supported version.
 
@@ -208,8 +210,8 @@ The WhatsApp adapter limits outbound free-form text to the 24-hour customer
 service window. It surfaces error 131047 when that window is closed; it does not
 substitute an approved template. It retries one response carrying an explicit
 Cloud API throttling code after `retry_delay`, but does not retry network
-timeouts. Meta may batch messages and retry failed webhook deliveries for up to
-seven days.
+timeouts. If a later text chunk fails, earlier chunks remain visible. Meta may
+batch messages and retry failed webhook deliveries for up to seven days.
 
 `serve()` runs until it is cancelled or the adapter ends. It owns every turn in
 an AnyIO task group, so no turn task outlives it. Cancellation closes the

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -146,7 +146,7 @@ and the verification token in Meta. Subscribe the route to `messages`.
 
 The task group owns the channel service and waits for cancellation and cleanup during shutdown.
 The lifespan and route must use the same process and async event-loop thread.
-Run one host process for each WhatsApp phone number. Terminate TLS and limit
+Route each WhatsApp phone number to exactly one live host process. Terminate TLS and limit
 request body size in the ASGI server or reverse proxy.
 The default Graph API version is `v26.0`; pass `api_version` for another
 supported version.
@@ -206,7 +206,7 @@ delivery instead of holding that conversation's turn slot. It does not retry
 timeouts or other ambiguous failures because Slack may already have accepted
 the message. If a later text chunk fails, earlier chunks remain visible.
 
-The WhatsApp adapter limits outbound free-form text to the 24-hour customer
+WhatsApp Cloud API limits outbound free-form text to the 24-hour customer
 service window. It surfaces error 131047 when that window is closed; it does not
 substitute an approved template. It retries one response carrying an explicit
 Cloud API throttling code after `retry_delay`, but does not retry network

--- a/pydantic_ai_harness/channels/whatsapp.py
+++ b/pydantic_ai_harness/channels/whatsapp.py
@@ -1,0 +1,322 @@
+"""WhatsApp Cloud API channel adapter.
+
+External assumptions verified 2026-08-31:
+
+* Webhook verification uses the configured GET challenge and POST requests use
+  `X-Hub-Signature-256` over the exact request body.
+* Webhooks may contain batched messages and Meta retries failed deliveries for
+  up to seven days.
+* Free-form replies are limited to 4096 characters and to the 24-hour customer
+  service window.
+* Graph API v26.0 is the current default. Callers can select another supported
+  version with `api_version`.
+
+Re-check these assumptions against
+https://developers.facebook.com/documentation/business-messaging/whatsapp/
+before changing verification, deduplication, parsing, or delivery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import math
+from collections.abc import AsyncIterator, Iterator, Mapping
+from types import TracebackType
+
+import httpx
+from pydantic import TypeAdapter, ValidationError
+from typing_extensions import Self
+
+from pydantic_ai_harness.channels._types import (
+    ChannelError,
+    InboundMessage,
+    WebhookRequest,
+    WebhookResponse,
+)
+from pydantic_ai_harness.channels._webhook import RecentMessageIds, WebhookInbox
+
+_API_BASE = 'https://graph.facebook.com'
+_DEFAULT_API_VERSION = 'v26.0'
+_MAX_TEXT_CHARS = 4096
+_MAX_SEEN_MESSAGES = 10_000
+_REQUEST_TIMEOUT = 10.0
+_THROTTLING_ERROR_CODES = frozenset({4, 80007, 130429, 131056})
+_MAPPING_ADAPTER = TypeAdapter(dict[str, object])
+_LIST_ADAPTER = TypeAdapter(list[object])
+
+
+class WhatsAppChannel:
+    """Connect one business phone number through the official Cloud API."""
+
+    def __init__(
+        self,
+        access_token: str,
+        phone_number_id: str,
+        app_secret: str,
+        verify_token: str,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        api_version: str = _DEFAULT_API_VERSION,
+        max_queued_messages: int = 100,
+        retry_delay: float = 1.0,
+    ) -> None:
+        """Configure the WhatsApp adapter without opening it.
+
+        Args:
+            access_token: System User token with WhatsApp messaging access.
+            phone_number_id: Business phone number id used for replies.
+            app_secret: Meta app secret used to authenticate POST webhooks.
+            verify_token: Private value checked during the GET webhook handshake.
+            http_client: Optional client whose lifecycle remains owned by the caller.
+            api_version: Graph API version, including the leading `v`.
+            max_queued_messages: Maximum verified messages waiting for the host.
+            retry_delay: Delay before one retry for an explicit throttling error.
+
+        Raises:
+            ValueError: If configuration is empty or a limit is invalid.
+        """
+        credentials = {
+            'access_token': access_token,
+            'phone_number_id': phone_number_id,
+            'app_secret': app_secret,
+            'verify_token': verify_token,
+        }
+        for name, value in credentials.items():
+            if not value:
+                raise ValueError(f'{name} must not be empty')
+        if not _valid_api_version(api_version):
+            raise ValueError('api_version must look like v26.0')
+        if type(max_queued_messages) is not int or max_queued_messages <= 0:
+            raise ValueError('max_queued_messages must be a positive integer')
+        if retry_delay < 0 or not math.isfinite(retry_delay):
+            raise ValueError('retry_delay must be finite and not negative')
+
+        self._access_token = access_token
+        self._phone_number_id = phone_number_id
+        self._app_secret = app_secret.encode()
+        self._verify_token = verify_token
+        self._provided_client = http_client
+        self._client: httpx.AsyncClient | None = None
+        self._owns_client = False
+        self._ready = False
+        self._api_version = api_version
+        self._inbox = WebhookInbox(max_queued_messages)
+        self._seen_messages = RecentMessageIds(_MAX_SEEN_MESSAGES)
+        self._retry_delay = retry_delay
+
+    async def __aenter__(self) -> Self:
+        """Open the HTTP client and begin accepting message webhooks."""
+        if self._client is not None:
+            raise RuntimeError('WhatsAppChannel is already open')
+        self._inbox.open()
+        self._client = self._provided_client or httpx.AsyncClient()
+        self._owns_client = self._provided_client is None
+        self._ready = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Close the internally created HTTP client, if any."""
+        self._ready = False
+        self._inbox.close()
+        await self._close_owned_client()
+        self._client = None
+        return None
+
+    async def _close_owned_client(self) -> None:
+        if self._owns_client and self._client is not None:
+            await self._client.aclose()
+        self._owns_client = False
+
+    def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
+        """Verify a webhook request and enqueue its inbound text messages."""
+        method = request.method.upper()
+        if method == 'GET':
+            return self._verify_challenge(request.query)
+        if method != 'POST':
+            return WebhookResponse(405)
+        if not self._valid_signature(request):
+            return WebhookResponse(401)
+
+        try:
+            payload = _MAPPING_ADAPTER.validate_json(request.body)
+        except ValidationError:
+            return WebhookResponse(400)
+        if payload.get('object') != 'whatsapp_business_account':
+            return WebhookResponse(200)
+
+        for message in self._parse_messages(payload):
+            if not self._ready:
+                return WebhookResponse(503)
+            if message.message_id in self._seen_messages:
+                continue
+            if not self._inbox.put(message):
+                return WebhookResponse(503)
+            self._seen_messages.add(message.message_id)
+        return WebhookResponse(200)
+
+    def _verify_challenge(self, query: Mapping[str, str]) -> WebhookResponse:
+        mode = query.get('hub.mode')
+        token = query.get('hub.verify_token')
+        challenge = query.get('hub.challenge')
+        if (
+            mode == 'subscribe'
+            and token is not None
+            and hmac.compare_digest(
+                self._verify_token.encode(),
+                token.encode('utf-8', 'replace'),
+            )
+            and challenge is not None
+        ):
+            return WebhookResponse(200, challenge)
+        return WebhookResponse(403)
+
+    def _valid_signature(self, request: WebhookRequest) -> bool:
+        headers = {name.lower(): value for name, value in request.headers.items()}
+        signature = headers.get('x-hub-signature-256')
+        if signature is None:
+            return False
+        expected = 'sha256=' + hmac.new(self._app_secret, request.body, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected.encode(), signature.encode('utf-8', 'replace'))
+
+    def _parse_messages(self, payload: Mapping[str, object]) -> Iterator[InboundMessage]:
+        entries = _list(payload.get('entry'))
+        if entries is None:
+            return
+        for raw_entry in entries:
+            entry = _mapping(raw_entry)
+            if entry is None:
+                continue
+            changes = _list(entry.get('changes'))
+            if changes is None:
+                continue
+            for raw_change in changes:
+                change = _mapping(raw_change)
+                if change is None or change.get('field') != 'messages':
+                    continue
+                value = _mapping(change.get('value'))
+                if value is None or not self._matches_phone_number(value):
+                    continue
+                messages = _list(value.get('messages'))
+                if messages is None:
+                    continue
+                for raw_message in messages:
+                    message = _parse_text_message(raw_message)
+                    if message is not None:
+                        yield message
+
+    def _matches_phone_number(self, value: Mapping[str, object]) -> bool:
+        metadata = _mapping(value.get('metadata'))
+        return metadata is not None and metadata.get('phone_number_id') == self._phone_number_id
+
+    def messages(self) -> AsyncIterator[InboundMessage]:
+        """Yield verified text messages until cancelled."""
+        return self._inbox.messages()
+
+    async def send_text(self, conversation_id: str, text: str) -> None:
+        """Send free-form text in ordered chunks within the Cloud API limit."""
+        if not text:
+            raise ValueError('text must not be empty')
+        for start in range(0, len(text), _MAX_TEXT_CHARS):
+            payload: dict[str, object] = {
+                'messaging_product': 'whatsapp',
+                'recipient_type': 'individual',
+                'to': conversation_id,
+                'type': 'text',
+                'text': {'body': text[start : start + _MAX_TEXT_CHARS]},
+            }
+            try:
+                await self._post_message(payload)
+            except _Throttled:
+                await asyncio.sleep(self._retry_delay)
+                await self._post_message(payload)
+
+    async def _post_message(self, payload: Mapping[str, object]) -> None:
+        client = self._client
+        if client is None:
+            raise RuntimeError('WhatsAppChannel must be opened before use')
+        try:
+            response = await client.post(
+                f'{_API_BASE}/{self._api_version}/{self._phone_number_id}/messages',
+                headers={'Authorization': f'Bearer {self._access_token}'},
+                json=dict(payload),
+                timeout=_REQUEST_TIMEOUT,
+            )
+        except httpx.RequestError:
+            raise ChannelError('WhatsApp Cloud API request failed: send message') from None
+        try:
+            envelope = _MAPPING_ADAPTER.validate_json(response.content)
+        except ValidationError:
+            raise ChannelError('WhatsApp Cloud API returned an invalid response: send message') from None
+        messages = _list(envelope.get('messages'))
+        if messages is not None:
+            return
+        code, message = _api_error(envelope)
+        if code in _THROTTLING_ERROR_CODES:
+            raise _Throttled(message or 'unknown WhatsApp Cloud API error')
+        raise ChannelError(message or 'unknown WhatsApp Cloud API error')
+
+
+class _Throttled(ChannelError):
+    """A Cloud API throttling error that is safe to retry once."""
+
+
+def _valid_api_version(value: str) -> bool:
+    if not value.startswith('v'):
+        return False
+    major, separator, minor = value[1:].partition('.')
+    return bool(separator and major.isdigit() and minor.isdigit())
+
+
+def _mapping(value: object) -> dict[str, object] | None:
+    try:
+        return _MAPPING_ADAPTER.validate_python(value)
+    except ValidationError:
+        return None
+
+
+def _list(value: object) -> list[object] | None:
+    try:
+        return _LIST_ADAPTER.validate_python(value)
+    except ValidationError:
+        return None
+
+
+def _parse_text_message(value: object) -> InboundMessage | None:
+    message = _mapping(value)
+    if message is None or message.get('type') != 'text':
+        return None
+    sender_id = message.get('from')
+    message_id = message.get('id')
+    text = _mapping(message.get('text'))
+    body = text.get('body') if text is not None else None
+    if not isinstance(sender_id, str) or not isinstance(message_id, str) or not isinstance(body, str) or not body:
+        return None
+    return InboundMessage(
+        conversation_id=sender_id,
+        sender_id=sender_id,
+        message_id=message_id,
+        text=body,
+    )
+
+
+def _api_error(envelope: Mapping[str, object]) -> tuple[int | None, str | None]:
+    error = _mapping(envelope.get('error'))
+    if error is None:
+        return None, None
+    code = error.get('code')
+    message = error.get('message')
+    normalized_code = code if isinstance(code, int) else None
+    normalized_message = message if isinstance(message, str) else 'unknown WhatsApp Cloud API error'
+    return (
+        normalized_code,
+        f'WhatsApp Cloud API error {normalized_code}: {normalized_message}'
+        if normalized_code is not None
+        else normalized_message,
+    )

--- a/pydantic_ai_harness/channels/whatsapp.py
+++ b/pydantic_ai_harness/channels/whatsapp.py
@@ -18,13 +18,14 @@ before changing verification, deduplication, parsing, or delivery.
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import hmac
 import math
-from collections.abc import AsyncIterator, Iterator, Mapping
+from collections.abc import AsyncGenerator, Iterator, Mapping
+from contextlib import aclosing
 from types import TracebackType
 
+import anyio
 import httpx
 from pydantic import TypeAdapter, ValidationError
 from typing_extensions import Self
@@ -125,7 +126,7 @@ class WhatsAppChannel:
         """Close the internally created HTTP client, if any."""
         self._ready = False
         self._inbox.close()
-        # A failed batch can cache IDs for messages discarded with the inbox.
+        # A failed batch can cache IDs for messages left in the old inbox.
         self._seen_messages.clear()
         await self._close_owned_client()
         self._client = None
@@ -137,7 +138,7 @@ class WhatsAppChannel:
         self._owns_client = False
 
     def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
-        """Verify a webhook request and enqueue its inbound text messages."""
+        """Verify and enqueue messages on the async thread that runs `messages()`."""
         method = request.method.upper()
         if method == 'GET':
             return self._verify_challenge(request.query)
@@ -217,9 +218,11 @@ class WhatsAppChannel:
         metadata = _mapping(value.get('metadata'))
         return metadata is not None and metadata.get('phone_number_id') == self._phone_number_id
 
-    def messages(self) -> AsyncIterator[InboundMessage]:
+    async def messages(self) -> AsyncGenerator[InboundMessage, None]:
         """Yield verified text messages until the channel closes or the task is cancelled."""
-        return self._inbox.messages()
+        async with aclosing(self._inbox.messages()) as messages:
+            async for message in messages:
+                yield message
 
     async def send_text(self, conversation_id: str, text: str) -> None:
         """Send free-form text in ordered chunks within the Cloud API limit."""
@@ -236,7 +239,7 @@ class WhatsAppChannel:
             try:
                 await self._post_message(payload)
             except _Throttled:
-                await asyncio.sleep(self._retry_delay)
+                await anyio.sleep(self._retry_delay)
                 await self._post_message(payload)
 
     async def _post_message(self, payload: Mapping[str, object]) -> None:

--- a/pydantic_ai_harness/channels/whatsapp.py
+++ b/pydantic_ai_harness/channels/whatsapp.py
@@ -131,7 +131,7 @@ class WhatsAppChannel:
             with anyio.CancelScope(shield=True):
                 await self._client.aclose()
 
-    def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
+    async def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
         """Verify and enqueue messages on the async thread that runs `messages()`."""
         method = request.method.upper()
         if method == 'GET':

--- a/pydantic_ai_harness/channels/whatsapp.py
+++ b/pydantic_ai_harness/channels/whatsapp.py
@@ -125,6 +125,8 @@ class WhatsAppChannel:
         """Close the internally created HTTP client, if any."""
         self._ready = False
         self._inbox.close()
+        # A failed batch can cache IDs for messages discarded with the inbox.
+        self._seen_messages.clear()
         await self._close_owned_client()
         self._client = None
         return None
@@ -216,7 +218,7 @@ class WhatsAppChannel:
         return metadata is not None and metadata.get('phone_number_id') == self._phone_number_id
 
     def messages(self) -> AsyncIterator[InboundMessage]:
-        """Yield verified text messages until cancelled."""
+        """Yield verified text messages until the channel closes or the task is cancelled."""
         return self._inbox.messages()
 
     async def send_text(self, conversation_id: str, text: str) -> None:

--- a/pydantic_ai_harness/channels/whatsapp.py
+++ b/pydantic_ai_harness/channels/whatsapp.py
@@ -22,8 +22,8 @@ import hashlib
 import hmac
 import math
 from collections.abc import AsyncGenerator, Iterator, Mapping
-from contextlib import aclosing
 from types import TracebackType
+from typing import NoReturn
 
 import anyio
 import httpx
@@ -100,8 +100,6 @@ class WhatsAppChannel:
         self._verify_token = verify_token
         self._provided_client = http_client
         self._client: httpx.AsyncClient | None = None
-        self._owns_client = False
-        self._ready = False
         self._api_version = api_version
         self._inbox = WebhookInbox(max_queued_messages)
         self._seen_messages = RecentMessageIds(_MAX_SEEN_MESSAGES)
@@ -113,8 +111,6 @@ class WhatsAppChannel:
             raise RuntimeError('WhatsAppChannel is already open')
         self._inbox.open()
         self._client = self._provided_client or httpx.AsyncClient()
-        self._owns_client = self._provided_client is None
-        self._ready = True
         return self
 
     async def __aexit__(
@@ -122,21 +118,18 @@ class WhatsAppChannel:
         exc_type: type[BaseException] | None,
         exc: BaseException | None,
         traceback: TracebackType | None,
-    ) -> bool | None:
+    ) -> None:
         """Close the internally created HTTP client, if any."""
-        self._ready = False
         self._inbox.close()
         # A failed batch can cache IDs for messages left in the old inbox.
         self._seen_messages.clear()
         await self._close_owned_client()
         self._client = None
-        return None
 
     async def _close_owned_client(self) -> None:
-        if self._owns_client and self._client is not None:
+        if self._provided_client is None and self._client is not None:
             with anyio.CancelScope(shield=True):
                 await self._client.aclose()
-        self._owns_client = False
 
     def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:
         """Verify and enqueue messages on the async thread that runs `messages()`."""
@@ -156,8 +149,6 @@ class WhatsAppChannel:
             return WebhookResponse(200)
 
         for message in self._parse_messages(payload):
-            if not self._ready:
-                return WebhookResponse(503)
             if message.message_id in self._seen_messages:
                 continue
             if not self._inbox.put(message):
@@ -219,11 +210,9 @@ class WhatsAppChannel:
         metadata = _mapping(value.get('metadata'))
         return metadata is not None and metadata.get('phone_number_id') == self._phone_number_id
 
-    async def messages(self) -> AsyncGenerator[InboundMessage, None]:
+    def messages(self) -> AsyncGenerator[InboundMessage, None]:
         """Yield verified text messages until the channel closes or the task is cancelled."""
-        async with aclosing(self._inbox.messages()) as messages:
-            async for message in messages:
-                yield message
+        return self._inbox.messages()
 
     async def send_text(self, conversation_id: str, text: str) -> None:
         """Send free-form text in ordered chunks within the Cloud API limit."""
@@ -263,10 +252,7 @@ class WhatsAppChannel:
         messages = _list(envelope.get('messages'))
         if messages is not None:
             return
-        code, message = _api_error(envelope)
-        if code in _THROTTLING_ERROR_CODES:
-            raise _Throttled(message or 'unknown WhatsApp Cloud API error')
-        raise ChannelError(message or 'unknown WhatsApp Cloud API error')
+        _raise_api_error(envelope)
 
 
 class _Throttled(ChannelError):
@@ -312,17 +298,19 @@ def _parse_text_message(value: object) -> InboundMessage | None:
     )
 
 
-def _api_error(envelope: Mapping[str, object]) -> tuple[int | None, str | None]:
+def _raise_api_error(envelope: Mapping[str, object]) -> NoReturn:
     error = _mapping(envelope.get('error'))
     if error is None:
-        return None, None
+        raise ChannelError('unknown WhatsApp Cloud API error')
     code = error.get('code')
     message = error.get('message')
     normalized_code = code if isinstance(code, int) else None
     normalized_message = message if isinstance(message, str) else 'unknown WhatsApp Cloud API error'
-    return (
-        normalized_code,
+    detail = (
         f'WhatsApp Cloud API error {normalized_code}: {normalized_message}'
         if normalized_code is not None
-        else normalized_message,
+        else normalized_message
     )
+    if normalized_code in _THROTTLING_ERROR_CODES:
+        raise _Throttled(detail)
+    raise ChannelError(detail)

--- a/pydantic_ai_harness/channels/whatsapp.py
+++ b/pydantic_ai_harness/channels/whatsapp.py
@@ -134,7 +134,8 @@ class WhatsAppChannel:
 
     async def _close_owned_client(self) -> None:
         if self._owns_client and self._client is not None:
-            await self._client.aclose()
+            with anyio.CancelScope(shield=True):
+                await self._client.aclose()
         self._owns_client = False
 
     def handle_webhook(self, request: WebhookRequest) -> WebhookResponse:

--- a/tests/channels/test_whatsapp.py
+++ b/tests/channels/test_whatsapp.py
@@ -260,8 +260,7 @@ class TestWhatsAppChannel:
                 assert await webhook_status(channel, request) == 200
                 assert (await anext(messages)).text == 'second'
 
-    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
-    async def test_webhook_runs_agent_and_posts_reply(self, anyio_backend: str) -> None:
+    async def test_webhook_runs_agent_and_posts_reply(self) -> None:
         posted = anyio.Event()
         posts: list[dict[str, object]] = []
 

--- a/tests/channels/test_whatsapp.py
+++ b/tests/channels/test_whatsapp.py
@@ -236,6 +236,30 @@ class TestWhatsAppChannel:
                 assert (await anext(messages)).text == 'second'
         assert await webhook_status(channel, second) == 503
 
+    async def test_queue_full_mid_batch_resumes_on_redelivery(self) -> None:
+        channel = WhatsAppChannel(
+            'token',
+            _PHONE_ID,
+            _APP_SECRET,
+            'verify-token',
+            max_queued_messages=1,
+        )
+        request = signed_request(
+            webhook_payload(
+                [
+                    text_message('wamid.1', body='first'),
+                    text_message('wamid.2', body='second'),
+                ]
+            )
+        )
+
+        async with channel:
+            async with aclosing(channel.messages()) as messages:
+                assert await webhook_status(channel, request) == 503
+                assert (await anext(messages)).text == 'first'
+                assert await webhook_status(channel, request) == 200
+                assert (await anext(messages)).text == 'second'
+
     @pytest.mark.parametrize('anyio_backend', ['asyncio'])
     async def test_webhook_runs_agent_and_posts_reply(self, anyio_backend: str) -> None:
         posted = anyio.Event()

--- a/tests/channels/test_whatsapp.py
+++ b/tests/channels/test_whatsapp.py
@@ -358,9 +358,18 @@ class TestWhatsAppChannel:
 
         with pytest.raises(StopAsyncIteration):
             await pending_message
+        await client.aclose()
+
+    async def test_reopening_accepts_a_message_discarded_during_shutdown(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
+        request = signed_request(webhook_payload([text_message()]))
 
         async with channel:
-            assert channel.handle_webhook(signed_request(webhook_payload([text_message()]))).status_code == 200
+            assert channel.handle_webhook(request).status_code == 200
+
+        async with channel:
+            assert channel.handle_webhook(request).status_code == 200
             assert (await anext(channel.messages())).message_id == 'wamid.1'
         await client.aclose()
 

--- a/tests/channels/test_whatsapp.py
+++ b/tests/channels/test_whatsapp.py
@@ -236,6 +236,25 @@ class TestWhatsAppChannel:
                 assert (await anext(messages)).text == 'second'
         assert channel.handle_webhook(second).status_code == 503
 
+    async def test_bounds_recent_message_deduplication(self) -> None:
+        channel = WhatsAppChannel(
+            'token',
+            _PHONE_ID,
+            _APP_SECRET,
+            'verify-token',
+            max_queued_messages=1,
+        )
+
+        async with channel:
+            async with aclosing(channel.messages()) as messages:
+                for index in range(10_001):
+                    request = signed_request(webhook_payload([text_message(f'wamid.{index}', body=str(index))]))
+                    assert channel.handle_webhook(request).status_code == 200
+                    await anext(messages)
+                first = signed_request(webhook_payload([text_message('wamid.0', body='first again')]))
+                assert channel.handle_webhook(first).status_code == 200
+                assert (await anext(messages)).text == 'first again'
+
     async def test_chunks_messages_and_retries_one_throttling_error(self) -> None:
         posts: list[dict[str, object]] = []
         paths: list[str] = []

--- a/tests/channels/test_whatsapp.py
+++ b/tests/channels/test_whatsapp.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import hmac
 import json
+from collections.abc import AsyncGenerator
+from contextlib import aclosing
 
+import anyio
 import httpx
 import pytest
 from pydantic import TypeAdapter
 
-from pydantic_ai_harness.channels import ChannelError, WebhookRequest
+from pydantic_ai_harness.channels import ChannelError, InboundMessage, WebhookRequest
 from pydantic_ai_harness.channels.whatsapp import WhatsAppChannel
 
 _BODY_ADAPTER = TypeAdapter(dict[str, object])
@@ -122,10 +124,11 @@ class TestWhatsAppChannel:
         )
 
         async with channel:
-            assert channel.handle_webhook(request).status_code == 200
-            assert channel.handle_webhook(request).status_code == 200
-            first = await anext(channel.messages())
-            second = await anext(channel.messages())
+            async with aclosing(channel.messages()) as messages:
+                assert channel.handle_webhook(request).status_code == 200
+                assert channel.handle_webhook(request).status_code == 200
+                first = await anext(messages)
+                second = await anext(messages)
 
         assert (first.conversation_id, first.sender_id, first.message_id, first.text) == (
             '15551234567',
@@ -199,17 +202,18 @@ class TestWhatsAppChannel:
         }
 
         async with channel:
-            assert channel.handle_webhook(signed_request(payload)).status_code == 200
-            assert (await anext(channel.messages())).message_id == 'accepted'
+            async with aclosing(channel.messages()) as messages:
+                assert channel.handle_webhook(signed_request(payload)).status_code == 200
+                assert (await anext(messages)).message_id == 'accepted'
 
-            invalid_entries = webhook_payload('invalid')
-            assert channel.handle_webhook(signed_request(invalid_entries)).status_code == 200
-            assert (
-                channel.handle_webhook(
-                    signed_request({'object': 'whatsapp_business_account', 'entry': 'invalid'})
-                ).status_code
-                == 200
-            )
+                invalid_entries = webhook_payload('invalid')
+                assert channel.handle_webhook(signed_request(invalid_entries)).status_code == 200
+                assert (
+                    channel.handle_webhook(
+                        signed_request({'object': 'whatsapp_business_account', 'entry': 'invalid'})
+                    ).status_code
+                    == 200
+                )
 
     async def test_queue_full_leaves_message_retryable(self) -> None:
         channel = WhatsAppChannel(
@@ -224,11 +228,12 @@ class TestWhatsAppChannel:
 
         assert channel.handle_webhook(first).status_code == 503
         async with channel:
-            assert channel.handle_webhook(first).status_code == 200
-            assert channel.handle_webhook(second).status_code == 503
-            assert (await anext(channel.messages())).text == 'first'
-            assert channel.handle_webhook(second).status_code == 200
-            assert (await anext(channel.messages())).text == 'second'
+            async with aclosing(channel.messages()) as messages:
+                assert channel.handle_webhook(first).status_code == 200
+                assert channel.handle_webhook(second).status_code == 503
+                assert (await anext(messages)).text == 'first'
+                assert channel.handle_webhook(second).status_code == 200
+                assert (await anext(messages)).text == 'second'
         assert channel.handle_webhook(second).status_code == 503
 
     async def test_chunks_messages_and_retries_one_throttling_error(self) -> None:
@@ -344,33 +349,48 @@ class TestWhatsAppChannel:
         request = signed_request(webhook_payload([text_message()]))
 
         assert channel.handle_webhook(request).status_code == 503
-        async with channel:
-            assert channel.handle_webhook(request).status_code == 200
+        async with aclosing(channel.messages()) as messages:
+            async with channel:
+                assert channel.handle_webhook(request).status_code == 200
+            assert (await anext(messages)).message_id == 'wamid.1'
         assert client.is_closed
         assert channel.handle_webhook(request).status_code == 503
 
     async def test_closing_channel_ends_pending_message_iterator(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
         channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
-        async with channel:
-            pending_message = asyncio.ensure_future(anext(channel.messages()))
-            await asyncio.sleep(0)
+        iterator_stopped = anyio.Event()
 
-        with pytest.raises(StopAsyncIteration):
-            await pending_message
+        async def wait_for_message(messages: AsyncGenerator[InboundMessage, None]) -> None:
+            with pytest.raises(StopAsyncIteration):
+                await anext(messages)
+            iterator_stopped.set()
+
+        async with anyio.create_task_group() as task_group:
+            async with channel:
+                messages = channel.messages()
+                task_group.start_soon(wait_for_message, messages)
+                await anyio.sleep(0)
+            with anyio.fail_after(1):
+                await iterator_stopped.wait()
         await client.aclose()
 
-    async def test_reopening_accepts_a_message_discarded_during_shutdown(self) -> None:
+    async def test_reopening_resets_recent_message_ids(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
         channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
         request = signed_request(webhook_payload([text_message()]))
+        old_messages = channel.messages()
 
         async with channel:
             assert channel.handle_webhook(request).status_code == 200
+        assert (await anext(old_messages)).message_id == 'wamid.1'
+        with pytest.raises(StopAsyncIteration):
+            await anext(old_messages)
 
         async with channel:
-            assert channel.handle_webhook(request).status_code == 200
-            assert (await anext(channel.messages())).message_id == 'wamid.1'
+            async with aclosing(channel.messages()) as messages:
+                assert channel.handle_webhook(request).status_code == 200
+                assert (await anext(messages)).message_id == 'wamid.1'
         await client.aclose()
 
     async def test_requires_open_channel_and_nonempty_text(self) -> None:

--- a/tests/channels/test_whatsapp.py
+++ b/tests/channels/test_whatsapp.py
@@ -76,21 +76,25 @@ def text_message(message_id: str = 'wamid.1', *, body: str = 'hello', sender: st
     }
 
 
+async def webhook_status(channel: WhatsAppChannel, request: WebhookRequest) -> int:
+    return (await channel.handle_webhook(request)).status_code
+
+
 @pytest.mark.anyio
 class TestWhatsAppChannel:
     async def test_verifies_challenge(self) -> None:
         channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
-        accepted = channel.handle_webhook(challenge_request())
+        accepted = await channel.handle_webhook(challenge_request())
         assert (accepted.status_code, accepted.body) == (200, 'challenge')
 
-        assert channel.handle_webhook(challenge_request(token='wrong')).status_code == 403
+        assert await webhook_status(channel, challenge_request(token='wrong')) == 403
         missing_challenge = WebhookRequest(
             method='GET',
             headers={},
             query={'hub.mode': 'subscribe', 'hub.verify_token': 'verify-token'},
             body=b'',
         )
-        assert channel.handle_webhook(missing_challenge).status_code == 403
+        assert await webhook_status(channel, missing_challenge) == 403
         wrong_mode = WebhookRequest(
             method='GET',
             headers={},
@@ -101,8 +105,8 @@ class TestWhatsAppChannel:
             },
             body=b'',
         )
-        assert channel.handle_webhook(wrong_mode).status_code == 403
-        assert channel.handle_webhook(signed_request({}, method='PUT')).status_code == 405
+        assert await webhook_status(channel, wrong_mode) == 403
+        assert await webhook_status(channel, signed_request({}, method='PUT')) == 405
 
     async def test_normalizes_batched_text_and_suppresses_duplicates(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
@@ -125,8 +129,8 @@ class TestWhatsAppChannel:
 
         async with channel:
             async with aclosing(channel.messages()) as messages:
-                assert channel.handle_webhook(request).status_code == 200
-                assert channel.handle_webhook(request).status_code == 200
+                assert await webhook_status(channel, request) == 200
+                assert await webhook_status(channel, request) == 200
                 first = await anext(messages)
                 second = await anext(messages)
 
@@ -142,7 +146,7 @@ class TestWhatsAppChannel:
 
     async def test_rejects_invalid_signatures_and_payloads(self) -> None:
         channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
-        assert channel.handle_webhook(WebhookRequest('POST', {}, {}, b'{}')).status_code == 401
+        assert await webhook_status(channel, WebhookRequest('POST', {}, {}, b'{}')) == 401
 
         non_ascii = WebhookRequest(
             'POST',
@@ -150,8 +154,8 @@ class TestWhatsAppChannel:
             {},
             b'{}',
         )
-        assert channel.handle_webhook(non_ascii).status_code == 401
-        assert channel.handle_webhook(signed_request({}, secret='wrong')).status_code == 401
+        assert await webhook_status(channel, non_ascii) == 401
+        assert await webhook_status(channel, signed_request({}, secret='wrong')) == 401
 
         malformed_body = b'not json'
         malformed_signature = 'sha256=' + hmac.new(_APP_SECRET.encode(), malformed_body, hashlib.sha256).hexdigest()
@@ -161,8 +165,8 @@ class TestWhatsAppChannel:
             {},
             malformed_body,
         )
-        assert channel.handle_webhook(malformed).status_code == 400
-        assert channel.handle_webhook(signed_request({'object': 'other'})).status_code == 200
+        assert await webhook_status(channel, malformed) == 400
+        assert await webhook_status(channel, signed_request({'object': 'other'})) == 200
 
     async def test_filters_statuses_other_numbers_and_malformed_messages(self) -> None:
         channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
@@ -203,17 +207,13 @@ class TestWhatsAppChannel:
 
         async with channel:
             async with aclosing(channel.messages()) as messages:
-                assert channel.handle_webhook(signed_request(payload)).status_code == 200
+                assert await webhook_status(channel, signed_request(payload)) == 200
                 assert (await anext(messages)).message_id == 'accepted'
 
                 invalid_entries = webhook_payload('invalid')
-                assert channel.handle_webhook(signed_request(invalid_entries)).status_code == 200
-                assert (
-                    channel.handle_webhook(
-                        signed_request({'object': 'whatsapp_business_account', 'entry': 'invalid'})
-                    ).status_code
-                    == 200
-                )
+                assert await webhook_status(channel, signed_request(invalid_entries)) == 200
+                request = signed_request({'object': 'whatsapp_business_account', 'entry': 'invalid'})
+                assert await webhook_status(channel, request) == 200
 
     async def test_queue_full_leaves_message_retryable(self) -> None:
         channel = WhatsAppChannel(
@@ -226,15 +226,15 @@ class TestWhatsAppChannel:
         first = signed_request(webhook_payload([text_message('wamid.1', body='first')]))
         second = signed_request(webhook_payload([text_message('wamid.2', body='second')]))
 
-        assert channel.handle_webhook(first).status_code == 503
+        assert await webhook_status(channel, first) == 503
         async with channel:
             async with aclosing(channel.messages()) as messages:
-                assert channel.handle_webhook(first).status_code == 200
-                assert channel.handle_webhook(second).status_code == 503
+                assert await webhook_status(channel, first) == 200
+                assert await webhook_status(channel, second) == 503
                 assert (await anext(messages)).text == 'first'
-                assert channel.handle_webhook(second).status_code == 200
+                assert await webhook_status(channel, second) == 200
                 assert (await anext(messages)).text == 'second'
-        assert channel.handle_webhook(second).status_code == 503
+        assert await webhook_status(channel, second) == 503
 
     @pytest.mark.parametrize('anyio_backend', ['asyncio'])
     async def test_webhook_runs_agent_and_posts_reply(self, anyio_backend: str) -> None:
@@ -254,7 +254,7 @@ class TestWhatsAppChannel:
         async with anyio.create_task_group() as task_group:
             task_group.start_soon(host.serve)
             with anyio.fail_after(1):
-                while channel.handle_webhook(request).status_code == 503:
+                while await webhook_status(channel, request) == 503:
                     await anyio.sleep(0)
                 await posted.wait()
             task_group.cancel_scope.cancel()
@@ -382,13 +382,13 @@ class TestWhatsAppChannel:
         channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
         request = signed_request(webhook_payload([text_message()]))
 
-        assert channel.handle_webhook(request).status_code == 503
+        assert await webhook_status(channel, request) == 503
         async with channel:
             async with aclosing(channel.messages()) as messages:
-                assert channel.handle_webhook(request).status_code == 200
+                assert await webhook_status(channel, request) == 200
                 assert (await anext(messages)).message_id == 'wamid.1'
         assert client.is_closed
-        assert channel.handle_webhook(request).status_code == 503
+        assert await webhook_status(channel, request) == 503
 
     async def test_reopening_resets_recent_message_ids(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
@@ -396,12 +396,12 @@ class TestWhatsAppChannel:
         request = signed_request(webhook_payload([text_message()]))
         async with channel:
             async with aclosing(channel.messages()) as messages:
-                assert channel.handle_webhook(request).status_code == 200
+                assert await webhook_status(channel, request) == 200
                 assert (await anext(messages)).message_id == 'wamid.1'
 
         async with channel:
             async with aclosing(channel.messages()) as messages:
-                assert channel.handle_webhook(request).status_code == 200
+                assert await webhook_status(channel, request) == 200
                 assert (await anext(messages)).message_id == 'wamid.1'
         await client.aclose()
 

--- a/tests/channels/test_whatsapp.py
+++ b/tests/channels/test_whatsapp.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+
+import httpx
+import pytest
+from pydantic import TypeAdapter
+
+from pydantic_ai_harness.channels import ChannelError, WebhookRequest
+from pydantic_ai_harness.channels.whatsapp import WhatsAppChannel
+
+_BODY_ADAPTER = TypeAdapter(dict[str, object])
+_APP_SECRET = 'app-secret'
+_PHONE_ID = '123456789'
+
+
+def response(payload: object, *, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=payload)
+
+
+def signed_request(payload: object, *, secret: str = _APP_SECRET, method: str = 'POST') -> WebhookRequest:
+    body = json.dumps(payload, separators=(',', ':')).encode()
+    signature = 'sha256=' + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return WebhookRequest(
+        method=method,
+        headers={'X-Hub-Signature-256': signature},
+        query={},
+        body=body,
+    )
+
+
+def challenge_request(*, token: str = 'verify-token', challenge: str = 'challenge') -> WebhookRequest:
+    return WebhookRequest(
+        method='GET',
+        headers={},
+        query={
+            'hub.mode': 'subscribe',
+            'hub.verify_token': token,
+            'hub.challenge': challenge,
+        },
+        body=b'',
+    )
+
+
+def webhook_payload(messages: object, *, phone_number_id: str = _PHONE_ID) -> dict[str, object]:
+    return {
+        'object': 'whatsapp_business_account',
+        'entry': [
+            {
+                'id': 'WABA1',
+                'changes': [
+                    {
+                        'field': 'messages',
+                        'value': {
+                            'metadata': {'phone_number_id': phone_number_id},
+                            'messages': messages,
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def text_message(message_id: str = 'wamid.1', *, body: str = 'hello', sender: str = '15551234567') -> dict[str, object]:
+    return {
+        'from': sender,
+        'id': message_id,
+        'type': 'text',
+        'text': {'body': body},
+    }
+
+
+@pytest.mark.anyio
+class TestWhatsAppChannel:
+    async def test_verifies_challenge(self) -> None:
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
+        accepted = channel.handle_webhook(challenge_request())
+        assert (accepted.status_code, accepted.body) == (200, 'challenge')
+
+        assert channel.handle_webhook(challenge_request(token='wrong')).status_code == 403
+        missing_challenge = WebhookRequest(
+            method='GET',
+            headers={},
+            query={'hub.mode': 'subscribe', 'hub.verify_token': 'verify-token'},
+            body=b'',
+        )
+        assert channel.handle_webhook(missing_challenge).status_code == 403
+        wrong_mode = WebhookRequest(
+            method='GET',
+            headers={},
+            query={
+                'hub.mode': 'unsubscribe',
+                'hub.verify_token': 'verify-token',
+                'hub.challenge': 'challenge',
+            },
+            body=b'',
+        )
+        assert channel.handle_webhook(wrong_mode).status_code == 403
+        assert channel.handle_webhook(signed_request({}, method='PUT')).status_code == 405
+
+    async def test_normalizes_batched_text_and_suppresses_duplicates(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
+        channel = WhatsAppChannel(
+            'token',
+            _PHONE_ID,
+            _APP_SECRET,
+            'verify-token',
+            http_client=client,
+            max_queued_messages=2,
+        )
+        request = signed_request(
+            webhook_payload(
+                [
+                    text_message('wamid.1', body='first'),
+                    text_message('wamid.2', body='second'),
+                ]
+            )
+        )
+
+        async with channel:
+            assert channel.handle_webhook(request).status_code == 200
+            assert channel.handle_webhook(request).status_code == 200
+            first = await anext(channel.messages())
+            second = await anext(channel.messages())
+
+        assert (first.conversation_id, first.sender_id, first.message_id, first.text) == (
+            '15551234567',
+            '15551234567',
+            'wamid.1',
+            'first',
+        )
+        assert second.message_id == 'wamid.2'
+        assert client.is_closed is False
+        await client.aclose()
+
+    async def test_rejects_invalid_signatures_and_payloads(self) -> None:
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
+        assert channel.handle_webhook(WebhookRequest('POST', {}, {}, b'{}')).status_code == 401
+
+        non_ascii = WebhookRequest(
+            'POST',
+            {'x-hub-signature-256': 'sha256=é'},
+            {},
+            b'{}',
+        )
+        assert channel.handle_webhook(non_ascii).status_code == 401
+        assert channel.handle_webhook(signed_request({}, secret='wrong')).status_code == 401
+
+        malformed_body = b'not json'
+        malformed_signature = 'sha256=' + hmac.new(_APP_SECRET.encode(), malformed_body, hashlib.sha256).hexdigest()
+        malformed = WebhookRequest(
+            'POST',
+            {'x-hub-signature-256': malformed_signature},
+            {},
+            malformed_body,
+        )
+        assert channel.handle_webhook(malformed).status_code == 400
+        assert channel.handle_webhook(signed_request({'object': 'other'})).status_code == 200
+
+    async def test_filters_statuses_other_numbers_and_malformed_messages(self) -> None:
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
+        payload: dict[str, object] = {
+            'object': 'whatsapp_business_account',
+            'entry': [
+                123,
+                {'changes': 'invalid'},
+                {
+                    'changes': [
+                        123,
+                        {'field': 'statuses', 'value': {}},
+                        {'field': 'messages', 'value': 123},
+                        {
+                            'field': 'messages',
+                            'value': {
+                                'metadata': {'phone_number_id': 'other'},
+                                'messages': [text_message('ignored')],
+                            },
+                        },
+                        {
+                            'field': 'messages',
+                            'value': {
+                                'metadata': {'phone_number_id': _PHONE_ID},
+                                'messages': [
+                                    123,
+                                    {'type': 'image'},
+                                    {**text_message('empty'), 'text': {'body': ''}},
+                                    {**text_message('bad-sender'), 'from': 123},
+                                    text_message('accepted'),
+                                ],
+                            },
+                        },
+                    ]
+                },
+            ],
+        }
+
+        async with channel:
+            assert channel.handle_webhook(signed_request(payload)).status_code == 200
+            assert (await anext(channel.messages())).message_id == 'accepted'
+
+            invalid_entries = webhook_payload('invalid')
+            assert channel.handle_webhook(signed_request(invalid_entries)).status_code == 200
+            assert (
+                channel.handle_webhook(
+                    signed_request({'object': 'whatsapp_business_account', 'entry': 'invalid'})
+                ).status_code
+                == 200
+            )
+
+    async def test_queue_full_leaves_message_retryable(self) -> None:
+        channel = WhatsAppChannel(
+            'token',
+            _PHONE_ID,
+            _APP_SECRET,
+            'verify-token',
+            max_queued_messages=1,
+        )
+        first = signed_request(webhook_payload([text_message('wamid.1', body='first')]))
+        second = signed_request(webhook_payload([text_message('wamid.2', body='second')]))
+
+        assert channel.handle_webhook(first).status_code == 503
+        async with channel:
+            assert channel.handle_webhook(first).status_code == 200
+            assert channel.handle_webhook(second).status_code == 503
+            assert (await anext(channel.messages())).text == 'first'
+            assert channel.handle_webhook(second).status_code == 200
+            assert (await anext(channel.messages())).text == 'second'
+        assert channel.handle_webhook(second).status_code == 503
+
+    async def test_chunks_messages_and_retries_one_throttling_error(self) -> None:
+        posts: list[dict[str, object]] = []
+        paths: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            paths.append(request.url.path)
+            posts.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            if len(posts) == 1:
+                return response(
+                    {
+                        'error': {
+                            'code': 130429,
+                            'message': 'Rate limit hit',
+                        }
+                    },
+                    status_code=429,
+                )
+            return response({'messages': [{'id': f'wamid.{len(posts)}'}]})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = WhatsAppChannel(
+            'token',
+            _PHONE_ID,
+            _APP_SECRET,
+            'verify-token',
+            http_client=client,
+            api_version='v24.0',
+            retry_delay=0,
+        )
+
+        async with channel:
+            await channel.send_text('15551234567', 'a' * 4097)
+
+        assert [post['text'] for post in posts] == [
+            {'body': 'a' * 4096},
+            {'body': 'a' * 4096},
+            {'body': 'a'},
+        ]
+        assert all(post['to'] == '15551234567' for post in posts)
+        assert paths == [
+            f'/v24.0/{_PHONE_ID}/messages',
+            f'/v24.0/{_PHONE_ID}/messages',
+            f'/v24.0/{_PHONE_ID}/messages',
+        ]
+        await client.aclose()
+
+    async def test_surfaces_service_window_and_unknown_api_errors(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return response(
+                    {
+                        'error': {
+                            'code': 131047,
+                            'message': 'Re-engagement message',
+                        }
+                    },
+                    status_code=400,
+                )
+            return response({})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
+
+        async with channel:
+            with pytest.raises(ChannelError, match='Re-engagement message'):
+                await channel.send_text('15551234567', 'outside window')
+            with pytest.raises(ChannelError, match='unknown WhatsApp Cloud API error'):
+                await channel.send_text('15551234567', 'unknown')
+
+        assert calls == 2
+        await client.aclose()
+
+    async def test_surfaces_invalid_and_transport_responses_without_token(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return httpx.Response(500, content=b'not json')
+            raise httpx.ConnectError('offline', request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = WhatsAppChannel(
+            'secret-token',
+            _PHONE_ID,
+            _APP_SECRET,
+            'verify-token',
+            http_client=client,
+        )
+
+        async with channel:
+            with pytest.raises(ChannelError, match='invalid response'):
+                await channel.send_text('15551234567', 'invalid')
+            with pytest.raises(ChannelError, match='request failed') as exc_info:
+                await channel.send_text('15551234567', 'offline')
+
+        assert exc_info.value.__suppress_context__ is True
+        assert 'secret-token' not in str(exc_info.value)
+        await client.aclose()
+
+    async def test_owned_client_closes_and_webhooks_require_open_channel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client_class = httpx.AsyncClient
+        client = client_class(transport=httpx.MockTransport(lambda request: response({})))
+        monkeypatch.setattr(httpx, 'AsyncClient', lambda: client)
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
+        request = signed_request(webhook_payload([text_message()]))
+
+        assert channel.handle_webhook(request).status_code == 503
+        async with channel:
+            assert channel.handle_webhook(request).status_code == 200
+        assert client.is_closed
+        assert channel.handle_webhook(request).status_code == 503
+
+    async def test_closing_channel_ends_pending_message_iterator(self) -> None:
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
+        async with channel:
+            pending_message = asyncio.ensure_future(anext(channel.messages()))
+            await asyncio.sleep(0)
+
+        with pytest.raises(StopAsyncIteration):
+            await pending_message
+
+        async with channel:
+            assert channel.handle_webhook(signed_request(webhook_payload([text_message()]))).status_code == 200
+            assert (await anext(channel.messages())).message_id == 'wamid.1'
+        await client.aclose()
+
+    async def test_requires_open_channel_and_nonempty_text(self) -> None:
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token')
+        with pytest.raises(RuntimeError, match='opened'):
+            await channel.send_text('15551234567', 'hello')
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
+        async with channel:
+            with pytest.raises(ValueError, match='text'):
+                await channel.send_text('15551234567', '')
+            with pytest.raises(RuntimeError, match='already open'):
+                await channel.__aenter__()
+        await client.aclose()
+
+    def test_validates_configuration(self) -> None:
+        base: tuple[str, str, str, str] = ('token', _PHONE_ID, _APP_SECRET, 'verify-token')
+        for index, name in enumerate(('access_token', 'phone_number_id', 'app_secret', 'verify_token')):
+            values: list[str] = list(base)
+            values[index] = ''
+            with pytest.raises(ValueError, match=name):
+                WhatsAppChannel(*values)
+
+        with pytest.raises(ValueError, match='api_version'):
+            WhatsAppChannel(*base, api_version='latest')
+        for value in (0, True):
+            with pytest.raises(ValueError, match='max_queued_messages'):
+                WhatsAppChannel(*base, max_queued_messages=value)
+        with pytest.raises(ValueError, match='retry_delay'):
+            WhatsAppChannel(*base, retry_delay=-1)
+        with pytest.raises(ValueError, match='retry_delay'):
+            WhatsAppChannel(*base, retry_delay=float('nan'))

--- a/tests/channels/test_whatsapp.py
+++ b/tests/channels/test_whatsapp.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-from collections.abc import AsyncGenerator
 from contextlib import aclosing
 
 import anyio
 import httpx
 import pytest
 from pydantic import TypeAdapter
+from pydantic_ai import Agent
 
-from pydantic_ai_harness.channels import ChannelError, InboundMessage, WebhookRequest
+from pydantic_ai_harness.channels import ChannelError, ChannelHost, WebhookRequest
 from pydantic_ai_harness.channels.whatsapp import WhatsAppChannel
 
 _BODY_ADAPTER = TypeAdapter(dict[str, object])
@@ -236,24 +236,39 @@ class TestWhatsAppChannel:
                 assert (await anext(messages)).text == 'second'
         assert channel.handle_webhook(second).status_code == 503
 
-    async def test_bounds_recent_message_deduplication(self) -> None:
-        channel = WhatsAppChannel(
-            'token',
-            _PHONE_ID,
-            _APP_SECRET,
-            'verify-token',
-            max_queued_messages=1,
-        )
+    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
+    async def test_webhook_runs_agent_and_posts_reply(self, anyio_backend: str) -> None:
+        posted = anyio.Event()
+        posts: list[dict[str, object]] = []
 
-        async with channel:
-            async with aclosing(channel.messages()) as messages:
-                for index in range(10_001):
-                    request = signed_request(webhook_payload([text_message(f'wamid.{index}', body=str(index))]))
-                    assert channel.handle_webhook(request).status_code == 200
-                    await anext(messages)
-                first = signed_request(webhook_payload([text_message('wamid.0', body='first again')]))
-                assert channel.handle_webhook(first).status_code == 200
-                assert (await anext(messages)).text == 'first again'
+        def handler(request: httpx.Request) -> httpx.Response:
+            posts.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            posted.set()
+            return response({'messages': [{'id': 'wamid.reply'}]})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
+        host = ChannelHost(Agent('test'), channel, allowed_senders={'15551234567'})
+        request = signed_request(webhook_payload([text_message()]))
+
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(host.serve)
+            with anyio.fail_after(1):
+                while channel.handle_webhook(request).status_code == 503:
+                    await anyio.sleep(0)
+                await posted.wait()
+            task_group.cancel_scope.cancel()
+        await client.aclose()
+
+        assert posts == [
+            {
+                'messaging_product': 'whatsapp',
+                'recipient_type': 'individual',
+                'to': '15551234567',
+                'type': 'text',
+                'text': {'body': 'success (no tool calls)'},
+            }
+        ]
 
     async def test_chunks_messages_and_retries_one_throttling_error(self) -> None:
         posts: list[dict[str, object]] = []
@@ -368,43 +383,21 @@ class TestWhatsAppChannel:
         request = signed_request(webhook_payload([text_message()]))
 
         assert channel.handle_webhook(request).status_code == 503
-        async with aclosing(channel.messages()) as messages:
-            async with channel:
+        async with channel:
+            async with aclosing(channel.messages()) as messages:
                 assert channel.handle_webhook(request).status_code == 200
-            assert (await anext(messages)).message_id == 'wamid.1'
+                assert (await anext(messages)).message_id == 'wamid.1'
         assert client.is_closed
         assert channel.handle_webhook(request).status_code == 503
-
-    async def test_closing_channel_ends_pending_message_iterator(self) -> None:
-        client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
-        channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
-        iterator_stopped = anyio.Event()
-
-        async def wait_for_message(messages: AsyncGenerator[InboundMessage, None]) -> None:
-            with pytest.raises(StopAsyncIteration):
-                await anext(messages)
-            iterator_stopped.set()
-
-        async with anyio.create_task_group() as task_group:
-            async with channel:
-                messages = channel.messages()
-                task_group.start_soon(wait_for_message, messages)
-                await anyio.sleep(0)
-            with anyio.fail_after(1):
-                await iterator_stopped.wait()
-        await client.aclose()
 
     async def test_reopening_resets_recent_message_ids(self) -> None:
         client = httpx.AsyncClient(transport=httpx.MockTransport(lambda request: response({})))
         channel = WhatsAppChannel('token', _PHONE_ID, _APP_SECRET, 'verify-token', http_client=client)
         request = signed_request(webhook_payload([text_message()]))
-        old_messages = channel.messages()
-
         async with channel:
-            assert channel.handle_webhook(request).status_code == 200
-        assert (await anext(old_messages)).message_id == 'wamid.1'
-        with pytest.raises(StopAsyncIteration):
-            await anext(old_messages)
+            async with aclosing(channel.messages()) as messages:
+                assert channel.handle_webhook(request).status_code == 200
+                assert (await anext(messages)).message_id == 'wamid.1'
 
         async with channel:
             async with aclosing(channel.messages()) as messages:


### PR DESCRIPTION
Part of #737. Stacked on #740.

## Summary
- add the official WhatsApp Cloud API adapter for signed GET and POST webhooks
- reuse the bounded awaitable webhook ingress from #740
- keep batch parsing, throttling, and delivery policy outside the agent loop
- handle partial-batch redelivery without duplicating admitted messages
- lead with a complete Starlette example and state the Cloud API reply window

## Verification
- asyncio adapter and host integration tests
- Ruff, strict Pyright, full test suite, and 100% branch coverage
- docs parity, executable snippets, and Fable adversarial review

No dependency changes.
