### PR TITLE
Make corrupt `FileStepStore` coverage deterministic

### DIFF
--- a/tests/step_persistence/test_step_persistence.py
+++ b/tests/step_persistence/test_step_persistence.py
@@ -360,9 +360,11 @@ class TestFileStepStore:
     async def test_snapshot_record_suppresses_retry_if_key_ledger_write_was_interrupted(self, tmp_path: Path) -> None:
         store = FileStepStore(tmp_path)
         snapshot = ContinuableSnapshot(run_id='r1', step_index=1, messages=[], idempotency_key='0:1:complete')
+        snapshot_dir = tmp_path / 'r1' / 'snapshots'
+        snapshot_dir.mkdir(parents=True)
+        (snapshot_dir / 'broken.json').write_text('{', encoding='utf-8')
         await store.save_snapshot(snapshot)
         (tmp_path / 'r1' / 'snapshot-keys.jsonl').unlink()
-        (tmp_path / 'r1' / 'snapshots' / 'broken.json').write_text('{', encoding='utf-8')
 
         await store.save_snapshot(snapshot)
 


### PR DESCRIPTION
## Summary

Creates the corrupt snapshot fixture before the first valid save, so the existing idempotency-key recovery test exercises the corrupt-file branch regardless of filesystem glob order.

This is a test-only change. It adds no new test and does not change production behavior.

## Linked Issue

Fixes #784

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] Targeted test, Ruff, formatting, and commit hooks pass locally
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks (not RST double backticks)