### PR TITLE
Shield the cancel+`gather` teardown in `guardrails` parallel mode and `MontyExecutor`

### DIFF
--- a/pydantic_ai_harness/_monty_exec.py
+++ b/pydantic_ai_harness/_monty_exec.py
@@ -22,6 +22,8 @@ from collections.abc import Callable, Container, Coroutine
 from dataclasses import dataclass, field
 from typing import Any
 
+import anyio
+
 try:
     from pydantic_monty import (
         CollectString,
@@ -131,8 +133,15 @@ class MontyExecutor:
                 # point; await them so dispatched work (e.g. sub-agent runs mutating shared
                 # usage) has fully unwound before this returns. `return_exceptions=True` keeps
                 # one task's teardown error from masking the original exception, and the
-                # results are deliberately discarded.
-                await asyncio.gather(*cancelled, return_exceptions=True)
+                # results are deliberately discarded. Shielded: run cancellation can land here
+                # with an enclosing anyio scope already cancelled, and that scope re-cancels
+                # its tasks on every event-loop cycle -- each delivery either aborts this await
+                # outright (abandoning the tasks mid-unwind) or is forwarded through the
+                # `gather` into every task, breaking any await their cleanup performs. The
+                # shield holds for anyio-scope cancellation; a raw second `Task.cancel()` can
+                # still pierce it.
+                with anyio.CancelScope(shield=True):
+                    await asyncio.gather(*cancelled, return_exceptions=True)
         return state
 
     async def _handle_function(self, snapshot: FunctionSnapshot) -> MontyState:

--- a/pydantic_ai_harness/guardrails/_capability.py
+++ b/pydantic_ai_harness/guardrails/_capability.py
@@ -34,6 +34,7 @@ from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import anyio
 from pydantic_ai.capabilities import AbstractCapability, CapabilityOrdering, Instrumentation, WrapModelRequestHandler
 from pydantic_ai.exceptions import ModelRetry, SkipModelRequest, UserError
 from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, UserPromptPart
@@ -301,7 +302,16 @@ class InputGuardrail(AbstractCapability[AgentDepsT]):
                 if not task.done():
                     task.cancel()
 
-            await asyncio.gather(guard_task, handler_task, return_exceptions=True)
+            # Run cancellation (`cancel_run()`, `anyio.fail_after`) can land here with an
+            # enclosing anyio scope already cancelled, and that scope re-cancels its tasks on
+            # every event-loop cycle -- each delivery either aborts the drain below outright
+            # (abandoning the guard and handler tasks mid-unwind) or is forwarded through the
+            # `gather` into both tasks, breaking any await their cleanup performs. Shield the
+            # drain so both tasks fully unwind before the cancellation propagates. The shield
+            # holds for anyio-scope cancellation; a raw second `Task.cancel()` can still
+            # pierce it.
+            with anyio.CancelScope(shield=True):
+                await asyncio.gather(guard_task, handler_task, return_exceptions=True)
 
 
 @dataclass

--- a/pydantic_ai_harness/guardrails/_capability.py
+++ b/pydantic_ai_harness/guardrails/_capability.py
@@ -310,6 +310,16 @@ class InputGuardrail(AbstractCapability[AgentDepsT]):
             # drain so both tasks fully unwind before the cancellation propagates. The shield
             # holds for anyio-scope cancellation; a raw second `Task.cancel()` can still
             # pierce it.
+            #
+            # Not an anyio task group, deliberately. The children being raw asyncio tasks is
+            # what confines the re-delivery to this host task: anyio only re-cancels tasks its
+            # scopes track, so each child sees exactly one `.cancel()` and unwinds cleanly. As
+            # task-group children they would be re-cancelled inside their own cleanup on every
+            # cycle -- the failure above, one level down. A task group also cannot shield only
+            # its drain (`tg.cancel_scope.shield = True` covers the whole race, blocking
+            # `cancel_run()` outright), and anyio >= 4 wraps child exceptions in
+            # `BaseExceptionGroup`, which would keep the guard's `SkipModelRequest` from
+            # reaching pydantic-ai unwrapped.
             with anyio.CancelScope(shield=True):
                 await asyncio.gather(guard_task, handler_task, return_exceptions=True)
 

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -2558,7 +2558,7 @@ class TestCodeMode:
                 while not release.is_set():
                     try:
                         await release.wait()
-                    except asyncio.CancelledError:
+                    except asyncio.CancelledError:  # pragma: no cover - regression path without the teardown shield
                         extra_cancels += 1
                 unwound.set()
                 raise

--- a/tests/code_mode/test_code_mode.py
+++ b/tests/code_mode/test_code_mode.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Literal, TypeVar
 from unittest.mock import MagicMock
 
+import anyio
 import pytest
 from pydantic_ai import (
     AbstractToolset,
@@ -2516,6 +2517,102 @@ class TestCodeMode:
         assert unwound.is_set()
         with pytest.raises(ModelRetry, match='Type error in code'):
             await wrapper.call_tool('run_code', {'code': 'x'}, ctx, tools['run_code'])
+
+    async def test_cancelled_scope_teardown_awaits_dispatched_work(self) -> None:
+        """The executor's cleanup `gather` is shielded from an already-cancelled anyio
+        scope, so still-pending dispatched work unwinds gracefully before `run_code`
+        returns (#559).
+
+        The sandbox defers `blocker()` and `cleanup_tool()`, then calls the sequential
+        `barrier()`. The barrier awaits `blocker` first, leaving `cleanup_tool`'s task
+        in `_pending`; cancelling the scope kills `blocker` at the barrier await, so
+        the executor's cleanup owns a still-running dispatched task while the enclosing
+        scope stays cancelled. Without the shield, that scope re-cancels the host every
+        event-loop cycle: either the cleanup `gather` is abandoned outright (the pending
+        task outlives `run_code`) or each re-cancel is forwarded through the `gather` to
+        the pending task, breaking every await of its cancellation handler. With the
+        shield the task sees exactly one cancellation, its handler's awaits survive, and
+        the runner stays blocked in the cleanup until the handler is released. Sequencing
+        is event-driven; the yield loop only gives an unshielded cleanup cycles to
+        misbehave.
+        """
+        blocker_started = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        cancel_seen = asyncio.Event()
+        release = asyncio.Event()
+        unwound = asyncio.Event()
+        extra_cancels = 0
+
+        async def blocker() -> str:
+            blocker_started.set()
+            await asyncio.Event().wait()
+            return 'unreachable'  # pragma: no cover
+
+        async def cleanup_tool() -> str:
+            nonlocal extra_cancels
+            cleanup_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancel_seen.set()
+                while not release.is_set():
+                    try:
+                        await release.wait()
+                    except asyncio.CancelledError:
+                        extra_cancels += 1
+                unwound.set()
+                raise
+            return 'unreachable'  # pragma: no cover
+
+        def barrier() -> str:
+            return 'unreachable'  # pragma: no cover - cancelled at the barrier, never dispatched
+
+        class _SeqToolset(AbstractToolset[object]):
+            """Marks `barrier` as sequential; the other tools stay parallel."""
+
+            def __init__(self) -> None:
+                self._inner = _build_function_toolset(blocker, cleanup_tool, barrier)
+
+            @property
+            def id(self) -> str | None:
+                return None  # pragma: no cover
+
+            async def get_tools(self, ctx: RunContext[object]) -> dict[str, ToolsetTool[object]]:
+                tools = await self._inner.get_tools(ctx)
+                return {
+                    n: dc_replace(t, tool_def=dc_replace(t.tool_def, sequential=True)) if n == 'barrier' else t
+                    for n, t in tools.items()
+                }
+
+            async def call_tool(
+                self, name: str, tool_args: dict[str, Any], ctx: RunContext[object], tool: ToolsetTool[object]
+            ) -> Any:
+                return await self._inner.call_tool(name, tool_args, ctx, tool)
+
+        wrapper = CodeModeToolset[object](wrapped=_SeqToolset(), tool_selector='all')
+        ctx = await build_ctx(None, wrapper)
+        tools = await wrapper.get_tools(ctx)
+
+        scope = anyio.CancelScope()
+
+        async def runner() -> None:
+            with scope:
+                code = 'a = blocker()\nb = cleanup_tool()\nbarrier()'
+                await wrapper.call_tool('run_code', {'code': code}, ctx, tools['run_code'])
+
+        task = asyncio.create_task(runner())
+        await blocker_started.wait()
+        await cleanup_started.wait()
+        scope.cancel()
+        await cancel_seen.wait()
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not task.done(), 'cleanup must wait for dispatched work to finish unwinding'
+        release.set()
+        await task
+        assert scope.cancelled_caught
+        assert unwound.is_set()
+        assert extra_cancels == 0, f'cancelled scope must not re-cancel dispatched work, got {extra_cancels} re-cancels'
 
     async def test_worker_crash_becomes_model_retry_and_resets_state(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A `MontyCrashedError` (worker death) becomes a retry with the session reset.

--- a/tests/guardrails/test_input_guardrail.py
+++ b/tests/guardrails/test_input_guardrail.py
@@ -6,6 +6,7 @@ import asyncio
 import dataclasses
 from typing import Any
 
+import anyio
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -513,10 +514,10 @@ class TestInputGuardrailParallel:
         """If the caller cancels the run mid-flight, the `finally` block must still drain
         guard and handler tasks instead of leaking them.
 
-        Regression guard for a reviewed concern about whether `asyncio.shield` was needed
-        around the cleanup `gather`. It isn't — the outer cancel is consumed by the
-        `asyncio.wait` above, so the subsequent `cancel()` + `gather()` in `finally`
-        complete without being re-cancelled.
+        A single raw cancel is consumed by the `asyncio.wait` above the `finally`, so the
+        `cancel()` + `gather()` drain completes even without a shield. The shield matters
+        when the cancellation arrives through an already-cancelled anyio scope, covered by
+        `test_teardown_survives_cancelled_scope`.
         """
         run_ctx, req_ctx = _build_ctx_and_req()
 
@@ -547,6 +548,57 @@ class TestInputGuardrailParallel:
 
         leftover = {t for t in asyncio.all_tasks() if t is not current and not t.done()} - before
         assert leftover == set(), f'guard/handler tasks must be drained on outer cancel, got: {leftover}'
+
+    async def test_teardown_survives_cancelled_scope(self):
+        """The `finally` drain is shielded, so cancellation delivered through an
+        already-cancelled anyio scope (run cancellation, `anyio.fail_after`) cannot
+        abandon the guard and handler tasks mid-unwind (#559).
+
+        In a cancelled anyio scope every unshielded await is re-cancelled, so without the
+        shield `wrap_model_request` returns while the guard is still unwinding. Sequencing
+        is event-driven: the runner must stay blocked in the drain until the guard's
+        cancellation handler is released, and the handler must have fully unwound by the
+        time the runner completes.
+        """
+        run_ctx, req_ctx = _build_ctx_and_req()
+        started = asyncio.Event()
+        cancel_seen = asyncio.Event()
+        release = asyncio.Event()
+        unwound = asyncio.Event()
+
+        async def slow_handler(_: Any) -> ModelResponse:
+            started.set()
+            await asyncio.Event().wait()
+            return ModelResponse(parts=[TextPart(content='never')])  # pragma: no cover
+
+        async def slow_guard(_: str) -> bool:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancel_seen.set()
+                await release.wait()
+                unwound.set()
+                raise
+            return True  # pragma: no cover
+
+        ig = InputGuardrail(guard=slow_guard, parallel=True)
+        scope = anyio.CancelScope()
+
+        async def runner() -> None:
+            with scope:
+                await ig.wrap_model_request(run_ctx, request_context=req_ctx, handler=slow_handler)
+
+        task = asyncio.create_task(runner())
+        await started.wait()
+        scope.cancel()
+        await cancel_seen.wait()
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not task.done(), 'the drain must wait for the guard to finish unwinding'
+        release.set()
+        await task
+        assert scope.cancelled_caught
+        assert unwound.is_set()
 
 
 class TestInputGuardrailTracing:


### PR DESCRIPTION
## Summary

Pydantic AI run cancellation (`cancel_run()` / an external timeout) can arrive while an enclosing anyio cancel scope is already cancelled, and a cancelled anyio scope re-delivers cancellation to its tasks on every event-loop cycle. Two teardowns awaited their cancelled tasks without a shield:

- `guardrails/_capability.py`, parallel `wrap_model_request`: the `finally` drain over the guard and handler tasks.
- `_monty_exec.py`, `MontyExecutor.run`: the cleanup `gather` over still-pending dispatched tasks (shared by `CodeMode` and `DynamicWorkflow`).

Under that repeated delivery, each cycle either aborts the drain outright (the tasks outlive the call mid-unwind) or is forwarded through the `gather` into every task, breaking any await their cancellation cleanup performs. Both drains are now wrapped in `anyio.CancelScope(shield=True)`, matching the stream-teardown precedent in pydantic/pydantic-ai#7095. As `experimental/acp` documents, the shield holds for anyio-scope cancellation; a raw repeated `Task.cancel()` can still pierce it.

The new tests are event-sequenced (no sleep-based races): each drives the teardown from inside a cancelled `anyio.CancelScope`, holds the task's cancellation handler on an event, and asserts that the caller stays blocked until the handler is released, that the handler's awaits survive (the Monty test counts re-cancels and requires zero), and that the work has fully unwound when the caller returns. The Monty test reaches the executor's cleanup through the sequential-barrier path, the one place a dispatched task is still running in `_pending` when the teardown owns it. Both tests fail against the unshielded code. The stale docstring on `test_no_dangling_tasks_on_outer_cancellation` (which recorded that no shield was needed) now points at the case where it is.

Fixes #559

## How I verified

- `uv run --no-sync ruff format --check .` -- 326 files already formatted
- `uv run --no-sync ruff check .` -- all checks passed
- `uv run --no-sync pytest -p no:cacheprovider tests/guardrails tests/code_mode tests/dynamic_workflow` -- 564 passed
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/_monty_exec.py pydantic_ai_harness/guardrails/_capability.py tests/code_mode/test_code_mode.py tests/guardrails/test_input_guardrail.py` -- 0 errors
- Regression check: with the two source files reverted, both new tests fail (guardrails: the runner returns while the guard is still unwinding; code_mode: the pending task is re-cancelled every cycle). With the fix, both pass 10/10 repeated runs.
