### PR TITLE
Name the internal `Agent` in `SummarizingCompaction`, `ToolOutputLimits`, `SystemReminders`, `Advisor` and `PydanticAIChatModel` so Logfire attributes their runs

### DIFF
--- a/agent_docs/capability-authoring.md
+++ b/agent_docs/capability-authoring.md
@@ -129,6 +129,24 @@ warnings where practical.
   editors, and stack traces (`modal_sandbox` is the reference; `filesystem` is
   0-based pending migration).
 
+### Internal Agents Carry The Capability's Name
+
+A capability that constructs its own `Agent` (a summarizer, an advisor, a
+reminder generator) passes `name=` explicitly, set to the capability's
+snake_case name: `Agent(model, name='summarizing_compaction', ...)`. That name
+is the `agent_name` on the run span, which is what Logfire groups runs and
+costs by.
+
+Without it, core infers the name from the caller's frame locals. Inside a
+capability method that lands on `agent`, `self`, or whatever a durability
+wrapper happened to bind, so the run is unattributable in tracing. Matching
+the capability name lets a reader trace spend straight back to the
+capability without knowing its internals.
+
+Test it through `instrument_all_agents` + `agent_run_names(capfire)` from
+`tests/conftest.py`; per-agent `instrument=` on the outer agent does not reach
+the inner one.
+
 ### Policy Lives In The Pluggable Component
 
 When a capability takes a dependency behind a `Protocol` -- `PlanStore`,

--- a/agent_docs/review-checklist.md
+++ b/agent_docs/review-checklist.md
@@ -97,6 +97,9 @@ README, or source code.
 ## Tests
 
 - Tests cover the public `Agent(..., capabilities=[...])` path where possible.
+- Every `Agent` the capability constructs internally passes `name=` (the
+  capability's snake_case name) and a test asserts it on the run span. See
+  `capability-authoring.md` "Internal Agents Carry The Capability's Name".
 - Lower-level tests cover lifecycle, schemas, retries, and metadata when needed.
 - Error paths and important option combinations are covered.
 - For a stateful capability, or one that overrides `for_run`, require a public

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -395,6 +395,8 @@ The span name is the static `compact_messages`; the strategy is an attribute, no
 
 `gen_ai.conversation.compacted` is the GenAI semantic convention's flag; the rest is harness-specific. Token counts use the strategy's `tokenizer` when set, otherwise the ~4-chars-per-token heuristic. Raw message content is not recorded.
 
+`SummarizingCompaction` runs its summarizer as a nested `Agent` named `summarizing_compaction`, so under `Agent.instrument_all()` (or `logfire.instrument_pydantic_ai()`) its runs carry `agent_name = summarizing_compaction`. Filter on that to track summarization usage and cost separately from the parent agent.
+
 ## Compaction receipts
 
 Compaction is a memory wipe the model cannot veto and often cannot detect, which invites *resumption drift* -- the model confabulates continuity with history it no longer has. A receipt makes the wipe legible: after a boundary-crossing strategy rewrites history it appends a short, deterministic note recording how much was compacted, warning that what survives is secondhand, and -- when a handle provider is attached -- an identifier for persisted run history.

--- a/pydantic_ai_harness/advisor/_capability.py
+++ b/pydantic_ai_harness/advisor/_capability.py
@@ -136,6 +136,7 @@ class Advisor(NativeOrLocalTool[AgentDepsT]):
                 settings = ModelSettings(max_tokens=max_tokens) if max_tokens is not None else None
                 advisor_agent = Agent(
                     model,
+                    name='advisor',
                     output_type=str,
                     instructions=(
                         'You are an expert advisor. Give concise, actionable advice to the executor model '

--- a/pydantic_ai_harness/browser_use/_model.py
+++ b/pydantic_ai_harness/browser_use/_model.py
@@ -153,7 +153,7 @@ class PydanticAIChatModel(BaseChatModel):
     def __init__(self, model: Model | KnownModelName | str) -> None:
         self._model = infer_model(model)
         self.model: str = self._model.model_name
-        self._agent = Agent(self._model)
+        self._agent = Agent(self._model, name='browser_use')
 
     @property
     def provider(self) -> str:

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -450,6 +450,11 @@ harness-specific. Token counts use the strategy's `tokenizer` when set, otherwis
 ~4-chars-per-token heuristic.
 Raw message content is not recorded.
 
+`SummarizingCompaction` runs its summarizer as a nested `Agent` named `summarizing_compaction`,
+so under `Agent.instrument_all()` (or `logfire.instrument_pydantic_ai()`) its runs carry
+`agent_name = summarizing_compaction`. Filter on that to track summarization usage and cost
+separately from the parent agent.
+
 ## Compaction receipts
 
 Compaction is a memory wipe the model cannot veto and often cannot detect, which invites

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -649,6 +649,7 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
         # `Model[Any]`, mirroring core's own `reinject_system_prompt` idiom.
         agent: Agent[None, str] = Agent(
             cast('Model[Any] | str', model),
+            name='summarizing_compaction',
             instructions=self.instructions,
             model_settings=self.model_settings,
         )

--- a/pydantic_ai_harness/system_reminders/_capability.py
+++ b/pydantic_ai_harness/system_reminders/_capability.py
@@ -338,7 +338,7 @@ class LLMReminder(Generic[AgentDepsT]):
     async def _generate_from_transcript(self, ctx: RunContext[AgentDepsT], transcript: str) -> str | None:
         agent = self._agent
         if agent is None:
-            agent = Agent(self.model, instructions=self.instructions, output_type=str)
+            agent = Agent(self.model, name='system_reminders', instructions=self.instructions, output_type=str)
             self._agent = agent
         result = await agent.run(transcript, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
         text = result.output.strip()

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -448,7 +448,9 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
         action = self._resolve_summarize(action_path)
         model = self._summary_model(ctx, action)
         prompt = self.summary_prompt.format(tool_name=tool_name, output=text)
-        agent: Agent[None, str] = Agent(model, instructions='You summarize oversized tool output.')
+        agent: Agent[None, str] = Agent(
+            model, name='tool_output_limits', instructions='You summarize oversized tool output.'
+        )
         run = await agent.run(prompt, usage=ctx.usage, usage_limits=reserved_usage_limits(ctx.usage_limits))
         return run.output.strip()
 

--- a/tests/advisor/test_advisor.py
+++ b/tests/advisor/test_advisor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import pytest
 from inline_snapshot import snapshot
@@ -24,6 +25,10 @@ from pydantic_ai.settings import ModelSettings
 from pydantic_ai.usage import UsageLimits
 
 from pydantic_ai_harness.advisor import Advisor
+from tests.conftest import agent_run_names  # pyright: ignore[reportMissingTypeStubs]
+
+if TYPE_CHECKING:
+    from logfire.testing import CaptureLogfire
 
 pytestmark = pytest.mark.anyio
 
@@ -117,6 +122,27 @@ class TestAdvisor:
 
         assert advisor_prompts == ['How should I deploy this?']
         assert advisor_settings == [ModelSettings(max_tokens=2048)]
+
+    @pytest.mark.usefixtures('instrument_all_agents')
+    async def test_local_advisor_run_is_named_after_the_capability(self, capfire: CaptureLogfire) -> None:
+        def advisor_model(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            return ModelResponse(parts=[TextPart('Use a staged rollout.')])
+
+        def executor(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            if not _has_tool_return(messages):
+                return ModelResponse(parts=[ToolCallPart('advisor', {'prompt': 'How?'}, tool_call_id='advisor-1')])
+            return ModelResponse(parts=[TextPart('done')])
+
+        advisor = _ProviderFunctionModel('anthropic', advisor_model)
+        agent = Agent(
+            _ProviderFunctionModel('anthropic', executor, supports_advisor=True),
+            name='outer',
+            capabilities=[Advisor(advisor)],
+        )
+
+        await agent.run('Plan the deployment.')
+
+        assert 'advisor' in agent_run_names(capfire)
 
     async def test_unsupported_native_profile_exposes_local_tool(self) -> None:
         seen: list[ModelRequestParameters] = []

--- a/tests/browser_use/test_model.py
+++ b/tests/browser_use/test_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from typing import TYPE_CHECKING
 
 import pytest
 from browser_use.llm.messages import (
@@ -29,6 +30,10 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.models.test import TestModel
 
 from pydantic_ai_harness.browser_use import PydanticAIChatModel, resolve_chat_model
+from tests.conftest import agent_run_names  # pyright: ignore[reportMissingTypeStubs]
+
+if TYPE_CHECKING:
+    from logfire.testing import CaptureLogfire
 
 
 class _Facts(BaseModel):
@@ -152,6 +157,13 @@ class TestPydanticAIChatModel:
         assert isinstance(facts.completion, _Facts)
         assert isinstance(text.completion, str)
         assert isinstance(other.completion, _Other)
+
+    @pytest.mark.usefixtures('instrument_all_agents')
+    async def test_run_is_named_after_the_capability(self, capfire: CaptureLogfire) -> None:
+        model = PydanticAIChatModel(TestModel())
+        await model.ainvoke([UserMessage(content='hello')])
+
+        assert agent_run_names(capfire) == ['browser_use']
 
     def test_identity_properties(self) -> None:
         model = PydanticAIChatModel('test')

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -87,6 +87,7 @@ from pydantic_ai_harness.compaction._summarizing_compaction import (
     _format_messages,
 )
 from pydantic_ai_harness.step_persistence import InMemoryStepStore, StepPersistence
+from tests.conftest import agent_run_names  # pyright: ignore[reportMissingTypeStubs]
 
 try:
     from logfire.testing import CaptureLogfire
@@ -2693,6 +2694,18 @@ class TestCompactionSpan:
         spans = _compact_spans(capfire)
         assert len(spans) == 1
         assert spans[0]['attributes']['compaction.strategy'] == 'SummarizingCompaction'
+
+    @pytest.mark.anyio
+    @pytest.mark.usefixtures('instrument_all_agents')
+    async def test_summarizer_run_is_named_after_the_capability(self, capfire: CaptureLogfire) -> None:
+        agent = Agent(
+            TestModel(),
+            name='outer',
+            capabilities=[SummarizingCompaction(model=_recording_summarizer([]), max_messages=2, keep_messages=1)],
+        )
+        await agent.run('go', message_history=[_user('a'), _assistant('b'), _user('c'), _assistant('d')])
+
+        assert 'summarizing_compaction' in agent_run_names(capfire)
 
     @pytest.mark.anyio
     async def test_clamp_emits_span_only_when_a_part_is_clamped(self, capfire: CaptureLogfire) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ import pytest
 from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
 
+if TYPE_CHECKING:
+    from logfire.testing import CaptureLogfire
+
 # `dirty-equals` matchers are typed as `DirtyEquals[T]`, not `T`, so passing
 # them where pydantic-ai expects concrete `str`/`datetime`/etc. fails pyright
 # strict. Following pydantic-ai's own conftest, re-export with TYPE_CHECKING
@@ -27,7 +30,7 @@ if TYPE_CHECKING:
 else:
     from dirty_equals import IsDatetime, IsInstance, IsNow, IsPartialDict, IsStr
 
-__all__ = ('IsDatetime', 'IsInstance', 'IsNow', 'IsPartialDict', 'IsStr')
+__all__ = ('IsDatetime', 'IsInstance', 'IsNow', 'IsPartialDict', 'IsStr', 'agent_run_names')
 
 # Prevent accidental real model requests during tests.
 pydantic_ai.models.ALLOW_MODEL_REQUESTS = False
@@ -56,3 +59,30 @@ def allow_model_requests() -> Iterator[None]:
     """Temporarily allow real model requests within a test."""
     with pydantic_ai.models.override_allow_model_requests(True):
         yield
+
+
+@pytest.fixture
+def instrument_all_agents() -> Iterator[None]:
+    """Instrument every `Agent` for the test, including ones a capability builds internally.
+
+    Per-agent `instrument=` does not reach agents a capability constructs on its own, so
+    this is the only way to observe their run spans.
+    """
+    Agent.instrument_all(True)
+    try:
+        yield
+    finally:
+        Agent.instrument_all(False)
+
+
+def agent_run_names(capfire: CaptureLogfire) -> list[str]:
+    """The `agent_name` of every agent run span, in export order.
+
+    Capabilities that build an internal `Agent` must name it, otherwise core infers a name from
+    the caller's frame locals and Logfire groups the run under something like `self`.
+    """
+    return [
+        str(span['attributes']['agent_name'])
+        for span in capfire.exporter.exported_spans_as_dict()
+        if 'agent_name' in span['attributes']
+    ]

--- a/tests/system_reminders/test_system_reminders.py
+++ b/tests/system_reminders/test_system_reminders.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -39,6 +39,10 @@ from tests._recording_durability import (  # pyright: ignore[reportMissingTypeSt
     RecordingDurability,
     RestrictedRunContext,
 )
+from tests.conftest import agent_run_names  # pyright: ignore[reportMissingTypeStubs]
+
+if TYPE_CHECKING:
+    from logfire.testing import CaptureLogfire
 
 pytestmark = pytest.mark.anyio
 
@@ -592,6 +596,17 @@ def _capture_model(store: dict[str, str], output: str = 'generated') -> Function
 
 
 class TestLLMReminder:
+    @pytest.mark.usefixtures('instrument_all_agents')
+    async def test_generation_run_is_named_after_the_capability(self, capfire: CaptureLogfire) -> None:
+        reminder = LLMReminder(model=FunctionModel(lambda _messages, _info: ModelResponse(parts=[TextPart('refocus')])))
+        agent = Agent(
+            TestModel(call_tools=[]), name='outer', capabilities=[SystemReminders(dynamic_reminders=[reminder])]
+        )
+
+        await agent.run('stay focused')
+
+        assert 'system_reminders' in agent_run_names(capfire)
+
     async def test_generation_dispatches_as_durable_operation(self) -> None:
         durability = RecordingDurability()
         capability = SystemReminders(

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -7,7 +7,7 @@ import os
 import time
 from datetime import timedelta
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -62,6 +62,10 @@ from pydantic_ai_harness.tool_output_limits._payload import (
 )
 from pydantic_ai_harness.tool_output_limits._store import _safe_segment
 from tests._recording_durability import RecordingDurability  # pyright: ignore[reportMissingTypeStubs]
+from tests.conftest import agent_run_names  # pyright: ignore[reportMissingTypeStubs]
+
+if TYPE_CHECKING:
+    from logfire.testing import CaptureLogfire
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -639,6 +643,21 @@ class TestSummarize:
 
         assert out == 'THE SUMMARY'
 
+    @pytest.mark.usefixtures('instrument_all_agents')
+    async def test_summarizer_run_is_named_after_the_capability(self, capfire: CaptureLogfire):
+        def large_output() -> str:
+            return 'x' * 100
+
+        agent = Agent(
+            TestModel(call_tools='all'),
+            name='outer',
+            capabilities=[ToolOutputLimits(bands=[Band(over=5, action=Summarize(model=_fixed_model('THE SUMMARY')))])],
+            toolsets=[FunctionToolset(tools=[large_output], id='large-output')],
+        )
+        await agent.run('call the tool')
+
+        assert 'tool_output_limits' in agent_run_names(capfire)
+
     async def test_model_summarizer_dispatches_as_durable_operation(self):
         def large_output() -> str:
             return 'x' * 100
@@ -742,7 +761,9 @@ class TestSummarize:
         with patch('pydantic_ai.Agent', return_value=mock_agent) as agent_type:
             assert await _run(cap, 'x' * 100, ctx=ctx) == 'FROM NAMED MODEL'
 
-        agent_type.assert_called_once_with('test:summary', instructions='You summarize oversized tool output.')
+        agent_type.assert_called_once_with(
+            'test:summary', name='tool_output_limits', instructions='You summarize oversized tool output.'
+        )
 
     async def test_realtime_run_without_a_model_raises(self):
         """A realtime run has no request-response model to summarize with; ask for one (#585)."""


### PR DESCRIPTION
## Why

A user tracking summarization spend in Logfire reported the `SummarizingCompaction` summarizer run showing up with `agent_name = self`. Core infers an unnamed `Agent`'s name by scanning the caller's frame locals for the agent object; inside a capability method (and especially under a durability wrapper) that lands on whatever the frame bound first, so the run is unattributable.

## What

- Pass `name=` explicitly for every `Agent` a capability constructs internally, set to the capability's snake_case name:
  - `SummarizingCompaction` -> `summarizing_compaction`
  - `ToolOutputLimits` (`Summarize` action) -> `tool_output_limits`
  - `SystemReminders` (`LLMReminder`) -> `system_reminders`
  - `Advisor` (local mode) -> `advisor`
  - `PydanticAIChatModel` (browser-use) -> `browser_use`
- Shared `instrument_all_agents` fixture + `agent_run_names(capfire)` helper in `tests/conftest.py`; per-agent `instrument=` on the outer agent does not reach the inner one, so `Agent.instrument_all()` is the only way to observe those spans. One test per capability asserts the run span's `agent_name`.
- Write the rule into `agent_docs/capability-authoring.md` and `agent_docs/review-checklist.md` so new capabilities follow it.
- Document the `agent_name` filter in the compaction README and `docs/compaction.md` (kept in parity).

## Verification

```
uv run --no-sync ruff format --check .   # clean
uv run --no-sync ruff check .            # clean
pyright on touched files                 # 0 errors
pytest tests/compaction tests/tool_output_limits tests/system_reminders tests/advisor tests/browser_use
# 959 passed, 1 skipped
```

The new compaction test was verified to fail before the fix (`['agent', 'outer']`) and pass after.
