### PR TITLE
Freeze the clock the per-call timeout test reads

### DIFF
--- a/tests/playwright/test_playwright.py
+++ b/tests/playwright/test_playwright.py
@@ -1651,7 +1651,13 @@ _NON_POSITIVE_TIMEOUT_CALLS: list[Callable[[PlaywrightBrowserToolset[None]], Awa
 
 
 class TestPerCallTimeout:
-    async def test_navigate_override_reaches_every_playwright_operation(self) -> None:
+    async def test_navigate_override_reaches_every_playwright_operation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Every stage is handed what is *left* of the budget, counted from a real clock, so a run slow
+        # enough to cross a millisecond leaves the trailing stage on 1110. Freeze the clock: the claim
+        # here is that the override reaches every stage rather than any stage falling back to the
+        # capability default, and `test_override_reaches_each_playwright_call` is where the
+        # countdown itself is asserted.
+        monkeypatch.setattr('pydantic_ai_harness.playwright._toolset.monotonic', lambda: 0.0)
         page = _FakePage()
         result = await _toolset(page, screenshot_on_navigate=True).navigate('https://example.com/', timeout_ms=1111)
         assert isinstance(result, ToolReturn)


### PR DESCRIPTION
`TestPerCallTimeout::test_navigate_override_reaches_every_playwright_operation` went red on a loaded CI runner:

```
Differing items:
{'screenshot': 1110} != {'screenshot': 1111}
```

`_Deadlines._remaining` is `max(1, budget_ms - int((monotonic() - self.started) * 1000))` -- each stage gets what is *left* of the budget, counted from a real clock. One `navigate` runs `goto`, `wait_for_load_state`, `inner_text` and `screenshot` in sequence, so a run slow enough to cross a single millisecond hands the trailing stage 1110 against an asserted 1111. Nothing about the run has to be slow for that; 1ms is the resolution the deduction is measured in.

What the test claims is that a per-call override reaches every stage rather than any stage falling back to the capability default, and the capability defaults are nowhere near 1111. So freeze the clock and let the assertion say exactly that. The countdown itself stays covered a few tests down by `test_override_reaches_each_playwright_call`, whose `under()` helper asserts a trailing stage lands just under its budget.

Checked that the freeze is what the assertion now rests on: swapping the frozen clock for one that advances makes the test fail.