### PR TITLE
Floor on released `pydantic-ai` 2.36.0 and drop the version straddle

### DIFF
--- a/pydantic_ai_harness/repo_context/_loader.py
+++ b/pydantic_ai_harness/repo_context/_loader.py
@@ -96,10 +96,12 @@ def find_dir_context_file(directory: Path, filenames: Sequence[str]) -> ContextF
 def render_context_file(file: ContextFile, *, label: str) -> str:
     """Render one file as a labeled block.
 
-    The closing tag sits on its own line, so a file's own trailing newline goes: keeping it would put
-    a blank line before the tag for every file that ends the way a text file should.
+    The closing tag sits on its own line, so the content's trailing line terminators go: keeping them
+    would put a blank line before the tag for every file that ends the way a text file should. Only the
+    terminators -- trailing spaces and tabs stay, being a hard line break in Markdown.
     """
-    return f'<context-file path="{label}">\n{file.content.rstrip()}\n</context-file>'
+    content = file.content.rstrip('\r\n')
+    return f'<context-file path="{label}">\n{content}\n</context-file>'
 
 
 def render_context_files(files: Sequence[ContextFile], *, relative_to: Path) -> str:

--- a/pydantic_ai_harness/repo_context/_loader.py
+++ b/pydantic_ai_harness/repo_context/_loader.py
@@ -94,8 +94,12 @@ def find_dir_context_file(directory: Path, filenames: Sequence[str]) -> ContextF
 
 
 def render_context_file(file: ContextFile, *, label: str) -> str:
-    """Render one file as a labeled block."""
-    return f'<context-file path="{label}">\n{file.content}\n</context-file>'
+    """Render one file as a labeled block.
+
+    The closing tag sits on its own line, so a file's own trailing newline goes: keeping it would put
+    a blank line before the tag for every file that ends the way a text file should.
+    """
+    return f'<context-file path="{label}">\n{file.content.rstrip()}\n</context-file>'
 
 
 def render_context_files(files: Sequence[ContextFile], *, relative_to: Path) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,18 @@ classifiers = [
 dependencies = [
     "genai-prices>=0.0.71",
     "httpx>=0.28.1",
-    # 2.33.0 is the release whose Anthropic provider is built on HTTPX2 and raises its own
-    # `anthropic` floor to 1.0.0 to match. Below it, slim hands the SDK a client of the other
-    # kind, and the pair only type-checks when both halves come from the same generation.
-    # Earlier floors are subsumed by it: the compaction estimator and the conversation-search
-    # indexer have to recognise `ToolAvailabilityDeltaPart` (2.23.0), the one `ModelRequestPart`
-    # carrying no `content`, so code walking request parts raises `AttributeError` rather than
-    # ignoring it (#577); `CodeMode` reads `ModelRequestParameters.revealed_tool_names` (2.22.0).
-    "pydantic-ai-slim>=2.33.0",
+    # 2.36.0 is the release that attributes each instruction to the source that contributed it, so the
+    # parts this package's capabilities contribute are separated by a blank line instead of running
+    # together into one paragraph (pydantic-ai#7595), and each carries an `InstructionId` an
+    # application can address to override it.
+    # Earlier floors are subsumed by it: 2.33.0's Anthropic provider is built on HTTPX2 and raises its
+    # own `anthropic` floor to 1.0.0 to match, and below it slim hands the SDK a client of the other
+    # kind, where the pair only type-checks when both halves come from the same generation; the
+    # compaction estimator and the conversation-search indexer have to recognise
+    # `ToolAvailabilityDeltaPart` (2.23.0), the one `ModelRequestPart` carrying no `content`, so code
+    # walking request parts raises `AttributeError` rather than ignoring it (#577); `CodeMode` reads
+    # `ModelRequestParameters.revealed_tool_names` (2.22.0).
+    "pydantic-ai-slim>=2.36.0",
 ]
 
 [project.optional-dependencies]
@@ -45,22 +49,22 @@ dependencies = [
 # without separately naming pydantic-ai-slim. (No openai/google pass-throughs: browser-use pins
 # provider SDKs that conflict with slim's floors when the workspace resolves all extras together.)
 anthropic = [
-    "pydantic-ai-slim[anthropic]>=2.33.0",
+    "pydantic-ai-slim[anthropic]>=2.36.0",
 ]
 cli = [
-    "pydantic-ai-slim[cli]>=2.33.0",
+    "pydantic-ai-slim[cli]>=2.36.0",
 ]
 code-mode = [
-    "pydantic-ai-slim[duckduckgo]>=2.33.0",
+    "pydantic-ai-slim[duckduckgo]>=2.36.0",
     "pydantic-monty>=0.0.19",
 ]
 # Extras metadata has no native redirect syntax, so aliases are represented as duplicate extras.
 codemode = [
-    "pydantic-ai-slim[duckduckgo]>=2.33.0",
+    "pydantic-ai-slim[duckduckgo]>=2.36.0",
     "pydantic-monty>=0.0.19",
 ]
 researcher = [
-    "pydantic-ai-slim[duckduckgo,web-fetch]>=2.33.0",
+    "pydantic-ai-slim[duckduckgo,web-fetch]>=2.36.0",
 ]
 temporal = [
     'pydantic-ai-slim[temporal]',

--- a/tests/coder/test_coder_integration.py
+++ b/tests/coder/test_coder_integration.py
@@ -1,7 +1,5 @@
 import asyncio
 import os
-import re
-from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -22,26 +20,6 @@ from pydantic_ai import (
 
 from pydantic_ai_harness import Coder
 from pydantic_ai_harness.repo_context import AgentContextInventory, AssetRoot
-
-
-def collapsed_instructions(messages: list[Any]) -> list[Any]:
-    """Compare instructions with every run of newlines collapsed to one.
-
-    Pydantic AI separates instruction parts contributed by different sources with a blank line, where
-    the version this package floors at joins them with a single newline. Collapsing runs of newlines
-    on both sides lets one recorded prompt hold across that bump. It flattens the blank lines inside
-    a part's own text too, which is why the prompt below reads more tightly than what is actually
-    sent -- what this test is about is the work the coder does, not how its prompt is glued together.
-
-    Drop this, and re-record the prompt as sent, once the floor moves past that release.
-    """
-    return [
-        replace(message, instructions=re.sub(r'\n+', '\n', message.instructions))
-        if isinstance(message, ModelRequest) and message.instructions is not None
-        else message
-        for message in messages
-    ]
-
 
 if TYPE_CHECKING:
 
@@ -140,7 +118,7 @@ async def test_coder_completes_task(
     )
     result = await agent.run(prompt)
 
-    assert collapsed_instructions(result.all_messages()) == snapshot(
+    assert result.all_messages() == snapshot(
         [
             ModelRequest(
                 parts=[
@@ -153,10 +131,15 @@ async def test_coder_completes_task(
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -237,10 +220,15 @@ text_renderer.py  (170 bytes)\
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -304,10 +292,15 @@ Plan updated: 3 step(s).
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -540,10 +533,15 @@ The README explicitly states "**each output format has its own renderer module**
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -596,10 +594,15 @@ No changes applied. Errors:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -647,10 +650,15 @@ Summary:\\ 0\\ completed,\\ 1\\ in\\ progress,\\ 2\\ pending\
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -698,10 +706,15 @@ No changes applied. Errors:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -806,10 +819,15 @@ def render_report(
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -868,10 +886,15 @@ def run(
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -950,10 +973,15 @@ No changes applied. Errors:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -1011,10 +1039,15 @@ def test_text_report_hides_internal_by_default() -> None:\
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -1134,10 +1167,15 @@ def test_service_text_remains_default_format() -> None:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -1176,10 +1214,15 @@ Available sub-agents:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,
@@ -1223,10 +1266,15 @@ Available sub-agents:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
+
 </context-file>
+
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
+
 You have a planning tool, `write_plan`. For multi-step work, call it first to lay out the steps, then keep it current: mark exactly one step `in_progress`, and mark a step `completed` as soon as it is fully done. Pass the full plan every time you call `write_plan`. Use `add_task` to append a single step, `update_task_status`/`update_task_statuses` to move steps between statuses, and `read_plan` to see step ids before a granular edit.
+
 You can delegate self-contained tasks to these sub-agents using the `delegate_task` tool. Each runs in its own fresh context and does not see this conversation, so pass everything it needs.
+
 Available sub-agents:
 - explorer: Explore the codebase and answer questions without modifying anything\
 """,

--- a/tests/coder/test_coder_integration.py
+++ b/tests/coder/test_coder_integration.py
@@ -131,7 +131,6 @@ async def test_coder_completes_task(
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -220,7 +219,6 @@ text_renderer.py  (170 bytes)\
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -292,7 +290,6 @@ Plan updated: 3 step(s).
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -533,7 +530,6 @@ The README explicitly states "**each output format has its own renderer module**
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -594,7 +590,6 @@ No changes applied. Errors:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -650,7 +645,6 @@ Summary:\\ 0\\ completed,\\ 1\\ in\\ progress,\\ 2\\ pending\
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -706,7 +700,6 @@ No changes applied. Errors:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -819,7 +812,6 @@ def render_report(
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -886,7 +878,6 @@ def run(
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -973,7 +964,6 @@ No changes applied. Errors:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -1039,7 +1029,6 @@ def test_text_report_hides_internal_by_default() -> None:\
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -1167,7 +1156,6 @@ def test_service_text_remains_default_format() -> None:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -1214,7 +1202,6 @@ Available sub-agents:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.
@@ -1266,7 +1253,6 @@ Available sub-agents:
                 instructions="""\
 <context-file path="AGENTS.md">
 Run tests with `pytest -q`. Keep domain policy separate from presentation and preserve public defaults.
-
 </context-file>
 
 Call `inventory_agent_context` to map where this repo keeps its coding-assistant setup (instruction dirs, skills, sub-agents, and hooks) so you can read and translate it.

--- a/tests/repo_context/test_repo_context.py
+++ b/tests/repo_context/test_repo_context.py
@@ -138,11 +138,12 @@ class TestRender:
         assert outside.as_posix() in rendered
 
     def test_trailing_newline_does_not_open_a_gap_before_the_closing_tag(self, tmp_path: Path) -> None:
-        path = _write(tmp_path / 'CLAUDE.md', 'be nice\n')
+        # The terminator goes; the two spaces before it stay, being a hard line break in Markdown.
+        path = _write(tmp_path / 'CLAUDE.md', 'be nice  \n')
         cf = ContextFile(directory=path.parent, path=path, content=path.read_text(encoding='utf-8'))
         assert (
             render_context_files([cf], relative_to=tmp_path)
-            == '<context-file path="CLAUDE.md">\nbe nice\n</context-file>'
+            == '<context-file path="CLAUDE.md">\nbe nice  \n</context-file>'
         )
 
 

--- a/tests/repo_context/test_repo_context.py
+++ b/tests/repo_context/test_repo_context.py
@@ -137,6 +137,14 @@ class TestRender:
         rendered = render_context_files([cf], relative_to=tmp_path / 'inner')
         assert outside.as_posix() in rendered
 
+    def test_trailing_newline_does_not_open_a_gap_before_the_closing_tag(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / 'CLAUDE.md', 'be nice\n')
+        cf = ContextFile(directory=path.parent, path=path, content=path.read_text(encoding='utf-8'))
+        assert (
+            render_context_files([cf], relative_to=tmp_path)
+            == '<context-file path="CLAUDE.md">\nbe nice\n</context-file>'
+        )
+
 
 class TestInstructions:
     def test_includes_files_and_inventory_hint(self, tmp_path: Path) -> None:

--- a/tests/test_coder.py
+++ b/tests/test_coder.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 from pydantic_ai import Agent
-from pydantic_ai import messages as _pydantic_ai_messages
 from pydantic_ai.capabilities import Capability
 from pydantic_ai.models.test import TestModel
 
@@ -18,8 +17,6 @@ from pydantic_ai_harness.shell import LLM_API_KEY_ENV_PATTERNS, Shell
 from pydantic_ai_harness.subagents import SubAgents
 from pydantic_ai_harness.tool_output_limits import ToolOutputLimits
 
-_ATTRIBUTES_INSTRUCTIONS = hasattr(_pydantic_ai_messages, 'InstructionId')
-
 
 def test_coder_constructs_agent() -> None:
     agent = Agent(TestModel(), capabilities=[Coder()])
@@ -31,18 +28,12 @@ def test_coder_agent_is_model_less_and_composed() -> None:
     assert isinstance(coder_agent, Agent)
     assert coder_agent.model is None
     assert coder_agent.name == 'coder'
-    # Pydantic AI attributes each instruction to the source that contributed it, so `_instructions`
-    # holds `SourcedInstruction`s where it used to hold bare strings. Assert the base prompt is still
-    # the agent's own either way rather than dropping the check: `'agent'` is the key an application
+    # Pydantic AI attributes each instruction to the source that contributed it. Assert the base prompt
+    # is still the agent's own rather than dropping the check: `'agent'` is the key an application
     # overriding this prompt addresses it by, and it would go silently missing if attribution changed.
-    if _ATTRIBUTES_INSTRUCTIONS:  # pragma: no cover - new-version path
-        # Read through `getattr` so this typechecks against the floor, where the list holds strings.
-        assert [
-            (getattr(instruction, 'instruction'), str(getattr(instruction, 'id')))
-            for instruction in coder_agent._instructions
-        ] == [('You are a coding agent built on Pydantic AI.', 'agent')]
-    else:  # pragma: no cover - old-version path
-        assert coder_agent._instructions == ['You are a coding agent built on Pydantic AI.']
+    assert [(instruction.instruction, str(instruction.id)) for instruction in coder_agent._instructions] == [
+        ('You are a coding agent built on Pydantic AI.', 'agent')
+    ]
     assert any(isinstance(capability, FileSystem) for capability in coder_agent.root_capability.capabilities)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1676,16 +1676,16 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.1.0"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/4d/cc5a70b9ea9381d36fb8ba8792569009971f504131e7d1dbd2c9a6bed69b/genai_prices-0.1.0.tar.gz", hash = "sha256:a6e3386a1de1220a49ed080f6f136069f47b1e5ff2741706d405287afcbe20d7", size = 90982, upload-time = "2026-07-30T13:01:19.969Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/70/76dcc9c76b416d2df9aa4c65553f88b75d2ba4fbfeb5efb137f078844cc3/genai_prices-0.1.5.tar.gz", hash = "sha256:04c2cbf4444a3b2f5d38c3b6ab8385ea28ab924ac6f9202bde9261f599be8b45", size = 109418, upload-time = "2026-08-31T09:36:22.848Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/56/a9dfac68e8b32a6f050a15ab62cc291803a3fb626f0bcb81a751704ecb97/genai_prices-0.1.0-py3-none-any.whl", hash = "sha256:337695a7d4d4f63bcd2ee91c3aa07e7b34b947745edafd6d1e47edfad3476d05", size = 95075, upload-time = "2026-07-30T13:01:18.917Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/14/28f578fa25391bb8983522f3e365e8735310f4b741e54cfed3a614f50384/genai_prices-0.1.5-py3-none-any.whl", hash = "sha256:5215706950decd833ce3527a9e1e745ad0dbdd35ce1b33ac1f7167699640b82a", size = 116330, upload-time = "2026-08-31T09:36:21.364Z" },
 ]
 
 [[package]]
@@ -3979,13 +3979,13 @@ requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=4.31.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.0" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.61.0" },
-    { name = "pydantic-ai-slim", specifier = ">=2.33.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.33.0" },
-    { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.33.0" },
+    { name = "pydantic-ai-slim", specifier = ">=2.36.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.36.0" },
+    { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.36.0" },
     { name = "pydantic-ai-slim", extras = ["dbos"], marker = "extra == 'dbos'" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.33.0" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'codemode'", specifier = ">=2.33.0" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo", "web-fetch"], marker = "extra == 'researcher'", specifier = ">=2.33.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.36.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'codemode'", specifier = ">=2.36.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo", "web-fetch"], marker = "extra == 'researcher'", specifier = ">=2.36.0" },
     { name = "pydantic-ai-slim", extras = ["mcp"], marker = "extra == 'stackone'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["spec"], marker = "extra == 'logfire'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["temporal"], marker = "extra == 'temporal'" },
@@ -4025,7 +4025,7 @@ lint = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.33.0"
+version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4040,9 +4040,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/00/ab2ec7a91f499e33fadd524f380acae3acf960f2f9140c8adce2e91c872b/pydantic_ai_slim-2.33.0.tar.gz", hash = "sha256:7809e3000df0265ee93e7c55ff1d852621a23b22ccb5ad790d9228e457cfb10a", size = 1229403, upload-time = "2026-08-21T05:05:55.276Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/ad/a1db6a8ea93d4f8b7a9adaab64204ccd40d236933285c564fcd4b9037173/pydantic_ai_slim-2.36.0.tar.gz", hash = "sha256:43b53401099352bbb0d1a1ecbcf8855bb7c3d0c680311ba006c5549ed6d61039", size = 1313875, upload-time = "2026-08-29T01:39:37.069Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/c0/d6120efa7f6466da2194e80032c483f8f8ececc5bafcf07cf064792f9702/pydantic_ai_slim-2.33.0-py3-none-any.whl", hash = "sha256:5ab28c9f6d7c0a6dd8e5c4f75ba4bcfa84a7f6aa0faa7b64209fbcaa981f922b", size = 1448791, upload-time = "2026-08-21T05:05:46.881Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0c/433c49819fa099700d69078586327b9dfad2c11492f96f51a13fa30208ad/pydantic_ai_slim-2.36.0-py3-none-any.whl", hash = "sha256:90957c37c99d3bfbfab4be632b733bf50d563686fbfbf8a2e42b6c91a4fca877", size = 1548738, upload-time = "2026-08-29T01:39:28.524Z" },
 ]
 
 [package.optional-dependencies]
@@ -4326,7 +4326,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.33.0"
+version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4336,9 +4336,9 @@ dependencies = [
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/68/7bbebffe9d7a2033182c92b5610e5c52840d3ca877337435e1737fe59ed3/pydantic_graph-2.33.0.tar.gz", hash = "sha256:ff4bfd7f6e10b85b0fb77c85100140733f295e9bd445ed60318221446413e224", size = 45163, upload-time = "2026-08-21T05:05:58.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/79/af5579c790ee5f670c270e4183d4c8411a6392c9b267022ea467e9e1c831/pydantic_graph-2.36.0.tar.gz", hash = "sha256:1222b50a141f88bca299dc21e94694277e6ef60d6f1bbbf490f2f2796851594a", size = 45191, upload-time = "2026-08-29T01:39:39.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/a5/73a9cd5a6dd5ca41391022597a9298aa50f9879df60299ac44f0eb7373e2/pydantic_graph-2.33.0-py3-none-any.whl", hash = "sha256:44e0ab3e0557e8e6f6ff2c939e1f15684b32029a14b55146cc88808a1c5cc464", size = 52648, upload-time = "2026-08-21T05:05:50.524Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f4/7b43affa018fa14ba0d8169fb2460ec496d4cb974c64bfc1f8e85fc4da44/pydantic_graph-2.36.0-py3-none-any.whl", hash = "sha256:c0c7cddb87038298b367036d799b4b605b2a23858869b2b661706df6e1b811f2", size = 52700, upload-time = "2026-08-29T01:39:32.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`pydantic-ai` 2.36.0 is out, so the two tests written to hold across that release while it was unreleased (#698) can assert the real thing.

2.36.0 attributes each instruction to the source that contributed it. That gives this package two things it wants: the instruction parts its capabilities contribute are separated by a blank line rather than running together into one paragraph (pydantic-ai#7595), and each part carries an `InstructionId` an application can address to override it.

- `tests/test_coder.py` reads `SourcedInstruction` attributes directly instead of through `getattr`, and drops the `hasattr` probe and both `# pragma: no cover` version branches.
- `tests/coder/test_coder_integration.py` records the prompt as it is actually sent. `collapsed_instructions` flattened every run of newlines on both sides so one recording could hold across the bump, which also flattened the blank lines inside a part's own text -- so the snapshot read more tightly than what the model received.

Seeing the prompt as sent immediately turned up a defect the collapsing had been hiding, fixed in the second commit: `render_context_file` puts `</context-file>` on its own line, so a context file whose content ends with a newline -- which is every file that ends the way a text file should -- got a blank line before the closing tag. It appeared fourteen times in the regenerated snapshot. `tests/repo_context/test_repo_context.py` now covers it directly.

The cassette is unchanged: `vcr_config` matches on `method` and `uri`, and the compared value is built locally from `result.all_messages()`.

Full suite passes with nothing else re-snapshotted.