### PR TITLE
Publish `AgentSpec` schema entries for `CodeMode`, `ConversationSearch`, `ModalSandbox`, and `Skills` via named `from_spec` signatures

### DIFF
--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -412,6 +412,22 @@ capabilities:
       max_retries: 5
 ```
 
+`mount` is expressed as one mapping or a list of them, each carrying `MountDir`'s
+keyword arguments (`host_path` and `virtual_path`, plus optional `mode`,
+`write_bytes_limit`, and `memory_usage_limit`); `CodeMode.from_spec` builds the real
+`MountDir` instances:
+
+```yaml
+capabilities:
+  - CodeMode:
+      mount:
+        - {host_path: /tmp/agent-work, virtual_path: /work, mode: read-write}
+```
+
+`os_access` takes a live OS implementation or a callback, which no spec can carry, so
+a spec naming it is rejected rather than dropped. Construct the capability in code to
+use it.
+
 ## Further reading
 
 - [Tool use via code](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic)

--- a/docs/conversation-search.md
+++ b/docs/conversation-search.md
@@ -121,9 +121,10 @@ warnings.filterwarnings('ignore', category=HarnessDeprecationWarning)
 
 A spec cannot carry a live `HistorySource`, so `ConversationSearch.from_spec` takes a
 `backend` naming a step-persistence store instead and reads it through
-`SnapshotHistorySource`. `backend`, `directory`, and `database` (defaults included)
-mirror `StepPersistence.from_spec`, so a spec that declares both capabilities with the
-same values reads the history the other writes:
+`SnapshotHistorySource`. Unlike `StepPersistence.from_spec`,
+`ConversationSearch.from_spec` requires a persistent `backend` (`file` or `sqlite`).
+Configure the same explicit `backend`, `directory`, or `database` values on both
+capabilities so one reads the history the other writes:
 
 ```yaml
 # agent.yaml

--- a/docs/conversation-search.md
+++ b/docs/conversation-search.md
@@ -117,6 +117,40 @@ warnings.filterwarnings('ignore', category=HarnessDeprecationWarning)
 | `add_instructions` | `True` | Emit a short note telling the model the recall tool exists. |
 | `tool_id` | `conversation-search` | Toolset id for the search tool. |
 
+## Agent spec (YAML/JSON)
+
+A spec cannot carry a live `HistorySource`, so `ConversationSearch.from_spec` takes a
+`backend` naming a step-persistence store instead and reads it through
+`SnapshotHistorySource`. `backend`, `directory`, and `database` (defaults included)
+mirror `StepPersistence.from_spec`, so a spec that declares both capabilities with the
+same values reads the history the other writes:
+
+```yaml
+# agent.yaml
+model: anthropic:claude-sonnet-4-6
+capabilities:
+  - StepPersistence:
+      backend: sqlite
+      database: sessions.db
+  - ConversationSearch:
+      backend: sqlite
+      database: sessions.db
+      scope: conversation
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import ConversationSearch, StepPersistence
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[StepPersistence, ConversationSearch])
+```
+
+There is no `memory` backend here: an in-memory store built while loading the spec
+could never be the instance a `StepPersistence` capability writes to, so it would
+always search nothing. To search an in-memory store, construct the capability in code
+and share the store instance. The search options (`scope`, `max_matches`, ...) carry
+the same defaults as the constructor.
+
 ## Limitations
 
 - Search only reaches what was persisted: history inherited from runs that never ran with `StepPersistence` (for example a long `message_history` passed in from an unpersisted session) cannot be recovered if compaction drops it before the first snapshot.

--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -238,6 +238,11 @@ from pydantic_ai_harness import ModalSandbox
 agent = Agent.from_file('agent.yaml', custom_capability_types=[ModalSandbox])
 ```
 
+Every option except `session` can appear in the spec. `session` takes a live,
+already-entered `ModalSandboxSession`, which no spec can carry, so a spec naming it is
+rejected rather than dropped: set `sandbox_id` to attach to an existing sandbox, or
+construct the capability in code to inject a session.
+
 ## API reference
 
 - [Pydantic AI capabilities](/ai/core-concepts/capabilities/)

--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -439,6 +439,22 @@ capabilities:
       max_retries: 5
 ```
 
+`mount` is expressed as one mapping or a list of them, each carrying `MountDir`'s
+keyword arguments (`host_path` and `virtual_path`, plus optional `mode`,
+`write_bytes_limit`, and `memory_usage_limit`); `CodeMode.from_spec` builds the real
+`MountDir` instances:
+
+```yaml
+capabilities:
+  - CodeMode:
+      mount:
+        - {host_path: /tmp/agent-work, virtual_path: /work, mode: read-write}
+```
+
+`os_access` takes a live OS implementation or a callback, which no spec can carry, so
+a spec naming it is rejected rather than dropped. Construct the capability in code to
+use it.
+
 ## Further reading
 
 - [Tool use via code](https://www.anthropic.com/engineering/code-execution-with-mcp) (Anthropic)

--- a/pydantic_ai_harness/code_mode/__init__.py
+++ b/pydantic_ai_harness/code_mode/__init__.py
@@ -1,6 +1,6 @@
 """Code mode capability: route tool calls through a sandboxed Python environment."""
 
-from pydantic_ai_harness.code_mode._capability import CodeMode
+from pydantic_ai_harness.code_mode._capability import CodeMode, CodeModeMountSpec
 from pydantic_ai_harness.code_mode._toolset import (
     CodeModeMount,
     CodeModeOS,
@@ -9,4 +9,12 @@ from pydantic_ai_harness.code_mode._toolset import (
     CodeModeToolset,
 )
 
-__all__ = ['CodeMode', 'CodeModeMount', 'CodeModeOS', 'CodeModeOSCallback', 'CodeModeResourceLimits', 'CodeModeToolset']
+__all__ = [
+    'CodeMode',
+    'CodeModeMount',
+    'CodeModeMountSpec',
+    'CodeModeOS',
+    'CodeModeOSCallback',
+    'CodeModeResourceLimits',
+    'CodeModeToolset',
+]

--- a/pydantic_ai_harness/code_mode/_capability.py
+++ b/pydantic_ai_harness/code_mode/_capability.py
@@ -63,6 +63,12 @@ def _mount_from_spec(mount: CodeModeMountSpec | Sequence[CodeModeMountSpec] | No
     """
     if mount is None:
         return None
+    entries = mount if isinstance(mount, Sequence) else [mount]
+    allowed_keys = CodeModeMountSpec.__annotations__.keys()
+    for entry in entries:
+        unknown_keys = entry.keys() - allowed_keys
+        if unknown_keys:
+            raise ValueError(f'Unknown mount spec key(s): {sorted(unknown_keys)}')
     validated = _MOUNT_SPEC_ADAPTER.validate_python(mount)
     if isinstance(validated, list):
         return [MountDir(**entry) for entry in validated]

--- a/pydantic_ai_harness/code_mode/_capability.py
+++ b/pydantic_ai_harness/code_mode/_capability.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import KW_ONLY, dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import TypeAdapter, ValidationError
 from pydantic_ai import AbstractToolset
@@ -63,12 +63,14 @@ def _mount_from_spec(mount: CodeModeMountSpec | Sequence[CodeModeMountSpec] | No
     """
     if mount is None:
         return None
-    entries = mount if isinstance(mount, Sequence) else [mount]
+    entries = cast(Sequence[object], mount if isinstance(mount, Sequence) else [mount])
     allowed_keys = CodeModeMountSpec.__annotations__.keys()
     for entry in entries:
-        unknown_keys = entry.keys() - allowed_keys
-        if unknown_keys:
-            raise ValueError(f'Unknown mount spec key(s): {sorted(unknown_keys)}')
+        if isinstance(entry, dict):
+            entry_dict = cast(dict[str, object], entry)
+            unknown_keys = entry_dict.keys() - allowed_keys
+            if unknown_keys:
+                raise ValueError(f'Unknown mount spec key(s): {sorted(unknown_keys)}')
     validated = _MOUNT_SPEC_ADAPTER.validate_python(mount)
     if isinstance(validated, list):
         return [MountDir(**entry) for entry in validated]

--- a/pydantic_ai_harness/code_mode/_capability.py
+++ b/pydantic_ai_harness/code_mode/_capability.py
@@ -10,11 +10,18 @@ from pydantic import TypeAdapter, ValidationError
 from pydantic_ai import AbstractToolset
 from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering
 from pydantic_ai.capabilities._tool_search import ToolSearch as _ToolSearch
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import ModelResponse, NativeToolSearchReturnPart, SystemPromptPart
 from pydantic_ai.tools import AgentDepsT, RunContext, ToolDefinition, ToolSelector
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 
-from pydantic_ai_harness.code_mode._toolset import CodeModeMount, CodeModeOS, CodeModeResourceLimits, CodeModeToolset
+from pydantic_ai_harness.code_mode._toolset import (
+    CodeModeMount,
+    CodeModeOS,
+    CodeModeResourceLimits,
+    CodeModeToolset,
+    MountDir,
+)
 
 if TYPE_CHECKING:
     from pydantic_ai.capabilities.abstract import ValidatedToolArgs
@@ -26,6 +33,40 @@ _DISCOVERY_ANNOUNCEMENT_PREFIX = (
     'New functions are now available inside `run_code`. Their signatures have been '
     'added to the available-functions catalog in the system prompt'
 )
+
+
+class CodeModeMountSpec(TypedDict):
+    """One `mount` entry as an agent spec expresses it: `MountDir`'s keyword arguments.
+
+    `MountDir` is a compiled class with no JSON representation of its own, so specs
+    describe mounts with this shape and `CodeMode.from_spec` constructs the real
+    `MountDir` instances. Omitted keys keep `MountDir`'s own defaults.
+    """
+
+    host_path: str
+    virtual_path: str
+    mode: NotRequired[Literal['read-only', 'read-write', 'overlay']]
+    write_bytes_limit: NotRequired[int | None]
+    memory_usage_limit: NotRequired[int]
+
+
+_MOUNT_SPEC_ADAPTER: TypeAdapter[CodeModeMountSpec | list[CodeModeMountSpec]] = TypeAdapter(
+    CodeModeMountSpec | list[CodeModeMountSpec]
+)
+
+
+def _mount_from_spec(mount: CodeModeMountSpec | Sequence[CodeModeMountSpec] | None) -> CodeModeMount | None:
+    """Build `MountDir` instances from spec mount entries, validating the entry shape first.
+
+    Validation happens here rather than in `MountDir` so a misspelled key fails with the
+    entry that carries it instead of an opaque constructor error.
+    """
+    if mount is None:
+        return None
+    validated = _MOUNT_SPEC_ADAPTER.validate_python(mount)
+    if isinstance(validated, list):
+        return [MountDir(**entry) for entry in validated]
+    return MountDir(**validated)
 
 
 @dataclass
@@ -201,6 +242,52 @@ class CodeMode(AbstractCapability[AgentDepsT]):
                 if isinstance(part, NativeToolSearchReturnPart):
                     self._announce_newly_discovered(ctx, _extract_discovered_names(part.content))
         return response
+
+    @classmethod
+    def from_spec(
+        cls,
+        tools: Literal['all'] | Sequence[str] | dict[str, Any] = 'all',
+        max_retries: int = 3,
+        *,
+        max_tool_calls: int = 100,
+        mount: CodeModeMountSpec | Sequence[CodeModeMountSpec] | None = None,
+        resource_limits: CodeModeResourceLimits | Literal['unlimited'] | None = None,
+        dynamic_catalog: bool = False,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
+        **unsupported: Any,
+    ) -> CodeMode[Any]:
+        """Build from an agent spec, covering the fields a spec can express.
+
+        Every parameter is named because this signature is what core reads to generate the
+        spec's JSON schema, and a field whose type has no JSON representation would
+        otherwise erase the whole `CodeMode` entry from that schema.
+
+        `mount` arrives as `CodeModeMountSpec` mappings and becomes `MountDir` instances.
+        `os_access` takes a live OS implementation or a callback, which no spec can carry,
+        so a spec naming it is rejected rather than dropped. The callable form of `tools`
+        is likewise construction-only; the `'all'`, name-list, and metadata-match forms
+        all serialize.
+        """
+        if 'os_access' in unsupported:
+            raise UserError(
+                'CodeMode cannot be built from a spec with `os_access`: it takes a live OS '
+                'implementation or a callback. Construct the capability in code to use it.'
+            )
+        if unsupported:
+            raise UserError(f'CodeMode has no spec field(s) {sorted(unsupported)}.')
+        return cls(
+            tools=tools,
+            max_retries=max_retries,
+            max_tool_calls=max_tool_calls,
+            mount=_mount_from_spec(mount),
+            resource_limits=resource_limits,
+            dynamic_catalog=dynamic_catalog,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
+        )
 
     def _announce_newly_discovered(self, ctx: RunContext[AgentDepsT], names: Sequence[str]) -> None:
         """Enqueue a system-prompt announcement for any names we haven't already announced."""

--- a/pydantic_ai_harness/conversation_search/README.md
+++ b/pydantic_ai_harness/conversation_search/README.md
@@ -110,6 +110,40 @@ warnings.filterwarnings('ignore', category=HarnessDeprecationWarning)
 | `add_instructions` | `True` | Emit a short note telling the model the recall tool exists. |
 | `tool_id` | `conversation-search` | Toolset id for the search tool. |
 
+## Agent spec (YAML/JSON)
+
+A spec cannot carry a live `HistorySource`, so `ConversationSearch.from_spec` takes a
+`backend` naming a step-persistence store instead and reads it through
+`SnapshotHistorySource`. `backend`, `directory`, and `database` (defaults included)
+mirror `StepPersistence.from_spec`, so a spec that declares both capabilities with the
+same values reads the history the other writes:
+
+```yaml
+# agent.yaml
+model: anthropic:claude-sonnet-4-6
+capabilities:
+  - StepPersistence:
+      backend: sqlite
+      database: sessions.db
+  - ConversationSearch:
+      backend: sqlite
+      database: sessions.db
+      scope: conversation
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import ConversationSearch, StepPersistence
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[StepPersistence, ConversationSearch])
+```
+
+There is no `memory` backend here: an in-memory store built while loading the spec
+could never be the instance a `StepPersistence` capability writes to, so it would
+always search nothing. To search an in-memory store, construct the capability in code
+and share the store instance. The search options (`scope`, `max_matches`, ...) carry
+the same defaults as the constructor.
+
 ## Limitations
 
 - Search only reaches what was persisted: history inherited from runs that never ran with `StepPersistence` (for example a long `message_history` passed in from an unpersisted session) cannot be recovered if compaction drops it before the first snapshot.

--- a/pydantic_ai_harness/conversation_search/README.md
+++ b/pydantic_ai_harness/conversation_search/README.md
@@ -114,9 +114,10 @@ warnings.filterwarnings('ignore', category=HarnessDeprecationWarning)
 
 A spec cannot carry a live `HistorySource`, so `ConversationSearch.from_spec` takes a
 `backend` naming a step-persistence store instead and reads it through
-`SnapshotHistorySource`. `backend`, `directory`, and `database` (defaults included)
-mirror `StepPersistence.from_spec`, so a spec that declares both capabilities with the
-same values reads the history the other writes:
+`SnapshotHistorySource`. Unlike `StepPersistence.from_spec`,
+`ConversationSearch.from_spec` requires a persistent `backend` (`file` or `sqlite`).
+Configure the same explicit `backend`, `directory`, or `database` values on both
+capabilities so one reads the history the other writes:
 
 ```yaml
 # agent.yaml

--- a/pydantic_ai_harness/conversation_search/_capability.py
+++ b/pydantic_ai_harness/conversation_search/_capability.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any, Literal
 
 from pydantic_ai.agent.abstract import AgentInstructions
 from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AgentToolset
 
 from pydantic_ai_harness._warn import warn_default_changed
-from pydantic_ai_harness.conversation_search._source import HistorySource
+from pydantic_ai_harness.conversation_search._source import HistorySource, SnapshotHistorySource
 from pydantic_ai_harness.conversation_search._toolset import (
     SCOPE_DEFAULT_CHANGE_IMPACT,
     ConversationSearchToolset,
@@ -144,6 +146,80 @@ class ConversationSearch(AbstractCapability[AgentDepsT]):
     def effective_scope(self) -> SearchScope:
         """The scope actually applied: the caller's choice, or `conversation` when unset."""
         return 'conversation' if self.scope is None else self.scope
+
+    @classmethod
+    def from_spec(
+        cls,
+        backend: Literal['file', 'sqlite'],
+        *,
+        directory: str = '.step-persistence',
+        database: str = '.step-persistence.db',
+        scope: SearchScope | None = None,
+        tool_id: str = 'conversation-search',
+        max_matches: int = 10,
+        context_lines: int = 5,
+        bm25_k1: float = 1.5,
+        bm25_b: float = 0.75,
+        add_instructions: bool = True,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
+        **unsupported: Any,
+    ) -> ConversationSearch[Any]:
+        """Build from an agent spec, covering the fields a spec can express.
+
+        Every parameter is named because this signature is what core reads to generate the
+        spec's JSON schema, and the bare `source` field has no JSON representation, which
+        would otherwise erase the whole `ConversationSearch` entry from that schema.
+
+        A spec cannot carry a live `HistorySource`, so `backend` names a step-persistence
+        store instead and the source becomes a `SnapshotHistorySource` over it. `backend`,
+        `directory`, and `database` mirror `StepPersistence.from_spec`, so a spec that
+        declares both capabilities with the same values reads the history the other
+        writes. There is no `memory` backend here: a store built from this spec could
+        never be the instance a `StepPersistence` capability writes to, so an in-memory
+        corpus would always search nothing. Share a store instance in code for that.
+        """
+        if 'source' in unsupported:
+            raise UserError(
+                'ConversationSearch cannot be built from a spec with `source`: it takes a live '
+                '`HistorySource`. Pass `backend` (with `directory` or `database`) to read a '
+                'step-persistence store, or construct the capability in code.'
+            )
+        if unsupported:
+            raise UserError(f'ConversationSearch has no spec field(s) {sorted(unsupported)}.')
+        if backend != 'file' and directory != '.step-persistence':
+            raise UserError('directory is only valid with backend="file"')
+        if backend != 'sqlite' and database != '.step-persistence.db':
+            raise UserError('database is only valid with backend="sqlite"')
+        if backend == 'file':
+            from pydantic_ai_harness.step_persistence import FileStepStore
+
+            source: HistorySource = SnapshotHistorySource(FileStepStore(directory))
+        elif backend == 'sqlite':
+            from pydantic_ai_harness.step_persistence import SqliteStepStore
+
+            source = SnapshotHistorySource(SqliteStepStore(database=database))
+        else:
+            raise UserError(
+                f'unknown backend {backend!r}; expected `file` or `sqlite`. There is no `memory` '
+                'backend: an in-memory store built here could never be the one a `StepPersistence` '
+                'capability writes to, so it would always search nothing. To search an in-memory '
+                'store, construct the capability in code and share the store instance.'
+            )
+        return cls(
+            source=source,
+            scope=scope,
+            tool_id=tool_id,
+            max_matches=max_matches,
+            context_lines=context_lines,
+            bm25_k1=bm25_k1,
+            bm25_b=bm25_b,
+            add_instructions=add_instructions,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
+        )
 
     def get_toolset(self) -> AgentToolset[AgentDepsT] | None:
         """Provide the `search_conversation_history` tool over the source."""

--- a/pydantic_ai_harness/modal_sandbox/README.md
+++ b/pydantic_ai_harness/modal_sandbox/README.md
@@ -286,6 +286,11 @@ from pydantic_ai_harness import ModalSandbox
 agent = Agent.from_file('agent.yaml', custom_capability_types=[ModalSandbox])
 ```
 
+Every option except `session` can appear in the spec. `session` takes a live,
+already-entered `ModalSandboxSession`, which no spec can carry, so a spec naming it is
+rejected rather than dropped: set `sandbox_id` to attach to an existing sandbox, or
+construct the capability in code to inject a session.
+
 ## Further reading
 
 - [Modal sandboxes](https://modal.com/docs/guide/sandbox)

--- a/pydantic_ai_harness/modal_sandbox/_capability.py
+++ b/pydantic_ai_harness/modal_sandbox/_capability.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any
 
 from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.exceptions import UserError
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AgentToolset
 
@@ -284,6 +286,66 @@ class ModalSandbox(AbstractCapability[AgentDepsT]):
         ceiling = self.max_command_timeout if self.max_command_timeout is not None else self.sandbox_timeout
         default_timeout = min(max(1, math.ceil(self.default_command_timeout)), ceiling)
         return template.format(default_timeout=default_timeout, max_timeout=ceiling)
+
+    @classmethod
+    def from_spec(
+        cls,
+        *,
+        image: str = _DEFAULT_IMAGE,
+        sandbox_id: str | None = None,
+        app_name: str = _DEFAULT_APP_NAME,
+        create_app_if_missing: bool = True,
+        sandbox_timeout: int = _DEFAULT_SANDBOX_TIMEOUT,
+        workdir: str | None = None,
+        env: Mapping[str, str] | None = None,
+        default_command_timeout: float = 60.0,
+        max_command_timeout: int | None = None,
+        max_output_bytes: int = DEFAULT_MAX_BYTES,
+        max_output_lines: int = DEFAULT_MAX_LINES,
+        max_read_bytes: int = _DEFAULT_MAX_READ_BYTES,
+        instructions: str | None = None,
+        id: str | None = None,
+        description: str | None = None,
+        defer_loading: bool = False,
+        **unsupported: Any,
+    ) -> ModalSandbox[Any]:
+        """Build from an agent spec, covering the fields a spec can express.
+
+        Every parameter is named because this signature is what core reads to generate the
+        spec's JSON schema, and the `session` field's type has no JSON representation,
+        which would otherwise erase the whole `ModalSandbox` entry from that schema.
+
+        `session` takes a live, already-entered `ModalSandboxSession`, which no spec can
+        carry, so a spec naming it is rejected rather than dropped. To reuse one sandbox
+        across runs from a spec, set `sandbox_id`; to control the session's lifetime
+        yourself, construct the capability in code.
+        """
+        if 'session' in unsupported:
+            raise UserError(
+                'ModalSandbox cannot be built from a spec with `session`: it takes a live, '
+                'already-entered `ModalSandboxSession`. Set `sandbox_id` to attach to an '
+                'existing sandbox, or construct the capability in code to inject a session.'
+            )
+        if unsupported:
+            raise UserError(f'ModalSandbox has no spec field(s) {sorted(unsupported)}.')
+        return cls(
+            image=image,
+            sandbox_id=sandbox_id,
+            app_name=app_name,
+            create_app_if_missing=create_app_if_missing,
+            sandbox_timeout=sandbox_timeout,
+            workdir=workdir,
+            env=env,
+            default_command_timeout=default_command_timeout,
+            max_command_timeout=max_command_timeout,
+            max_output_bytes=max_output_bytes,
+            max_output_lines=max_output_lines,
+            max_read_bytes=max_read_bytes,
+            instructions=instructions,
+            id=id,
+            description=description,
+            defer_loading=defer_loading,
+        )
 
     def get_toolset(self) -> AgentToolset[AgentDepsT]:
         """Build and return the Modal sandbox toolset."""

--- a/pydantic_ai_harness/skills/_capability.py
+++ b/pydantic_ai_harness/skills/_capability.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Callable, Collection, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import overload
+from typing import Any, overload
 
 from pydantic_ai.capabilities import AbstractCapability, Capability
 from pydantic_ai.tools import AgentDepsT
@@ -103,6 +103,27 @@ class Skills(AbstractCapability[AgentDepsT]):
                 stacklevel=2,
             )
         self._deferred_capabilities = tuple(self._to_capability(skill) for skill in definitions)
+
+    @classmethod
+    def from_spec(
+        cls,
+        directories: str | Path | Sequence[str | Path],
+        *,
+        include: Sequence[str] | None = None,
+        exclude: Sequence[str] | None = None,
+    ) -> Skills[Any]:
+        """Build from an agent spec, covering the fields a spec can express.
+
+        Every parameter is named because this signature is what core reads to generate the
+        spec's JSON schema. `__init__` annotates `include` and `exclude` as `Collection[str]`,
+        which has no JSON representation and would otherwise erase the long form of the
+        `Skills` entry from that schema; a spec delivers them as sequences anyway.
+        """
+        if include is not None and exclude is not None:
+            raise ValueError('include and exclude cannot be used together.')
+        if include is not None:
+            return cls(directories, include=include)
+        return cls(directories, exclude=exclude)
 
     def __repr__(self) -> str:
         """Show only the `Skills` configuration that callers control."""

--- a/tests/code_mode/test_spec.py
+++ b/tests/code_mode/test_spec.py
@@ -1,0 +1,106 @@
+"""`CodeMode` spec support: the published `AgentSpec` schema entry and `from_spec`.
+
+The `os_access: CodeModeOS | None` field has no JSON representation, and one such
+field used to erase the capability's whole schema entry. `from_spec` names the
+spec-expressible parameters, turns `CodeModeMountSpec` mappings into real `MountDir`
+instances, and rejects `os_access` by name.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+from pydantic_ai import AgentSpec
+from pydantic_ai.exceptions import UserError
+from pydantic_monty import MountDir
+
+from pydantic_ai_harness.code_mode import CodeMode
+
+
+class TestSchema:
+    def test_schema_publishes_the_capability_entry(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([CodeMode])
+        params: dict[str, Any] = schema['$defs']['spec_params_CodeMode']['properties']
+        assert {
+            'tools',
+            'max_retries',
+            'max_tool_calls',
+            'mount',
+            'resource_limits',
+            'dynamic_catalog',
+            'id',
+            'description',
+            'defer_loading',
+        } <= set(params)
+        assert 'os_access' not in params
+
+    def test_mounts_are_published_as_their_spec_shape(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([CodeMode])
+        mount_spec: dict[str, Any] = schema['$defs']['CodeModeMountSpec']
+        assert set(mount_spec['properties']) == {
+            'host_path',
+            'virtual_path',
+            'mode',
+            'write_bytes_limit',
+            'memory_usage_limit',
+        }
+        assert set(mount_spec['required']) == {'host_path', 'virtual_path'}
+
+
+class TestFromSpec:
+    def test_options_are_forwarded(self) -> None:
+        capability = CodeMode.from_spec(
+            tools=['search', 'fetch'],
+            max_retries=1,
+            max_tool_calls=7,
+            resource_limits={'max_duration_secs': 5.0},
+            dynamic_catalog=True,
+            id='cm',
+            description='sandboxed tools',
+            defer_loading=True,
+        )
+        assert capability.tools == ['search', 'fetch']
+        assert capability.max_retries == 1
+        assert capability.max_tool_calls == 7
+        assert capability.resource_limits == {'max_duration_secs': 5.0}
+        assert capability.dynamic_catalog is True
+        assert capability.id == 'cm'
+        assert capability.description == 'sandboxed tools'
+        assert capability.defer_loading is True
+
+    def test_a_single_mount_mapping_becomes_a_mount_dir(self, tmp_path: Path) -> None:
+        capability = CodeMode.from_spec(
+            mount={'host_path': str(tmp_path), 'virtual_path': '/work', 'mode': 'read-only'},
+        )
+        assert isinstance(capability.mount, MountDir)
+        assert capability.mount.virtual_path == '/work'
+        assert capability.mount.mode == 'read-only'
+
+    def test_a_mount_list_becomes_mount_dirs(self, tmp_path: Path) -> None:
+        capability = CodeMode.from_spec(
+            mount=[
+                {'host_path': str(tmp_path), 'virtual_path': '/a'},
+                {'host_path': str(tmp_path), 'virtual_path': '/b', 'write_bytes_limit': 1024},
+            ],
+        )
+        assert isinstance(capability.mount, list)
+        assert [mount.virtual_path for mount in capability.mount] == ['/a', '/b']
+        assert capability.mount[1].write_bytes_limit == 1024
+
+    def test_a_misshapen_mount_fails_on_the_entry_that_carries_it(self, tmp_path: Path) -> None:
+        bad: dict[str, Any] = {'mount': {'host_path': str(tmp_path), 'virtual': '/work'}}
+        with pytest.raises(ValidationError):
+            CodeMode.from_spec(**bad)
+
+    def test_live_os_access_is_rejected_by_name(self) -> None:
+        bad: dict[str, Any] = {'os_access': object()}
+        with pytest.raises(UserError, match='cannot be built from a spec with `os_access`'):
+            CodeMode.from_spec(**bad)
+
+    def test_unknown_fields_are_rejected(self) -> None:
+        bad: dict[str, Any] = {'sandbox': 'monty'}
+        with pytest.raises(UserError, match=r"no spec field\(s\) \['sandbox'\]"):
+            CodeMode.from_spec(**bad)

--- a/tests/code_mode/test_spec.py
+++ b/tests/code_mode/test_spec.py
@@ -90,9 +90,20 @@ class TestFromSpec:
         assert [mount.virtual_path for mount in capability.mount] == ['/a', '/b']
         assert capability.mount[1].write_bytes_limit == 1024
 
-    def test_a_misshapen_mount_fails_on_the_entry_that_carries_it(self, tmp_path: Path) -> None:
-        bad: dict[str, Any] = {'mount': {'host_path': str(tmp_path), 'virtual': '/work'}}
-        with pytest.raises(ValidationError):
+    def test_a_mount_missing_a_required_key_fails_validation(self, tmp_path: Path) -> None:
+        bad: dict[str, Any] = {'mount': {'host_path': str(tmp_path)}}
+        with pytest.raises(ValidationError, match='Field required'):
+            CodeMode.from_spec(**bad)
+
+    def test_an_unknown_mount_key_is_rejected(self, tmp_path: Path) -> None:
+        bad: dict[str, Any] = {
+            'mount': {
+                'host_path': str(tmp_path),
+                'virtual_path': '/work',
+                'write_bytes_limt': 1024,
+            },
+        }
+        with pytest.raises(ValueError, match=r"Unknown mount spec key\(s\): \['write_bytes_limt'\]"):
             CodeMode.from_spec(**bad)
 
     def test_live_os_access_is_rejected_by_name(self) -> None:

--- a/tests/code_mode/test_spec.py
+++ b/tests/code_mode/test_spec.py
@@ -106,6 +106,11 @@ class TestFromSpec:
         with pytest.raises(ValueError, match=r"Unknown mount spec key\(s\): \['write_bytes_limt'\]"):
             CodeMode.from_spec(**bad)
 
+    @pytest.mark.parametrize('mount', ['not-a-mapping', ['not-a-mapping']])
+    def test_a_non_mapping_mount_entry_fails_validation(self, mount: Any) -> None:
+        with pytest.raises(ValidationError):
+            CodeMode.from_spec(**{'mount': mount})
+
     def test_live_os_access_is_rejected_by_name(self) -> None:
         bad: dict[str, Any] = {'os_access': object()}
         with pytest.raises(UserError, match='cannot be built from a spec with `os_access`'):

--- a/tests/conversation_search/test_spec.py
+++ b/tests/conversation_search/test_spec.py
@@ -1,0 +1,152 @@
+"""`ConversationSearch` spec support: the published `AgentSpec` schema entry and `from_spec`.
+
+The bare `source: HistorySource` field has no JSON representation, and one such field
+used to erase the capability's whole schema entry, short form included. `from_spec`
+names the spec-expressible parameters instead, with `backend`/`directory`/`database`
+mirroring `StepPersistence.from_spec` so a spec can point both capabilities at the
+same store.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic_ai import Agent, AgentSpec
+from pydantic_ai.exceptions import UserError
+from pydantic_ai.models.test import TestModel
+
+from pydantic_ai_harness import HarnessDeprecationWarning
+from pydantic_ai_harness.conversation_search import ConversationSearch, SnapshotHistorySource
+from pydantic_ai_harness.step_persistence import FileStepStore, RunRecord, SqliteStepStore
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+class TestSchema:
+    def test_schema_publishes_the_capability_entry(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([ConversationSearch])
+        params: dict[str, Any] = schema['$defs']['spec_params_ConversationSearch']['properties']
+        assert {
+            'backend',
+            'directory',
+            'database',
+            'scope',
+            'tool_id',
+            'max_matches',
+            'context_lines',
+            'bm25_k1',
+            'bm25_b',
+            'add_instructions',
+            'id',
+            'description',
+            'defer_loading',
+        } <= set(params)
+        assert 'source' not in params
+
+    def test_short_form_takes_the_backend(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([ConversationSearch])
+        short: dict[str, Any] = schema['$defs']['short_spec_ConversationSearch']['properties']['ConversationSearch']
+        assert short['enum'] == ['file', 'sqlite']
+
+
+class TestFromSpec:
+    async def test_sqlite_backend_reads_the_named_database(self, tmp_path: Path) -> None:
+        database = tmp_path / 'sessions.db'
+        await SqliteStepStore(database=database).register_run(RunRecord(run_id='r1'))
+
+        capability = ConversationSearch.from_spec('sqlite', database=str(database), scope='all')
+
+        assert isinstance(capability.source, SnapshotHistorySource)
+        assert [run.run_id for run in await capability.source.list_runs()] == ['r1']
+
+    async def test_file_backend_reads_the_named_directory(self, tmp_path: Path) -> None:
+        directory = tmp_path / 'runs'
+        await FileStepStore(directory).register_run(RunRecord(run_id='r1'))
+
+        capability = ConversationSearch.from_spec('file', directory=str(directory), scope='all')
+
+        assert [run.run_id for run in await capability.source.list_runs()] == ['r1']
+
+    def test_search_options_are_forwarded(self, tmp_path: Path) -> None:
+        capability = ConversationSearch.from_spec(
+            'sqlite',
+            database=str(tmp_path / 'sessions.db'),
+            scope='conversation',
+            tool_id='recall',
+            max_matches=3,
+            context_lines=1,
+            bm25_k1=1.2,
+            bm25_b=0.5,
+            add_instructions=False,
+            id='cs',
+            description='recall tool',
+            defer_loading=True,
+        )
+        assert capability.scope == 'conversation'
+        assert capability.tool_id == 'recall'
+        assert capability.max_matches == 3
+        assert capability.context_lines == 1
+        assert capability.bm25_k1 == 1.2
+        assert capability.bm25_b == 0.5
+        assert capability.add_instructions is False
+        assert capability.id == 'cs'
+        assert capability.description == 'recall tool'
+        assert capability.defer_loading is True
+
+    def test_scope_left_unset_warns_like_the_constructor(self, tmp_path: Path) -> None:
+        with pytest.warns(HarnessDeprecationWarning):
+            ConversationSearch.from_spec('sqlite', database=str(tmp_path / 'sessions.db'))
+
+    async def test_loads_through_an_agent_spec(self, tmp_path: Path) -> None:
+        model = TestModel(call_tools=[])
+        agent = Agent.from_spec(
+            {
+                'capabilities': [
+                    {
+                        'ConversationSearch': {
+                            'backend': 'sqlite',
+                            'database': str(tmp_path / 'sessions.db'),
+                            'scope': 'all',
+                        }
+                    },
+                ],
+            },
+            custom_capability_types=[ConversationSearch],
+            model=model,
+        )
+        await agent.run('go')
+        assert model.last_model_request_parameters is not None
+        tool_names = [tool.name for tool in model.last_model_request_parameters.function_tools]
+        assert 'search_conversation_history' in tool_names
+
+
+class TestFromSpecRejections:
+    def test_a_live_source_is_rejected_by_name(self) -> None:
+        bad: dict[str, Any] = {'backend': 'sqlite', 'source': object()}
+        with pytest.raises(UserError, match='cannot be built from a spec with `source`'):
+            ConversationSearch.from_spec(**bad)
+
+    def test_unknown_fields_are_rejected(self) -> None:
+        bad: dict[str, Any] = {'backend': 'sqlite', 'corpus': 'everything'}
+        with pytest.raises(UserError, match=r"no spec field\(s\) \['corpus'\]"):
+            ConversationSearch.from_spec(**bad)
+
+    def test_the_memory_backend_is_refused(self) -> None:
+        bad: dict[str, Any] = {'backend': 'memory'}
+        with pytest.raises(UserError, match='no `memory`'):
+            ConversationSearch.from_spec(**bad)
+
+    def test_directory_requires_the_file_backend(self, tmp_path: Path) -> None:
+        with pytest.raises(UserError, match='directory is only valid with backend="file"'):
+            ConversationSearch.from_spec('sqlite', directory=str(tmp_path))
+
+    def test_database_requires_the_sqlite_backend(self, tmp_path: Path) -> None:
+        with pytest.raises(UserError, match='database is only valid with backend="sqlite"'):
+            ConversationSearch.from_spec('file', database=str(tmp_path / 'sessions.db'))

--- a/tests/modal_sandbox/test_spec.py
+++ b/tests/modal_sandbox/test_spec.py
@@ -1,0 +1,94 @@
+"""`ModalSandbox` spec support: the published `AgentSpec` schema entry and `from_spec`.
+
+The `session: ModalSandboxSession | None` field has no JSON representation, and one
+such field used to erase the capability's whole schema entry. `from_spec` names the
+spec-expressible parameters and rejects `session` by name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic_ai import AgentSpec
+from pydantic_ai.exceptions import UserError
+
+from pydantic_ai_harness.modal_sandbox import ModalSandbox
+
+
+class TestSchema:
+    def test_schema_publishes_the_capability_entry(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([ModalSandbox])
+        params: dict[str, Any] = schema['$defs']['spec_params_ModalSandbox']['properties']
+        assert {
+            'image',
+            'sandbox_id',
+            'app_name',
+            'create_app_if_missing',
+            'sandbox_timeout',
+            'workdir',
+            'env',
+            'default_command_timeout',
+            'max_command_timeout',
+            'max_output_bytes',
+            'max_output_lines',
+            'max_read_bytes',
+            'instructions',
+            'id',
+            'description',
+            'defer_loading',
+        } <= set(params)
+        assert 'session' not in params
+
+
+class TestFromSpec:
+    def test_owned_sandbox_settings_are_forwarded(self) -> None:
+        capability = ModalSandbox.from_spec(
+            image='ubuntu:24.04',
+            app_name='spec-app',
+            create_app_if_missing=False,
+            sandbox_timeout=600,
+            workdir='/work',
+            env={'TOKEN': 'x'},
+            default_command_timeout=30.0,
+            max_command_timeout=120,
+            max_output_bytes=1024,
+            max_output_lines=50,
+            max_read_bytes=2048,
+            instructions='use the sandbox',
+            id='ms',
+            description='cloud sandbox',
+            defer_loading=True,
+        )
+        assert capability.image == 'ubuntu:24.04'
+        assert capability.app_name == 'spec-app'
+        assert capability.create_app_if_missing is False
+        assert capability.sandbox_timeout == 600
+        assert capability.workdir == '/work'
+        assert capability.env == {'TOKEN': 'x'}
+        assert capability.default_command_timeout == 30.0
+        assert capability.max_command_timeout == 120
+        assert capability.max_output_bytes == 1024
+        assert capability.max_output_lines == 50
+        assert capability.max_read_bytes == 2048
+        assert capability.instructions == 'use the sandbox'
+        assert capability.id == 'ms'
+        assert capability.description == 'cloud sandbox'
+        assert capability.defer_loading is True
+
+    def test_attach_mode_round_trips(self) -> None:
+        assert ModalSandbox.from_spec(sandbox_id='sb-1').sandbox_id == 'sb-1'
+
+    def test_construction_validation_still_applies(self) -> None:
+        with pytest.raises(ValueError, match='only apply when creating a sandbox'):
+            ModalSandbox.from_spec(sandbox_id='sb-1', image='ubuntu:24.04')
+
+    def test_a_live_session_is_rejected_by_name(self) -> None:
+        bad: dict[str, Any] = {'session': object()}
+        with pytest.raises(UserError, match='cannot be built from a spec with `session`'):
+            ModalSandbox.from_spec(**bad)
+
+    def test_unknown_fields_are_rejected(self) -> None:
+        bad: dict[str, Any] = {'region': 'us-east'}
+        with pytest.raises(UserError, match=r"no spec field\(s\) \['region'\]"):
+            ModalSandbox.from_spec(**bad)

--- a/tests/skills/test_skills.py
+++ b/tests/skills/test_skills.py
@@ -228,6 +228,15 @@ class TestSkillValidation:
         with pytest.raises(ValueError, match='include and exclude cannot be used together'):
             Skills.from_spec(library, include=include, exclude=exclude)
 
+    def test_the_constructor_rejects_include_and_exclude_together(self, tmp_path: Path) -> None:
+        """The constructor keeps its own guard: `from_spec` raises before reaching it, so
+        this is the only path that exercises the `__init__` check the overloads mirror."""
+        library = tmp_path / 'skills'
+        library.mkdir()
+
+        with pytest.raises(ValueError, match='include and exclude cannot be used together'):
+            Skills(library, include=['alpha'], exclude=['alpha'])  # pyright: ignore[reportCallIssue, reportArgumentType]
+
     @pytest.mark.parametrize('selector', ['include', 'exclude'])
     def test_unknown_selected_skill_is_rejected(self, tmp_path: Path, selector: str) -> None:
         library = tmp_path / 'skills'

--- a/tests/skills/test_skills.py
+++ b/tests/skills/test_skills.py
@@ -4,9 +4,10 @@ import inspect
 import warnings
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import pytest
-from pydantic_ai import Agent
+from pydantic_ai import Agent, AgentSpec
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.messages import InstructionPart, LoadCapabilityReturnPart
 from pydantic_ai.models.test import TestModel
@@ -254,7 +255,7 @@ class TestSkillValidation:
         _write_skill(library, 'alpha')
 
         with pytest.raises(TypeError, match='include must contain only skill names as strings'):
-            Skills.from_spec(library, include=[1])
+            Skills.from_spec(library, include=[1])  # pyright: ignore[reportArgumentType]
 
     def test_multiple_unknown_skills_report_an_empty_library(self, tmp_path: Path) -> None:
         library = tmp_path / 'skills'
@@ -498,3 +499,38 @@ class TestSkillValidation:
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             Skills(library)
+
+
+class TestSpecSchema:
+    """The `include`/`exclude` types must not erase the long form from the spec schema.
+
+    `__init__` annotates them as `Collection[str]`, which has no JSON representation;
+    `Skills.from_spec` publishes them as string sequences instead.
+    """
+
+    def test_long_form_is_published(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([Skills])
+        params: dict[str, Any] = schema['$defs']['spec_params_Skills']['properties']
+        assert {'directories', 'include', 'exclude'} <= set(params)
+
+    def test_short_form_still_takes_the_directories(self) -> None:
+        schema = AgentSpec.model_json_schema_with_capabilities([Skills])
+        assert 'Skills' in schema['$defs']['short_spec_Skills']['properties']
+
+    def test_from_spec_forwards_include(self, tmp_path: Path) -> None:
+        library = tmp_path / 'skills'
+        _write_skill(library, 'alpha')
+        _write_skill(library, 'beta')
+
+        skills = Skills.from_spec(library, include=['alpha'])
+
+        assert [leaf.id for leaf in _leaves(skills)] == ['alpha']
+
+    def test_from_spec_forwards_exclude(self, tmp_path: Path) -> None:
+        library = tmp_path / 'skills'
+        _write_skill(library, 'alpha')
+        _write_skill(library, 'beta')
+
+        skills = Skills.from_spec(library, exclude=['alpha'])
+
+        assert [leaf.id for leaf in _leaves(skills)] == ['beta']


### PR DESCRIPTION
## Summary

`pydantic_ai._spec.filter_serializable_type` strips only `TypeVar` and `Callable`, so a field typed with an arbitrary class survives into the schema-generation `TypedDict`, and pydantic then drops the capability's whole `spec_<Name>` member from the `AgentSpec` capabilities union. One unrepresentable field erased every other field on the capability, and for `ConversationSearch` (whose `source` is bare, not optional) the short form died too.

Following the `SpendLimits.from_spec` shape, each of the four named capabilities now overrides `from_spec` with a fully named signature, which is what core reads to generate the schema:

- **`CodeMode`**: names `tools` (its serializable forms), `max_retries`, `max_tool_calls`, `mount`, `resource_limits`, `dynamic_catalog`, and the base fields. `mount` is expressed through a new `CodeModeMountSpec` mapping shape (validated, then turned into real `MountDir` instances, which are compiled classes with no JSON representation of their own). `os_access` takes a live OS implementation or a callback, so a spec naming it is rejected with an error naming the field.
- **`ConversationSearch`**: a spec cannot carry a live `HistorySource`, so `from_spec` takes `backend`/`directory`/`database` mirroring `StepPersistence.from_spec` (defaults included) and reads the store through `SnapshotHistorySource`; a spec that declares both capabilities with the same values reads the history the other writes. There is deliberately no `memory` backend: an in-memory store built while loading a spec can never be the instance a `StepPersistence` capability writes to, so it would always search nothing; the error says to share a store instance in code instead. `backend` is positional so the short form `- ConversationSearch: sqlite` works.
- **`ModalSandbox`**: names every field except `session`, which takes a live, already-entered `ModalSandboxSession` and is rejected by name with a pointer at `sandbox_id`. `__post_init__` mode-conflict validation still applies to spec-built instances.
- **`Skills`**: `__init__` annotates `include`/`exclude` as `Collection[str]`, which pydantic cannot schematize, so the long form was missing (the single-required-parameter short form was the only survivor). `from_spec` publishes them as `Sequence[str]` and forwards to the constructor, preserving all existing validation (string/`include`+`exclude` rejections). The base fields (`id`, `description`, `defer_loading`) are not added here: `Skills` overrides `apply` to expose only its per-skill deferred leaves, so those fields are inert on the container and publishing them would promise behavior the capability does not deliver.

Docs parity: the `CodeMode` and `ModalSandbox` spec sections (README + docs page) gain the mount shape and the rejected-field notes; `ConversationSearch` gains a new spec section in both places. The `Skills` docs already show `include` in YAML and its runtime behavior is unchanged.

Fixes #553

Interaction with #546: that open PR's `tests/test_capability_specs.py` tracks these four under `_TRACKERS['unrepresentable-field']` with `strict=True` xfails (`_NO_SCHEMA_ENTRY` for three, `_NO_BASE_FIELDS` for `Skills`). Whichever PR merges second needs those entries reconciled: the three `_NO_SCHEMA_ENTRY` lines get deleted, and the `Skills` `_NO_BASE_FIELDS` line stays (base fields are intentionally not published, per above).

## How I verified

- `uv run --no-sync ruff format --check .` -- 329 files already formatted
- `uv run --no-sync ruff check .` -- all checks passed
- `uv run --no-sync pytest -p no:cacheprovider tests/code_mode tests/modal_sandbox tests/conversation_search tests/skills tests/test_docs_parity.py tests/test_doc_snippets.py tests/test_placeholder.py` -- 1435 passed, 42 skipped
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright <the 5 changed source files and 4 changed/new test files>` -- 0 errors
- Reproduction before the fix: `AgentSpec.model_json_schema_with_capabilities([C])` published no `spec_`/`short_spec_` defs for `CodeMode`, `ConversationSearch`, or `ModalSandbox`, and only `short_spec_Skills` for `Skills`. After the fix all four publish their long forms (plus short forms for `ConversationSearch` and `Skills`); the new `TestSchema`/`TestSpecSchema` classes pin this as regression tests.
