### PR TITLE
Scrub ambient Logfire credentials in `tests/logfire_variables` so a local `.env` cannot reach the real Logfire API

### DIFF
--- a/tests/logfire_variables/conftest.py
+++ b/tests/logfire_variables/conftest.py
@@ -1,0 +1,31 @@
+"""Shared fixtures for the `logfire_variables` tests.
+
+These tests rely on the no-provider fallback: resolution uses code defaults
+because no Logfire variable provider is configured. Logfire lazily creates a
+`LogfireRemoteVariableProvider` that issues requests to the Logfire API
+whenever a credential such as `LOGFIRE_API_KEY` is present in `os.environ`,
+even with `send_to_logfire=False`. A credential inherited from the developer's
+shell, or from a `.env` file loaded into the process, would therefore make
+these tests write to the real Logfire API from background publish threads.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+_LOGFIRE_CREDENTIAL_VARS = ('LOGFIRE_TOKEN', 'LOGFIRE_API_KEY')
+
+
+@pytest.fixture(autouse=True, scope='package')
+def _scrub_logfire_credentials() -> Iterator[None]:
+    """Remove ambient Logfire credentials while this package's tests run.
+
+    Package scope orders this ahead of the module-scoped `logfire.configure()`
+    fixtures in the test modules, which capture `api_key` at configure time.
+    """
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        for name in _LOGFIRE_CREDENTIAL_VARS:
+            monkeypatch.delenv(name, raising=False)
+        yield

--- a/tests/logfire_variables/test_managed_prompt.py
+++ b/tests/logfire_variables/test_managed_prompt.py
@@ -26,6 +26,7 @@ import pytest
 from inline_snapshot import snapshot
 from logfire.testing import CaptureLogfire
 from logfire.variables import LabeledValue, Rollout, VariableConfig, VariablesConfig
+from logfire.variables.abstract import NoOpVariableProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.capabilities import Instrumentation
@@ -114,6 +115,19 @@ def span_attributes(capfire: CaptureLogfire) -> list[dict[str, Any]]:
 
 def test_public_reexport() -> None:
     assert ManagedPrompt is ManagedPromptFromPackage
+
+
+def test_no_variable_provider_is_configured() -> None:
+    """The resolution tests in this module rely on the no-provider fallback; assert it.
+
+    With a Logfire credential in `os.environ`, `logfire.configure()` lazily resolves a
+    `LogfireRemoteVariableProvider` that writes to the real Logfire API from background
+    threads, and the resolution tests then fail on span contents far from the cause.
+    `conftest.py` removes ambient credentials; this test fails at the boundary if a
+    credential still reaches the provider.
+    """
+    provider = logfire.DEFAULT_LOGFIRE_INSTANCE.config.get_variable_provider()
+    assert isinstance(provider, NoOpVariableProvider)
 
 
 def test_slug_becomes_prompt_variable_name() -> None:


### PR DESCRIPTION
## Summary

An ambient Logfire credential (a shell export, or a `.env` loaded into `os.environ` as in the issue's reproduction) makes `logfire.configure()` lazily resolve a `LogfireRemoteVariableProvider` even with `send_to_logfire=False` (`LogfireConfig._lazy_init_variable_provider` reads `LOGFIRE_API_KEY` whenever `variables=` was not passed). The `tests/logfire_variables` tests assume the no-provider fallback, so with a credential in scope they wrote to the production Logfire API from background publish threads and failed on span contents far from the cause. Reproduced on current `main`: `LOGFIRE_API_KEY=<fake> uv run pytest tests/logfire_variables` gives 2 failed, 1 error.

The `load_dotenv()` call named in the issue no longer exists on `main` (it lives on the unmerged `capability/guardrails` branch, as do `test_auto_create.py` and `test_temporal.py` from the repro output), but the ambient-credential vector still applies to the surviving `test_managed_prompt.py`, including two tests from the issue's failure list.

Changes, matching the issue's suggested fixes:

- `tests/logfire_variables/conftest.py`: a package-scoped autouse fixture removes `LOGFIRE_TOKEN` and `LOGFIRE_API_KEY` for the duration of the package. Package scope orders it ahead of the module-scoped `logfire.configure()` fixture, which captures `api_key` at configure time.
- `test_no_variable_provider_is_configured`: asserts the resolved provider is a `NoOpVariableProvider`, so a leaked credential fails loudly at the boundary instead of reaching the network.

Test-only change, so no README or docs page updates apply.

Fixes #566

## How I verified

- `uv run --no-sync pytest -p no:cacheprovider tests/logfire_variables`: 23 passed
- `LOGFIRE_API_KEY=<fake> LOGFIRE_TOKEN=<fake> uv run --no-sync pytest -p no:cacheprovider tests/logfire_variables -p no:randomly`: 23 passed (before this change: 2 failed, 1 error, with real HTTP requests to the Logfire API)
- With `conftest.py` temporarily removed and a fake `LOGFIRE_API_KEY` set, `test_no_variable_provider_is_configured` fails, confirming the boundary assertion catches a leak
- `uv run --no-sync ruff format --check .`: 327 files already formatted
- `uv run --no-sync ruff check .`: all checks passed
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright tests/logfire_variables/conftest.py tests/logfire_variables/test_managed_prompt.py`: 0 errors, 0 warnings