### PR TITLE
Publish spec-schema fields for `Advisor`, `SummarizingCompaction`, `ManagedPrompt`, and `PyaiDocs`

### DIFF
--- a/pydantic_ai_harness/advisor/_capability.py
+++ b/pydantic_ai_harness/advisor/_capability.py
@@ -10,7 +10,16 @@ from pydantic_ai import Agent
 from pydantic_ai.capabilities import ModelSelection, NativeOrLocalTool
 from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior, UserError
 from pydantic_ai.messages import ModelResponse
-from pydantic_ai.models import ModelRequestContext, parse_model_id
+
+# `KnownModelName` and `Model` back core's `ModelSelection` alias, which is the string
+# `'Model | KnownModelName | str'` evaluated against this module's globals when the
+# agent-spec schema reads `__init__` annotations, so both must be imported at runtime (#552).
+from pydantic_ai.models import (
+    KnownModelName,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    Model,  # noqa: F401  # pyright: ignore[reportUnusedImport]
+    ModelRequestContext,
+    parse_model_id,
+)
 from pydantic_ai.native_tools import AdvisorTool
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.tools import AgentDepsT, AgentNativeTool, RunContext

--- a/pydantic_ai_harness/logfire/_managed_prompt.py
+++ b/pydantic_ai_harness/logfire/_managed_prompt.py
@@ -208,3 +208,36 @@ class ManagedPrompt(AbstractCapability[AgentDepsT]):
                 return await handler()
             finally:
                 self._resolved.reset(token)
+
+    @classmethod
+    def from_spec(
+        cls,
+        name: str,
+        default: str,
+        *,
+        label: str | None = None,
+        targeting_key: str | None = None,
+        attributes: Mapping[str, Any] | None = None,
+        render_template: bool = False,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
+    ) -> ManagedPrompt[AgentDepsT]:
+        """Construct the capability from serializable spec options.
+
+        In a spec, `name` is always a prompt name (a `Variable` is not spec-serializable),
+        so `default` is required. `targeting_key` and `attributes` accept only static
+        values, and `logfire_instance` is not spec-serializable; spec-loaded instances
+        always resolve on the global default Logfire instance.
+        """
+        return cls(
+            name,
+            default=default,
+            label=label,
+            targeting_key=targeting_key,
+            attributes=attributes,
+            render_template=render_template,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
+        )

--- a/pydantic_ai_harness/pydantic_ai_docs/_deprecated.py
+++ b/pydantic_ai_harness/pydantic_ai_docs/_deprecated.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+# `@dataclass` rebuilds `__init__` in this module, so the inherited `local_docs_path: Path`
+# annotation must resolve against these globals when the agent-spec schema is built (#552).
+from pathlib import Path  # noqa: F401  # pyright: ignore[reportUnusedImport]
+
 from pydantic_ai.tools import AgentDepsT
 
 from pydantic_ai_harness.pydantic_ai_docs._capability import PydanticAIDocs

--- a/tests/advisor/test_advisor.py
+++ b/tests/advisor/test_advisor.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 
 import pytest
 from inline_snapshot import snapshot
-from pydantic_ai import AdvisorTool, Agent
+from pydantic_ai import AdvisorTool, Agent, AgentSpec
 from pydantic_ai.capabilities import AbstractCapability, PrefixTools
 from pydantic_ai.exceptions import UnexpectedModelBehavior, UsageLimitExceeded, UserError
 from pydantic_ai.messages import (
@@ -417,6 +417,15 @@ class TestAdvisor:
             Advisor('anthropic:', mode='native')
         with pytest.raises(ValueError, match='not supported by OpenRouter'):
             Advisor('openrouter:anthropic/claude-opus-4.8', mode='native', max_uses=1)
+
+    def test_spec_schema_publishes_init_fields(self) -> None:
+        # Regression for #552: core's `ModelSelection` alias resolves against this
+        # capability's module globals, so `Model` and `KnownModelName` must be
+        # importable there at runtime for the schema to publish any fields.
+        schema = AgentSpec.model_json_schema_with_capabilities([Advisor])
+        params = schema['$defs']['spec_params_Advisor']
+        assert set(params['properties']) == {'model', 'mode', 'max_uses', 'max_tokens', 'caching', 'forward_history'}
+        assert params['required'] == ['model']
 
     async def test_loads_string_model_from_agent_spec(self) -> None:
         agent = Agent.from_spec(

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from opentelemetry.trace import NoOpTracer, Tracer, get_tracer
-from pydantic_ai import Agent, Tool
+from pydantic_ai import Agent, AgentSpec, Tool
 from pydantic_ai.capabilities import AbstractCapability, ToolSearch
 from pydantic_ai.exceptions import ModelAPIError
 from pydantic_ai.messages import (
@@ -712,6 +712,35 @@ class TestWarnNearLimits:
 
 
 class TestCompaction:
+    def test_spec_schema_publishes_init_fields(self):
+        # Regression for #552: `Model` must stay importable at runtime in the
+        # capability's module so the spec schema can resolve `__init__` annotations.
+        schema = AgentSpec.model_json_schema_with_capabilities([SummarizingCompaction])
+        params = schema['$defs']['spec_params_SummarizingCompaction']
+        assert set(params['properties']) == {
+            'bridge_prefix',
+            'context_window',
+            'defer_loading',
+            'description',
+            'fallback_context_window',
+            'id',
+            'incremental',
+            'instructions',
+            'keep_messages',
+            'keep_tokens',
+            'keep_user_messages',
+            'keep_user_messages_max_chars',
+            'max_fraction',
+            'max_messages',
+            'max_tokens',
+            'model',
+            'model_settings',
+            'preserve_first_user_message',
+            'receipts',
+            'summary_prompt',
+            'tokenizer',
+        }
+
     def test_validation_no_trigger(self):
         with pytest.raises(ValueError, match='At least one of max_messages, max_tokens, or max_fraction must be set'):
             SummarizingCompaction(model='test', max_messages=None, max_tokens=None)

--- a/tests/logfire_variables/test_managed_prompt.py
+++ b/tests/logfire_variables/test_managed_prompt.py
@@ -27,7 +27,7 @@ from inline_snapshot import snapshot
 from logfire.testing import CaptureLogfire
 from logfire.variables import LabeledValue, Rollout, VariableConfig, VariablesConfig
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from pydantic_ai import Agent, RunContext
+from pydantic_ai import Agent, AgentSpec, RunContext
 from pydantic_ai.capabilities import Instrumentation
 from pydantic_ai.messages import ModelMessage, ModelRequest
 from pydantic_ai.models.test import TestModel
@@ -154,6 +154,61 @@ def test_prompt_prefix_in_slug_warns_and_is_stripped() -> None:
 def test_invalid_slug_raises() -> None:
     with pytest.raises(ValueError, match='invalid variable name'):
         ManagedPrompt('has spaces', default=DEFAULT)
+
+
+def test_spec_schema_publishes_from_spec_fields() -> None:
+    # Regression for #552: without the `from_spec` override, the unresolvable
+    # `Logfire` annotation on `__init__` collapsed the schema entry to a bare name.
+    schema = AgentSpec.model_json_schema_with_capabilities([ManagedPrompt])
+    params = schema['$defs']['spec_params_ManagedPrompt']
+    assert set(params['properties']) == {
+        'name',
+        'default',
+        'label',
+        'targeting_key',
+        'attributes',
+        'render_template',
+        'id',
+        'description',
+        'defer_loading',
+    }
+    assert sorted(params['required']) == ['default', 'name']
+
+
+def test_from_spec_builds_capability() -> None:
+    capability = ManagedPrompt[None].from_spec(
+        'spec_built_prompt',
+        'Fallback prompt.',
+        label='production',
+        targeting_key='user-1',
+        attributes={'plan': 'pro'},
+        render_template=True,
+        id='support-prompt',
+        description='Backs the support agent instructions.',
+    )
+    assert capability.name == 'spec_built_prompt'
+    assert capability.default == 'Fallback prompt.'
+    assert capability.label == 'production'
+    assert capability.targeting_key == 'user-1'
+    assert capability.attributes == {'plan': 'pro'}
+    assert capability.render_template is True
+    assert capability.id == 'support-prompt'
+    assert capability.description == 'Backs the support agent instructions.'
+    assert capability.logfire_instance is None
+
+
+async def test_agent_loads_from_spec() -> None:
+    agent = Agent.from_spec(
+        {
+            'model': 'test',
+            'capabilities': [{'ManagedPrompt': {'name': 'spec_loaded_prompt', 'default': 'From the spec.'}}],
+        },
+        custom_capability_types=[ManagedPrompt],
+    )
+
+    result = await agent.run('hello')
+
+    assert instructions_seen(result.all_messages()) == ['From the spec.']
 
 
 async def test_resolves_default_into_instructions() -> None:

--- a/tests/pydantic_ai_docs/test_deprecated_names.py
+++ b/tests/pydantic_ai_docs/test_deprecated_names.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 
 import pytest
-from pydantic_ai import Agent
+from pydantic_ai import Agent, AgentSpec
 
 from pydantic_ai_harness import HarnessDeprecationWarning
 from pydantic_ai_harness.pydantic_ai_docs import PydanticAIDocs, PydanticAIDocsToolset, PydanticAIDocsTopic
@@ -58,6 +58,18 @@ class TestPreRenameSpecCompatibility:
         )
         loaded = [c for c in agent.root_capability.capabilities if isinstance(c, PydanticAIDocs)]
         assert len(loaded) == 1
+
+    def test_spec_schema_publishes_init_fields(self) -> None:
+        # Regression for #552: `@dataclass` rebuilds `__init__` in `_deprecated.py`,
+        # so the inherited `Path` annotation must resolve there at runtime for the
+        # spec schema to publish any fields.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            from pydantic_ai_harness.docs import PyaiDocs  # noqa: PLC0415  # the shim warns at import time
+
+        schema = AgentSpec.model_json_schema_with_capabilities([PyaiDocs])
+        params = schema['$defs']['spec_params_PyaiDocs']
+        assert set(params['properties']) == {'cache', 'defer_loading', 'description', 'id', 'local_docs_path'}
 
     def test_experimental_shim_exposes_the_same_class(self) -> None:
         with warnings.catch_warnings():


### PR DESCRIPTION
## Summary

The agent-spec schema builder reads `__init__` annotations when `from_spec` is not overridden. When a name in those annotations does not resolve at runtime, it falls back to `AbstractCapability`'s variadic `from_spec`, and the capability's schema entry collapses to a bare `{"const": "<Name>"}` with no fields. Loading still worked; only schema validation was broken.

Each capability named in the issue needed a different depth of fix, matching the issue's verified map:

- **`PyaiDocs`** (`pydantic_ai_docs/_deprecated.py`): `@dataclass` rebuilds `__init__` in that module, so the inherited `local_docs_path: Path` annotation must resolve against its globals. Added a runtime `from pathlib import Path`.
- **`Advisor`** (`advisor/_capability.py`): core's `ModelSelection` alias is the string `'Model | KnownModelName | str'`, evaluated against the advisor module's globals. Added runtime imports of `Model` and `KnownModelName`. Its schema now publishes `model` (required), `mode`, `max_uses`, `max_tokens`, `caching`, and `forward_history`. As the issue notes, the missing `AbstractCapability` base fields are #554's territory and are not addressed here.
- **`ManagedPrompt`** (`logfire/_managed_prompt.py`): resolving `Logfire` at runtime would only move the failure into the nullable-drop tracked by #553, so it gets a `from_spec` override instead, covering the spec-serializable options (`name` and `default` required, plus `label`, `targeting_key`, `attributes`, `render_template`, and the `id`/`description`/`defer_loading` base fields). `logfire_instance` and the callable forms are not spec-serializable and are documented as such in the override's docstring.
- **`SummarizingCompaction`**: already resolves on current main (it imports `Model` at runtime since the durable-summarization work), so this PR only pins the published property set with a regression test.

Regression tests assert the exact `spec_params_<Name>` property sets via `AgentSpec.model_json_schema_with_capabilities`, following the shape of the existing `Memory` spec-schema test, plus `from_spec` construction and `Agent.from_spec` loading coverage for `ManagedPrompt`.

Note: #546 (which adds the `tests/test_capability_specs.py` guard whose xfails point at this issue) is not yet merged, so there are no `_NO_SCHEMA_ENTRY` lines to delete here; whichever lands second should reconcile the tracker map.

Fixes #552.

## How I verified

- `uv run --no-sync ruff format --check .` -- 326 files already formatted
- `uv run --no-sync ruff check .` -- all checks passed
- `uv run --no-sync pytest -p no:cacheprovider tests/advisor tests/compaction tests/logfire_variables tests/pydantic_ai_docs` -- 662 passed, 1 skipped
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright` on all 7 changed files -- 0 errors, 0 warnings
- Reproduced the issue before the fix (all four capabilities' entries were a bare `{"const": ...}`) and confirmed all four publish their fields after it.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks