### PR TITLE
Declare `Advisor`'s default `id` on the class

### DIFF
--- a/pydantic_ai_harness/advisor/_capability.py
+++ b/pydantic_ai_harness/advisor/_capability.py
@@ -81,6 +81,13 @@ class Advisor(NativeOrLocalTool[AgentDepsT]):
     Native execution keeps the provider's transcript behavior unchanged.
     """
 
+    id: str | None = 'advisor'
+    """One-off: an agent has one advisor, and its tool name is fixed.
+
+    Declared here rather than only passed up from `__init__`, so the class states it where a reader
+    -- and Pydantic AI, deciding what two of this capability under one `id` mean -- can see it.
+    """
+
     _local_uses: int = field(init=False, repr=False, default=0)
 
     def __init__(


### PR DESCRIPTION
`Advisor` passed `id='advisor'` up from inside its own `__init__`, so nothing outside the constructor could see that the class names its own id.

pydantic/pydantic-ai#7248 decides what two capabilities under one `id` mean from whether the class declares a default: one that does has said an agent has one of it, so a repeat is one configuration stated twice and merges; one that does not is anonymous, and a shared `id` is a naming collision the user made. Read that way `Advisor` was anonymous, and `test_rejects_duplicate_capability_or_tool_name` failed against #7248 — the test takes its resolving branch once the core has `combine`, but two advisors still collided.

Declaring the default in the class body is also the clearer statement of "one advisor per agent, and its tool name is fixed".

Verified three ways, with the core under test on `PYTHONPATH`:

| | `tests/advisor/` |
|---|---|
| released core, with this change | 20 passed |
| #7248 core, without this change | **1 failed** — the compat failure |
| #7248 core, with this change | 20 passed |

Nothing changes against the released core, which takes the id from the constructor either way.

## Checklist

- [x] Tests pass
- [ ] AI generated code
