### PR TITLE
Floor on released `pydantic-ai` 2.37.0 and drop the version straddle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,18 +30,7 @@ classifiers = [
 dependencies = [
     "genai-prices>=0.0.71",
     "httpx>=0.28.1",
-    # 2.36.0 is the release that attributes each instruction to the source that contributed it, so the
-    # parts this package's capabilities contribute are separated by a blank line instead of running
-    # together into one paragraph (pydantic-ai#7595), and each carries an `InstructionId` an
-    # application can address to override it.
-    # Earlier floors are subsumed by it: 2.33.0's Anthropic provider is built on HTTPX2 and raises its
-    # own `anthropic` floor to 1.0.0 to match, and below it slim hands the SDK a client of the other
-    # kind, where the pair only type-checks when both halves come from the same generation; the
-    # compaction estimator and the conversation-search indexer have to recognise
-    # `ToolAvailabilityDeltaPart` (2.23.0), the one `ModelRequestPart` carrying no `content`, so code
-    # walking request parts raises `AttributeError` rather than ignoring it (#577); `CodeMode` reads
-    # `ModelRequestParameters.revealed_tool_names` (2.22.0).
-    "pydantic-ai-slim>=2.36.0",
+    "pydantic-ai-slim>=2.37.0",
 ]
 
 [project.optional-dependencies]
@@ -49,22 +38,22 @@ dependencies = [
 # without separately naming pydantic-ai-slim. (No openai/google pass-throughs: browser-use pins
 # provider SDKs that conflict with slim's floors when the workspace resolves all extras together.)
 anthropic = [
-    "pydantic-ai-slim[anthropic]>=2.36.0",
+    "pydantic-ai-slim[anthropic]>=2.37.0",
 ]
 cli = [
-    "pydantic-ai-slim[cli]>=2.36.0",
+    "pydantic-ai-slim[cli]>=2.37.0",
 ]
 code-mode = [
-    "pydantic-ai-slim[duckduckgo]>=2.36.0",
+    "pydantic-ai-slim[duckduckgo]>=2.37.0",
     "pydantic-monty>=0.0.19",
 ]
 # Extras metadata has no native redirect syntax, so aliases are represented as duplicate extras.
 codemode = [
-    "pydantic-ai-slim[duckduckgo]>=2.36.0",
+    "pydantic-ai-slim[duckduckgo]>=2.37.0",
     "pydantic-monty>=0.0.19",
 ]
 researcher = [
-    "pydantic-ai-slim[duckduckgo,web-fetch]>=2.36.0",
+    "pydantic-ai-slim[duckduckgo,web-fetch]>=2.37.0",
 ]
 temporal = [
     'pydantic-ai-slim[temporal]',

--- a/tests/spend/test_spend.py
+++ b/tests/spend/test_spend.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib.metadata
 import json
 import warnings
 from collections.abc import Mapping, Sequence
@@ -800,13 +799,11 @@ class TestCompositionWarning:
         await agent.run('hi')
 
     async def test_a_durable_execution_capability_is_not_reported(self):
-        """It routes the request into a durable unit rather than rejecting what comes back.
+        """A durability capability is excluded even though it wraps the model request.
 
         Core also requires its dispatch to be the innermost wrapper, so listing `SpendLimits`
-        after it is the one correction a reader must not make. On `pydantic-ai-slim` 2.36 the
-        dispatch projects through the workflow runtime and stops at Temporal's dispatch error;
-        from 2.37 the operations run inline outside a durable container, so the run completes
-        and accrues like any other.
+        after it is the one correction a reader must not make. Durable capability operations pass
+        through outside a durable container, so the run completes and accrues normally.
         """
         pytest.importorskip('temporalio')
         from pydantic_ai.durable_exec.temporal import TemporalDurability  # noqa: PLC0415  # needs the temporal extra
@@ -819,17 +816,9 @@ class TestCompositionWarning:
             capabilities=[guard, TemporalDurability[None]()],
         )
 
-        dispatches_inline = tuple(
-            int(part) for part in importlib.metadata.version('pydantic-ai-slim').split('.')[:2]
-        ) >= (2, 37)
-
         with warnings.catch_warnings(record=True) as caught:
-            if dispatches_inline:  # pragma: no cover - latest-version path
-                await agent.run('hi')
-                assert (await guard.status())[0].spent.usd == Decimal('1')
-            else:
-                with pytest.raises(Exception, match='Not in workflow event loop'):
-                    await agent.run('hi')
+            await agent.run('hi')
+            assert (await guard.status())[0].spent.usd == Decimal('1')
 
         assert not [warning for warning in caught if isinstance(warning.message, SpendCompositionWarning)]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3979,13 +3979,13 @@ requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=4.31.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.0" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.61.0" },
-    { name = "pydantic-ai-slim", specifier = ">=2.36.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.36.0" },
-    { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.36.0" },
+    { name = "pydantic-ai-slim", specifier = ">=2.37.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.37.0" },
+    { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.37.0" },
     { name = "pydantic-ai-slim", extras = ["dbos"], marker = "extra == 'dbos'" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.36.0" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'codemode'", specifier = ">=2.36.0" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo", "web-fetch"], marker = "extra == 'researcher'", specifier = ">=2.36.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.37.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'codemode'", specifier = ">=2.37.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo", "web-fetch"], marker = "extra == 'researcher'", specifier = ">=2.37.0" },
     { name = "pydantic-ai-slim", extras = ["mcp"], marker = "extra == 'stackone'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["spec"], marker = "extra == 'logfire'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["temporal"], marker = "extra == 'temporal'" },
@@ -4025,7 +4025,7 @@ lint = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.36.0"
+version = "2.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4040,9 +4040,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/ad/a1db6a8ea93d4f8b7a9adaab64204ccd40d236933285c564fcd4b9037173/pydantic_ai_slim-2.36.0.tar.gz", hash = "sha256:43b53401099352bbb0d1a1ecbcf8855bb7c3d0c680311ba006c5549ed6d61039", size = 1313875, upload-time = "2026-08-29T01:39:37.069Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/29/6204f4a6a90a4741ef80453d65ed22ea953506abecdfd922dccf2ee50119/pydantic_ai_slim-2.37.0.tar.gz", hash = "sha256:c4743bdcd6fd0ea60d82088856f3dfcce93180543b2a66587547034f9dc36e57", size = 1317321, upload-time = "2026-09-01T02:07:39.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/0c/433c49819fa099700d69078586327b9dfad2c11492f96f51a13fa30208ad/pydantic_ai_slim-2.36.0-py3-none-any.whl", hash = "sha256:90957c37c99d3bfbfab4be632b733bf50d563686fbfbf8a2e42b6c91a4fca877", size = 1548738, upload-time = "2026-08-29T01:39:28.524Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3a/37891340c959c53f71d65eb45de84fccd722749bf8123fcd5a53094cf0c4/pydantic_ai_slim-2.37.0-py3-none-any.whl", hash = "sha256:439973ce2dae1e64631b05b803743fe44b3b1791514b16488c005b1ca4f2b3e7", size = 1552945, upload-time = "2026-09-01T02:07:31.076Z" },
 ]
 
 [package.optional-dependencies]
@@ -4326,7 +4326,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.36.0"
+version = "2.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4336,9 +4336,9 @@ dependencies = [
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/79/af5579c790ee5f670c270e4183d4c8411a6392c9b267022ea467e9e1c831/pydantic_graph-2.36.0.tar.gz", hash = "sha256:1222b50a141f88bca299dc21e94694277e6ef60d6f1bbbf490f2f2796851594a", size = 45191, upload-time = "2026-08-29T01:39:39.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/03/d7730770a7a564ec74d49872fde5e2606405c8380bb894dbfc47da36fa7a/pydantic_graph-2.37.0.tar.gz", hash = "sha256:447e4635f781ba525452d793be5935381a5a67aa4c81d0f53095cd8a8b626a94", size = 45188, upload-time = "2026-09-01T02:07:42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/f4/7b43affa018fa14ba0d8169fb2460ec496d4cb974c64bfc1f8e85fc4da44/pydantic_graph-2.36.0-py3-none-any.whl", hash = "sha256:c0c7cddb87038298b367036d799b4b605b2a23858869b2b661706df6e1b811f2", size = 52700, upload-time = "2026-08-29T01:39:32.131Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ad/1cd14e2f39bbee1ad6f511649ccb966d9ad11bcd2433c7377e2305dcecae/pydantic_graph-2.37.0-py3-none-any.whl", hash = "sha256:7b07237264b92f57aa06b1686315005e320099106534fc20da4081873f68c31f", size = 52701, upload-time = "2026-09-01T02:07:34.829Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Follow-up to #766, as discussed there.

2.37.0 is the release where a capability's `@durable_operation` methods pass through to the plain
function when the agent runs outside a durable container (pydantic-ai#7972, `8c5838dd3`). Below it,
composing a durability capability with `SpendLimits` or `StepPersistence` and running outside a
workflow makes those operations attempt a workflow dispatch and raise `Not in workflow event loop`,
so that configuration was broken on the floor we advertised.

#766 straddled both versions in the spend composition test to get `check` green on main. This raises
the floor to the release that actually fixed the problem and deletes the straddle:

- the six general `pydantic-ai-slim` floors go to `>=2.37.0` (the base dependency plus the five
  pass-through extras). The `>=2.18.0` feature-specific floors are subsumed and unchanged;
- `uv.lock` moves `pydantic-ai-slim` and `pydantic-graph` from 2.36.0 to 2.37.0;
- the test drops the `importlib.metadata` probe and the `if`/`else`, keeping the accrual assertion
  #766 added, and its docstring now states one invariant instead of describing two versions.

The `# pragma: no cover - latest-version path` goes with the straddle, which is worth calling out on
its own: it was sitting on the branch that every current install takes, so the behaviour we care
about was the uncovered one. Coverage of the changed method is now complete.

This also deletes the floor-rationale comment that had accumulated above the dependency, rather than
adding another paragraph to it. Why a given version is required belongs in the commit that raises the
floor, where `git blame` finds it, not in a comment that grows with every bump.

Precedent for handling a straddle this way: `7c8aee30` (#743), "Floor on released `pydantic-ai`
2.36.0 and drop the version straddle".

## Linked Issue

Fixes #768

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior (the straddled test collapses to a single contract)
- [x] `make lint && make typecheck && make test` passes locally
- [ ] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head

  **Needs `dependencies:approved`.** Raising the floor is the point of the PR, so `pyproject.toml`
  and `uv.lock` necessarily change.
- [x] Docstrings use single backticks (not RST double backticks)

## Verification

Ran locally against all three resolutions the CI jobs use:

| resolution | result |
| --- | --- |
| locked (`uv sync --locked`) | 5,592 passed, 63 skipped |
| lowest-direct, resolving `pydantic-ai-slim==2.37.0` | 5,592 passed, 63 skipped |
| latest (lock upgrade), `pydantic-ai-slim==2.37.0` | 5,592 passed, 63 skipped |

Plus ruff format (328 files), ruff lint, and pyright: 0 errors, 0 warnings. The later comment
deletion is TOML-only and was re-checked with `check toml` and `uv lock --check`.