### PR TITLE
Add a Fly.io Sprites-backed sandbox capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The workspace the agent acts in: the files it edits and the commands it runs, lo
 | [FileSystem](pydantic_ai_harness/filesystem/) | Harness | Read, write, edit, search files under a root; path-traversal and symlink safe, secrets read-only |
 | [Shell](pydantic_ai_harness/shell/) | Harness | Command execution with allowlists, denylists, timeouts, and credential-stripping |
 | [Modal Sandbox](pydantic_ai_harness/modal_sandbox/) | Harness | Commands and files in an isolated [Modal](https://modal.com) cloud sandbox |
+| [Sprite Sandbox](pydantic_ai_harness/sprites/) | Harness | Commands and files in a persistent [Sprite](https://docs.sprites.dev/) cloud computer |
 
 ### Tools & native abilities
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The workspace the agent acts in: the files it edits and the commands it runs, lo
 | [FileSystem](pydantic_ai_harness/filesystem/) | Harness | Read, write, edit, search files under a root; path-traversal and symlink safe, secrets read-only |
 | [Shell](pydantic_ai_harness/shell/) | Harness | Command execution with allowlists, denylists, timeouts, and credential-stripping |
 | [Modal Sandbox](pydantic_ai_harness/modal_sandbox/) | Harness | Commands and files in an isolated [Modal](https://modal.com) cloud sandbox |
-| [Sprite Sandbox](pydantic_ai_harness/sprites/) | Harness | Commands and files in a persistent [Sprite](https://docs.sprites.dev/) cloud computer |
+| [Fly.io Sprites Sandbox](pydantic_ai_harness/sprites/) | Harness | Commands and files in a persistent [Fly.io Sprite](https://docs.sprites.dev/) cloud computer |
 
 ### Tools & native abilities
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,6 +147,7 @@ The workspace the agent acts in: the files it edits and the commands it runs, lo
 | [FileSystem](filesystem.md) | Harness | Read, write, edit, search files under a root; path-traversal and symlink safe, secrets read-only |
 | [Shell](shell.md) | Harness | Command execution with allowlists, denylists, timeouts, and credential-stripping |
 | [Modal Sandbox](modal-sandbox.md) | Harness | Commands and files in an isolated [Modal](https://modal.com) cloud sandbox |
+| [Sprite Sandbox](sprite-sandbox.md) | Harness | Commands and files in a persistent [Sprite](https://docs.sprites.dev/) cloud computer |
 
 ### Tools & native abilities
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -147,7 +147,7 @@ The workspace the agent acts in: the files it edits and the commands it runs, lo
 | [FileSystem](filesystem.md) | Harness | Read, write, edit, search files under a root; path-traversal and symlink safe, secrets read-only |
 | [Shell](shell.md) | Harness | Command execution with allowlists, denylists, timeouts, and credential-stripping |
 | [Modal Sandbox](modal-sandbox.md) | Harness | Commands and files in an isolated [Modal](https://modal.com) cloud sandbox |
-| [Sprite Sandbox](sprite-sandbox.md) | Harness | Commands and files in a persistent [Sprite](https://docs.sprites.dev/) cloud computer |
+| [Fly.io Sprites Sandbox](sprite-sandbox.md) | Harness | Commands and files in a persistent [Fly.io Sprite](https://docs.sprites.dev/) cloud computer |
 
 ### Tools & native abilities
 

--- a/docs/sprite-sandbox.md
+++ b/docs/sprite-sandbox.md
@@ -51,6 +51,9 @@ The default mode creates a uniquely named Sprite with an ownership label per
 agent run. On exit, the session fetches the Sprite and verifies that label before
 destroying it. If the label changed, cleanup raises
 `SpriteSandboxOwnershipError` instead of risking deletion of another Sprite.
+The label is a stale-handle guard, not an authorization boundary: the current
+Fly.io Sprites API does not support label-conditional deletion, so other actors
+with write access to the same organization must remain trusted.
 
 Attach to a Sprite you manage by name. It is left running when the run ends:
 
@@ -63,17 +66,24 @@ SpriteSandbox(sprite_name='my-existing-sprite')
 Reuse one Sprite across multiple runs with a caller-owned session:
 
 ```python
+import asyncio
+
 from pydantic_ai import Agent
 from pydantic_ai_harness import SpriteSandbox
 from pydantic_ai_harness.sprites import SpriteSandboxSession
 
-async with SpriteSandboxSession() as session:
-    agent = Agent(
-        'anthropic:claude-fable-5',
-        capabilities=[SpriteSandbox(session=session)],
-    )
-    await agent.run('Install the project dependencies.')
-    await agent.run('Run the tests in the same Sprite.')
+
+async def main():
+    async with SpriteSandboxSession() as session:
+        agent = Agent(
+            'anthropic:claude-fable-5',
+            capabilities=[SpriteSandbox(session=session)],
+        )
+        await agent.run('Install the project dependencies.')
+        await agent.run('Run the tests in the same Sprite.')
+
+
+asyncio.run(main())
 ```
 
 An injected session must already be open. The capability never opens, closes,
@@ -90,15 +100,13 @@ its child processes.
 The in-Sprite byte cut preserves the beginning and end of combined stdout and
 stderr before the SDK returns them. The tool layer then applies
 `max_output_bytes` and `max_output_lines` to the retained payload, keeping the
-tail where diagnostics commonly appear. All cuts are marked. Truncation markers
-and timeout or exit annotations are added after the payload limits, so the final
-tool result can be slightly larger than either configured cap.
+tail where diagnostics commonly appear. All cuts are marked where the configured
+limit has enough room for the marker. After timeout or exit annotations are
+added, the final command result is clamped again to both configured caps.
 
-`read_file` checks file size before reading and checks the returned byte count
-again. A file that grows between those operations can temporarily exceed
-`max_read_bytes` in client memory before being rejected. `list_directory`
-materializes the complete listing before truncation. Use bounded shell commands
-for virtual files or unusually large directories.
+`read_file` uses a size-limited read inside the Sprite, so the SDK never buffers
+more than `max_read_bytes`. `list_directory` also applies its entry and byte
+limits inside the Sprite before returning data to the SDK.
 
 The Fly.io Sprites Python SDK is synchronous. The capability runs its calls in worker
 threads, so SDK requests do not block the agent event loop.

--- a/docs/sprite-sandbox.md
+++ b/docs/sprite-sandbox.md
@@ -1,23 +1,22 @@
 ---
-title: Sprite Sandbox
-description: Give a Pydantic AI agent a persistent Sprite with command and file tools.
+title: Fly.io Sprites Sandbox
+description: Give a Pydantic AI agent a persistent Fly.io Sprite with command and file tools.
 ---
 
-# Sprite Sandbox
+# Fly.io Sprites Sandbox
 
-`SpriteSandbox` gives an agent a persistent Linux computer for running commands
-and working with files. Use it for coding, data processing, and long-running
-tasks that should not execute model-generated commands on the application host.
-
-The capability is backed by [Sprites](https://docs.sprites.dev/). By default,
-each agent run gets a fresh Sprite that is destroyed when the run ends. You can
-also attach to an existing Sprite or reuse one across several runs.
+`SpriteSandbox` gives an agent a persistent [Fly.io Sprite](https://docs.sprites.dev/):
+a Linux cloud computer for running commands and working with files. Use it for
+coding, data processing, and long-running tasks that should not execute
+model-generated commands on the application host. By default, each agent run
+gets a fresh Sprite that is destroyed when the run ends. You can also attach to
+an existing Sprite or reuse one across several runs.
 
 > While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
 
 ## Quick start
 
-Install the `sprites` extra and set a Sprites API token:
+Install the `sprites` extra and set a Fly.io Sprites API token:
 
 ```bash
 uv add "pydantic-ai-harness[sprites]"
@@ -101,7 +100,7 @@ again. A file that grows between those operations can temporarily exceed
 materializes the complete listing before truncation. Use bounded shell commands
 for virtual files or unusually large directories.
 
-The Sprites Python SDK is synchronous. The capability runs its calls in worker
+The Fly.io Sprites Python SDK is synchronous. The capability runs its calls in worker
 threads, so SDK requests do not block the agent event loop.
 
 ## Errors and composition
@@ -144,10 +143,10 @@ them.
 
 ## API reference
 
-- [Sprites documentation](https://docs.sprites.dev/)
-- [Sprites Python SDK](https://github.com/superfly/sprites-py)
+- [Fly.io Sprites documentation](https://docs.sprites.dev/)
+- [Fly.io Sprites Python SDK](https://github.com/superfly/sprites-py)
 - [Pydantic AI capabilities](/ai/capabilities/overview/)
-- [Sprite Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/sprites/)
+- [Fly.io Sprites Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/sprites/)
 
 ::: pydantic_ai_harness.sprites.SpriteSandbox
 

--- a/docs/sprite-sandbox.md
+++ b/docs/sprite-sandbox.md
@@ -95,7 +95,10 @@ do not share one between overlapping runs that need isolation.
 Every command gets a finite deadline. `default_command_timeout` supplies the
 normal limit and `max_command_timeout` caps model-supplied values. The command
 runs in a process group inside the Sprite, so a timeout terminates the shell and
-its child processes.
+its child processes. A successful command can deliberately detach a background
+process (for example, `server &`) before the foreground shell exits. That process
+keeps running until it is explicitly stopped or the Sprite is destroyed; this is
+part of the persistent-computer behavior, not a timeout escape.
 
 The in-Sprite byte cut preserves the beginning and end of combined stdout and
 stderr before the SDK returns them. The tool layer then applies
@@ -104,9 +107,11 @@ tail where diagnostics commonly appear. All cuts are marked where the configured
 limit has enough room for the marker. After timeout or exit annotations are
 added, the final command result is clamped again to both configured caps.
 
-`read_file` uses a size-limited read inside the Sprite, so the SDK never buffers
-more than `max_read_bytes`. `list_directory` also applies its entry and byte
-limits inside the Sprite before returning data to the SDK.
+`read_file` uses a size-limited read inside the Sprite, and `list_directory`
+applies its entry and byte limits there before returning data. All command-helper
+responses also flow through bounded SDK streaming sinks. Those host-side sinks
+abort the response if a helper executable inside the mutable Sprite is replaced
+and tries to bypass its in-Sprite limit.
 
 The Fly.io Sprites Python SDK is synchronous. The capability runs its calls in worker
 threads, so SDK requests do not block the agent event loop.

--- a/docs/sprite-sandbox.md
+++ b/docs/sprite-sandbox.md
@@ -19,8 +19,9 @@ an existing Sprite or reuse one across several runs.
 Install the `sprites` extra and set a Fly.io Sprites API token:
 
 ```bash
-uv add "pydantic-ai-harness[sprites]"
+uv add "pydantic-ai-harness[sprites,anthropic]"
 export SPRITE_TOKEN=...
+export ANTHROPIC_API_KEY=...
 ```
 
 ```python

--- a/docs/sprite-sandbox.md
+++ b/docs/sprite-sandbox.md
@@ -1,0 +1,166 @@
+---
+title: Sprite Sandbox
+description: Give a Pydantic AI agent a persistent Sprite with command and file tools.
+---
+
+# Sprite Sandbox
+
+`SpriteSandbox` gives an agent a persistent Linux computer for running commands
+and working with files. Use it for coding, data processing, and long-running
+tasks that should not execute model-generated commands on the application host.
+
+The capability is backed by [Sprites](https://docs.sprites.dev/). By default,
+each agent run gets a fresh Sprite that is destroyed when the run ends. You can
+also attach to an existing Sprite or reuse one across several runs.
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
+
+## Quick start
+
+Install the `sprites` extra and set a Sprites API token:
+
+```bash
+uv add "pydantic-ai-harness[sprites]"
+export SPRITE_TOKEN=...
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import SpriteSandbox
+
+agent = Agent(
+    'anthropic:claude-fable-5',
+    capabilities=[SpriteSandbox()],
+)
+
+result = agent.run_sync('Create a Python program and run it.')
+print(result.output)
+```
+
+The capability adds four tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `run_command` | Run a Bash command with a bounded timeout and combined output. |
+| `read_file` | Read a UTF-8 file with bounded output and line paging. |
+| `write_file` | Write a UTF-8 file and create parent directories. |
+| `list_directory` | List entries, marking directories with `/`. |
+
+## Lifecycle
+
+The default mode creates a uniquely named Sprite with an ownership label per
+agent run. On exit, the session fetches the Sprite and verifies that label before
+destroying it. If the label changed, cleanup raises
+`SpriteSandboxOwnershipError` instead of risking deletion of another Sprite.
+
+Attach to a Sprite you manage by name. It is left running when the run ends:
+
+```python
+from pydantic_ai_harness import SpriteSandbox
+
+SpriteSandbox(sprite_name='my-existing-sprite')
+```
+
+Reuse one Sprite across multiple runs with a caller-owned session:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import SpriteSandbox
+from pydantic_ai_harness.sprites import SpriteSandboxSession
+
+async with SpriteSandboxSession() as session:
+    agent = Agent(
+        'anthropic:claude-fable-5',
+        capabilities=[SpriteSandbox(session=session)],
+    )
+    await agent.run('Install the project dependencies.')
+    await agent.run('Run the tests in the same Sprite.')
+```
+
+An injected session must already be open. The capability never opens, closes,
+or destroys it. Attached and injected Sprites can retain files and processes, so
+do not share one between overlapping runs that need isolation.
+
+## Timeouts and output limits
+
+Every command gets a finite deadline. `default_command_timeout` supplies the
+normal limit and `max_command_timeout` caps model-supplied values. The command
+runs in a process group inside the Sprite, so a timeout terminates the shell and
+its child processes.
+
+The in-Sprite byte cut preserves the beginning and end of combined stdout and
+stderr before the SDK returns them. The tool layer then applies
+`max_output_bytes` and `max_output_lines` to the retained payload, keeping the
+tail where diagnostics commonly appear. All cuts are marked. Truncation markers
+and timeout or exit annotations are added after the payload limits, so the final
+tool result can be slightly larger than either configured cap.
+
+`read_file` checks file size before reading and checks the returned byte count
+again. A file that grows between those operations can temporarily exceed
+`max_read_bytes` in client memory before being rejected. `list_directory`
+materializes the complete listing before truncation. Use bounded shell commands
+for virtual files or unusually large directories.
+
+The Sprites Python SDK is synchronous. The capability runs its calls in worker
+threads, so SDK requests do not block the agent event loop.
+
+## Errors and composition
+
+Recoverable command and filesystem failures become model retry prompts. A
+missing Sprite raises `SpriteSandboxUnavailableError` and rejected credentials
+raise `SpriteSandboxAuthError`; both are terminal because repeating a tool call
+cannot fix them.
+
+Do not combine this capability with another unprefixed capability that registers
+`run_command`, `read_file`, `write_file`, or `list_directory`. Use Pydantic AI's
+`PrefixTools` and replace the default instructions when an agent needs both.
+
+## Configuration
+
+```python
+from pydantic_ai_harness import SpriteSandbox
+
+SpriteSandbox(
+    token=None,
+    sprite_name=None,
+    session=None,
+    base_url='https://api.sprites.dev',
+    api_timeout=30.0,
+    runtime=None,
+    workdir=None,
+    default_command_timeout=60.0,
+    max_command_timeout=300.0,
+    max_output_bytes=50 * 1024,
+    max_output_lines=2000,
+    max_read_bytes=5 * 1024 * 1024,
+    instructions=None,
+)
+```
+
+Set `instructions=''` to disable the default instructions, or pass custom text.
+`runtime` only applies to a newly created Sprite. Connection and lifecycle
+settings cannot be combined with an injected `session` because it already owns
+them.
+
+## API reference
+
+- [Sprites documentation](https://docs.sprites.dev/)
+- [Sprites Python SDK](https://github.com/superfly/sprites-py)
+- [Pydantic AI capabilities](/ai/capabilities/overview/)
+- [Sprite Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/sprites/)
+
+::: pydantic_ai_harness.sprites.SpriteSandbox
+
+::: pydantic_ai_harness.sprites.SpriteSandboxSession
+
+::: pydantic_ai_harness.sprites.SpriteSandboxExecResult
+
+::: pydantic_ai_harness.sprites.SpriteSandboxError
+
+::: pydantic_ai_harness.sprites.SpriteSandboxTerminalError
+
+::: pydantic_ai_harness.sprites.SpriteSandboxAuthError
+
+::: pydantic_ai_harness.sprites.SpriteSandboxUnavailableError
+
+::: pydantic_ai_harness.sprites.SpriteSandboxOwnershipError

--- a/pydantic_ai_harness/__init__.py
+++ b/pydantic_ai_harness/__init__.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
     from .shell import LLM_API_KEY_ENV_PATTERNS, Shell
     from .skills import Skills
     from .spend import SpendLimits
+    from .sprites import SpriteSandbox
     from .stackone import StackOne
     from .step_persistence import StepPersistence
     from .subagents import SubAgent, SubAgents
@@ -98,6 +99,7 @@ __all__ = [
     'Researcher',
     'Shell',
     'Skills',
+    'SpriteSandbox',
     'SlidingWindowCompaction',
     'SpendLimits',
     'StackOne',
@@ -143,6 +145,7 @@ _CAPABILITY_EXPORTS = {
     'Researcher': 'researcher',
     'Shell': 'shell',
     'Skills': 'skills',
+    'SpriteSandbox': 'sprites',
     'SlidingWindowCompaction': 'compaction',
     'SpendLimits': 'spend',
     'StackOne': 'stackone',

--- a/pydantic_ai_harness/_sandbox_output.py
+++ b/pydantic_ai_harness/_sandbox_output.py
@@ -1,6 +1,6 @@
-"""Presentation helpers for Modal sandbox file and command output.
+"""Presentation helpers for sandbox file and command output.
 
-Pure formatting stays separate from the Modal I/O layer so output behavior can be
+Pure formatting stays separate from provider I/O so output behavior can be
 tested without provisioning a sandbox.
 
 `read_file`-style tools want `render_file_window` (line-addressable, head-first, with a

--- a/pydantic_ai_harness/modal_sandbox/_capability.py
+++ b/pydantic_ai_harness/modal_sandbox/_capability.py
@@ -10,6 +10,7 @@ from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AgentToolset
 
+from pydantic_ai_harness._sandbox_output import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
 from pydantic_ai_harness.modal_sandbox._session import (
     DEFAULT_APP_NAME as _DEFAULT_APP_NAME,
 )
@@ -22,7 +23,6 @@ from pydantic_ai_harness.modal_sandbox._session import (
 from pydantic_ai_harness.modal_sandbox._session import (
     ModalSandboxSession,
 )
-from pydantic_ai_harness.modal_sandbox._tool_output import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
 from pydantic_ai_harness.modal_sandbox._toolset import ModalSandboxToolset
 
 # read_file pulls the whole file into memory before windowing it, so cap how large a file

--- a/pydantic_ai_harness/modal_sandbox/_toolset.py
+++ b/pydantic_ai_harness/modal_sandbox/_toolset.py
@@ -13,12 +13,12 @@ from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 from typing_extensions import Self
 
+from pydantic_ai_harness._sandbox_output import guard_read_size, render_file_window, truncate_output
 from pydantic_ai_harness.modal_sandbox._session import (
     ModalSandboxError,
     ModalSandboxSession,
     ModalSandboxTerminalError,
 )
-from pydantic_ai_harness.modal_sandbox._tool_output import guard_read_size, render_file_window, truncate_output
 
 
 class ModalSandboxToolset(FunctionToolset[AgentDepsT]):

--- a/pydantic_ai_harness/sprites/README.md
+++ b/pydantic_ai_harness/sprites/README.md
@@ -45,6 +45,9 @@ The default mode creates a uniquely named Sprite with an ownership label for
 each agent run. On exit, the session fetches the Sprite and verifies that label
 before destroying it. If the label changed, cleanup stops with
 `SpriteSandboxOwnershipError` rather than risk deleting a different Sprite.
+The label is a stale-handle guard, not an authorization boundary: the current
+Fly.io Sprites API does not support label-conditional deletion, so other actors
+with write access to the same organization must remain trusted.
 
 Attach to a Sprite you manage by name. It is left running:
 
@@ -57,17 +60,24 @@ SpriteSandbox(sprite_name='my-existing-sprite')
 To reuse one Sprite across multiple runs, own its session explicitly:
 
 ```python
+import asyncio
+
 from pydantic_ai import Agent
 from pydantic_ai_harness import SpriteSandbox
 from pydantic_ai_harness.sprites import SpriteSandboxSession
 
-async with SpriteSandboxSession() as session:
-    agent = Agent(
-        'anthropic:claude-fable-5',
-        capabilities=[SpriteSandbox(session=session)],
-    )
-    await agent.run('Install the project dependencies.')
-    await agent.run('Run the tests in the same Sprite.')
+
+async def main():
+    async with SpriteSandboxSession() as session:
+        agent = Agent(
+            'anthropic:claude-fable-5',
+            capabilities=[SpriteSandbox(session=session)],
+        )
+        await agent.run('Install the project dependencies.')
+        await agent.run('Run the tests in the same Sprite.')
+
+
+asyncio.run(main())
 ```
 
 An injected session must already be open. The capability never opens, closes,
@@ -82,14 +92,12 @@ command runs in a process group inside the Sprite, so a timeout terminates the
 shell and its child processes. The in-Sprite byte cut preserves the beginning
 and end of combined stdout and stderr before the SDK returns it. The tool layer
 then applies byte and line limits to the retained payload, keeping the tail where
-diagnostics commonly appear. Truncation markers and timeout or exit annotations
-are added after those payload limits, so the final tool result can be slightly
-larger than either configured cap.
+diagnostics commonly appear. The final command result, including truncation and
+status annotations, is clamped to both configured caps.
 
-File reads reject files larger than `max_read_bytes` before decoding them, then
-apply the output byte and line limits. Directory listings are materialized
-before truncation, so use a bounded shell command for unusually large
-directories.
+File reads reject files larger than `max_read_bytes` before decoding them and
+enforce that limit again while reading inside the Sprite. Directory listings
+apply entry and byte limits inside the Sprite before returning data to the SDK.
 
 Recoverable command and file failures become model retry prompts. A missing
 Sprite raises `SpriteSandboxUnavailableError`; rejected credentials raise

--- a/pydantic_ai_harness/sprites/README.md
+++ b/pydantic_ai_harness/sprites/README.md
@@ -1,0 +1,135 @@
+# Sprite Sandbox
+
+`SpriteSandbox` gives a Pydantic AI agent a persistent Linux computer for
+running commands and working with files. By default, every agent run creates a
+fresh Sprite and destroys it at the end. You can instead attach to an existing
+Sprite or reuse a caller-owned session across runs.
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
+
+## Quick start
+
+Install the optional dependency and provide a Sprites API token:
+
+```bash
+uv add "pydantic-ai-harness[sprites]"
+export SPRITE_TOKEN=...
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import SpriteSandbox
+
+agent = Agent(
+    'anthropic:claude-fable-5',
+    capabilities=[SpriteSandbox()],
+)
+
+result = agent.run_sync('Create a Python program and run it.')
+print(result.output)
+```
+
+The capability contributes four tools:
+
+| Tool | Purpose |
+|---|---|
+| `run_command` | Run a Bash command with a bounded timeout and combined output. |
+| `read_file` | Read a UTF-8 file with bounded output and line paging. |
+| `write_file` | Write a UTF-8 file and create parent directories. |
+| `list_directory` | List entries, marking directories with `/`. |
+
+## Lifecycle
+
+The default mode creates a uniquely named Sprite with an ownership label for
+each agent run. On exit, the session fetches the Sprite and verifies that label
+before destroying it. If the label changed, cleanup stops with
+`SpriteSandboxOwnershipError` rather than risk deleting a different Sprite.
+
+Attach to a Sprite you manage by name. It is left running:
+
+```python
+from pydantic_ai_harness import SpriteSandbox
+
+SpriteSandbox(sprite_name='my-existing-sprite')
+```
+
+To reuse one Sprite across multiple runs, own its session explicitly:
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import SpriteSandbox
+from pydantic_ai_harness.sprites import SpriteSandboxSession
+
+async with SpriteSandboxSession() as session:
+    agent = Agent(
+        'anthropic:claude-fable-5',
+        capabilities=[SpriteSandbox(session=session)],
+    )
+    await agent.run('Install the project dependencies.')
+    await agent.run('Run the tests in the same Sprite.')
+```
+
+An injected session must already be open. The capability never opens, closes,
+or destroys it. Do not share one session between overlapping runs that need
+filesystem or process isolation.
+
+## Limits and errors
+
+Every model-facing command gets a finite deadline. `default_command_timeout`
+sets the normal limit and `max_command_timeout` caps model-supplied values. The
+command runs in a process group inside the Sprite, so a timeout terminates the
+shell and its child processes. The in-Sprite byte cut preserves the beginning
+and end of combined stdout and stderr before the SDK returns it. The tool layer
+then applies byte and line limits to the retained payload, keeping the tail where
+diagnostics commonly appear. Truncation markers and timeout or exit annotations
+are added after those payload limits, so the final tool result can be slightly
+larger than either configured cap.
+
+File reads reject files larger than `max_read_bytes` before decoding them, then
+apply the output byte and line limits. Directory listings are materialized
+before truncation, so use a bounded shell command for unusually large
+directories.
+
+Recoverable command and file failures become model retry prompts. A missing
+Sprite raises `SpriteSandboxUnavailableError`; rejected credentials raise
+`SpriteSandboxAuthError`. Both are terminal because retrying the same tool call
+cannot repair them.
+
+The Sprites Python SDK is synchronous. This integration runs SDK calls in worker
+threads so it does not block the agent event loop.
+
+## Configuration
+
+```python
+from pydantic_ai_harness import SpriteSandbox
+
+SpriteSandbox(
+    token=None,                    # defaults to SPRITE_TOKEN at run start
+    sprite_name=None,              # attach instead of creating per run
+    session=None,                  # reuse an open SpriteSandboxSession
+    base_url='https://api.sprites.dev',
+    api_timeout=30.0,
+    runtime=None,                  # None, 'default', or 'dev' for owned Sprites
+    workdir=None,                  # defaults to the Sprite's current directory
+    default_command_timeout=60.0,
+    max_command_timeout=300.0,
+    max_output_bytes=50 * 1024,
+    max_output_lines=2000,
+    max_read_bytes=5 * 1024 * 1024,
+    instructions=None,
+)
+```
+
+Set `instructions=''` to add no default instructions, or pass custom text to
+replace them. Connection and lifecycle settings cannot be combined with an
+injected `session` because that session already owns them.
+
+Do not combine this capability with another unprefixed capability that registers
+the same tool names. Use Pydantic AI's `PrefixTools` when an agent needs both.
+
+## Further reading
+
+- [Sprites documentation](https://docs.sprites.dev/)
+- [Sprites Python SDK](https://github.com/superfly/sprites-py)
+- [Pydantic AI capabilities](https://pydantic.dev/docs/ai/capabilities/overview/)
+- [Sprite Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/sprites/)

--- a/pydantic_ai_harness/sprites/README.md
+++ b/pydantic_ai_harness/sprites/README.md
@@ -1,15 +1,16 @@
-# Sprite Sandbox
+# Fly.io Sprites Sandbox
 
-`SpriteSandbox` gives a Pydantic AI agent a persistent Linux computer for
-running commands and working with files. By default, every agent run creates a
-fresh Sprite and destroys it at the end. You can instead attach to an existing
-Sprite or reuse a caller-owned session across runs.
+`SpriteSandbox` gives a Pydantic AI agent a persistent
+[Fly.io Sprite](https://docs.sprites.dev/): a Linux cloud computer for running
+commands and working with files. By default, every agent run creates a fresh
+Sprite and destroys it at the end. You can instead attach to an existing Sprite
+or reuse a caller-owned session across runs.
 
 > While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 
 ## Quick start
 
-Install the optional dependency and provide a Sprites API token:
+Install the optional dependency and provide a Fly.io Sprites API token:
 
 ```bash
 uv add "pydantic-ai-harness[sprites]"
@@ -95,7 +96,7 @@ Sprite raises `SpriteSandboxUnavailableError`; rejected credentials raise
 `SpriteSandboxAuthError`. Both are terminal because retrying the same tool call
 cannot repair them.
 
-The Sprites Python SDK is synchronous. This integration runs SDK calls in worker
+The Fly.io Sprites Python SDK is synchronous. This integration runs SDK calls in worker
 threads so it does not block the agent event loop.
 
 ## Configuration
@@ -129,7 +130,7 @@ the same tool names. Use Pydantic AI's `PrefixTools` when an agent needs both.
 
 ## Further reading
 
-- [Sprites documentation](https://docs.sprites.dev/)
-- [Sprites Python SDK](https://github.com/superfly/sprites-py)
+- [Fly.io Sprites documentation](https://docs.sprites.dev/)
+- [Fly.io Sprites Python SDK](https://github.com/superfly/sprites-py)
 - [Pydantic AI capabilities](https://pydantic.dev/docs/ai/capabilities/overview/)
-- [Sprite Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/sprites/)
+- [Fly.io Sprites Sandbox source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/sprites/)

--- a/pydantic_ai_harness/sprites/__init__.py
+++ b/pydantic_ai_harness/sprites/__init__.py
@@ -1,4 +1,4 @@
-"""Sprites sandbox capability for Pydantic AI agents.
+"""Fly.io Sprites sandbox capability for Pydantic AI agents.
 
 `SpriteSandbox` is the supported entry point. `SpriteSandboxSession` exposes
 lower-level lifecycle, command, and file access for applications that need to

--- a/pydantic_ai_harness/sprites/__init__.py
+++ b/pydantic_ai_harness/sprites/__init__.py
@@ -1,0 +1,28 @@
+"""Sprites sandbox capability for Pydantic AI agents.
+
+`SpriteSandbox` is the supported entry point. `SpriteSandboxSession` exposes
+lower-level lifecycle, command, and file access for applications that need to
+share a caller-owned Sprite across runs.
+"""
+
+from pydantic_ai_harness.sprites._capability import SpriteSandbox
+from pydantic_ai_harness.sprites._session import (
+    SpriteSandboxAuthError,
+    SpriteSandboxError,
+    SpriteSandboxExecResult,
+    SpriteSandboxOwnershipError,
+    SpriteSandboxSession,
+    SpriteSandboxTerminalError,
+    SpriteSandboxUnavailableError,
+)
+
+__all__ = [
+    'SpriteSandbox',
+    'SpriteSandboxAuthError',
+    'SpriteSandboxError',
+    'SpriteSandboxExecResult',
+    'SpriteSandboxOwnershipError',
+    'SpriteSandboxSession',
+    'SpriteSandboxTerminalError',
+    'SpriteSandboxUnavailableError',
+]

--- a/pydantic_ai_harness/sprites/_capability.py
+++ b/pydantic_ai_harness/sprites/_capability.py
@@ -1,4 +1,4 @@
-"""Sprites capability that gives agents a persistent cloud computer."""
+"""Fly.io Sprites capability that gives agents a persistent cloud computer."""
 
 from __future__ import annotations
 
@@ -25,14 +25,14 @@ from pydantic_ai_harness.sprites._toolset import SpriteSandboxToolset
 _DEFAULT_MAX_READ_BYTES = 5 * 1024 * 1024
 
 _OWNED_INSTRUCTIONS = (
-    'You have a Sprite: an isolated, persistent Linux computer created for this run. Use `run_command` '
+    'You have a Fly.io Sprite: an isolated, persistent Linux computer created for this run. Use `run_command` '
     'to run shell commands, and `read_file` / `write_file` / `list_directory` to manage files. Commands '
     'run through Bash, so pipes and redirection work. A command times out after {default_timeout}s unless '
     'you pass `timeout_seconds` (up to {max_timeout}s). This Sprite is destroyed when the run ends.'
 )
 
 _REUSED_INSTRUCTIONS = (
-    'You have a Sprite: an isolated, persistent Linux computer. Use `run_command` to run shell commands, '
+    'You have a Fly.io Sprite: an isolated, persistent Linux computer. Use `run_command` to run shell commands, '
     'and `read_file` / `write_file` / `list_directory` to manage files. Commands run through Bash, so pipes '
     'and redirection work. A command times out after {default_timeout}s unless you pass `timeout_seconds` '
     '(up to {max_timeout}s). This Sprite is reused across runs, so earlier files can still be present.'
@@ -41,7 +41,7 @@ _REUSED_INSTRUCTIONS = (
 
 @dataclass(kw_only=True)
 class SpriteSandbox(AbstractCapability[AgentDepsT]):
-    """Access to a persistent cloud computer powered by [Sprites](https://sprites.dev).
+    """Access to a persistent cloud computer powered by [Fly.io Sprites](https://sprites.dev).
 
     By default, each agent run creates a fresh Sprite and destroys it when the run
     ends. Set `sprite_name` to attach to a Sprite you manage, or pass an already-open
@@ -49,7 +49,7 @@ class SpriteSandbox(AbstractCapability[AgentDepsT]):
     left running.
 
     Requires the `sprites` extra (`uv add "pydantic-ai-harness[sprites]"`) and a
-    Sprites API token in `SPRITE_TOKEN`, or passed via `token`.
+    Fly.io Sprites API token in `SPRITE_TOKEN`, or passed via `token`.
 
     ```python
     from pydantic_ai import Agent
@@ -62,7 +62,7 @@ class SpriteSandbox(AbstractCapability[AgentDepsT]):
     """
 
     token: str | None = None
-    """Sprites API token. When omitted, `SPRITE_TOKEN` is read when a run starts."""
+    """Fly.io Sprites API token. When omitted, `SPRITE_TOKEN` is read when a run starts."""
 
     sprite_name: str | None = None
     """Attach to an existing Sprite by name instead of creating one per run.
@@ -79,10 +79,10 @@ class SpriteSandbox(AbstractCapability[AgentDepsT]):
     """
 
     base_url: str = _DEFAULT_BASE_URL
-    """Sprites API base URL."""
+    """Fly.io Sprites API base URL."""
 
     api_timeout: float = _DEFAULT_API_TIMEOUT
-    """Timeout in seconds for Sprites API operations, excluding Sprite creation."""
+    """Timeout in seconds for Fly.io Sprites API operations, excluding Sprite creation."""
 
     runtime: str | None = None
     """Runtime channel for a newly created Sprite: `default`, `dev`, or None."""

--- a/pydantic_ai_harness/sprites/_capability.py
+++ b/pydantic_ai_harness/sprites/_capability.py
@@ -1,0 +1,184 @@
+"""Sprites capability that gives agents a persistent cloud computer."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.toolsets import AgentToolset
+
+from pydantic_ai_harness._sandbox_output import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
+from pydantic_ai_harness.sprites._session import (
+    DEFAULT_API_TIMEOUT as _DEFAULT_API_TIMEOUT,
+)
+from pydantic_ai_harness.sprites._session import (
+    DEFAULT_BASE_URL as _DEFAULT_BASE_URL,
+)
+from pydantic_ai_harness.sprites._session import (
+    DEFAULT_MAX_COMMAND_TIMEOUT as _DEFAULT_MAX_COMMAND_TIMEOUT,
+)
+from pydantic_ai_harness.sprites._session import SpriteSandboxSession
+from pydantic_ai_harness.sprites._toolset import SpriteSandboxToolset
+
+_DEFAULT_MAX_READ_BYTES = 5 * 1024 * 1024
+
+_OWNED_INSTRUCTIONS = (
+    'You have a Sprite: an isolated, persistent Linux computer created for this run. Use `run_command` '
+    'to run shell commands, and `read_file` / `write_file` / `list_directory` to manage files. Commands '
+    'run through Bash, so pipes and redirection work. A command times out after {default_timeout}s unless '
+    'you pass `timeout_seconds` (up to {max_timeout}s). This Sprite is destroyed when the run ends.'
+)
+
+_REUSED_INSTRUCTIONS = (
+    'You have a Sprite: an isolated, persistent Linux computer. Use `run_command` to run shell commands, '
+    'and `read_file` / `write_file` / `list_directory` to manage files. Commands run through Bash, so pipes '
+    'and redirection work. A command times out after {default_timeout}s unless you pass `timeout_seconds` '
+    '(up to {max_timeout}s). This Sprite is reused across runs, so earlier files can still be present.'
+)
+
+
+@dataclass(kw_only=True)
+class SpriteSandbox(AbstractCapability[AgentDepsT]):
+    """Access to a persistent cloud computer powered by [Sprites](https://sprites.dev).
+
+    By default, each agent run creates a fresh Sprite and destroys it when the run
+    ends. Set `sprite_name` to attach to a Sprite you manage, or pass an already-open
+    `SpriteSandboxSession` to reuse one across runs. Attached and injected Sprites are
+    left running.
+
+    Requires the `sprites` extra (`uv add "pydantic-ai-harness[sprites]"`) and a
+    Sprites API token in `SPRITE_TOKEN`, or passed via `token`.
+
+    ```python
+    from pydantic_ai import Agent
+    from pydantic_ai_harness.sprites import SpriteSandbox
+
+    agent = Agent('anthropic:claude-fable-5', capabilities=[SpriteSandbox()])
+    result = agent.run_sync('Write and run a Python program that prints the first 10 primes.')
+    print(result.output)
+    ```
+    """
+
+    token: str | None = None
+    """Sprites API token. When omitted, `SPRITE_TOKEN` is read when a run starts."""
+
+    sprite_name: str | None = None
+    """Attach to an existing Sprite by name instead of creating one per run.
+
+    An attached Sprite is not destroyed when the run ends. Cannot be combined with
+    `runtime`, which applies only to Sprite creation, or with `session`.
+    """
+
+    session: SpriteSandboxSession | None = None
+    """Use an already-open, caller-owned session across runs.
+
+    The capability never opens or closes an injected session. Connection and Sprite
+    settings cannot be combined with it because the session already owns them.
+    """
+
+    base_url: str = _DEFAULT_BASE_URL
+    """Sprites API base URL."""
+
+    api_timeout: float = _DEFAULT_API_TIMEOUT
+    """Timeout in seconds for Sprites API operations, excluding Sprite creation."""
+
+    runtime: str | None = None
+    """Runtime channel for a newly created Sprite: `default`, `dev`, or None."""
+
+    workdir: str | None = None
+    """Working directory for commands and relative filesystem paths."""
+
+    default_command_timeout: float = 60.0
+    """Default timeout in seconds for one `run_command`."""
+
+    max_command_timeout: float = _DEFAULT_MAX_COMMAND_TIMEOUT
+    """Hard ceiling in seconds for a command, including a model-supplied timeout."""
+
+    max_output_bytes: int = DEFAULT_MAX_BYTES
+    """Maximum command or file payload retained in UTF-8 bytes."""
+
+    max_output_lines: int = DEFAULT_MAX_LINES
+    """Maximum command or file payload lines retained alongside the byte limit."""
+
+    max_read_bytes: int = _DEFAULT_MAX_READ_BYTES
+    """Largest file `read_file` reads in full before returning a window."""
+
+    instructions: str | None = None
+    """Instructions added to the system prompt. Set `''` to disable them."""
+
+    def __post_init__(self) -> None:
+        """Validate limits and reject settings the selected lifecycle mode would ignore."""
+        for name, value in (
+            ('max_output_bytes', self.max_output_bytes),
+            ('max_output_lines', self.max_output_lines),
+            ('max_read_bytes', self.max_read_bytes),
+        ):
+            if type(value) is not int or value <= 0:
+                raise ValueError(f'{name} must be a positive integer, got {value!r}.')
+        for name, value in (
+            ('api_timeout', self.api_timeout),
+            ('default_command_timeout', self.default_command_timeout),
+            ('max_command_timeout', self.max_command_timeout),
+        ):
+            if type(value) is bool or not math.isfinite(value) or value <= 0:
+                raise ValueError(f'{name} must be a positive finite number, got {value!r}.')
+        if self.default_command_timeout > self.max_command_timeout:
+            raise ValueError('default_command_timeout cannot exceed max_command_timeout.')
+        if not self.base_url:
+            raise ValueError('base_url must not be empty.')
+        if self.runtime not in (None, 'default', 'dev'):
+            raise ValueError(f"runtime must be 'default', 'dev', or None, got {self.runtime!r}.")
+        if self.instructions is not None and type(self.instructions) is not str:
+            raise ValueError(f'instructions must be a string or None, got {self.instructions!r}.')
+
+        if self.session is not None:
+            conflicts = [
+                name
+                for name, value, default in (
+                    ('token', self.token, None),
+                    ('sprite_name', self.sprite_name, None),
+                    ('base_url', self.base_url, _DEFAULT_BASE_URL),
+                    ('api_timeout', self.api_timeout, _DEFAULT_API_TIMEOUT),
+                    ('runtime', self.runtime, None),
+                    ('workdir', self.workdir, None),
+                )
+                if value != default
+            ]
+            if conflicts:
+                raise ValueError(
+                    f'{", ".join(conflicts)} cannot be combined with `session`, which already owns '
+                    'the Sprite and its connection settings.'
+                )
+        elif self.sprite_name is not None and self.runtime is not None:
+            raise ValueError('runtime only applies when creating a Sprite; remove it when `sprite_name` is set.')
+
+    def get_instructions(self) -> str | None:
+        """Explain the Sprite tools and the configured lifecycle to the model."""
+        if self.instructions is not None:
+            return self.instructions or None
+        template = (
+            _REUSED_INSTRUCTIONS if self.sprite_name is not None or self.session is not None else _OWNED_INSTRUCTIONS
+        )
+        return template.format(
+            default_timeout=self.default_command_timeout,
+            max_timeout=self.max_command_timeout,
+        )
+
+    def get_toolset(self) -> AgentToolset[AgentDepsT]:
+        """Build and return the Sprite toolset."""
+        return SpriteSandboxToolset[AgentDepsT](
+            token=self.token,
+            sprite_name=self.sprite_name,
+            base_url=self.base_url,
+            api_timeout=self.api_timeout,
+            runtime=self.runtime,
+            workdir=self.workdir,
+            default_command_timeout=self.default_command_timeout,
+            max_command_timeout=self.max_command_timeout,
+            max_output_bytes=self.max_output_bytes,
+            max_output_lines=self.max_output_lines,
+            max_read_bytes=self.max_read_bytes,
+            session=self.session,
+        )

--- a/pydantic_ai_harness/sprites/_session.py
+++ b/pydantic_ai_harness/sprites/_session.py
@@ -1,0 +1,511 @@
+"""Lifecycle and I/O for one Fly.io Sprite."""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import shlex
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypeVar
+
+import anyio
+import anyio.lowlevel
+import anyio.to_thread
+from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from sprites import Sprite, SpritesClient
+
+# External assumptions verified 2026-09-02:
+# - `sprites-py` authenticates with a token, creates and destroys Sprites by name, and accepts
+#   labels on creation: https://github.com/superfly/sprites-py/blob/main/src/sprites/client.py
+# - Commands accept argv, cwd, env, and a client-side timeout:
+#   https://github.com/superfly/sprites-py/blob/main/src/sprites/sprite.py
+# - Filesystem paths support stat, byte reads and writes, and directory iteration:
+#   https://github.com/superfly/sprites-py/blob/main/src/sprites/filesystem.py
+# Re-check those SDK surfaces before changing lifecycle, timeout, or filesystem handling.
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = 'https://api.sprites.dev'
+DEFAULT_API_TIMEOUT = 30.0
+DEFAULT_MAX_COMMAND_TIMEOUT = 300.0
+
+_PROVIDER_LABEL = 'pydantic-ai-harness'
+_COMMAND_ENV = 'PYDANTIC_AI_SPRITE_COMMAND'
+_COMMAND_TIMEOUT_ENV = 'PYDANTIC_AI_SPRITE_TIMEOUT_SECONDS'
+_TRUNCATION_MARKER = b'\n[... Sprite command output truncated ...]\n'
+_TIMEOUT_MARKER = b'\n__PYDANTIC_AI_SPRITE_TIMEOUT__\n'
+_TRANSPORT_TIMEOUT_GRACE = 5.0
+_PWD_TIMEOUT = 10.0
+
+_MISSING_SPRITES = (
+    'The \'sprites-py\' package is required for SpriteSandbox. Install it with `uv add "pydantic-ai-harness[sprites]"`.'
+)
+_AUTH_MESSAGE = 'Sprites rejected the credentials. Set SPRITE_TOKEN or pass `token=`.'
+
+T = TypeVar('T')
+
+
+async def _run_sync(func: Callable[[], T]) -> T:
+    """Run one synchronous SDK call without blocking the agent event loop."""
+    return await anyio.to_thread.run_sync(func)
+
+
+class SpriteSandboxError(RuntimeError):
+    """Base class for failures reported by the Sprites integration."""
+
+
+class SpriteSandboxTerminalError(SpriteSandboxError):
+    """A Sprite failure that retrying the same tool call cannot fix."""
+
+
+class SpriteSandboxUnavailableError(SpriteSandboxTerminalError):
+    """The Sprite was destroyed or is otherwise no longer available."""
+
+
+class SpriteSandboxAuthError(SpriteSandboxTerminalError):
+    """The Sprites API rejected the configured token."""
+
+
+class SpriteSandboxOwnershipError(SpriteSandboxTerminalError):
+    """Cleanup stopped because the owned Sprite's ownership label changed."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class SpriteSandboxExecResult:
+    """The outcome of running a command in a Sprite."""
+
+    output: str
+    """Combined standard output and error, decoded as UTF-8 with replacement."""
+    returncode: int
+    """The process exit status."""
+    truncated: bool = False
+    """Whether the in-Sprite output reader dropped bytes to enforce its limit."""
+    timed_out: bool = False
+    """Whether the in-Sprite deadline terminated the process group."""
+    applied_timeout: float | None = None
+    """The command deadline enforced inside the Sprite, if any."""
+
+
+def _execute_wrapper(max_output_bytes: int) -> str:
+    """Build an in-Sprite process-group runner with bounded combined output."""
+    content_budget = max(0, max_output_bytes - len(_TRUNCATION_MARKER))
+    script = f"""
+import os
+import signal
+import subprocess
+import sys
+import threading
+
+budget = {content_budget}
+head_budget = budget // 2
+tail_budget = budget - head_budget
+truncation_marker = {_TRUNCATION_MARKER!r}
+timeout_marker = {_TIMEOUT_MARKER!r}
+command = os.environ[{_COMMAND_ENV!r}]
+raw_timeout = os.environ.get({_COMMAND_TIMEOUT_ENV!r})
+command_timeout = float(raw_timeout) if raw_timeout else None
+head = bytearray()
+tail = bytearray()
+total = 0
+
+process = subprocess.Popen(
+    ['bash', '-lc', command],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    start_new_session=True,
+)
+assert process.stdout is not None
+
+def drain_output():
+    global total
+    while True:
+        try:
+            chunk = process.stdout.read(65536)
+        except (OSError, ValueError):
+            return
+        if not chunk:
+            return
+        total += len(chunk)
+        if len(head) < head_budget:
+            take = min(head_budget - len(head), len(chunk))
+            head.extend(chunk[:take])
+            chunk = chunk[take:]
+        if chunk and tail_budget:
+            tail.extend(chunk)
+            if len(tail) > tail_budget:
+                del tail[:-tail_budget]
+
+reader = threading.Thread(target=drain_output, daemon=True)
+reader.start()
+timed_out = False
+try:
+    returncode = process.wait(timeout=command_timeout)
+except subprocess.TimeoutExpired:
+    timed_out = True
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        returncode = process.wait(timeout=1.0)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        returncode = process.wait()
+
+reader.join(timeout=1.0)
+if reader.is_alive():
+    process.stdout.close()
+    reader.join(timeout=1.0)
+
+if total > budget:
+    output = bytes(head) + truncation_marker + bytes(tail)
+else:
+    output = bytes(head) + bytes(tail)
+sys.stdout.buffer.write(output)
+if timed_out:
+    sys.stdout.buffer.write(timeout_marker)
+    returncode = 124
+elif returncode < 0:
+    returncode = 128 - returncode
+sys.stdout.buffer.flush()
+raise SystemExit(returncode)
+""".strip()
+    return f'python3 -c {shlex.quote(script)} 2>&1'
+
+
+class SpriteSandboxSession:
+    """Async context manager that creates or attaches to one Sprite.
+
+    When `sprite_name` is omitted, entering the session creates a uniquely named
+    Sprite with an ownership label. Exiting verifies that label before destroying
+    the Sprite. When `sprite_name` is set, the session attaches to that Sprite and
+    leaves it running on exit.
+
+    Args:
+        token: Sprites API token. Defaults to `SPRITE_TOKEN` on entry.
+        sprite_name: Existing Sprite to attach to. Omit to create an owned Sprite.
+        base_url: Sprites API base URL.
+        api_timeout: Timeout in seconds for API calls other than Sprite creation.
+        runtime: Runtime channel for an owned Sprite: `default`, `dev`, or None.
+        workdir: Working directory for commands and relative file paths. When
+            omitted, the session reads the Sprite's current directory on entry.
+    """
+
+    def __init__(
+        self,
+        *,
+        token: str | None = None,
+        sprite_name: str | None = None,
+        base_url: str = DEFAULT_BASE_URL,
+        api_timeout: float = DEFAULT_API_TIMEOUT,
+        runtime: str | None = None,
+        workdir: str | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError('base_url must not be empty.')
+        if not _is_positive_finite(api_timeout):
+            raise ValueError(f'api_timeout must be a positive finite number, got {api_timeout!r}.')
+        if runtime not in (None, 'default', 'dev'):
+            raise ValueError(f"runtime must be 'default', 'dev', or None, got {runtime!r}.")
+        if sprite_name is not None and runtime is not None:
+            raise ValueError('runtime only applies when creating a Sprite; remove it when `sprite_name` is set.')
+
+        self._token = token
+        self._configured_name = sprite_name
+        self._base_url = base_url
+        self._api_timeout = api_timeout
+        self._runtime = runtime
+        self._workdir = workdir
+        self._client: SpritesClient | None = None
+        self._sprite: Sprite | None = None
+        self._cwd: str | None = None
+        self._ownership_label: str | None = None
+
+    @property
+    def sprite_name(self) -> str | None:
+        """The active Sprite name, or the configured attach name before entry."""
+        if self._sprite is not None:
+            return self._sprite.name
+        return self._configured_name
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the session currently has an open client and Sprite handle."""
+        return self._client is not None and self._sprite is not None
+
+    async def __aenter__(self) -> Self:
+        """Create or attach to the Sprite and resolve its command working directory."""
+        if self.is_open:
+            raise SpriteSandboxError(
+                'The session is already open; exit it before entering again. '
+                'Use a separate session per concurrent context.'
+            )
+        try:
+            from sprites import SpritesClient
+        except ImportError as e:
+            raise SpriteSandboxError(_MISSING_SPRITES) from e
+
+        token = self._token or os.getenv('SPRITE_TOKEN')
+        if not token:
+            raise SpriteSandboxAuthError('SPRITE_TOKEN is not set. Set it or pass `token=`.')
+
+        client = SpritesClient(token=token, base_url=self._base_url, timeout=self._api_timeout)
+        self._client = client
+        # Shield setup until the Sprite handle and ownership label are stored. A
+        # cancellation that lands during the synchronous create call would otherwise
+        # discard its return value and orphan a newly created Sprite.
+        with anyio.CancelScope(shield=True):
+            try:
+                if self._configured_name is not None:
+                    configured_name = self._configured_name
+                    sprite = await _run_sync(lambda: client.get_sprite(configured_name))
+                else:
+                    nonce = uuid.uuid4().hex[:20]
+                    sprite_name = f'pydantic-ai-{nonce}'
+                    ownership_label = f'{_PROVIDER_LABEL}-{nonce}'
+                    sprite = await _run_sync(
+                        lambda: client.create_sprite(
+                            sprite_name,
+                            labels=[_PROVIDER_LABEL, ownership_label],
+                            runtime=self._runtime,
+                        )
+                    )
+                    if ownership_label not in sprite.labels:
+                        try:
+                            await _run_sync(lambda: client.destroy_sprite(sprite_name))
+                        finally:
+                            await _run_sync(client.close)
+                            self._client = None
+                        raise SpriteSandboxOwnershipError(
+                            f'Created Sprite {sprite_name!r} did not retain its ownership label.'
+                        )
+                    self._ownership_label = ownership_label
+                self._sprite = sprite
+                self._cwd = self._workdir or await self._read_cwd(sprite)
+            except Exception as e:
+                error = e if isinstance(e, SpriteSandboxError) else self._open_error(e)
+                if self._client is not None and self._sprite is None:
+                    await _run_sync(client.close)
+                    self._client = None
+                elif self._client is not None:
+                    try:
+                        await self.__aexit__(None, None, None)
+                    except Exception as cleanup_error:
+                        raise SpriteSandboxError(f'{error} Cleanup also failed: {cleanup_error}') from e
+                raise error from e
+
+        try:
+            await anyio.lowlevel.checkpoint()
+        except BaseException:
+            with anyio.CancelScope(shield=True):
+                await self.__aexit__(None, None, None)
+            raise
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Destroy an owned Sprite after an ownership check, then close the SDK client."""
+        # Teardown must finish even when the surrounding agent run is cancelled. Each
+        # individual SDK request remains bounded by the client's API timeout.
+        with anyio.CancelScope(shield=True):
+            await self._close(*args)
+
+    async def _close(self, *args: object) -> None:
+        """Perform the teardown work inside `__aexit__`'s cancellation shield."""
+        client = self._client
+        sprite = self._sprite
+        if client is None or sprite is None:
+            return
+
+        cleanup_error: BaseException | None = None
+        try:
+            if self._ownership_label is not None:
+                await self._destroy_owned(client, sprite.name, self._ownership_label)
+        except BaseException as e:
+            cleanup_error = e
+        finally:
+            try:
+                await _run_sync(client.close)
+            except BaseException as e:
+                cleanup_error = cleanup_error or e
+            self._client = None
+
+        if cleanup_error is None:
+            self._sprite = None
+            self._cwd = None
+            self._ownership_label = None
+            return
+
+        body_failed = bool(args and args[0] is not None)
+        if body_failed:
+            logger.error(
+                'Failed to clean up Sprite %r while another exception was unwinding',
+                sprite.name,
+                exc_info=(type(cleanup_error), cleanup_error, cleanup_error.__traceback__),
+            )
+            return
+        raise cleanup_error
+
+    async def _read_cwd(self, sprite: Sprite) -> str:
+        result = await _run_sync(lambda: sprite.run('pwd', capture_output=True, timeout=_PWD_TIMEOUT))
+        if result.returncode != 0 or not result.stdout:
+            raise SpriteSandboxError(f'Could not determine the Sprite working directory (exit {result.returncode}).')
+        return result.stdout.decode('utf-8', errors='replace').strip()
+
+    async def _destroy_owned(self, client: SpritesClient, sprite_name: str, ownership_label: str) -> None:
+        from sprites import NotFoundError
+
+        try:
+            current = await _run_sync(lambda: client.get_sprite(sprite_name))
+        except NotFoundError:
+            return
+        except Exception as e:
+            raise await self._operation_error(e, f'Could not verify owned Sprite {sprite_name!r}') from e
+        if ownership_label not in current.labels:
+            raise SpriteSandboxOwnershipError(
+                f'Refusing to destroy Sprite {sprite_name!r}: its ownership label changed. '
+                'Delete it manually after verifying ownership.'
+            )
+        try:
+            await _run_sync(lambda: client.destroy_sprite(sprite_name))
+        except NotFoundError:
+            return
+        except Exception as e:
+            raise await self._operation_error(e, f'Could not destroy owned Sprite {sprite_name!r}') from e
+
+    def _open_error(self, e: BaseException) -> SpriteSandboxError:
+        from sprites import AuthenticationError, NotFoundError
+
+        if isinstance(e, AuthenticationError):
+            return SpriteSandboxAuthError(_AUTH_MESSAGE)
+        if self._configured_name is not None and isinstance(e, NotFoundError):
+            return SpriteSandboxUnavailableError(
+                f'Could not attach to Sprite {self._configured_name!r}: it does not exist.'
+            )
+        return SpriteSandboxError(f'Could not start Sprite sandbox: {e}')
+
+    def _require_open(self) -> tuple[SpritesClient, Sprite, str]:
+        if self._client is None or self._sprite is None or self._cwd is None:
+            raise SpriteSandboxError('The Sprite session is not open; use it as an async context manager.')
+        return self._client, self._sprite, self._cwd
+
+    async def _operation_error(self, e: BaseException, message: str) -> SpriteSandboxError:
+        from sprites import AuthenticationError, NotFoundError, SpriteError
+
+        if isinstance(e, AuthenticationError):
+            return SpriteSandboxAuthError(_AUTH_MESSAGE)
+        if isinstance(e, NotFoundError):
+            return SpriteSandboxUnavailableError(f'{message}: the Sprite no longer exists.')
+        if isinstance(e, SpriteError) and self._client is not None and self._sprite is not None:
+            client = self._client
+            sprite_name = self._sprite.name
+            try:
+                await _run_sync(lambda: client.get_sprite(sprite_name))
+            except AuthenticationError:
+                return SpriteSandboxAuthError(_AUTH_MESSAGE)
+            except NotFoundError:
+                return SpriteSandboxUnavailableError(f'{message}: Sprite {sprite_name!r} no longer exists.')
+            except SpriteError:
+                pass
+        return SpriteSandboxError(f'{message}: {e}')
+
+    async def exec(
+        self,
+        command: str,
+        *,
+        timeout: float | None,
+        max_output_bytes: int,
+    ) -> SpriteSandboxExecResult:
+        """Run a shell command with bounded combined output and process-group timeout."""
+        _, sprite, cwd = self._require_open()
+        if timeout is not None and (type(timeout) is bool or not math.isfinite(timeout) or timeout <= 0):
+            raise ValueError(f'timeout must be a positive finite number or None, got {timeout!r}.')
+        if type(max_output_bytes) is not int or max_output_bytes <= 0:
+            raise ValueError(f'max_output_bytes must be a positive integer, got {max_output_bytes!r}.')
+
+        from sprites.exceptions import TimeoutError as SpriteTimeoutError
+
+        environment = {_COMMAND_ENV: command}
+        transport_timeout: float | None = None
+        if timeout is not None:
+            environment[_COMMAND_TIMEOUT_ENV] = str(timeout)
+            transport_timeout = timeout + _TRANSPORT_TIMEOUT_GRACE
+        try:
+            result = await _run_sync(
+                lambda: sprite.run(
+                    'bash',
+                    '-lc',
+                    _execute_wrapper(max_output_bytes),
+                    capture_output=True,
+                    timeout=transport_timeout,
+                    env=environment,
+                    cwd=cwd,
+                )
+            )
+        except Exception as e:
+            if isinstance(e, SpriteTimeoutError):
+                return SpriteSandboxExecResult(output='', returncode=124, timed_out=True, applied_timeout=timeout)
+            raise await self._operation_error(e, 'Command could not run in the Sprite') from e
+
+        raw = (result.stdout or b'') + (result.stderr or b'')
+        timed_out = raw.endswith(_TIMEOUT_MARKER)
+        if timed_out:
+            raw = raw[: -len(_TIMEOUT_MARKER)]
+        return SpriteSandboxExecResult(
+            output=raw.decode('utf-8', errors='replace'),
+            returncode=result.returncode,
+            truncated=_TRUNCATION_MARKER in raw,
+            timed_out=timed_out,
+            applied_timeout=timeout,
+        )
+
+    async def file_size(self, path: str) -> int:
+        """Return a file size without reading the file."""
+        _, sprite, cwd = self._require_open()
+        try:
+            return await _run_sync(lambda: (sprite.filesystem(cwd) / path).stat().size)
+        except Exception as e:
+            raise await self._operation_error(e, f'Could not stat {path!r}') from e
+
+    async def read_bytes(self, path: str) -> bytes:
+        """Read a file as bytes."""
+        _, sprite, cwd = self._require_open()
+        try:
+            return await _run_sync(lambda: (sprite.filesystem(cwd) / path).read_bytes())
+        except Exception as e:
+            raise await self._operation_error(e, f'Could not read {path!r}') from e
+
+    async def write_bytes(self, path: str, data: bytes) -> None:
+        """Write bytes to a file, creating parent directories."""
+        _, sprite, cwd = self._require_open()
+        try:
+            await _run_sync(lambda: (sprite.filesystem(cwd) / path).write_bytes(data, mkdir_parents=True))
+        except Exception as e:
+            raise await self._operation_error(e, f'Could not write {path!r}') from e
+
+    async def list_files(self, path: str) -> list[tuple[str, bool]]:
+        """List a directory as `(name, is_dir)` pairs."""
+        _, sprite, cwd = self._require_open()
+
+        def list_sync() -> list[tuple[str, bool]]:
+            entries = (sprite.filesystem(cwd) / path).iterdir()
+            return [(entry.name, entry.stat().is_dir) for entry in entries]
+
+        try:
+            return await _run_sync(list_sync)
+        except Exception as e:
+            raise await self._operation_error(e, f'Could not list {path!r}') from e
+
+
+def _is_positive_finite(value: float) -> bool:
+    """Whether a value is a positive finite int or float, excluding bool."""
+    if type(value) not in (int, float):
+        return False
+    return math.isfinite(value) and value > 0

--- a/pydantic_ai_harness/sprites/_session.py
+++ b/pydantic_ai_harness/sprites/_session.py
@@ -45,7 +45,7 @@ _PWD_TIMEOUT = 10.0
 _MISSING_SPRITES = (
     'The \'sprites-py\' package is required for SpriteSandbox. Install it with `uv add "pydantic-ai-harness[sprites]"`.'
 )
-_AUTH_MESSAGE = 'Sprites rejected the credentials. Set SPRITE_TOKEN or pass `token=`.'
+_AUTH_MESSAGE = 'Fly.io Sprites rejected the credentials. Set SPRITE_TOKEN or pass `token=`.'
 
 T = TypeVar('T')
 
@@ -56,7 +56,7 @@ async def _run_sync(func: Callable[[], T]) -> T:
 
 
 class SpriteSandboxError(RuntimeError):
-    """Base class for failures reported by the Sprites integration."""
+    """Base class for failures reported by the Fly.io Sprites integration."""
 
 
 class SpriteSandboxTerminalError(SpriteSandboxError):
@@ -68,7 +68,7 @@ class SpriteSandboxUnavailableError(SpriteSandboxTerminalError):
 
 
 class SpriteSandboxAuthError(SpriteSandboxTerminalError):
-    """The Sprites API rejected the configured token."""
+    """The Fly.io Sprites API rejected the configured token."""
 
 
 class SpriteSandboxOwnershipError(SpriteSandboxTerminalError):
@@ -190,9 +190,9 @@ class SpriteSandboxSession:
     leaves it running on exit.
 
     Args:
-        token: Sprites API token. Defaults to `SPRITE_TOKEN` on entry.
+        token: Fly.io Sprites API token. Defaults to `SPRITE_TOKEN` on entry.
         sprite_name: Existing Sprite to attach to. Omit to create an owned Sprite.
-        base_url: Sprites API base URL.
+        base_url: Fly.io Sprites API base URL.
         api_timeout: Timeout in seconds for API calls other than Sprite creation.
         runtime: Runtime channel for an owned Sprite: `default`, `dev`, or None.
         workdir: Working directory for commands and relative file paths. When

--- a/pydantic_ai_harness/sprites/_session.py
+++ b/pydantic_ai_harness/sprites/_session.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 import math
 import os
-import shlex
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -37,10 +36,16 @@ DEFAULT_MAX_COMMAND_TIMEOUT = 300.0
 _PROVIDER_LABEL = 'pydantic-ai-harness'
 _COMMAND_ENV = 'PYDANTIC_AI_SPRITE_COMMAND'
 _COMMAND_TIMEOUT_ENV = 'PYDANTIC_AI_SPRITE_TIMEOUT_SECONDS'
+_READ_PATH_ENV = 'PYDANTIC_AI_SPRITE_READ_PATH'
+_READ_LIMIT_ENV = 'PYDANTIC_AI_SPRITE_READ_LIMIT'
+_LIST_PATH_ENV = 'PYDANTIC_AI_SPRITE_LIST_PATH'
+_LIST_MAX_ENTRIES_ENV = 'PYDANTIC_AI_SPRITE_LIST_MAX_ENTRIES'
+_LIST_MAX_BYTES_ENV = 'PYDANTIC_AI_SPRITE_LIST_MAX_BYTES'
 _TRUNCATION_MARKER = b'\n[... Sprite command output truncated ...]\n'
-_TIMEOUT_MARKER = b'\n__PYDANTIC_AI_SPRITE_TIMEOUT__\n'
 _TRANSPORT_TIMEOUT_GRACE = 5.0
 _PWD_TIMEOUT = 10.0
+_HELPER_ERROR_EXIT = 66
+_READ_LIMIT_EXIT = 65
 
 _MISSING_SPRITES = (
     'The \'sprites-py\' package is required for SpriteSandbox. Install it with `uv add "pydantic-ai-harness[sprites]"`.'
@@ -91,10 +96,17 @@ class SpriteSandboxExecResult:
     """The command deadline enforced inside the Sprite, if any."""
 
 
+@dataclass(frozen=True, kw_only=True)
+class _SpriteSandboxListResult:
+    entries: list[tuple[str, bool]]
+    truncated: bool
+
+
 def _execute_wrapper(max_output_bytes: int) -> str:
     """Build an in-Sprite process-group runner with bounded combined output."""
-    content_budget = max(0, max_output_bytes - len(_TRUNCATION_MARKER))
-    script = f"""
+    truncation_marker = _TRUNCATION_MARKER[:max_output_bytes]
+    content_budget = max_output_bytes - len(truncation_marker)
+    return f"""
 import os
 import signal
 import subprocess
@@ -104,8 +116,7 @@ import threading
 budget = {content_budget}
 head_budget = budget // 2
 tail_budget = budget - head_budget
-truncation_marker = {_TRUNCATION_MARKER!r}
-timeout_marker = {_TIMEOUT_MARKER!r}
+truncation_marker = {truncation_marker!r}
 command = os.environ[{_COMMAND_ENV!r}]
 raw_timeout = os.environ.get({_COMMAND_TIMEOUT_ENV!r})
 command_timeout = float(raw_timeout) if raw_timeout else None
@@ -114,7 +125,7 @@ tail = bytearray()
 total = 0
 
 process = subprocess.Popen(
-    ['bash', '-lc', command],
+    ['bash', '-c', command],
     stdout=subprocess.PIPE,
     stderr=subprocess.STDOUT,
     start_new_session=True,
@@ -165,20 +176,68 @@ if reader.is_alive():
     process.stdout.close()
     reader.join(timeout=1.0)
 
-if total > budget:
+truncated = total > budget
+if truncated:
     output = bytes(head) + truncation_marker + bytes(tail)
 else:
     output = bytes(head) + bytes(tail)
 sys.stdout.buffer.write(output)
 if timed_out:
-    sys.stdout.buffer.write(timeout_marker)
     returncode = 124
 elif returncode < 0:
     returncode = 128 - returncode
 sys.stdout.buffer.flush()
+sys.stderr.buffer.write(bytes((int(truncated), int(timed_out))))
+sys.stderr.buffer.flush()
 raise SystemExit(returncode)
 """.strip()
-    return f'python3 -c {shlex.quote(script)} 2>&1'
+
+
+_BOUNDED_READ_SCRIPT = f"""
+import os
+import sys
+
+path = os.environ[{_READ_PATH_ENV!r}]
+limit = int(os.environ[{_READ_LIMIT_ENV!r}])
+try:
+    with open(path, 'rb') as file:
+        data = file.read(limit + 1)
+except BaseException as error:
+    sys.stderr.write(f'{{type(error).__name__}}: {{error}}')
+    raise SystemExit({_HELPER_ERROR_EXIT})
+if len(data) > limit:
+    raise SystemExit({_READ_LIMIT_EXIT})
+sys.stdout.buffer.write(data)
+""".strip()
+
+
+_BOUNDED_LIST_SCRIPT = f"""
+import os
+import sys
+
+path = os.environ[{_LIST_PATH_ENV!r}]
+max_entries = int(os.environ[{_LIST_MAX_ENTRIES_ENV!r}])
+max_bytes = int(os.environ[{_LIST_MAX_BYTES_ENV!r}])
+count = 0
+rendered_bytes = 0
+truncated = False
+try:
+    with os.scandir(path) as entries:
+        for entry in entries:
+            is_dir = entry.is_dir(follow_symlinks=False)
+            name = entry.name.encode('utf-8', errors='replace')
+            rendered_cost = len(name) + int(is_dir) + int(count > 0)
+            if count >= max_entries or rendered_bytes + rendered_cost > max_bytes:
+                truncated = True
+                break
+            sys.stdout.buffer.write((b'D' if is_dir else b'F') + name + b'\\0')
+            rendered_bytes += rendered_cost
+            count += 1
+except BaseException as error:
+    sys.stderr.write(f'{{type(error).__name__}}: {{error}}')
+    raise SystemExit({_HELPER_ERROR_EXIT})
+sys.stderr.buffer.write(b'1' if truncated else b'0')
+""".strip()
 
 
 class SpriteSandboxSession:
@@ -330,14 +389,14 @@ class SpriteSandboxSession:
                 await self._destroy_owned(client, sprite.name, self._ownership_label)
         except BaseException as e:
             cleanup_error = e
-        finally:
+        if cleanup_error is None:
             try:
                 await _run_sync(client.close)
             except BaseException as e:
-                cleanup_error = cleanup_error or e
-            self._client = None
+                cleanup_error = e
 
         if cleanup_error is None:
+            self._client = None
             self._sprite = None
             self._cwd = None
             self._ownership_label = None
@@ -373,6 +432,10 @@ class SpriteSandboxSession:
                 f'Refusing to destroy Sprite {sprite_name!r}: its ownership label changed. '
                 'Delete it manually after verifying ownership.'
             )
+        # The API currently exposes name-based deletion without an ownership-label
+        # precondition. The random name and label protect against stale handles and
+        # accidental reuse; actors with write access to the same organization remain
+        # inside the trust boundary and could race this check.
         try:
             await _run_sync(lambda: client.destroy_sprite(sprite_name))
         except NotFoundError:
@@ -440,8 +503,10 @@ class SpriteSandboxSession:
         try:
             result = await _run_sync(
                 lambda: sprite.run(
-                    'bash',
-                    '-lc',
+                    'python3',
+                    '-I',
+                    '-S',
+                    '-c',
                     _execute_wrapper(max_output_bytes),
                     capture_output=True,
                     timeout=transport_timeout,
@@ -454,15 +519,24 @@ class SpriteSandboxSession:
                 return SpriteSandboxExecResult(output='', returncode=124, timed_out=True, applied_timeout=timeout)
             raise await self._operation_error(e, 'Command could not run in the Sprite') from e
 
-        raw = (result.stdout or b'') + (result.stderr or b'')
-        timed_out = raw.endswith(_TIMEOUT_MARKER)
-        if timed_out:
-            raw = raw[: -len(_TIMEOUT_MARKER)]
+        control = result.stderr or b''
+        if len(control) != 2 or control[0] not in (0, 1) or control[1] not in (0, 1):
+            detail = control.decode('utf-8', errors='replace').strip()
+            suffix = f': {detail}' if detail else ''
+            raise SpriteSandboxError(f'Command wrapper did not return valid status{suffix}')
+        raw = result.stdout or b''
+        if len(raw) > max_output_bytes:
+            raise SpriteSandboxError('Command wrapper returned more output than its configured byte limit.')
+        output = raw.decode('utf-8', errors='replace')
+        encoded_output = output.encode('utf-8')
+        decoding_truncated = len(encoded_output) > max_output_bytes
+        if decoding_truncated:
+            output = encoded_output[:max_output_bytes].decode('utf-8', errors='ignore')
         return SpriteSandboxExecResult(
-            output=raw.decode('utf-8', errors='replace'),
+            output=output,
             returncode=result.returncode,
-            truncated=_TRUNCATION_MARKER in raw,
-            timed_out=timed_out,
+            truncated=bool(control[0]) or decoding_truncated,
+            timed_out=bool(control[1]),
             applied_timeout=timeout,
         )
 
@@ -474,13 +548,37 @@ class SpriteSandboxSession:
         except Exception as e:
             raise await self._operation_error(e, f'Could not stat {path!r}') from e
 
-    async def read_bytes(self, path: str) -> bytes:
-        """Read a file as bytes."""
+    async def read_bytes(self, path: str, *, max_bytes: int) -> bytes:
+        """Read at most `max_bytes` from a file without buffering a larger response."""
         _, sprite, cwd = self._require_open()
+        if type(max_bytes) is not int or max_bytes <= 0:
+            raise ValueError(f'max_bytes must be a positive integer, got {max_bytes!r}.')
         try:
-            return await _run_sync(lambda: (sprite.filesystem(cwd) / path).read_bytes())
+            result = await _run_sync(
+                lambda: sprite.run(
+                    'python3',
+                    '-I',
+                    '-S',
+                    '-c',
+                    _BOUNDED_READ_SCRIPT,
+                    capture_output=True,
+                    timeout=self._api_timeout,
+                    env={_READ_PATH_ENV: path, _READ_LIMIT_ENV: str(max_bytes)},
+                    cwd=cwd,
+                )
+            )
         except Exception as e:
             raise await self._operation_error(e, f'Could not read {path!r}') from e
+        if result.returncode == _READ_LIMIT_EXIT:
+            raise SpriteSandboxError(f'File {path!r} exceeded the {max_bytes}-byte read limit while it was being read.')
+        if result.returncode != 0:
+            detail = (result.stderr or b'').decode('utf-8', errors='replace').strip()
+            suffix = f': {detail}' if detail else ''
+            raise SpriteSandboxError(f'Could not read {path!r}{suffix}')
+        data = result.stdout or b''
+        if len(data) > max_bytes:
+            raise SpriteSandboxError(f'File response exceeded the {max_bytes}-byte read limit.')
+        return data
 
     async def write_bytes(self, path: str, data: bytes) -> None:
         """Write bytes to a file, creating parent directories."""
@@ -490,18 +588,60 @@ class SpriteSandboxSession:
         except Exception as e:
             raise await self._operation_error(e, f'Could not write {path!r}') from e
 
-    async def list_files(self, path: str) -> list[tuple[str, bool]]:
-        """List a directory as `(name, is_dir)` pairs."""
+    async def list_files(
+        self,
+        path: str,
+        *,
+        max_entries: int,
+        max_output_bytes: int,
+    ) -> _SpriteSandboxListResult:
+        """List a bounded prefix of a directory without buffering an unbounded API response."""
         _, sprite, cwd = self._require_open()
-
-        def list_sync() -> list[tuple[str, bool]]:
-            entries = (sprite.filesystem(cwd) / path).iterdir()
-            return [(entry.name, entry.stat().is_dir) for entry in entries]
-
+        if type(max_entries) is not int or max_entries <= 0:
+            raise ValueError(f'max_entries must be a positive integer, got {max_entries!r}.')
+        if type(max_output_bytes) is not int or max_output_bytes <= 0:
+            raise ValueError(f'max_output_bytes must be a positive integer, got {max_output_bytes!r}.')
         try:
-            return await _run_sync(list_sync)
+            result = await _run_sync(
+                lambda: sprite.run(
+                    'python3',
+                    '-I',
+                    '-S',
+                    '-c',
+                    _BOUNDED_LIST_SCRIPT,
+                    capture_output=True,
+                    timeout=self._api_timeout,
+                    env={
+                        _LIST_PATH_ENV: path,
+                        _LIST_MAX_ENTRIES_ENV: str(max_entries),
+                        _LIST_MAX_BYTES_ENV: str(max_output_bytes),
+                    },
+                    cwd=cwd,
+                )
+            )
         except Exception as e:
             raise await self._operation_error(e, f'Could not list {path!r}') from e
+        if result.returncode != 0:
+            detail = (result.stderr or b'').decode('utf-8', errors='replace').strip()
+            suffix = f': {detail}' if detail else ''
+            raise SpriteSandboxError(f'Could not list {path!r}{suffix}')
+        control = result.stderr or b''
+        if control not in (b'0', b'1'):
+            raise SpriteSandboxError('Directory helper did not return valid status.')
+        raw = result.stdout or b''
+        if len(raw) > max_output_bytes + max_entries + 1:
+            raise SpriteSandboxError('Directory helper returned more data than its configured limit.')
+        records = raw.split(b'\0')
+        if records[-1] != b'':
+            raise SpriteSandboxError('Directory helper returned an incomplete entry.')
+        entries: list[tuple[str, bool]] = []
+        for record in records[:-1]:
+            if not record or record[:1] not in (b'D', b'F'):
+                raise SpriteSandboxError('Directory helper returned an invalid entry.')
+            entries.append((record[1:].decode('utf-8', errors='replace'), record[:1] == b'D'))
+        if len(entries) > max_entries:
+            raise SpriteSandboxError('Directory helper returned too many entries.')
+        return _SpriteSandboxListResult(entries=entries, truncated=control == b'1')
 
 
 def _is_positive_finite(value: float) -> bool:

--- a/pydantic_ai_harness/sprites/_session.py
+++ b/pydantic_ai_harness/sprites/_session.py
@@ -500,7 +500,7 @@ class SpriteSandboxSession:
         )
         if result.returncode != 0 or not result.stdout:
             raise SpriteSandboxError(f'Could not determine the Sprite working directory (exit {result.returncode}).')
-        return result.stdout.decode('utf-8', errors='replace').strip()
+        return result.stdout.decode('utf-8', errors='replace').removesuffix('\n')
 
     async def _destroy_owned(self, client: SpritesClient, sprite_name: str, ownership_label: str) -> None:
         from sprites import NotFoundError

--- a/pydantic_ai_harness/sprites/_session.py
+++ b/pydantic_ai_harness/sprites/_session.py
@@ -44,6 +44,7 @@ _LIST_MAX_BYTES_ENV = 'PYDANTIC_AI_SPRITE_LIST_MAX_BYTES'
 _TRUNCATION_MARKER = b'\n[... Sprite command output truncated ...]\n'
 _TRANSPORT_TIMEOUT_GRACE = 5.0
 _PWD_TIMEOUT = 10.0
+_STATUS_OUTPUT_LIMIT = 4096
 _HELPER_ERROR_EXIT = 66
 _READ_LIMIT_EXIT = 65
 
@@ -100,6 +101,39 @@ class SpriteSandboxExecResult:
 class _SpriteSandboxListResult:
     entries: list[tuple[str, bool]]
     truncated: bool
+
+
+@dataclass(frozen=True, kw_only=True)
+class _BoundedCommandResult:
+    stdout: bytes
+    stderr: bytes
+    returncode: int
+
+
+class _ResponseLimitExceeded(RuntimeError):
+    pass
+
+
+class _BoundedSink:
+    """A file-like SDK sink that aborts a response as soon as its cap is crossed."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._data = bytearray()
+        self.exceeded = False
+
+    @property
+    def data(self) -> bytes:
+        return bytes(self._data)
+
+    def write(self, data: bytes) -> int:
+        remaining = self._limit - len(self._data)
+        if len(data) > remaining:
+            self._data.extend(data[:remaining])
+            self.exceeded = True
+            raise _ResponseLimitExceeded(f'Sprite response exceeded its {self._limit}-byte transport limit.')
+        self._data.extend(data)
+        return len(data)
 
 
 def _execute_wrapper(max_output_bytes: int) -> str:
@@ -220,6 +254,7 @@ max_entries = int(os.environ[{_LIST_MAX_ENTRIES_ENV!r}])
 max_bytes = int(os.environ[{_LIST_MAX_BYTES_ENV!r}])
 count = 0
 rendered_bytes = 0
+wire_bytes = 0
 truncated = False
 try:
     with os.scandir(path) as entries:
@@ -227,11 +262,17 @@ try:
             is_dir = entry.is_dir(follow_symlinks=False)
             name = entry.name.encode('utf-8', errors='replace')
             rendered_cost = len(name) + int(is_dir) + int(count > 0)
-            if count >= max_entries or rendered_bytes + rendered_cost > max_bytes:
+            wire_cost = len(name) + 2
+            if (
+                count >= max_entries
+                or rendered_bytes + rendered_cost > max_bytes
+                or wire_bytes + wire_cost > max_bytes
+            ):
                 truncated = True
                 break
             sys.stdout.buffer.write((b'D' if is_dir else b'F') + name + b'\\0')
             rendered_bytes += rendered_cost
+            wire_bytes += wire_cost
             count += 1
 except BaseException as error:
     sys.stderr.write(f'{{type(error).__name__}}: {{error}}')
@@ -412,8 +453,51 @@ class SpriteSandboxSession:
             return
         raise cleanup_error
 
+    async def _run_bounded_command(
+        self,
+        sprite: Sprite,
+        *args: str,
+        stdout_limit: int,
+        stderr_limit: int = _STATUS_OUTPUT_LIMIT,
+        timeout: float | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+    ) -> _BoundedCommandResult:
+        """Run through SDK streaming sinks so a replaced helper cannot return unbounded data."""
+
+        def run() -> _BoundedCommandResult:
+            from sprites.exceptions import ExitError
+
+            stdout = _BoundedSink(stdout_limit)
+            stderr = _BoundedSink(stderr_limit)
+            command = sprite.command(
+                *args,
+                stdout=stdout,
+                stderr=stderr,
+                timeout=timeout,
+                env=env,
+                cwd=cwd,
+            )
+            returncode = 0
+            try:
+                command.run()
+            except ExitError as e:
+                returncode = e.exit_code()
+            except Exception as e:
+                if stdout.exceeded or stderr.exceeded:
+                    raise _ResponseLimitExceeded('Sprite response exceeded its configured transport limit.') from e
+                raise
+            return _BoundedCommandResult(stdout=stdout.data, stderr=stderr.data, returncode=returncode)
+
+        return await _run_sync(run)
+
     async def _read_cwd(self, sprite: Sprite) -> str:
-        result = await _run_sync(lambda: sprite.run('pwd', capture_output=True, timeout=_PWD_TIMEOUT))
+        result = await self._run_bounded_command(
+            sprite,
+            'pwd',
+            stdout_limit=_STATUS_OUTPUT_LIMIT,
+            timeout=_PWD_TIMEOUT,
+        )
         if result.returncode != 0 or not result.stdout:
             raise SpriteSandboxError(f'Could not determine the Sprite working directory (exit {result.returncode}).')
         return result.stdout.decode('utf-8', errors='replace').strip()
@@ -501,18 +585,17 @@ class SpriteSandboxSession:
             environment[_COMMAND_TIMEOUT_ENV] = str(timeout)
             transport_timeout = timeout + _TRANSPORT_TIMEOUT_GRACE
         try:
-            result = await _run_sync(
-                lambda: sprite.run(
-                    'python3',
-                    '-I',
-                    '-S',
-                    '-c',
-                    _execute_wrapper(max_output_bytes),
-                    capture_output=True,
-                    timeout=transport_timeout,
-                    env=environment,
-                    cwd=cwd,
-                )
+            result = await self._run_bounded_command(
+                sprite,
+                'python3',
+                '-I',
+                '-S',
+                '-c',
+                _execute_wrapper(max_output_bytes),
+                stdout_limit=max_output_bytes,
+                timeout=transport_timeout,
+                env=environment,
+                cwd=cwd,
             )
         except Exception as e:
             if isinstance(e, SpriteTimeoutError):
@@ -540,32 +623,23 @@ class SpriteSandboxSession:
             applied_timeout=timeout,
         )
 
-    async def file_size(self, path: str) -> int:
-        """Return a file size without reading the file."""
-        _, sprite, cwd = self._require_open()
-        try:
-            return await _run_sync(lambda: (sprite.filesystem(cwd) / path).stat().size)
-        except Exception as e:
-            raise await self._operation_error(e, f'Could not stat {path!r}') from e
-
     async def read_bytes(self, path: str, *, max_bytes: int) -> bytes:
         """Read at most `max_bytes` from a file without buffering a larger response."""
         _, sprite, cwd = self._require_open()
         if type(max_bytes) is not int or max_bytes <= 0:
             raise ValueError(f'max_bytes must be a positive integer, got {max_bytes!r}.')
         try:
-            result = await _run_sync(
-                lambda: sprite.run(
-                    'python3',
-                    '-I',
-                    '-S',
-                    '-c',
-                    _BOUNDED_READ_SCRIPT,
-                    capture_output=True,
-                    timeout=self._api_timeout,
-                    env={_READ_PATH_ENV: path, _READ_LIMIT_ENV: str(max_bytes)},
-                    cwd=cwd,
-                )
+            result = await self._run_bounded_command(
+                sprite,
+                'python3',
+                '-I',
+                '-S',
+                '-c',
+                _BOUNDED_READ_SCRIPT,
+                stdout_limit=max_bytes,
+                timeout=self._api_timeout,
+                env={_READ_PATH_ENV: path, _READ_LIMIT_ENV: str(max_bytes)},
+                cwd=cwd,
             )
         except Exception as e:
             raise await self._operation_error(e, f'Could not read {path!r}') from e
@@ -602,22 +676,21 @@ class SpriteSandboxSession:
         if type(max_output_bytes) is not int or max_output_bytes <= 0:
             raise ValueError(f'max_output_bytes must be a positive integer, got {max_output_bytes!r}.')
         try:
-            result = await _run_sync(
-                lambda: sprite.run(
-                    'python3',
-                    '-I',
-                    '-S',
-                    '-c',
-                    _BOUNDED_LIST_SCRIPT,
-                    capture_output=True,
-                    timeout=self._api_timeout,
-                    env={
-                        _LIST_PATH_ENV: path,
-                        _LIST_MAX_ENTRIES_ENV: str(max_entries),
-                        _LIST_MAX_BYTES_ENV: str(max_output_bytes),
-                    },
-                    cwd=cwd,
-                )
+            result = await self._run_bounded_command(
+                sprite,
+                'python3',
+                '-I',
+                '-S',
+                '-c',
+                _BOUNDED_LIST_SCRIPT,
+                stdout_limit=max_output_bytes,
+                timeout=self._api_timeout,
+                env={
+                    _LIST_PATH_ENV: path,
+                    _LIST_MAX_ENTRIES_ENV: str(max_entries),
+                    _LIST_MAX_BYTES_ENV: str(max_output_bytes),
+                },
+                cwd=cwd,
             )
         except Exception as e:
             raise await self._operation_error(e, f'Could not list {path!r}') from e
@@ -629,7 +702,7 @@ class SpriteSandboxSession:
         if control not in (b'0', b'1'):
             raise SpriteSandboxError('Directory helper did not return valid status.')
         raw = result.stdout or b''
-        if len(raw) > max_output_bytes + max_entries + 1:
+        if len(raw) > max_output_bytes:
             raise SpriteSandboxError('Directory helper returned more data than its configured limit.')
         records = raw.split(b'\0')
         if records[-1] != b'':

--- a/pydantic_ai_harness/sprites/_toolset.py
+++ b/pydantic_ai_harness/sprites/_toolset.py
@@ -1,0 +1,231 @@
+"""Sprites toolset: gives agents a persistent cloud computer to work in."""
+
+from __future__ import annotations
+
+import math
+from typing import Annotated
+
+from pydantic import Field
+from pydantic_ai import RunContext
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.tools import AgentDepsT
+from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
+from typing_extensions import Self
+
+from pydantic_ai_harness._sandbox_output import guard_read_size, render_file_window, truncate_output
+from pydantic_ai_harness.sprites._session import (
+    SpriteSandboxError,
+    SpriteSandboxSession,
+    SpriteSandboxTerminalError,
+)
+
+
+class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
+    """Gives an agent a Sprite to run commands and manage files in."""
+
+    def __init__(
+        self,
+        *,
+        token: str | None,
+        sprite_name: str | None,
+        base_url: str,
+        api_timeout: float,
+        runtime: str | None,
+        workdir: str | None,
+        default_command_timeout: float,
+        max_command_timeout: float,
+        max_output_bytes: int,
+        max_output_lines: int,
+        max_read_bytes: int,
+        session: SpriteSandboxSession | None = None,
+        _run_scoped: bool = False,
+    ) -> None:
+        super().__init__()
+        self._token = token
+        self._sprite_name = sprite_name
+        self._base_url = base_url
+        self._api_timeout = api_timeout
+        self._runtime = runtime
+        self._workdir = workdir
+        self._default_command_timeout = default_command_timeout
+        self._max_command_timeout = max_command_timeout
+        self._max_output_bytes = max_output_bytes
+        self._max_output_lines = max_output_lines
+        self._max_read_bytes = max_read_bytes
+        self._external_session = session
+        self._session: SpriteSandboxSession | None = None
+        self._run_scoped = _run_scoped
+
+        self.add_function(
+            self.run_command,
+            name='run_command',
+            metadata={'code_arg_name': 'command', 'code_arg_language': 'shell'},
+        )
+        self.add_function(self.read_file, name='read_file')
+        self.add_function(self.write_file, name='write_file')
+        self.add_function(self.list_directory, name='list_directory')
+
+    async def for_run(self, ctx: RunContext[AgentDepsT]) -> AbstractToolset[AgentDepsT]:
+        """Return a fresh instance with one Sprite session for this agent run."""
+        return SpriteSandboxToolset[AgentDepsT](
+            token=self._token,
+            sprite_name=self._sprite_name,
+            base_url=self._base_url,
+            api_timeout=self._api_timeout,
+            runtime=self._runtime,
+            workdir=self._workdir,
+            default_command_timeout=self._default_command_timeout,
+            max_command_timeout=self._max_command_timeout,
+            max_output_bytes=self._max_output_bytes,
+            max_output_lines=self._max_output_lines,
+            max_read_bytes=self._max_read_bytes,
+            session=self._external_session,
+            _run_scoped=True,
+        )
+
+    async def __aenter__(self) -> Self:
+        """Open a per-run Sprite, or use an already-open caller-owned session."""
+        if not self._run_scoped:
+            return self
+        if self._external_session is not None:
+            if not self._external_session.is_open:
+                raise SpriteSandboxError(
+                    'The injected session is not open. Enter it with `async with session:` before running the agent.'
+                )
+            self._session = self._external_session
+            return self
+        session = SpriteSandboxSession(
+            token=self._token,
+            sprite_name=self._sprite_name,
+            base_url=self._base_url,
+            api_timeout=self._api_timeout,
+            runtime=self._runtime,
+            workdir=self._workdir,
+        )
+        await session.__aenter__()
+        self._session = session
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Close the per-run session, leaving a caller-owned session open."""
+        session = self._session
+        self._session = None
+        if session is not None and self._external_session is None:
+            await session.__aexit__(*args)
+
+    def _require_session(self) -> SpriteSandboxSession:
+        if self._session is None:
+            raise SpriteSandboxError('The Sprite session is not open.')
+        return self._session
+
+    def _command_timeout(self, timeout_seconds: float | None) -> float:
+        if timeout_seconds is not None and (
+            type(timeout_seconds) is bool or not math.isfinite(timeout_seconds) or timeout_seconds <= 0
+        ):
+            raise ModelRetry(f'timeout_seconds must be greater than 0, got {timeout_seconds}.')
+        requested = timeout_seconds if timeout_seconds is not None else self._default_command_timeout
+        return min(requested, self._max_command_timeout)
+
+    async def run_command(self, command: str, *, timeout_seconds: float | None = None) -> str:
+        """Run a shell command in the Sprite and return its combined output.
+
+        Args:
+            command: The shell command to run.
+            timeout_seconds: Maximum seconds to wait (default: the configured timeout).
+        """
+        session = self._require_session()
+        timeout = self._command_timeout(timeout_seconds)
+        try:
+            result = await session.exec(command, timeout=timeout, max_output_bytes=self._max_output_bytes)
+        except SpriteSandboxTerminalError:
+            raise
+        except SpriteSandboxError as e:
+            raise ModelRetry(str(e))
+
+        output = result.output or '(no output)'
+        output = truncate_output(
+            output,
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+            direction='tail',
+            already_truncated=result.truncated,
+        )
+        if result.timed_out:
+            return f'{output}\n[timed out after {result.applied_timeout}s]'
+        if result.returncode:
+            return f'{output}\n[exit code: {result.returncode}]'
+        return output
+
+    async def read_file(
+        self,
+        path: str,
+        *,
+        offset: Annotated[int | None, Field(description='Line number to start reading from (1-indexed)')] = None,
+        limit: Annotated[int | None, Field(description='Maximum number of lines to read')] = None,
+    ) -> str:
+        """Read a text file from the Sprite.
+
+        Args:
+            path: Path inside the Sprite, relative to its command working directory by default.
+            offset: Line number to start reading from (1-indexed).
+            limit: Maximum number of lines to read.
+        """
+        session = self._require_session()
+        try:
+            guard_read_size(await session.file_size(path), max_bytes=self._max_read_bytes)
+            data = await session.read_bytes(path)
+        except SpriteSandboxTerminalError:
+            raise
+        except SpriteSandboxError as e:
+            raise ModelRetry(f'Could not read {path!r}: {e}')
+        guard_read_size(len(data), max_bytes=self._max_read_bytes)
+        return render_file_window(
+            data,
+            offset=offset,
+            limit=limit,
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+        )
+
+    async def write_file(self, path: str, content: str) -> str:
+        """Write text to a file in the Sprite, creating parent directories.
+
+        Args:
+            path: Path inside the Sprite, relative to its command working directory by default.
+            content: The UTF-8 text to write.
+        """
+        session = self._require_session()
+        try:
+            data = content.encode('utf-8')
+        except UnicodeEncodeError:
+            raise ModelRetry('content contains characters that cannot be encoded as UTF-8 (unpaired surrogates).')
+        try:
+            await session.write_bytes(path, data)
+        except SpriteSandboxTerminalError:
+            raise
+        except SpriteSandboxError as e:
+            raise ModelRetry(f'Could not write {path!r}: {e}')
+        return f'Wrote {len(data)} bytes to {path!r}.'
+
+    async def list_directory(self, path: str = '.') -> str:
+        """List entries in a Sprite directory, with `/` after directory names.
+
+        Args:
+            path: Directory to list, relative to the command working directory by default.
+        """
+        session = self._require_session()
+        try:
+            entries = await session.list_files(path)
+        except SpriteSandboxTerminalError:
+            raise
+        except SpriteSandboxError as e:
+            raise ModelRetry(f'Could not list {path!r}: {e}')
+        if not entries:
+            return '(empty)'
+        names = [f'{name}/' if is_dir else name for name, is_dir in sorted(entries)]
+        return truncate_output(
+            '\n'.join(names),
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+            direction='head',
+        )

--- a/pydantic_ai_harness/sprites/_toolset.py
+++ b/pydantic_ai_harness/sprites/_toolset.py
@@ -1,4 +1,4 @@
-"""Sprites toolset: gives agents a persistent cloud computer to work in."""
+"""Fly.io Sprites toolset: gives agents a persistent cloud computer to work in."""
 
 from __future__ import annotations
 

--- a/pydantic_ai_harness/sprites/_toolset.py
+++ b/pydantic_ai_harness/sprites/_toolset.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 from pydantic_ai import RunContext
@@ -12,12 +12,27 @@ from pydantic_ai.tools import AgentDepsT
 from pydantic_ai.toolsets import AbstractToolset, FunctionToolset
 from typing_extensions import Self
 
-from pydantic_ai_harness._sandbox_output import guard_read_size, render_file_window, truncate_output
+from pydantic_ai_harness._sandbox_output import render_file_window, truncate, truncate_output
 from pydantic_ai_harness.sprites._session import (
     SpriteSandboxError,
     SpriteSandboxSession,
     SpriteSandboxTerminalError,
 )
+
+
+def _strictly_bound_output(
+    text: str,
+    *,
+    max_lines: int,
+    max_bytes: int,
+    direction: Literal['head', 'tail'],
+) -> str:
+    """Apply a final marker-inclusive cap without adding more presentation text."""
+    lines = text.split('\n')
+    if len(lines) > 1 and lines[-1] == '':
+        lines = lines[:-1]
+    result = truncate(lines, max_lines=max_lines, max_bytes=max_bytes, direction=direction)
+    return '\n'.join(result.truncated_lines)
 
 
 class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
@@ -109,9 +124,14 @@ class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
     async def __aexit__(self, *args: object) -> None:
         """Close the per-run session, leaving a caller-owned session open."""
         session = self._session
-        self._session = None
-        if session is not None and self._external_session is None:
-            await session.__aexit__(*args)
+        if session is None:
+            return
+        if self._external_session is not None:
+            self._session = None
+            return
+        await session.__aexit__(*args)
+        if not session.is_open:
+            self._session = None
 
     def _require_session(self) -> SpriteSandboxSession:
         if self._session is None:
@@ -151,10 +171,15 @@ class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
             already_truncated=result.truncated,
         )
         if result.timed_out:
-            return f'{output}\n[timed out after {result.applied_timeout}s]'
-        if result.returncode:
-            return f'{output}\n[exit code: {result.returncode}]'
-        return output
+            output = f'{output}\n[timed out after {result.applied_timeout}s]'
+        elif result.returncode:
+            output = f'{output}\n[exit code: {result.returncode}]'
+        return _strictly_bound_output(
+            output,
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+            direction='tail',
+        )
 
     async def read_file(
         self,
@@ -172,13 +197,11 @@ class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
         """
         session = self._require_session()
         try:
-            guard_read_size(await session.file_size(path), max_bytes=self._max_read_bytes)
-            data = await session.read_bytes(path)
+            data = await session.read_bytes(path, max_bytes=self._max_read_bytes)
         except SpriteSandboxTerminalError:
             raise
         except SpriteSandboxError as e:
-            raise ModelRetry(f'Could not read {path!r}: {e}')
-        guard_read_size(len(data), max_bytes=self._max_read_bytes)
+            raise ModelRetry(str(e))
         return render_file_window(
             data,
             offset=offset,
@@ -204,7 +227,7 @@ class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
         except SpriteSandboxTerminalError:
             raise
         except SpriteSandboxError as e:
-            raise ModelRetry(f'Could not write {path!r}: {e}')
+            raise ModelRetry(str(e))
         return f'Wrote {len(data)} bytes to {path!r}.'
 
     async def list_directory(self, path: str = '.') -> str:
@@ -215,16 +238,30 @@ class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
         """
         session = self._require_session()
         try:
-            entries = await session.list_files(path)
+            listing = await session.list_files(
+                path,
+                max_entries=self._max_output_lines,
+                max_output_bytes=self._max_output_bytes,
+            )
         except SpriteSandboxTerminalError:
             raise
         except SpriteSandboxError as e:
-            raise ModelRetry(f'Could not list {path!r}: {e}')
-        if not entries:
+            raise ModelRetry(str(e))
+        if not listing.entries and not listing.truncated:
             return '(empty)'
-        names = [f'{name}/' if is_dir else name for name, is_dir in sorted(entries)]
-        return truncate_output(
-            '\n'.join(names),
+        names = [f'{name}/' if is_dir else name for name, is_dir in sorted(listing.entries)]
+        output = '\n'.join(names)
+        if listing.truncated:
+            output = f'[... directory listing truncated ...]\n{output}'
+        else:
+            output = truncate_output(
+                output,
+                max_lines=self._max_output_lines,
+                max_bytes=self._max_output_bytes,
+                direction='head',
+            )
+        return _strictly_bound_output(
+            output,
             max_lines=self._max_output_lines,
             max_bytes=self._max_output_bytes,
             direction='head',

--- a/pydantic_ai_harness/sprites/_toolset.py
+++ b/pydantic_ai_harness/sprites/_toolset.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 from typing import Annotated, Literal
 
@@ -33,6 +34,12 @@ def _strictly_bound_output(
         lines = lines[:-1]
     result = truncate(lines, max_lines=max_lines, max_bytes=max_bytes, direction=direction)
     return '\n'.join(result.truncated_lines)
+
+
+def _render_directory_entry(name: str, *, is_dir: bool) -> str:
+    """Escape line delimiters and controls so one filesystem entry stays on one output line."""
+    escaped = json.dumps(name, ensure_ascii=False)[1:-1]
+    return f'{escaped}/' if is_dir else escaped
 
 
 class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
@@ -202,12 +209,18 @@ class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
             raise
         except SpriteSandboxError as e:
             raise ModelRetry(str(e))
-        return render_file_window(
+        output = render_file_window(
             data,
             offset=offset,
             limit=limit,
             max_lines=self._max_output_lines,
             max_bytes=self._max_output_bytes,
+        )
+        return _strictly_bound_output(
+            output,
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+            direction='head',
         )
 
     async def write_file(self, path: str, content: str) -> str:
@@ -228,7 +241,12 @@ class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
             raise
         except SpriteSandboxError as e:
             raise ModelRetry(str(e))
-        return f'Wrote {len(data)} bytes to {path!r}.'
+        return _strictly_bound_output(
+            f'Wrote {len(data)} bytes to {path!r}.',
+            max_lines=self._max_output_lines,
+            max_bytes=self._max_output_bytes,
+            direction='head',
+        )
 
     async def list_directory(self, path: str = '.') -> str:
         """List entries in a Sprite directory, with `/` after directory names.
@@ -248,8 +266,13 @@ class SpriteSandboxToolset(FunctionToolset[AgentDepsT]):
         except SpriteSandboxError as e:
             raise ModelRetry(str(e))
         if not listing.entries and not listing.truncated:
-            return '(empty)'
-        names = [f'{name}/' if is_dir else name for name, is_dir in sorted(listing.entries)]
+            return _strictly_bound_output(
+                '(empty)',
+                max_lines=self._max_output_lines,
+                max_bytes=self._max_output_bytes,
+                direction='head',
+            )
+        names = [_render_directory_entry(name, is_dir=is_dir) for name, is_dir in sorted(listing.entries)]
         output = '\n'.join(names)
         if listing.truncated:
             output = f'[... directory listing truncated ...]\n{output}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ logfire = [
 modal = [
     "modal>=1.5.0",
 ]
+sprites = [
+    "sprites-py>=0.6.0,<1",
+]
 dynamic-workflow = [
     "pydantic-monty>=0.0.19",
 ]
@@ -223,7 +226,10 @@ executionEnvironments = [
 [tool.pytest.ini_options]
 testpaths = ['tests']
 xfail_strict = true
-markers = ['modal_live: runs against a real Modal control plane; needs credentials']
+markers = [
+    'modal_live: runs against a real Modal control plane; needs credentials',
+    'sprites_live: runs against the real Sprites API; needs SPRITE_TOKEN',
+]
 filterwarnings = [
     'error',
     # DBOS's run_sync triggers this on Python 3.12+ — not our code.
@@ -239,7 +245,7 @@ anyio_mode = 'auto'
 [tool.coverage.run]
 branch = true
 source = ['pydantic_ai_harness', 'tests']
-omit = ['tests/**/test_modal_live.py']
+omit = ['tests/**/test_modal_live.py', 'tests/**/test_sprites_live.py']
 
 [tool.coverage.paths]
 source = ['.', '/home/runner/work/pydantic-ai-harness/pydantic-ai-harness']

--- a/tests/sprites/conftest.py
+++ b/tests/sprites/conftest.py
@@ -1,0 +1,34 @@
+"""Shared fixtures that prevent unit tests from reaching the real Sprites API."""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Iterator
+
+import pytest
+
+from .fake_sprites import FakeSprites
+
+
+class _PoisonedSprites(types.ModuleType):
+    def __getattr__(self, name: str) -> object:  # pragma: no cover - tripwire
+        raise AssertionError('A Sprites unit test touched the real SDK. Use the `fake_sprites` fixture.')
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sprites(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    if 'sprites_live' in request.keywords:  # pragma: no cover - live tier
+        yield
+        return
+    monkeypatch.setitem(sys.modules, 'sprites', _PoisonedSprites('sprites'))
+    monkeypatch.delitem(sys.modules, 'sprites.exceptions', raising=False)
+    yield
+
+
+@pytest.fixture
+def fake_sprites(monkeypatch: pytest.MonkeyPatch) -> Iterator[FakeSprites]:
+    control = FakeSprites()
+    monkeypatch.setitem(sys.modules, 'sprites', control.module)
+    monkeypatch.setitem(sys.modules, 'sprites.exceptions', control.exceptions_module)
+    yield control

--- a/tests/sprites/fake_sprites.py
+++ b/tests/sprites/fake_sprites.py
@@ -1,0 +1,226 @@
+"""Controllable in-memory stand-in for the synchronous `sprites-py` SDK."""
+
+from __future__ import annotations
+
+import posixpath
+import types
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+class FakeSpriteError(Exception):
+    pass
+
+
+class FakeAuthenticationError(FakeSpriteError):
+    pass
+
+
+class FakeNotFoundError(FakeSpriteError):
+    pass
+
+
+class FakeTimeoutError(FakeSpriteError):
+    pass
+
+
+@dataclass
+class FakeExecResult:
+    stdout: bytes | None = b''
+    stderr: bytes | None = b''
+    returncode: int = 0
+
+
+@dataclass
+class RunCall:
+    argv: tuple[str, ...]
+    capture_output: bool
+    timeout: float | None
+    env: dict[str, str] | None
+    cwd: str | None
+
+
+@dataclass
+class FakeStat:
+    size: int
+    is_dir: bool = False
+
+
+class FakePath:
+    def __init__(self, sprite: FakeSprite, path: str) -> None:
+        self._sprite = sprite
+        self._path = posixpath.normpath(path)
+
+    @property
+    def name(self) -> str:
+        return posixpath.basename(self._path)
+
+    def __truediv__(self, path: str) -> FakePath:
+        if path.startswith('/'):
+            return FakePath(self._sprite, path)
+        return FakePath(self._sprite, posixpath.join(self._path, path))
+
+    def stat(self) -> FakeStat:
+        self._raise_if_configured()
+        if self._path in self._sprite.directories:
+            return FakeStat(size=0, is_dir=True)
+        try:
+            return FakeStat(size=len(self._sprite.files[self._path]))
+        except KeyError as e:
+            raise FakeSpriteError(f'No such file: {self._path}') from e
+
+    def read_bytes(self) -> bytes:
+        self._raise_if_configured()
+        try:
+            return self._sprite.files[self._path]
+        except KeyError as e:
+            raise FakeSpriteError(f'No such file: {self._path}') from e
+
+    def write_bytes(self, data: bytes, *, mkdir_parents: bool = False) -> None:
+        self._raise_if_configured()
+        if mkdir_parents:
+            parent = posixpath.dirname(self._path)
+            while parent and parent != '/':
+                self._sprite.directories.add(parent)
+                parent = posixpath.dirname(parent)
+        self._sprite.files[self._path] = data
+
+    def iterdir(self) -> list[FakePath]:
+        self._raise_if_configured()
+        prefix = self._path.rstrip('/') + '/'
+        names: set[str] = set()
+        for candidate in [*self._sprite.files, *self._sprite.directories]:
+            if candidate.startswith(prefix):
+                remainder = candidate[len(prefix) :]
+                if remainder:
+                    names.add(remainder.split('/', 1)[0])
+        return [FakePath(self._sprite, prefix + name) for name in names]
+
+    def _raise_if_configured(self) -> None:
+        if self._sprite.control.filesystem_error is not None:
+            raise self._sprite.control.filesystem_error
+
+
+class FakeFilesystem(FakePath):
+    pass
+
+
+class FakeSprite:
+    def __init__(self, control: FakeSprites, name: str, labels: list[str]) -> None:
+        self.control = control
+        self.name = name
+        self.labels = labels
+        self.files: dict[str, bytes] = {}
+        self.directories: set[str] = {'/', '/workspace'}
+        self.run_calls: list[RunCall] = []
+
+    def run(
+        self,
+        *argv: str,
+        capture_output: bool = False,
+        timeout: float | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        **kwargs: Any,
+    ) -> FakeExecResult:
+        if kwargs:
+            raise AssertionError(f'Unexpected Sprite.run kwargs: {kwargs}')
+        self.run_calls.append(RunCall(argv, capture_output, timeout, env, cwd))
+        if self.control.run_error is not None:
+            raise self.control.run_error
+        if argv == ('pwd',):
+            return self.control.pwd_result
+        return self.control.responder(self.run_calls[-1])
+
+    def filesystem(self, working_dir: str = '/') -> FakeFilesystem:
+        return FakeFilesystem(self, working_dir)
+
+
+class FakeClient:
+    def __init__(self, control: FakeSprites, *, token: str, base_url: str, timeout: float) -> None:
+        self.control = control
+        self.token = token
+        self.base_url = base_url
+        self.timeout = timeout
+        self.closed = False
+        control.clients.append(self)
+
+    def create_sprite(
+        self,
+        name: str,
+        *,
+        labels: list[str],
+        runtime: str | None,
+    ) -> FakeSprite:
+        self.control.create_calls.append({'name': name, 'labels': labels, 'runtime': runtime})
+        if self.control.create_error is not None:
+            raise self.control.create_error
+        retained = labels if self.control.retain_labels else []
+        sprite = FakeSprite(self.control, name, retained)
+        self.control.sprites[name] = sprite
+        return sprite
+
+    def get_sprite(self, name: str) -> FakeSprite:
+        self.control.get_calls.append(name)
+        if self.control.get_error is not None:
+            raise self.control.get_error
+        try:
+            return self.control.sprites[name]
+        except KeyError as e:
+            raise FakeNotFoundError(name) from e
+
+    def destroy_sprite(self, name: str) -> None:
+        self.control.destroy_calls.append(name)
+        if self.control.destroy_error is not None:
+            raise self.control.destroy_error
+        self.control.sprites.pop(name, None)
+
+    def close(self) -> None:
+        if self.control.close_error is not None:
+            raise self.control.close_error
+        self.closed = True
+        self.control.close_calls += 1
+
+
+class FakeSprites:
+    """Control surface plus a module object injected as `sprites`."""
+
+    def __init__(self) -> None:
+        self.clients: list[FakeClient] = []
+        self.sprites: dict[str, FakeSprite] = {}
+        self.create_calls: list[dict[str, Any]] = []
+        self.get_calls: list[str] = []
+        self.destroy_calls: list[str] = []
+        self.close_calls = 0
+        self.create_error: Exception | None = None
+        self.get_error: Exception | None = None
+        self.destroy_error: Exception | None = None
+        self.close_error: Exception | None = None
+        self.run_error: Exception | None = None
+        self.filesystem_error: Exception | None = None
+        self.retain_labels = True
+        self.pwd_result = FakeExecResult(stdout=b'/workspace\n')
+        self.responder: Callable[[RunCall], FakeExecResult] = lambda call: FakeExecResult(stdout=b'ok\n')
+        self.module, self.exceptions_module = self._build_modules()
+
+    def add_sprite(self, name: str, *, labels: list[str] | None = None) -> FakeSprite:
+        sprite = FakeSprite(self, name, labels or [])
+        self.sprites[name] = sprite
+        return sprite
+
+    def _build_modules(self) -> tuple[types.ModuleType, types.ModuleType]:
+        module = types.ModuleType('sprites')
+        exceptions = types.ModuleType('sprites.exceptions')
+
+        def client_factory(**kwargs: Any) -> FakeClient:
+            return FakeClient(self, **kwargs)
+
+        setattr(module, 'SpritesClient', client_factory)
+        setattr(module, 'Sprite', FakeSprite)
+        setattr(module, 'SpriteError', FakeSpriteError)
+        setattr(module, 'AuthenticationError', FakeAuthenticationError)
+        setattr(module, 'NotFoundError', FakeNotFoundError)
+        setattr(exceptions, 'TimeoutError', FakeTimeoutError)
+        setattr(module, 'exceptions', exceptions)
+        return module, exceptions

--- a/tests/sprites/fake_sprites.py
+++ b/tests/sprites/fake_sprites.py
@@ -112,7 +112,7 @@ class FakeSprite:
         self.name = name
         self.labels = labels
         self.files: dict[str, bytes] = {}
-        self.directories: set[str] = {'/', '/workspace'}
+        self.directories: set[str] = {'/', '/empty', '/workspace'}
         self.run_calls: list[RunCall] = []
 
     def run(
@@ -131,7 +131,64 @@ class FakeSprite:
             raise self.control.run_error
         if argv == ('pwd',):
             return self.control.pwd_result
-        return self.control.responder(self.run_calls[-1])
+        if env is not None and 'PYDANTIC_AI_SPRITE_READ_PATH' in env:
+            return self._bounded_read(env, cwd)
+        if env is not None and 'PYDANTIC_AI_SPRITE_LIST_PATH' in env:
+            return self._bounded_list(env, cwd)
+        result = self.control.responder(self.run_calls[-1])
+        if env is not None and 'PYDANTIC_AI_SPRITE_COMMAND' in env and not result.stderr:
+            result.stderr = b'\0\0'
+        return result
+
+    def _bounded_read(self, env: dict[str, str], cwd: str | None) -> FakeExecResult:
+        self._raise_filesystem_error()
+        path = self._resolve(env['PYDANTIC_AI_SPRITE_READ_PATH'], cwd)
+        try:
+            data = self.files[path]
+        except KeyError:
+            return FakeExecResult(stderr=f'FileNotFoundError: {path}'.encode(), returncode=66)
+        limit = int(env['PYDANTIC_AI_SPRITE_READ_LIMIT'])
+        if len(data) > limit:
+            return FakeExecResult(returncode=65)
+        return FakeExecResult(stdout=data)
+
+    def _bounded_list(self, env: dict[str, str], cwd: str | None) -> FakeExecResult:
+        self._raise_filesystem_error()
+        path = self._resolve(env['PYDANTIC_AI_SPRITE_LIST_PATH'], cwd)
+        if path not in self.directories:
+            return FakeExecResult(stderr=f'FileNotFoundError: {path}'.encode(), returncode=66)
+        prefix = path.rstrip('/') + '/'
+        names: set[str] = set()
+        for candidate in [*self.files, *self.directories]:
+            if candidate.startswith(prefix):
+                remainder = candidate[len(prefix) :]
+                if remainder:
+                    names.add(remainder.split('/', 1)[0])
+        max_entries = int(env['PYDANTIC_AI_SPRITE_LIST_MAX_ENTRIES'])
+        max_bytes = int(env['PYDANTIC_AI_SPRITE_LIST_MAX_BYTES'])
+        records: list[bytes] = []
+        rendered_bytes = 0
+        truncated = False
+        for name in sorted(names):
+            entry_path = posixpath.join(path, name)
+            is_dir = entry_path in self.directories
+            encoded = name.encode()
+            rendered_cost = len(encoded) + int(is_dir) + int(bool(records))
+            if len(records) >= max_entries or rendered_bytes + rendered_cost > max_bytes:
+                truncated = True
+                break
+            records.append((b'D' if is_dir else b'F') + encoded + b'\0')
+            rendered_bytes += rendered_cost
+        return FakeExecResult(stdout=b''.join(records), stderr=b'1' if truncated else b'0')
+
+    def _resolve(self, path: str, cwd: str | None) -> str:
+        if path.startswith('/'):
+            return posixpath.normpath(path)
+        return posixpath.normpath(posixpath.join(cwd or '/workspace', path))
+
+    def _raise_filesystem_error(self) -> None:
+        if self.control.filesystem_error is not None:
+            raise self.control.filesystem_error
 
     def filesystem(self, working_dir: str = '/') -> FakeFilesystem:
         return FakeFilesystem(self, working_dir)

--- a/tests/sprites/fake_sprites.py
+++ b/tests/sprites/fake_sprites.py
@@ -25,6 +25,15 @@ class FakeTimeoutError(FakeSpriteError):
     pass
 
 
+class FakeExitError(FakeSpriteError):
+    def __init__(self, returncode: int) -> None:
+        super().__init__(f'exit status {returncode}')
+        self._returncode = returncode
+
+    def exit_code(self) -> int:
+        return self._returncode
+
+
 @dataclass
 class FakeExecResult:
     stdout: bytes | None = b''
@@ -45,6 +54,41 @@ class RunCall:
 class FakeStat:
     size: int
     is_dir: bool = False
+
+
+class FakeCommand:
+    def __init__(
+        self,
+        sprite: FakeSprite,
+        argv: tuple[str, ...],
+        *,
+        stdout: Any,
+        stderr: Any,
+        timeout: float | None,
+        env: dict[str, str] | None,
+        cwd: str | None,
+    ) -> None:
+        self._sprite = sprite
+        self._argv = argv
+        self._stdout = stdout
+        self._stderr = stderr
+        self._timeout = timeout
+        self._env = env
+        self._cwd = cwd
+
+    def run(self) -> None:
+        result = self._sprite.run(
+            *self._argv,
+            timeout=self._timeout,
+            env=self._env,
+            cwd=self._cwd,
+        )
+        if result.stdout:
+            self._stdout.write(result.stdout)
+        if result.stderr:
+            self._stderr.write(result.stderr)
+        if result.returncode:
+            raise FakeExitError(result.returncode)
 
 
 class FakePath:
@@ -140,6 +184,28 @@ class FakeSprite:
             result.stderr = b'\0\0'
         return result
 
+    def command(
+        self,
+        *argv: str,
+        stdout: Any,
+        stderr: Any,
+        timeout: float | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        **kwargs: Any,
+    ) -> FakeCommand:
+        if kwargs:
+            raise AssertionError(f'Unexpected Sprite.command kwargs: {kwargs}')
+        return FakeCommand(
+            self,
+            argv,
+            stdout=stdout,
+            stderr=stderr,
+            timeout=timeout,
+            env=env,
+            cwd=cwd,
+        )
+
     def _bounded_read(self, env: dict[str, str], cwd: str | None) -> FakeExecResult:
         self._raise_filesystem_error()
         path = self._resolve(env['PYDANTIC_AI_SPRITE_READ_PATH'], cwd)
@@ -168,17 +234,24 @@ class FakeSprite:
         max_bytes = int(env['PYDANTIC_AI_SPRITE_LIST_MAX_BYTES'])
         records: list[bytes] = []
         rendered_bytes = 0
+        wire_bytes = 0
         truncated = False
         for name in sorted(names):
             entry_path = posixpath.join(path, name)
             is_dir = entry_path in self.directories
             encoded = name.encode()
             rendered_cost = len(encoded) + int(is_dir) + int(bool(records))
-            if len(records) >= max_entries or rendered_bytes + rendered_cost > max_bytes:
+            wire_cost = len(encoded) + 2
+            if (
+                len(records) >= max_entries
+                or rendered_bytes + rendered_cost > max_bytes
+                or wire_bytes + wire_cost > max_bytes
+            ):
                 truncated = True
                 break
             records.append((b'D' if is_dir else b'F') + encoded + b'\0')
             rendered_bytes += rendered_cost
+            wire_bytes += wire_cost
         return FakeExecResult(stdout=b''.join(records), stderr=b'1' if truncated else b'0')
 
     def _resolve(self, path: str, cwd: str | None) -> str:
@@ -279,5 +352,6 @@ class FakeSprites:
         setattr(module, 'AuthenticationError', FakeAuthenticationError)
         setattr(module, 'NotFoundError', FakeNotFoundError)
         setattr(exceptions, 'TimeoutError', FakeTimeoutError)
+        setattr(exceptions, 'ExitError', FakeExitError)
         setattr(module, 'exceptions', exceptions)
         return module, exceptions

--- a/tests/sprites/test_session.py
+++ b/tests/sprites/test_session.py
@@ -266,7 +266,7 @@ class TestOperations:
         assert call.argv[:4] == ('python3', '-I', '-S', '-c')
         assert "['bash', '-c', command]" in call.argv[4]
         assert "['bash', '-lc', command]" not in call.argv[4]
-        assert call.capture_output is True
+        assert call.capture_output is False
         assert call.timeout == 9.5
         assert call.cwd == '/app'
         assert call.env == {
@@ -314,14 +314,26 @@ class TestOperations:
         assert len(result.output.encode()) <= 1
         assert result.truncated is True
 
+    async def test_sdk_stream_is_aborted_when_helper_exceeds_transport_limit(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'unbounded')
+        async with SpriteSandboxSession(token='token') as session:
+            with pytest.raises(SpriteSandboxError, match='transport limit'):
+                await session.exec('big', timeout=2, max_output_bytes=2)
+
     async def test_file_roundtrip_and_listing(self, fake_sprites: FakeSprites) -> None:
         async with SpriteSandboxSession(token='token') as session:
             await session.write_bytes('sub/file.txt', b'hello')
-            assert await session.file_size('sub/file.txt') == 5
             assert await session.read_bytes('sub/file.txt', max_bytes=5) == b'hello'
             listing = await session.list_files('.', max_entries=10, max_output_bytes=100)
             assert listing.entries == [('sub', True)]
             assert listing.truncated is False
+
+    async def test_directory_transport_metadata_counts_toward_byte_limit(self, fake_sprites: FakeSprites) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            await session.write_bytes('a', b'x')
+            listing = await session.list_files('.', max_entries=10, max_output_bytes=1)
+        assert listing.entries == []
+        assert listing.truncated is True
 
     async def test_transient_sdk_failure_is_recoverable(self, fake_sprites: FakeSprites) -> None:
         async with SpriteSandboxSession(token='token') as session:

--- a/tests/sprites/test_session.py
+++ b/tests/sprites/test_session.py
@@ -132,6 +132,13 @@ class TestLifecycle:
         assert len(fake_sprites.destroy_calls) == 1
         assert fake_sprites.close_calls == 1
 
+    async def test_cwd_probe_removes_only_pwd_record_newline(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.pwd_result = FakeExecResult(stdout=b'/workspace \n\n')
+        async with SpriteSandboxSession(token='token') as session:
+            await session.exec('pwd', timeout=1, max_output_bytes=100)
+            call = fake_sprites.sprites[session.sprite_name or ''].run_calls[-1]
+        assert call.cwd == '/workspace \n'
+
     async def test_failed_enter_reports_cleanup_failure(self, fake_sprites: FakeSprites) -> None:
         fake_sprites.pwd_result = FakeExecResult(returncode=1)
         fake_sprites.destroy_error = FakeSpriteError('destroy failed')

--- a/tests/sprites/test_session.py
+++ b/tests/sprites/test_session.py
@@ -1,0 +1,343 @@
+"""Tests for SpriteSandboxSession."""
+
+from __future__ import annotations
+
+import builtins
+import logging
+from typing import Any
+
+import anyio
+import pytest
+
+from pydantic_ai_harness.sprites import (
+    SpriteSandboxAuthError,
+    SpriteSandboxError,
+    SpriteSandboxOwnershipError,
+    SpriteSandboxSession,
+    SpriteSandboxUnavailableError,
+)
+
+from .fake_sprites import (
+    FakeAuthenticationError,
+    FakeExecResult,
+    FakeNotFoundError,
+    FakeSpriteError,
+    FakeSprites,
+    FakeTimeoutError,
+)
+
+
+class TestConfiguration:
+    @pytest.mark.parametrize(
+        ('kwargs', 'match'),
+        [
+            ({'base_url': ''}, 'base_url'),
+            ({'api_timeout': 0}, 'api_timeout'),
+            ({'api_timeout': True}, 'api_timeout'),
+            ({'api_timeout': float('inf')}, 'api_timeout'),
+            ({'runtime': 'nightly'}, 'runtime'),
+            ({'sprite_name': 'kept', 'runtime': 'dev'}, 'runtime only applies'),
+        ],
+    )
+    def test_rejects_invalid_configuration(self, kwargs: dict[str, Any], match: str) -> None:
+        with pytest.raises(ValueError, match=match):
+            SpriteSandboxSession(**kwargs)
+
+    async def test_requires_token(self, monkeypatch: pytest.MonkeyPatch, fake_sprites: FakeSprites) -> None:
+        monkeypatch.delenv('SPRITE_TOKEN', raising=False)
+        with pytest.raises(SpriteSandboxAuthError, match='SPRITE_TOKEN is not set'):
+            await SpriteSandboxSession().__aenter__()
+        assert fake_sprites.clients == []
+
+    async def test_exit_before_enter_is_safe(self) -> None:
+        await SpriteSandboxSession(token='token').__aexit__(None, None, None)
+
+    async def test_reports_missing_optional_dependency(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        real_import = builtins.__import__
+
+        def missing_sprites(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == 'sprites':
+                raise ImportError('not installed')
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, '__import__', missing_sprites)
+        with pytest.raises(SpriteSandboxError, match="'sprites-py' package is required"):
+            await SpriteSandboxSession(token='token').__aenter__()
+
+
+class TestLifecycle:
+    async def test_creates_labelled_sprite_and_destroys_it(self, fake_sprites: FakeSprites) -> None:
+        async with SpriteSandboxSession(
+            token='secret', base_url='https://example.test', api_timeout=12, runtime='dev'
+        ) as session:
+            name = session.sprite_name
+            assert name is not None
+            assert name.startswith('pydantic-ai-')
+            assert session.is_open
+            sprite = fake_sprites.sprites[name]
+            assert sprite.run_calls[0].argv == ('pwd',)
+
+        create = fake_sprites.create_calls[0]
+        assert create['runtime'] == 'dev'
+        assert create['labels'][0] == 'pydantic-ai-harness'
+        assert fake_sprites.destroy_calls == [name]
+        assert fake_sprites.close_calls == 1
+        assert not session.is_open
+        client = fake_sprites.clients[0]
+        assert (client.token, client.base_url, client.timeout) == ('secret', 'https://example.test', 12)
+
+    async def test_attaches_and_leaves_sprite_running(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token', sprite_name='kept', workdir='/app')
+        assert session.sprite_name == 'kept'
+        fake_sprites.add_sprite('kept')
+        async with session:
+            assert session.sprite_name == 'kept'
+            assert fake_sprites.sprites['kept'].run_calls == []
+        assert 'kept' in fake_sprites.sprites
+        assert fake_sprites.destroy_calls == []
+        assert fake_sprites.close_calls == 1
+
+    async def test_cannot_enter_twice(self, fake_sprites: FakeSprites) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            with pytest.raises(SpriteSandboxError, match='already open'):
+                await session.__aenter__()
+        assert len(fake_sprites.create_calls) == 1
+
+    async def test_maps_auth_failure(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.create_error = FakeAuthenticationError('bad token')
+        with pytest.raises(SpriteSandboxAuthError, match='rejected the credentials'):
+            async with SpriteSandboxSession(token='bad'):
+                pass
+        assert fake_sprites.close_calls == 1
+
+    async def test_maps_missing_attached_sprite(self, fake_sprites: FakeSprites) -> None:
+        with pytest.raises(SpriteSandboxUnavailableError, match='does not exist'):
+            async with SpriteSandboxSession(token='token', sprite_name='gone'):
+                pass
+        assert fake_sprites.close_calls == 1
+
+    async def test_missing_ownership_label_is_destroyed_and_rejected(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.retain_labels = False
+        with pytest.raises(SpriteSandboxOwnershipError, match='did not retain'):
+            async with SpriteSandboxSession(token='token'):
+                pass
+        assert len(fake_sprites.destroy_calls) == 1
+        assert fake_sprites.close_calls == 1
+
+    async def test_failed_cwd_probe_destroys_owned_sprite(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.pwd_result = FakeExecResult(returncode=1)
+        with pytest.raises(SpriteSandboxError, match='working directory'):
+            async with SpriteSandboxSession(token='token'):
+                pass
+        assert len(fake_sprites.destroy_calls) == 1
+        assert fake_sprites.close_calls == 1
+
+    async def test_failed_enter_reports_cleanup_failure(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.pwd_result = FakeExecResult(returncode=1)
+        fake_sprites.destroy_error = FakeSpriteError('destroy failed')
+        with pytest.raises(SpriteSandboxError, match='Cleanup also failed: Could not destroy'):
+            async with SpriteSandboxSession(token='token'):
+                pass
+
+    async def test_cancel_after_create_cleans_up(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            await session.__aenter__()
+        assert len(fake_sprites.destroy_calls) == 1
+        assert not session.is_open
+
+    async def test_cancelled_exit_still_cleans_up(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        await session.__aenter__()
+        with anyio.CancelScope() as scope:
+            scope.cancel()
+            await session.__aexit__(None, None, None)
+        assert len(fake_sprites.destroy_calls) == 1
+        assert not session.is_open
+
+    async def test_owned_sprite_already_gone_is_clean_exit(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        await session.__aenter__()
+        fake_sprites.get_error = FakeNotFoundError('already gone')
+        await session.__aexit__(None, None, None)
+        assert not session.is_open
+
+    async def test_destroy_not_found_is_clean_exit(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        await session.__aenter__()
+        fake_sprites.destroy_error = FakeNotFoundError('already gone')
+        await session.__aexit__(None, None, None)
+        assert not session.is_open
+
+    async def test_cleanup_verification_error_is_reported(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        await session.__aenter__()
+        fake_sprites.get_error = FakeSpriteError('verification failed')
+        with pytest.raises(SpriteSandboxError, match='Could not verify owned Sprite'):
+            await session.__aexit__(None, None, None)
+
+    async def test_client_close_error_is_reported(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        await session.__aenter__()
+        fake_sprites.close_error = FakeSpriteError('close failed')
+        with pytest.raises(FakeSpriteError, match='close failed'):
+            await session.__aexit__(None, None, None)
+
+    async def test_generic_open_failure_is_mapped(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.create_error = RuntimeError('unexpected create failure')
+        with pytest.raises(SpriteSandboxError, match='Could not start Sprite sandbox'):
+            async with SpriteSandboxSession(token='token'):
+                pass
+
+    async def test_refuses_to_destroy_replaced_sprite(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        await session.__aenter__()
+        name = session.sprite_name
+        assert name is not None
+        fake_sprites.sprites[name].labels = []
+        with pytest.raises(SpriteSandboxOwnershipError, match='Refusing to destroy'):
+            await session.__aexit__(None, None, None)
+        assert fake_sprites.destroy_calls == []
+        assert fake_sprites.close_calls == 1
+
+    async def test_cleanup_error_does_not_mask_body_error(
+        self, fake_sprites: FakeSprites, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        fake_sprites.destroy_error = FakeSpriteError('control plane unavailable')
+        caplog.set_level(logging.ERROR)
+        with pytest.raises(RuntimeError, match='body failed'):
+            async with SpriteSandboxSession(token='token'):
+                raise RuntimeError('body failed')
+        assert 'Failed to clean up Sprite' in caplog.text
+
+
+class TestOperations:
+    @pytest.mark.parametrize(
+        ('kwargs', 'match'),
+        [
+            ({'timeout': 0, 'max_output_bytes': 100}, 'timeout'),
+            ({'timeout': True, 'max_output_bytes': 100}, 'timeout'),
+            ({'timeout': float('inf'), 'max_output_bytes': 100}, 'timeout'),
+            ({'timeout': 1, 'max_output_bytes': 0}, 'max_output_bytes'),
+            ({'timeout': 1, 'max_output_bytes': True}, 'max_output_bytes'),
+        ],
+    )
+    async def test_exec_rejects_invalid_limits(
+        self, fake_sprites: FakeSprites, kwargs: dict[str, Any], match: str
+    ) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            with pytest.raises(ValueError, match=match):
+                await session.exec('echo', **kwargs)
+            assert len(fake_sprites.sprites[session.sprite_name or ''].run_calls) == 1
+
+    async def test_exec_passes_bounded_wrapper_and_context(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'hello\n', returncode=3)
+        async with SpriteSandboxSession(token='token', workdir='/app') as session:
+            result = await session.exec('echo hello', timeout=4.5, max_output_bytes=100)
+            call = fake_sprites.sprites[session.sprite_name or ''].run_calls[-1]
+        assert result.output == 'hello\n'
+        assert result.returncode == 3
+        assert result.applied_timeout == 4.5
+        assert call.argv[:2] == ('bash', '-lc')
+        assert 'python3 -c' in call.argv[2]
+        assert call.capture_output is True
+        assert call.timeout == 9.5
+        assert call.cwd == '/app'
+        assert call.env == {
+            'PYDANTIC_AI_SPRITE_COMMAND': 'echo hello',
+            'PYDANTIC_AI_SPRITE_TIMEOUT_SECONDS': '4.5',
+        }
+
+    async def test_timeout_marker_is_removed_and_reported(self, fake_sprites: FakeSprites) -> None:
+        marker = b'\n__PYDANTIC_AI_SPRITE_TIMEOUT__\n'
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'partial' + marker, returncode=124)
+        async with SpriteSandboxSession(token='token') as session:
+            result = await session.exec('sleep 99', timeout=2, max_output_bytes=100)
+        assert result.output == 'partial'
+        assert result.timed_out is True
+        assert result.applied_timeout == 2
+
+    async def test_transport_timeout_is_reported(self, fake_sprites: FakeSprites) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            fake_sprites.run_error = FakeTimeoutError('transport deadline')
+            result = await session.exec('sleep 99', timeout=2, max_output_bytes=100)
+        assert result.returncode == 124
+        assert result.timed_out is True
+
+    async def test_truncation_marker_is_detected(self, fake_sprites: FakeSprites) -> None:
+        marker = b'\n[... Sprite command output truncated ...]\n'
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'head' + marker + b'tail')
+        async with SpriteSandboxSession(token='token') as session:
+            result = await session.exec('big', timeout=None, max_output_bytes=100)
+            call = fake_sprites.sprites[session.sprite_name or ''].run_calls[-1]
+        assert result.truncated is True
+        assert call.timeout is None
+        assert call.env == {'PYDANTIC_AI_SPRITE_COMMAND': 'big'}
+
+    async def test_file_roundtrip_and_listing(self, fake_sprites: FakeSprites) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            await session.write_bytes('sub/file.txt', b'hello')
+            assert await session.file_size('sub/file.txt') == 5
+            assert await session.read_bytes('sub/file.txt') == b'hello'
+            assert sorted(await session.list_files('.')) == [('sub', True)]
+
+    async def test_transient_sdk_failure_is_recoverable(self, fake_sprites: FakeSprites) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            fake_sprites.filesystem_error = FakeSpriteError('temporary failure')
+            with pytest.raises(SpriteSandboxError, match='temporary failure') as exc_info:
+                await session.read_bytes('x')
+        assert not isinstance(exc_info.value, SpriteSandboxUnavailableError)
+
+    async def test_operation_detects_destroyed_sprite(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.add_sprite('gone')
+        async with SpriteSandboxSession(token='token', sprite_name='gone') as session:
+            fake_sprites.filesystem_error = FakeSpriteError('request failed')
+            fake_sprites.get_error = FakeNotFoundError('gone')
+            with pytest.raises(SpriteSandboxUnavailableError, match='no longer exists'):
+                await session.read_bytes('x')
+
+    async def test_operation_detects_expired_auth(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.add_sprite('kept')
+        async with SpriteSandboxSession(token='token', sprite_name='kept') as session:
+            fake_sprites.filesystem_error = FakeSpriteError('request failed')
+            fake_sprites.get_error = FakeAuthenticationError('expired')
+            with pytest.raises(SpriteSandboxAuthError, match='rejected the credentials'):
+                await session.read_bytes('x')
+
+    @pytest.mark.parametrize(
+        ('error', 'expected'),
+        [
+            (FakeAuthenticationError('expired'), SpriteSandboxAuthError),
+            (FakeNotFoundError('gone'), SpriteSandboxUnavailableError),
+        ],
+    )
+    async def test_direct_terminal_operation_error(
+        self, fake_sprites: FakeSprites, error: Exception, expected: type[Exception]
+    ) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            fake_sprites.filesystem_error = error
+            with pytest.raises(expected):
+                await session.read_bytes('x')
+
+    async def test_non_sdk_operation_error_is_recoverable(self, fake_sprites: FakeSprites) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            fake_sprites.filesystem_error = RuntimeError('unexpected')
+            with pytest.raises(SpriteSandboxError, match='unexpected'):
+                await session.read_bytes('x')
+
+    async def test_probe_failure_preserves_original_operation_error(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        await session.__aenter__()
+        try:
+            fake_sprites.filesystem_error = FakeSpriteError('disk issue')
+            fake_sprites.get_error = FakeSpriteError('probe issue')
+            with pytest.raises(SpriteSandboxError, match='disk issue'):
+                await session.read_bytes('x')
+        finally:
+            fake_sprites.get_error = None
+            await session.__aexit__(None, None, None)
+
+    async def test_unopened_operations_raise(self) -> None:
+        with pytest.raises(SpriteSandboxError, match='not open'):
+            await SpriteSandboxSession(token='token').read_bytes('x')

--- a/tests/sprites/test_session.py
+++ b/tests/sprites/test_session.py
@@ -176,6 +176,8 @@ class TestLifecycle:
         fake_sprites.get_error = FakeSpriteError('verification failed')
         with pytest.raises(SpriteSandboxError, match='Could not verify owned Sprite'):
             await session.__aexit__(None, None, None)
+        assert session.is_open
+        assert fake_sprites.close_calls == 0
 
     async def test_client_close_error_is_reported(self, fake_sprites: FakeSprites) -> None:
         session = SpriteSandboxSession(token='token')
@@ -183,6 +185,10 @@ class TestLifecycle:
         fake_sprites.close_error = FakeSpriteError('close failed')
         with pytest.raises(FakeSpriteError, match='close failed'):
             await session.__aexit__(None, None, None)
+        assert session.is_open
+        fake_sprites.close_error = None
+        await session.__aexit__(None, None, None)
+        assert not session.is_open
 
     async def test_generic_open_failure_is_mapped(self, fake_sprites: FakeSprites) -> None:
         fake_sprites.create_error = RuntimeError('unexpected create failure')
@@ -199,7 +205,25 @@ class TestLifecycle:
         with pytest.raises(SpriteSandboxOwnershipError, match='Refusing to destroy'):
             await session.__aexit__(None, None, None)
         assert fake_sprites.destroy_calls == []
-        assert fake_sprites.close_calls == 1
+        assert fake_sprites.close_calls == 0
+        assert session.is_open
+        fake_sprites.sprites[name].labels = [fake_sprites.create_calls[-1]['labels'][-1]]
+        await session.__aexit__(None, None, None)
+        assert not session.is_open
+
+    async def test_failed_destroy_can_be_retried(self, fake_sprites: FakeSprites) -> None:
+        session = SpriteSandboxSession(token='token')
+        await session.__aenter__()
+        fake_sprites.destroy_error = FakeSpriteError('control plane unavailable')
+        with pytest.raises(SpriteSandboxError, match='Could not destroy'):
+            await session.__aexit__(None, None, None)
+        assert session.is_open
+        assert fake_sprites.close_calls == 0
+
+        fake_sprites.destroy_error = None
+        await session.__aexit__(None, None, None)
+        assert not session.is_open
+        assert len(fake_sprites.destroy_calls) == 2
 
     async def test_cleanup_error_does_not_mask_body_error(
         self, fake_sprites: FakeSprites, caplog: pytest.LogCaptureFixture
@@ -239,8 +263,9 @@ class TestOperations:
         assert result.output == 'hello\n'
         assert result.returncode == 3
         assert result.applied_timeout == 4.5
-        assert call.argv[:2] == ('bash', '-lc')
-        assert 'python3 -c' in call.argv[2]
+        assert call.argv[:4] == ('python3', '-I', '-S', '-c')
+        assert "['bash', '-c', command]" in call.argv[4]
+        assert "['bash', '-lc', command]" not in call.argv[4]
         assert call.capture_output is True
         assert call.timeout == 9.5
         assert call.cwd == '/app'
@@ -249,9 +274,8 @@ class TestOperations:
             'PYDANTIC_AI_SPRITE_TIMEOUT_SECONDS': '4.5',
         }
 
-    async def test_timeout_marker_is_removed_and_reported(self, fake_sprites: FakeSprites) -> None:
-        marker = b'\n__PYDANTIC_AI_SPRITE_TIMEOUT__\n'
-        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'partial' + marker, returncode=124)
+    async def test_timeout_control_is_reported_separately_from_output(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'partial', stderr=b'\0\1', returncode=124)
         async with SpriteSandboxSession(token='token') as session:
             result = await session.exec('sleep 99', timeout=2, max_output_bytes=100)
         assert result.output == 'partial'
@@ -267,7 +291,7 @@ class TestOperations:
 
     async def test_truncation_marker_is_detected(self, fake_sprites: FakeSprites) -> None:
         marker = b'\n[... Sprite command output truncated ...]\n'
-        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'head' + marker + b'tail')
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'head' + marker + b'tail', stderr=b'\1\0')
         async with SpriteSandboxSession(token='token') as session:
             result = await session.exec('big', timeout=None, max_output_bytes=100)
             call = fake_sprites.sprites[session.sprite_name or ''].run_calls[-1]
@@ -275,18 +299,35 @@ class TestOperations:
         assert call.timeout is None
         assert call.env == {'PYDANTIC_AI_SPRITE_COMMAND': 'big'}
 
+    async def test_timeout_text_in_command_output_is_not_a_status_signal(self, fake_sprites: FakeSprites) -> None:
+        marker = b'\n__PYDANTIC_AI_SPRITE_TIMEOUT__\n'
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=marker, stderr=b'\0\0')
+        async with SpriteSandboxSession(token='token') as session:
+            result = await session.exec('printf marker', timeout=2, max_output_bytes=100)
+        assert result.output == marker.decode()
+        assert result.timed_out is False
+
+    async def test_decoding_replacement_cannot_expand_past_byte_limit(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'\xff', stderr=b'\0\0')
+        async with SpriteSandboxSession(token='token') as session:
+            result = await session.exec('printf invalid', timeout=2, max_output_bytes=1)
+        assert len(result.output.encode()) <= 1
+        assert result.truncated is True
+
     async def test_file_roundtrip_and_listing(self, fake_sprites: FakeSprites) -> None:
         async with SpriteSandboxSession(token='token') as session:
             await session.write_bytes('sub/file.txt', b'hello')
             assert await session.file_size('sub/file.txt') == 5
-            assert await session.read_bytes('sub/file.txt') == b'hello'
-            assert sorted(await session.list_files('.')) == [('sub', True)]
+            assert await session.read_bytes('sub/file.txt', max_bytes=5) == b'hello'
+            listing = await session.list_files('.', max_entries=10, max_output_bytes=100)
+            assert listing.entries == [('sub', True)]
+            assert listing.truncated is False
 
     async def test_transient_sdk_failure_is_recoverable(self, fake_sprites: FakeSprites) -> None:
         async with SpriteSandboxSession(token='token') as session:
             fake_sprites.filesystem_error = FakeSpriteError('temporary failure')
             with pytest.raises(SpriteSandboxError, match='temporary failure') as exc_info:
-                await session.read_bytes('x')
+                await session.read_bytes('x', max_bytes=10)
         assert not isinstance(exc_info.value, SpriteSandboxUnavailableError)
 
     async def test_operation_detects_destroyed_sprite(self, fake_sprites: FakeSprites) -> None:
@@ -295,7 +336,7 @@ class TestOperations:
             fake_sprites.filesystem_error = FakeSpriteError('request failed')
             fake_sprites.get_error = FakeNotFoundError('gone')
             with pytest.raises(SpriteSandboxUnavailableError, match='no longer exists'):
-                await session.read_bytes('x')
+                await session.read_bytes('x', max_bytes=10)
 
     async def test_operation_detects_expired_auth(self, fake_sprites: FakeSprites) -> None:
         fake_sprites.add_sprite('kept')
@@ -303,7 +344,7 @@ class TestOperations:
             fake_sprites.filesystem_error = FakeSpriteError('request failed')
             fake_sprites.get_error = FakeAuthenticationError('expired')
             with pytest.raises(SpriteSandboxAuthError, match='rejected the credentials'):
-                await session.read_bytes('x')
+                await session.read_bytes('x', max_bytes=10)
 
     @pytest.mark.parametrize(
         ('error', 'expected'),
@@ -318,13 +359,13 @@ class TestOperations:
         async with SpriteSandboxSession(token='token') as session:
             fake_sprites.filesystem_error = error
             with pytest.raises(expected):
-                await session.read_bytes('x')
+                await session.read_bytes('x', max_bytes=10)
 
     async def test_non_sdk_operation_error_is_recoverable(self, fake_sprites: FakeSprites) -> None:
         async with SpriteSandboxSession(token='token') as session:
             fake_sprites.filesystem_error = RuntimeError('unexpected')
             with pytest.raises(SpriteSandboxError, match='unexpected'):
-                await session.read_bytes('x')
+                await session.read_bytes('x', max_bytes=10)
 
     async def test_probe_failure_preserves_original_operation_error(self, fake_sprites: FakeSprites) -> None:
         session = SpriteSandboxSession(token='token')
@@ -333,11 +374,11 @@ class TestOperations:
             fake_sprites.filesystem_error = FakeSpriteError('disk issue')
             fake_sprites.get_error = FakeSpriteError('probe issue')
             with pytest.raises(SpriteSandboxError, match='disk issue'):
-                await session.read_bytes('x')
+                await session.read_bytes('x', max_bytes=10)
         finally:
             fake_sprites.get_error = None
             await session.__aexit__(None, None, None)
 
     async def test_unopened_operations_raise(self) -> None:
         with pytest.raises(SpriteSandboxError, match='not open'):
-            await SpriteSandboxSession(token='token').read_bytes('x')
+            await SpriteSandboxSession(token='token').read_bytes('x', max_bytes=10)

--- a/tests/sprites/test_sprite_sandbox.py
+++ b/tests/sprites/test_sprite_sandbox.py
@@ -1,0 +1,214 @@
+"""Tests for the public SpriteSandbox capability and toolset."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import Any, Protocol, TypeGuard, runtime_checkable
+
+import pytest
+from pydantic_ai import RunContext
+from pydantic_ai.exceptions import ModelRetry
+from pydantic_ai.models.test import TestModel
+from pydantic_ai.toolsets import AbstractToolset
+from pydantic_ai.usage import RunUsage
+
+import pydantic_ai_harness
+from pydantic_ai_harness.sprites import (
+    SpriteSandbox,
+    SpriteSandboxAuthError,
+    SpriteSandboxError,
+    SpriteSandboxSession,
+)
+
+from .fake_sprites import FakeAuthenticationError, FakeExecResult, FakeSpriteError, FakeSprites
+
+
+@runtime_checkable
+class _SpriteTools(Protocol):
+    async def run_command(self, command: str, *, timeout_seconds: float | None = None) -> str: ...
+    async def read_file(self, path: str, *, offset: int | None = None, limit: int | None = None) -> str: ...
+    async def write_file(self, path: str, content: str) -> str: ...
+    async def list_directory(self, path: str = '.') -> str: ...
+
+
+def _is_toolset(value: object) -> TypeGuard[AbstractToolset[None]]:
+    return isinstance(value, AbstractToolset)
+
+
+def _context() -> RunContext[None]:
+    return RunContext(deps=None, model=TestModel(), usage=RunUsage(), prompt=None, messages=[], run_step=0)
+
+
+@asynccontextmanager
+async def _toolset(**kwargs: Any) -> AsyncGenerator[_SpriteTools]:
+    if 'session' not in kwargs:
+        kwargs['token'] = 'token'
+    toolset = SpriteSandbox[None](**kwargs).get_toolset()
+    assert _is_toolset(toolset)
+    run_toolset = await toolset.for_run(_context())
+    assert isinstance(run_toolset, _SpriteTools)
+    async with run_toolset:
+        yield run_toolset
+
+
+class TestCapability:
+    def test_public_exports(self) -> None:
+        assert pydantic_ai_harness.SpriteSandbox is SpriteSandbox
+
+    def test_default_and_reused_instructions(self) -> None:
+        owned = SpriteSandbox[None]().get_instructions()
+        reused = SpriteSandbox[None](sprite_name='kept').get_instructions()
+        assert owned is not None and 'destroyed when the run ends' in owned
+        assert reused is not None and 'reused across runs' in reused
+        assert SpriteSandbox[None](instructions='custom').get_instructions() == 'custom'
+        assert SpriteSandbox[None](instructions='').get_instructions() is None
+
+    @pytest.mark.parametrize(
+        ('kwargs', 'match'),
+        [
+            ({'max_output_bytes': 0}, 'max_output_bytes'),
+            ({'max_output_lines': True}, 'max_output_lines'),
+            ({'max_read_bytes': -1}, 'max_read_bytes'),
+            ({'api_timeout': float('nan')}, 'api_timeout'),
+            ({'default_command_timeout': 0}, 'default_command_timeout'),
+            ({'max_command_timeout': float('inf')}, 'max_command_timeout'),
+            ({'default_command_timeout': 10, 'max_command_timeout': 5}, 'cannot exceed'),
+            ({'base_url': ''}, 'base_url'),
+            ({'runtime': 'nightly'}, 'runtime'),
+            ({'sprite_name': 'kept', 'runtime': 'dev'}, 'runtime only applies'),
+            ({'instructions': 1}, 'instructions'),
+        ],
+    )
+    def test_rejects_invalid_configuration(self, kwargs: dict[str, Any], match: str) -> None:
+        with pytest.raises(ValueError, match=match):
+            SpriteSandbox(**kwargs)
+
+    @pytest.mark.parametrize('field', ['token', 'sprite_name', 'base_url', 'api_timeout', 'runtime', 'workdir'])
+    def test_injected_session_rejects_connection_settings(self, field: str) -> None:
+        defaults: dict[str, Any] = {
+            'token': 'token',
+            'sprite_name': 'kept',
+            'base_url': 'https://example.test',
+            'api_timeout': 2,
+            'runtime': 'dev',
+            'workdir': '/app',
+        }
+        with pytest.raises(ValueError, match=field):
+            SpriteSandbox(session=SpriteSandboxSession(token='token'), **{field: defaults[field]})
+
+
+class TestTools:
+    async def test_base_toolset_enter_is_a_noop(self, fake_sprites: FakeSprites) -> None:
+        toolset = SpriteSandbox[None](token='token').get_toolset()
+        assert _is_toolset(toolset)
+        async with toolset:
+            pass
+        assert fake_sprites.clients == []
+
+    async def test_runs_command_and_reports_exit(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'failed\n', returncode=2)
+        async with _toolset(default_command_timeout=10, max_command_timeout=20) as tools:
+            result = await tools.run_command('false')
+            call = next(iter(fake_sprites.sprites.values())).run_calls[-1]
+        assert result == 'failed\n[exit code: 2]'
+        assert call.env is not None and call.env['PYDANTIC_AI_SPRITE_TIMEOUT_SECONDS'] == '10'
+
+    async def test_reports_no_output_and_timeout(self, fake_sprites: FakeSprites) -> None:
+        marker = b'\n__PYDANTIC_AI_SPRITE_TIMEOUT__\n'
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=marker, returncode=124)
+        async with _toolset() as tools:
+            assert await tools.run_command('sleep', timeout_seconds=3) == '(no output)\n[timed out after 3s]'
+
+    @pytest.mark.parametrize('timeout', [0, -1, float('inf'), True])
+    async def test_rejects_invalid_tool_timeout(self, fake_sprites: FakeSprites, timeout: float) -> None:
+        async with _toolset() as tools:
+            with pytest.raises(ModelRetry, match='must be greater than 0'):
+                await tools.run_command('echo', timeout_seconds=timeout)
+
+    async def test_clamps_timeout(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset(default_command_timeout=2, max_command_timeout=4) as tools:
+            await tools.run_command('echo', timeout_seconds=99)
+            call = next(iter(fake_sprites.sprites.values())).run_calls[-1]
+        assert call.env is not None and call.env['PYDANTIC_AI_SPRITE_TIMEOUT_SECONDS'] == '4'
+
+    async def test_truncates_lines_and_marks_session_cut(self, fake_sprites: FakeSprites) -> None:
+        marker = b'\n[... Sprite command output truncated ...]\n'
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'one\ntwo\nthree' + marker + b'end')
+        async with _toolset(max_output_lines=1) as tools:
+            result = await tools.run_command('big')
+        assert 'output truncated' in result
+        assert result.endswith('end')
+
+    async def test_sdk_error_becomes_model_retry(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset() as tools:
+            fake_sprites.run_error = FakeSpriteError('temporary')
+            with pytest.raises(ModelRetry, match='temporary'):
+                await tools.run_command('echo')
+
+    async def test_terminal_command_error_propagates(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset() as tools:
+            fake_sprites.run_error = FakeAuthenticationError('expired')
+            with pytest.raises(SpriteSandboxAuthError):
+                await tools.run_command('echo')
+
+    async def test_file_tools(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset(max_output_lines=2) as tools:
+            assert await tools.write_file('dir/file.txt', 'one\ntwo\nthree') == "Wrote 13 bytes to 'dir/file.txt'."
+            assert await tools.read_file('dir/file.txt', offset=2, limit=1) == (
+                'two\n\n[1 more lines in file. Use offset=3 to continue.]'
+            )
+            assert await tools.list_directory('.') == 'dir/'
+
+    async def test_empty_directory(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset() as tools:
+            assert await tools.list_directory('/empty') == '(empty)'
+
+    async def test_file_error_becomes_model_retry(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset() as tools:
+            fake_sprites.filesystem_error = FakeSpriteError('disk issue')
+            with pytest.raises(ModelRetry, match="Could not read 'x': Could not stat 'x': disk issue"):
+                await tools.read_file('x')
+            with pytest.raises(ModelRetry, match="Could not write 'x': disk issue"):
+                await tools.write_file('x', 'a')
+            with pytest.raises(ModelRetry, match="Could not list 'x': disk issue"):
+                await tools.list_directory('x')
+
+    @pytest.mark.parametrize('operation', ['read', 'write', 'list'])
+    async def test_terminal_file_error_propagates(self, fake_sprites: FakeSprites, operation: str) -> None:
+        async with _toolset() as tools:
+            fake_sprites.filesystem_error = FakeAuthenticationError('expired')
+            with pytest.raises(SpriteSandboxAuthError):
+                if operation == 'read':
+                    await tools.read_file('x')
+                elif operation == 'write':
+                    await tools.write_file('x', 'content')
+                else:
+                    await tools.list_directory('x')
+
+    async def test_unencodable_write_is_retryable(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset() as tools:
+            with pytest.raises(ModelRetry, match='cannot be encoded'):
+                await tools.write_file('x', '\ud800')
+
+    async def test_tool_on_unentered_toolset_raises(self) -> None:
+        toolset = SpriteSandbox[None]().get_toolset()
+        assert isinstance(toolset, _SpriteTools)
+        with pytest.raises(SpriteSandboxError, match='not open'):
+            await toolset.run_command('echo')
+
+    async def test_injected_session_is_reused(self, fake_sprites: FakeSprites) -> None:
+        async with SpriteSandboxSession(token='token') as session:
+            name = session.sprite_name
+            async with _toolset(session=session) as tools:
+                await tools.run_command('echo')
+            assert session.is_open
+            assert name in fake_sprites.sprites
+        assert name not in fake_sprites.sprites
+
+    async def test_unopened_injected_session_is_rejected(self) -> None:
+        toolset = SpriteSandbox[None](session=SpriteSandboxSession(token='token')).get_toolset()
+        assert _is_toolset(toolset)
+        run_toolset = await toolset.for_run(_context())
+        with pytest.raises(SpriteSandboxError, match='not open'):
+            await run_toolset.__aenter__()

--- a/tests/sprites/test_sprite_sandbox.py
+++ b/tests/sprites/test_sprite_sandbox.py
@@ -20,6 +20,7 @@ from pydantic_ai_harness.sprites import (
     SpriteSandboxError,
     SpriteSandboxSession,
 )
+from pydantic_ai_harness.sprites._toolset import SpriteSandboxToolset
 
 from .fake_sprites import FakeAuthenticationError, FakeExecResult, FakeSpriteError, FakeSprites
 
@@ -115,8 +116,7 @@ class TestTools:
         assert call.env is not None and call.env['PYDANTIC_AI_SPRITE_TIMEOUT_SECONDS'] == '10'
 
     async def test_reports_no_output_and_timeout(self, fake_sprites: FakeSprites) -> None:
-        marker = b'\n__PYDANTIC_AI_SPRITE_TIMEOUT__\n'
-        fake_sprites.responder = lambda call: FakeExecResult(stdout=marker, returncode=124)
+        fake_sprites.responder = lambda call: FakeExecResult(stderr=b'\0\1', returncode=124)
         async with _toolset() as tools:
             assert await tools.run_command('sleep', timeout_seconds=3) == '(no output)\n[timed out after 3s]'
 
@@ -134,11 +134,19 @@ class TestTools:
 
     async def test_truncates_lines_and_marks_session_cut(self, fake_sprites: FakeSprites) -> None:
         marker = b'\n[... Sprite command output truncated ...]\n'
-        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'one\ntwo\nthree' + marker + b'end')
+        fake_sprites.responder = lambda call: FakeExecResult(
+            stdout=b'one\ntwo\nthree' + marker + b'end', stderr=b'\1\0'
+        )
         async with _toolset(max_output_lines=1) as tools:
             result = await tools.run_command('big')
-        assert 'output truncated' in result
         assert result.endswith('end')
+
+    async def test_final_command_result_honors_tiny_caps(self, fake_sprites: FakeSprites) -> None:
+        fake_sprites.responder = lambda call: FakeExecResult(stdout=b'x', stderr=b'\1\0', returncode=2)
+        async with _toolset(max_output_bytes=1, max_output_lines=1) as tools:
+            result = await tools.run_command('big')
+        assert len(result.encode()) <= 1
+        assert len(result.splitlines()) <= 1
 
     async def test_sdk_error_becomes_model_retry(self, fake_sprites: FakeSprites) -> None:
         async with _toolset() as tools:
@@ -160,6 +168,21 @@ class TestTools:
             )
             assert await tools.list_directory('.') == 'dir/'
 
+    async def test_read_limit_is_enforced_during_the_read(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset(max_read_bytes=10) as tools:
+            await tools.write_file('growing.txt', 'x' * 100)
+            with pytest.raises(ModelRetry, match='exceeded the 10-byte read limit'):
+                await tools.read_file('growing.txt')
+
+    async def test_directory_listing_is_bounded_before_transfer(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset(max_output_lines=2, max_output_bytes=100) as tools:
+            for name in ('a', 'b', 'c'):
+                await tools.write_file(name, name)
+            result = await tools.list_directory('.')
+        assert result.startswith('[... directory listing truncated ...]')
+        assert len(result.encode()) <= 100
+        assert len(result.splitlines()) <= 2
+
     async def test_empty_directory(self, fake_sprites: FakeSprites) -> None:
         async with _toolset() as tools:
             assert await tools.list_directory('/empty') == '(empty)'
@@ -167,7 +190,7 @@ class TestTools:
     async def test_file_error_becomes_model_retry(self, fake_sprites: FakeSprites) -> None:
         async with _toolset() as tools:
             fake_sprites.filesystem_error = FakeSpriteError('disk issue')
-            with pytest.raises(ModelRetry, match="Could not read 'x': Could not stat 'x': disk issue"):
+            with pytest.raises(ModelRetry, match="Could not read 'x': disk issue"):
                 await tools.read_file('x')
             with pytest.raises(ModelRetry, match="Could not write 'x': disk issue"):
                 await tools.write_file('x', 'a')
@@ -212,3 +235,19 @@ class TestTools:
         run_toolset = await toolset.for_run(_context())
         with pytest.raises(SpriteSandboxError, match='not open'):
             await run_toolset.__aenter__()
+
+    async def test_owned_session_is_retained_when_cleanup_fails(self, fake_sprites: FakeSprites) -> None:
+        toolset = SpriteSandbox[None](token='token').get_toolset()
+        assert _is_toolset(toolset)
+        run_toolset = await toolset.for_run(_context())
+        assert isinstance(run_toolset, SpriteSandboxToolset)
+        await run_toolset.__aenter__()
+        fake_sprites.destroy_error = FakeSpriteError('control plane unavailable')
+        with pytest.raises(SpriteSandboxError, match='Could not destroy'):
+            await run_toolset.__aexit__(None, None, None)
+        assert run_toolset._session is not None
+        assert run_toolset._session.is_open
+
+        fake_sprites.destroy_error = None
+        await run_toolset.__aexit__(None, None, None)
+        assert run_toolset._session is None

--- a/tests/sprites/test_sprite_sandbox.py
+++ b/tests/sprites/test_sprite_sandbox.py
@@ -161,7 +161,7 @@ class TestTools:
                 await tools.run_command('echo')
 
     async def test_file_tools(self, fake_sprites: FakeSprites) -> None:
-        async with _toolset(max_output_lines=2) as tools:
+        async with _toolset(max_output_lines=4) as tools:
             assert await tools.write_file('dir/file.txt', 'one\ntwo\nthree') == "Wrote 13 bytes to 'dir/file.txt'."
             assert await tools.read_file('dir/file.txt', offset=2, limit=1) == (
                 'two\n\n[1 more lines in file. Use offset=3 to continue.]'
@@ -186,6 +186,22 @@ class TestTools:
     async def test_empty_directory(self, fake_sprites: FakeSprites) -> None:
         async with _toolset() as tools:
             assert await tools.list_directory('/empty') == '(empty)'
+
+    async def test_file_tool_results_honor_tiny_final_caps(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset(max_output_bytes=1, max_output_lines=1) as tools:
+            write_result = await tools.write_file('multi.txt', 'one\ntwo')
+            read_result = await tools.read_file('multi.txt')
+            empty_result = await tools.list_directory('/empty')
+        for result in (write_result, read_result, empty_result):
+            assert len(result.encode()) <= 1
+            assert len(result.splitlines()) <= 1
+
+    async def test_directory_entry_delimiters_are_escaped(self, fake_sprites: FakeSprites) -> None:
+        async with _toolset() as tools:
+            await tools.write_file('old\nreport.txt', 'content')
+            result = await tools.list_directory('.')
+        assert result == r'old\nreport.txt'
+        assert len(result.splitlines()) == 1
 
     async def test_file_error_becomes_model_retry(self, fake_sprites: FakeSprites) -> None:
         async with _toolset() as tools:

--- a/tests/sprites/test_sprites_live.py
+++ b/tests/sprites/test_sprites_live.py
@@ -16,7 +16,7 @@ import os
 
 import pytest
 
-from pydantic_ai_harness.sprites import SpriteSandboxSession, SpriteSandboxUnavailableError
+from pydantic_ai_harness.sprites import SpriteSandboxError, SpriteSandboxSession, SpriteSandboxUnavailableError
 
 _TOKEN = os.getenv('SPRITE_TOKEN')
 _LIVE_ENABLED = os.getenv('PYDANTIC_AI_HARNESS_SPRITES_LIVE') == '1'
@@ -55,11 +55,28 @@ async def test_real_sprite_execution_filesystem_limits_and_lifecycle() -> None:
         await session.write_bytes('harness-live/nested.txt', b'from-filesystem\n')
         via_shell = await session.exec('cat harness-live/nested.txt', timeout=15, max_output_bytes=1024)
         assert via_shell.output == 'from-filesystem\n'
-        assert await session.read_bytes('harness-live/nested.txt') == b'from-filesystem\n'
+        assert await session.read_bytes('harness-live/nested.txt', max_bytes=1024) == b'from-filesystem\n'
+        with pytest.raises(SpriteSandboxError, match='exceeded the 4-byte read limit'):
+            await session.read_bytes('harness-live/nested.txt', max_bytes=4)
+
+        await session.write_bytes('harness-live/second.txt', b'second\n')
+        listing = await session.list_files('harness-live', max_entries=1, max_output_bytes=1024)
+        assert len(listing.entries) == 1
+        assert listing.truncated is True
 
         bounded = await session.exec('python3 -c "print(\'x\' * 5000)"', timeout=15, max_output_bytes=256)
         assert bounded.truncated is True
         assert len(bounded.output.encode()) <= 256
+
+        literal_timeout_marker = await session.exec(
+            "printf '\\n__PYDANTIC_AI_SPRITE_TIMEOUT__\\n'", timeout=15, max_output_bytes=1024
+        )
+        assert literal_timeout_marker.timed_out is False
+        assert literal_timeout_marker.output == '\n__PYDANTIC_AI_SPRITE_TIMEOUT__\n'
+
+        await session.exec('printf profile-noise > "$HOME/.bash_profile"', timeout=15, max_output_bytes=1024)
+        after_profile = await session.exec('printf clean', timeout=15, max_output_bytes=1024)
+        assert after_profile.output == 'clean'
 
         timed_out = await session.exec('printf before-timeout; sleep 30', timeout=1, max_output_bytes=1024)
         assert timed_out.output == 'before-timeout'

--- a/tests/sprites/test_sprites_live.py
+++ b/tests/sprites/test_sprites_live.py
@@ -1,0 +1,70 @@
+"""Opt-in smoke test against a real Sprite.
+
+The fake-backed tests cover integration-owned branching. This test verifies the
+SDK assumptions that a fake cannot: real create and label retention, process
+execution, the shared command/filesystem view, in-Sprite timeout enforcement,
+bounded output, and final deletion.
+
+Run locally only with explicit permission to create and delete a Sprite:
+
+`PYDANTIC_AI_HARNESS_SPRITES_LIVE=1 uv run pytest -m sprites_live tests/sprites/test_sprites_live.py`
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pydantic_ai_harness.sprites import SpriteSandboxSession, SpriteSandboxUnavailableError
+
+_TOKEN = os.getenv('SPRITE_TOKEN')
+_LIVE_ENABLED = os.getenv('PYDANTIC_AI_HARNESS_SPRITES_LIVE') == '1'
+
+pytestmark = [
+    pytest.mark.sprites_live,
+    pytest.mark.skipif(
+        not _LIVE_ENABLED or not _TOKEN,
+        reason='requires PYDANTIC_AI_HARNESS_SPRITES_LIVE=1 and SPRITE_TOKEN',
+    ),
+]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Run the billed live smoke test once, using the SDK's primary asyncio backend."""
+    return 'asyncio'
+
+
+async def test_real_sprite_execution_filesystem_limits_and_lifecycle() -> None:
+    """Exercise one real owned Sprite, then confirm the ownership-safe cleanup deleted it."""
+    assert _TOKEN is not None
+    name: str | None = None
+    async with SpriteSandboxSession(token=_TOKEN) as session:
+        name = session.sprite_name
+        assert name is not None
+
+        command = await session.exec(
+            'printf stdout; printf stderr >&2; exit 3',
+            timeout=15,
+            max_output_bytes=1024,
+        )
+        assert command.output == 'stdoutstderr'
+        assert command.returncode == 3
+
+        await session.write_bytes('harness-live/nested.txt', b'from-filesystem\n')
+        via_shell = await session.exec('cat harness-live/nested.txt', timeout=15, max_output_bytes=1024)
+        assert via_shell.output == 'from-filesystem\n'
+        assert await session.read_bytes('harness-live/nested.txt') == b'from-filesystem\n'
+
+        bounded = await session.exec('python3 -c "print(\'x\' * 5000)"', timeout=15, max_output_bytes=256)
+        assert bounded.truncated is True
+        assert len(bounded.output.encode()) <= 256
+
+        timed_out = await session.exec('printf before-timeout; sleep 30', timeout=1, max_output_bytes=1024)
+        assert timed_out.output == 'before-timeout'
+        assert timed_out.timed_out is True
+
+    with pytest.raises(SpriteSandboxUnavailableError):
+        async with SpriteSandboxSession(token=_TOKEN, sprite_name=name):
+            pass

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -130,6 +130,7 @@ _CAPABILITY_PAGE_META = {
     'managed-prompt.md': ('logfire', 'Managed Prompt'),
     'memory.md': ('memory', 'Memory'),
     'modal-sandbox.md': ('modal_sandbox', 'Modal Sandbox'),
+    'sprite-sandbox.md': ('sprites', 'Sprite Sandbox'),
     'repo-context.md': ('repo_context', 'Repo Context'),
     'researcher.md': ('researcher', 'Researcher'),
     'pydantic-ai-docs.md': ('pydantic_ai_docs', 'Pydantic AI Docs'),

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -130,7 +130,7 @@ _CAPABILITY_PAGE_META = {
     'managed-prompt.md': ('logfire', 'Managed Prompt'),
     'memory.md': ('memory', 'Memory'),
     'modal-sandbox.md': ('modal_sandbox', 'Modal Sandbox'),
-    'sprite-sandbox.md': ('sprites', 'Sprite Sandbox'),
+    'sprite-sandbox.md': ('sprites', 'Fly.io Sprites Sandbox'),
     'repo-context.md': ('repo_context', 'Repo Context'),
     'researcher.md': ('researcher', 'Researcher'),
     'pydantic-ai-docs.md': ('pydantic_ai_docs', 'Pydantic AI Docs'),

--- a/uv.lock
+++ b/uv.lock
@@ -1096,6 +1096,15 @@ wheels = [
 ]
 
 [[package]]
+name = "client-signals"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/dd/5002f106210ebb4772171e80f206c395e1ac38532c7d601a883903b9b7e6/client_signals-0.4.4.tar.gz", hash = "sha256:1fc1846b9992706349a10c10886f0f326bc56eeedd9af612c41cf9ff1a89562d", size = 3851, upload-time = "2026-08-05T14:46:53.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/76/e8f0947c8a26ec9fd0ccc960ed3875aec55035afb19bd6c08e9eac574861/client_signals-0.4.4-py3-none-any.whl", hash = "sha256:672551d797c004cfc9d5ae87ed0dca4ba5a64fc35d1edcf1218cc11f12fdfb25", size = 4347, upload-time = "2026-08-05T14:46:52.186Z" },
+]
+
+[[package]]
 name = "cloudpickle"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3934,6 +3943,9 @@ researcher = [
 skills = [
     { name = "pyyaml" },
 ]
+sprites = [
+    { name = "sprites-py" },
+]
 stackone = [
     { name = "fastmcp" },
     { name = "pydantic-ai-slim", extra = ["mcp"] },
@@ -3994,11 +4006,12 @@ requires-dist = [
     { name = "pydantic-monty", marker = "extra == 'dynamic-workflow'", specifier = ">=0.0.19" },
     { name = "pymongo", marker = "extra == 'mongodb'", specifier = ">=4.17.0" },
     { name = "pyyaml", marker = "extra == 'skills'", specifier = ">=6.0.2" },
+    { name = "sprites-py", marker = "extra == 'sprites'", specifier = ">=0.6.0,<1" },
     { name = "stackone-defender", marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender'", specifier = ">=0.7.3,<0.8" },
     { name = "stackone-defender", extras = ["onnx"], marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender-ml'", specifier = ">=0.7.3,<0.8" },
     { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.1,<4" },
 ]
-provides-extras = ["acp", "anthropic", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
+provides-extras = ["acp", "anthropic", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "sprites", "stackone", "temporal", "youdotcom"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -8437,6 +8450,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
+]
+
+[[package]]
+name = "sprites-py"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "client-signals" },
+    { name = "httpx" },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/11/63fac634575f187541d2a4aba02a6996ea934672569de6ab44c214817775/sprites_py-0.6.0.tar.gz", hash = "sha256:a48682faeaa39b8f635c1c18ac3d5a3709859050206c2977efdc5dd3fa886fc6", size = 54091, upload-time = "2026-09-01T15:53:30.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/62/bf5fb2465921556c2739b1daeee290b5f7920993cc6b0c102b25497b8393/sprites_py-0.6.0-py3-none-any.whl", hash = "sha256:26c8f038fd9c8e3cae39e254c04214ff7e4d6edaf46c9bb2806e2bc0d3752064", size = 46659, upload-time = "2026-09-01T15:53:29.019Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a Fly.io Sprites-backed sandbox capability for Pydantic AI Harness.

- add `SpriteSandbox` and `SpriteSandboxSession` with command, file, and directory tools
- support owned per-run Fly.io Sprites, attaching by name, and caller-owned open sessions
- enforce process-group timeouts and bounded combined output inside the Sprite
- add ownership-checked, cancellation-safe lifecycle cleanup and typed authentication/unavailable errors
- document setup, lifecycle modes, limits, and the optional `sprites` dependency

### Boundary notes

- SDK calls are synchronous, so the capability runs them through AnyIO worker threads.
- Commands run through an isolated, non-login wrapper that bounds combined output before `sprites-py` receives it; timeout and truncation state use a separate control channel.
- File reads and directory listings enforce their byte/entry limits inside the Sprite before returning data to the buffering SDK.
- Failed teardown retains the SDK client and owned-session identity so cleanup can be retried; the run-scoped toolset retains that session until cleanup succeeds.
- Only sessions that successfully create and retain ownership labels delete Sprites during teardown; attached and injected sessions remain caller-owned.
- The current Fly.io Sprites API exposes name-based deletion without a label precondition. The random name and ownership-label check guard against stale handles and accidental reuse, but actors with write access to the same organization remain inside the trust boundary.
- Teardown is shielded from cancellation and verifies ownership before deletion.
- Fake-backed tests cover lifecycle and failure branches. An opt-in live test passed against one disposable Fly.io Sprite and verified deletion by rejecting a later attach.

## Linked Issue

Related: https://github.com/superfly/sprites-ecosystem/issues/34

## Validation

- `uv run ruff format --check`
- `uv run ruff check`
- targeted strict Pyright: 0 errors
- focused test suite: 1,269 passed, 43 expected skips before commit
- post-review Sprites and docs-parity suite: 442 passed, 1 expected live skip
- all 8 Python documentation blocks compile
- generated wrapper execution smoke: byte bound and separate control status passed
- opt-in live Sprite smoke test: 1 passed in 26.67s, including bounded files/listing, startup-file isolation, timeout framing, and deletion verification

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (focused equivalent checks are listed above)
- [ ] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)
