### PR TITLE
Floor on released `pydantic-ai` 2.38.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
     "genai-prices>=0.0.71",
     "httpx>=0.28.1",
-    "pydantic-ai-slim>=2.37.0",
+    "pydantic-ai-slim>=2.38.0",
 ]
 
 [project.optional-dependencies]
@@ -38,22 +38,22 @@ dependencies = [
 # without separately naming pydantic-ai-slim. (No openai/google pass-throughs: browser-use pins
 # provider SDKs that conflict with slim's floors when the workspace resolves all extras together.)
 anthropic = [
-    "pydantic-ai-slim[anthropic]>=2.37.0",
+    "pydantic-ai-slim[anthropic]>=2.38.0",
 ]
 cli = [
-    "pydantic-ai-slim[cli]>=2.37.0",
+    "pydantic-ai-slim[cli]>=2.38.0",
 ]
 code-mode = [
-    "pydantic-ai-slim[duckduckgo]>=2.37.0",
+    "pydantic-ai-slim[duckduckgo]>=2.38.0",
     "pydantic-monty>=0.0.19",
 ]
 # Extras metadata has no native redirect syntax, so aliases are represented as duplicate extras.
 codemode = [
-    "pydantic-ai-slim[duckduckgo]>=2.37.0",
+    "pydantic-ai-slim[duckduckgo]>=2.38.0",
     "pydantic-monty>=0.0.19",
 ]
 researcher = [
-    "pydantic-ai-slim[duckduckgo,web-fetch]>=2.37.0",
+    "pydantic-ai-slim[duckduckgo,web-fetch]>=2.38.0",
 ]
 temporal = [
     'pydantic-ai-slim[temporal]',
@@ -157,15 +157,14 @@ bump = true
 # An override *replaces* every requirement on the package it names, so it erases the floors slim
 # declares as well as browser-use's pins, and `lowest-direct` resolves `pydantic-ai-slim` to its
 # floor while taking provider SDKs to the newest release the range admits. `anthropic` therefore
-# repeats the floor slim declares: `anthropic>=1` is the HTTPX2 generation, and the
-# `pydantic-ai-slim` floor above is the release built on it, so both halves of that pair resolve
-# together under every resolution mode. Move this floor whenever that one moves.
+# repeats the floor slim declares, so both halves of that pair resolve together under every
+# resolution mode. Move this floor whenever that one moves.
 #
 # This has to stay here, under `[tool.uv]`, even though uv warns on every invocation that `uv.toml`
 # shadows it: uv 0.12.1 reads `override-dependencies` only from the workspace root's `pyproject.toml`.
 # Moved into `uv.toml` it silences the warning and stops applying, and resolution then fails outright
 # on browser-use's exact pins.
-override-dependencies = ['anthropic>=1.0.0', 'openai>=2.45.0']
+override-dependencies = ['anthropic>=1.3.0', 'openai>=2.45.0']
 
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ pydantic-evals = false
 
 [manifest]
 overrides = [
-    { name = "anthropic", specifier = ">=1.0.0" },
+    { name = "anthropic", specifier = ">=1.3.0" },
     { name = "openai", specifier = ">=2.45.0" },
 ]
 
@@ -385,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "1.0.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -398,9 +398,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/aa/4978e58035bd6c638c7b483450a68b7ef2d732ab78885e27bb9db0cff1a2/anthropic-1.0.0.tar.gz", hash = "sha256:42be3c97604af7252c5898413aee076ace6c46e9bca0d0d90ceb77c7d3719027", size = 1077769, upload-time = "2026-08-20T19:59:00.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/50/463166f02179ab279edb61de1589a6f69cb3838d6a2fb6f2c92a3f8042f1/anthropic-1.3.0.tar.gz", hash = "sha256:6873492a77ede8849a161ab1bc78bc9a1e492a006d0b5bb4c57ac77845df838a", size = 1148177, upload-time = "2026-09-01T17:37:10.392Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/5b/db4a854aebf5d33a5ab714c46af6eb85ee44f390ed29b7b325c00b9f11ed/anthropic-1.0.0-py3-none-any.whl", hash = "sha256:32dd52e9e1d774393b27182f451398ba4262287a4d0eab30887f89f1481b3ae4", size = 1171725, upload-time = "2026-08-20T19:58:58.725Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5d/7863a9961d320c23787c7b594956afe4e878f9c0ae2376b11a20e416791d/anthropic-1.3.0-py3-none-any.whl", hash = "sha256:e7e7dbebf9f3c84a23954ab989378af6ae10a4d1804c81e9fea4b5ced695ce75", size = 1296959, upload-time = "2026-09-01T17:37:08.525Z" },
 ]
 
 [[package]]
@@ -1676,16 +1676,16 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.1.5"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/70/76dcc9c76b416d2df9aa4c65553f88b75d2ba4fbfeb5efb137f078844cc3/genai_prices-0.1.5.tar.gz", hash = "sha256:04c2cbf4444a3b2f5d38c3b6ab8385ea28ab924ac6f9202bde9261f599be8b45", size = 109418, upload-time = "2026-08-31T09:36:22.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/16/e5a507d42c0eb629b48ebe6c278f2d8c3f929bb6b28f18108bdd66d8ae12/genai_prices-0.1.6.tar.gz", hash = "sha256:802c1e4cc3ed5e70a09083b83af441a58d91f62e12768f7f1b6b26c98a33fcac", size = 111810, upload-time = "2026-09-02T14:53:54.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/14/28f578fa25391bb8983522f3e365e8735310f4b741e54cfed3a614f50384/genai_prices-0.1.5-py3-none-any.whl", hash = "sha256:5215706950decd833ce3527a9e1e745ad0dbdd35ce1b33ac1f7167699640b82a", size = 116330, upload-time = "2026-08-31T09:36:21.364Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a1/43fa2a4c5557cd977e83eecec265b0b77b726b0c7b9f2f180b46c6fdb458/genai_prices-0.1.6-py3-none-any.whl", hash = "sha256:35ac8043dbcf2958488129413bfecba7304fe12a68ad4a78c5b0d15281e82814", size = 118834, upload-time = "2026-09-02T14:53:53.758Z" },
 ]
 
 [[package]]
@@ -3979,13 +3979,13 @@ requires-dist = [
     { name = "logfire", marker = "extra == 'logfire'", specifier = ">=4.31.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.5.0" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.61.0" },
-    { name = "pydantic-ai-slim", specifier = ">=2.37.0" },
-    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.37.0" },
-    { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.37.0" },
+    { name = "pydantic-ai-slim", specifier = ">=2.38.0" },
+    { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.38.0" },
+    { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", extras = ["dbos"], marker = "extra == 'dbos'" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.37.0" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'codemode'", specifier = ">=2.37.0" },
-    { name = "pydantic-ai-slim", extras = ["duckduckgo", "web-fetch"], marker = "extra == 'researcher'", specifier = ">=2.37.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.38.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'codemode'", specifier = ">=2.38.0" },
+    { name = "pydantic-ai-slim", extras = ["duckduckgo", "web-fetch"], marker = "extra == 'researcher'", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", extras = ["mcp"], marker = "extra == 'stackone'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["spec"], marker = "extra == 'logfire'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["temporal"], marker = "extra == 'temporal'" },
@@ -4025,7 +4025,7 @@ lint = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.37.0"
+version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4040,9 +4040,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/29/6204f4a6a90a4741ef80453d65ed22ea953506abecdfd922dccf2ee50119/pydantic_ai_slim-2.37.0.tar.gz", hash = "sha256:c4743bdcd6fd0ea60d82088856f3dfcce93180543b2a66587547034f9dc36e57", size = 1317321, upload-time = "2026-09-01T02:07:39.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/1e/9baa25614062be6fe05c3691816bbd1bcf538a5828bcd9fc7732ca89a2b3/pydantic_ai_slim-2.38.0.tar.gz", hash = "sha256:2e486a8558e9075ca37d545b0e90e241a9d7e2c8b4b5f8255ac9c527dca96a05", size = 1371724, upload-time = "2026-09-03T07:57:29.165Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/3a/37891340c959c53f71d65eb45de84fccd722749bf8123fcd5a53094cf0c4/pydantic_ai_slim-2.37.0-py3-none-any.whl", hash = "sha256:439973ce2dae1e64631b05b803743fe44b3b1791514b16488c005b1ca4f2b3e7", size = 1552945, upload-time = "2026-09-01T02:07:31.076Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/db/794b281a4314666f726de4c713e77190945d087065b1bd361c1a5086cef8/pydantic_ai_slim-2.38.0-py3-none-any.whl", hash = "sha256:58bcb7d574eca0f69831855b550236844172bb393d21f7c477faa1bb7d368822", size = 1615570, upload-time = "2026-09-03T07:57:21.89Z" },
 ]
 
 [package.optional-dependencies]
@@ -4326,7 +4326,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.37.0"
+version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4336,9 +4336,9 @@ dependencies = [
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/03/d7730770a7a564ec74d49872fde5e2606405c8380bb894dbfc47da36fa7a/pydantic_graph-2.37.0.tar.gz", hash = "sha256:447e4635f781ba525452d793be5935381a5a67aa4c81d0f53095cd8a8b626a94", size = 45188, upload-time = "2026-09-01T02:07:42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/0c/140ffa7f0a92267b71cb4ef6a9340e36d341420e18fe537a98c9968bfa14/pydantic_graph-2.38.0.tar.gz", hash = "sha256:3ecab71ba43b754c016ee0d84eeb472089cfaebbfca9116a77596c4f350f9920", size = 45189, upload-time = "2026-09-03T07:57:31.302Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/ad/1cd14e2f39bbee1ad6f511649ccb966d9ad11bcd2433c7377e2305dcecae/pydantic_graph-2.37.0-py3-none-any.whl", hash = "sha256:7b07237264b92f57aa06b1686315005e320099106534fc20da4081873f68c31f", size = 52701, upload-time = "2026-09-01T02:07:34.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/33/52cf89abe3180beea7f6a921a8f43260f827e1e48181464d344812bc9188/pydantic_graph-2.38.0-py3-none-any.whl", hash = "sha256:00f5f0e6cb7b3126a394fe4c64f175f1c0d587acea075238c3678d9464bd5f58", size = 52700, upload-time = "2026-09-03T07:57:24.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Prerequisite for #711. The three adoption PRs — #712 (filesystem events), #713 (compaction lifecycle
events) and #714 (callback deprecations) — all import `CapabilityEvent` at module scope, and it does
not exist on the floor we advertise. On `pydantic-ai-slim>=2.37.0` every one of them fails at
collection:

```
ImportError: cannot import name 'CapabilityEvent' from 'pydantic_ai'. Did you mean: 'CapabilityFunc'?
```

Unlike #766's, this is not a straddle we can carry: the events *are* the feature, so there is no
2.37-compatible branch to fall back to. 2.38.0 is the release that has the family — `CustomEvent`,
`CapabilityEvent`, `ctx.emit()` and `@on_event` (pydantic-ai#6258, `f8cc1d603`).

- the six general `pydantic-ai-slim` floors go to `>=2.38.0` (the base dependency plus the five
  pass-through extras). The `>=2.18.0` feature-specific floors are subsumed and unchanged;
- `uv.lock` moves `pydantic-ai-slim` and `pydantic-graph` from 2.37.0 to 2.38.0, and picks up
  `genai-prices` 0.1.6 with them;
- the `[tool.uv]` `anthropic` override goes to `>=1.3.0`, because 2.38.0 raised slim's own
  `anthropic` floor from 1.0.0 to 1.3.0. An override *replaces* every requirement on the package it
  names, including slim's, so the entry exists to repeat whatever slim declares; its comment says to
  move it whenever slim's moves. Left at `>=1.0.0`, `lowest-direct` resolves slim 2.38.0 against an
  `anthropic` below the floor it declares.

The comment paragraph that named the specific generation (`anthropic>=1` is the HTTPX2 generation)
comes out. The override's job is to repeat whatever slim declares, whatever that is; naming one
generation dated the comment to a floor that has since moved twice.

Precedent: `3d0a7524` (#769) and `7c8aee30` (#743) before it.

## Linked Issue

Fixes #779

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior (no behavior change; the existing suite is the check)
- [x] `make lint && make typecheck && make test` passes locally
- [ ] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head

  **Needs `dependencies:approved`.** Raising the floor is the point of the PR, so `pyproject.toml`
  and `uv.lock` necessarily change.
- [x] Docstrings use single backticks (not RST double backticks)

## Verification

Ran locally against the resolutions the CI jobs use:

| resolution | `pydantic-ai-slim` | `anthropic` | result |
| --- | --- | --- | --- |
| locked (`uv sync --locked`) | 2.38.0 | 1.3.0 | 5,594 passed, 63 skipped |
| `--resolution lowest-direct` | 2.38.0 | 1.3.0 | 5,594 passed, 63 skipped |

The latest-version job resolves to the same pair: 2.38.0 is the newest release, so the lock is
already at it.

`lowest-direct` is where the `anthropic` override matters. Left at `>=1.0.0` it resolves
`anthropic==1.0.0` against slim 2.38.0, which declares `>=1.3.0` — the override erases that
requirement, so uv resolves it happily and nothing complains until something reaches for an API
only the newer SDK has. At `>=1.3.0` both halves of the pair land on the floor slim actually
advertises.

`uv lock --locked` is clean, and pre-commit's `check toml` passes.
