### PR TITLE
Record why the provider SDK override cannot move out of `[tool.uv]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,11 @@ bump = true
 # repeats the floor slim declares: `anthropic>=1` is the HTTPX2 generation, and the
 # `pydantic-ai-slim` floor above is the release built on it, so both halves of that pair resolve
 # together under every resolution mode. Move this floor whenever that one moves.
+#
+# This has to stay here, under `[tool.uv]`, even though uv warns on every invocation that `uv.toml`
+# shadows it: uv 0.12.1 reads `override-dependencies` only from the workspace root's `pyproject.toml`.
+# Moved into `uv.toml` it silences the warning and stops applying, and resolution then fails outright
+# on browser-use's exact pins.
 override-dependencies = ['anthropic>=1.0.0', 'openai>=2.45.0']
 
 


### PR DESCRIPTION
Every `uv` invocation in this repo prints:

```
warning: Found both a `uv.toml` file and a `[tool.uv]` section in an adjacent `pyproject.toml`.
The following fields from `[tool.uv]` will be ignored in favor of the `uv.toml` file:
- override-dependencies
```

That reads as "this setting is dead, move it" -- and it is wrong. uv 0.12.1 applies `override-dependencies` only from the workspace root's `pyproject.toml`.

Verified both directions:

- Delete `override-dependencies` from `[tool.uv]`, keep everything else: `uv lock` fails -- `browser-use>=0.13.6 depends on anthropic==0.76.0` against slim's `anthropic>=1.0.0`, unsatisfiable. So it is being applied, warning notwithstanding.
- Move it verbatim into `uv.toml`: the warning goes away, `[manifest] overrides` is still written into `uv.lock` from the previous resolution, and `uv lock` fails with the same unsatisfiable browser-use conflict. So uv.toml is not where it takes effect.

Comment only -- no dependency, lock, or code change. It exists so the next person to read that warning does not spend the afternoon I did.