### PR TITLE
Accept either duplicate-capability-`id` behavior in the `Advisor` test

### DIFF
--- a/tests/advisor/test_advisor.py
+++ b/tests/advisor/test_advisor.py
@@ -54,6 +54,15 @@ def _has_tool_return(messages: Sequence[ModelMessage]) -> bool:
     return any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts)
 
 
+_RESOLVES_DUPLICATE_IDS = hasattr(AbstractCapability, 'combine')
+"""Whether the installed `pydantic-ai` resolves two capabilities sharing an `id` rather than raising.
+
+Keyed on the hook itself rather than a version number: the release that introduces
+`AbstractCapability.combine` (pydantic/pydantic-ai#7248) is not cut yet, so there is no number to
+compare against, and asking whether the behaviour is present needs no bookkeeping once there is.
+"""
+
+
 class TestAdvisor:
     async def test_uses_native_advisor_for_matching_provider(self) -> None:
         seen: list[ModelRequestParameters] = []
@@ -389,8 +398,12 @@ class TestAdvisor:
     async def test_rejects_duplicate_capability_or_tool_name(self) -> None:
         model = FunctionModel(lambda _messages, _info: ModelResponse(parts=[TextPart('done')]))
 
-        with pytest.raises(UserError, match="Capability id 'advisor' is used by multiple capabilities"):
-            Agent(model, capabilities=[Advisor(model), Advisor(model)])
+        if _RESOLVES_DUPLICATE_IDS:  # pragma: no cover - depends on the installed core
+            # An agent has one advisor, so the two resolve to one instead of colliding.
+            await Agent(model, capabilities=[Advisor(model), Advisor(model)]).run('Review this.')
+        else:  # pragma: no cover - depends on the installed core
+            with pytest.raises(UserError, match="Capability id 'advisor' is used by multiple capabilities"):
+                Agent(model, capabilities=[Advisor(model), Advisor(model)])
 
         def advisor(prompt: str) -> str:  # pragma: no cover
             return prompt


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Unblocks the `harness compat` job on pydantic/pydantic-ai#7248.

That PR gives one-off capabilities a default `id` and, when two share one, resolves them through a new `AbstractCapability.combine` rather than raising. `Advisor` already carries `id='advisor'`, so under it two `Advisor()` capabilities compose instead of colliding — and `test_rejects_duplicate_capability_or_tool_name` asserts the collision, so the compat job fails on a behaviour change that is intended.

The test now asks which behaviour the installed core has:

```python
_RESOLVES_DUPLICATE_IDS = hasattr(AbstractCapability, 'combine')
```

Keyed on the hook rather than a version number, because the release carrying it is not cut yet — there is no number to compare against, and once there is, this needs no bookkeeping. The tool-name half of the test is unchanged and runs either way.

This is deliberately **only** the compatibility shim. Teaching the harness capabilities how they actually compose — including the `Coder()` + `Researcher()` composition that pydantic/pydantic-ai#7781 is about — is #767, which cannot merge until pydantic-ai releases.

## Validation

- 237 tests pass against released `pydantic-ai-slim` 2.36.0 (`hasattr` false, so the raise is still asserted)
- The same tests pass against pydantic/pydantic-ai#7248's branch (`hasattr` true, so composition is asserted)
- `tests/spend/test_spend.py` needed nothing: #766 already made it version-tolerant
- One file changed; `pyproject.toml` and `uv.lock` untouched

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks
