### PR TITLE
Connect `ChannelHost` to verified Slack events

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ Core also ships loop-customization capabilities for production servers: [Select 
 
 And the agent plugs into any interface: [ACP](pydantic_ai_harness/experimental/acp/) *(experimental, Harness)* serves it to editors like Zed over the [Agent Client Protocol](https://agentclientprotocol.com), and core ships the [web chat UI](https://ai.pydantic.dev/web/), [CLI](https://ai.pydantic.dev/cli/), [frontend adapters](https://ai.pydantic.dev/ui/) (AG-UI, Vercel AI), and [realtime voice](https://ai.pydantic.dev/realtime/).
 
+Harness also ships [Channels](pydantic_ai_harness/channels/) for running text-output agents from
+verified Slack messages while caller-owned HTTP and queue infrastructure handles delivery.
+
 Community packages extend the same capability system further; see [third-party capabilities](https://ai.pydantic.dev/capabilities/third-party/).
 
 ## Composing from blocks

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,32 +1,61 @@
 ---
 title: Channels
-description: Run Pydantic AI agents from verified messages received through chat providers.
+description: Run Pydantic AI agents from verified Slack messages.
 ---
 
 # Channels
 
-Channels run a text-output Pydantic AI agent for messages received from chat providers. Use them
-when an HTTP endpoint, queue consumer, or polling loop needs to preserve conversation history and
-send the agent's response through the provider that delivered the message.
+Channels let a Pydantic AI agent answer Slack mentions and continue each Slack thread with its own message history.
 
-[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
+## Install
 
-> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
+Channels uses the base Harness package. This example uses an OpenAI model and FastAPI:
 
-## Quick start
+```bash
+uv add pydantic-ai-harness "pydantic-ai-slim[openai]" fastapi uvicorn
+```
 
-`ChannelHost` sits outside `AbstractCapability`. It starts each turn through the agent's public
-`run()` method, so capabilities, tools, model settings, and output validation configured on the
-agent continue to apply.
+## Set up Slack
 
-```python
+1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps).
+2. Under **OAuth & Permissions**, add the bot scopes `app_mentions:read` and `chat:write`, then install the app to the workspace. Copy the bot token that starts with `xoxb-`.
+3. Under **Basic Information**, copy the signing secret.
+4. Start the example below on a public HTTPS URL, enable **Event Subscriptions**, set the request URL to `https://your-host/slack/events`, and subscribe to the `app_mention` bot event.
+5. Copy the workspace ID that starts with `T` from the Slack browser URL `app.slack.com/client/T.../`.
+
+Set the four required environment variables:
+
+```bash
+export OPENAI_API_KEY='your-openai-api-key'
+export SLACK_SIGNING_SECRET='your-slack-signing-secret'
+export SLACK_BOT_TOKEN='xoxb-your-bot-token'
+export SLACK_TEAM_ID='T-your-workspace-id'
+```
+
+Slack's installation screen handles OAuth. The package does not open a browser or implement an OAuth redirect. Browser interaction is required once to create, configure, and install the Slack app.
+
+## Run
+
+Save this as `app.py`:
+
+```python {names="defined"}
+import logging
 import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 import anyio
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import PlainTextResponse
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
-from pydantic_ai_harness.channels.slack import SlackChannel, SlackUrlVerification
+from pydantic_ai_harness.channels.slack import (
+    SlackChannel,
+    SlackError,
+    SlackSignatureError,
+    SlackUrlVerification,
+)
 
 agent = Agent('openai:gpt-5.6-sol', output_type=str)
 slack = SlackChannel(
@@ -38,77 +67,71 @@ host = ChannelHost(agent, slack)
 send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
 
 
-def accept_slack_request(raw_body: bytes, headers: dict[str, str]) -> str | None:
-    request = slack.parse_request(raw_body, headers)
-    if isinstance(request, SlackUrlVerification):
-        return request.challenge
-    if request is not None:
-        send_events.send_nowait(request)
-    return None
-
-
 async def consume_events() -> None:
     async with receive_events:
         async for event in receive_events:
-            await host.handle(event)
+            try:
+                await host.handle(event)
+            except Exception:
+                logging.exception('Slack event failed')
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    async with anyio.create_task_group() as group:
+        group.start_soon(consume_events)
+        yield
+        group.cancel_scope.cancel()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.post('/slack/events')
+async def receive_slack_event(request: Request) -> Response:
+    raw_body = await request.body()
+    try:
+        parsed = slack.parse_request(raw_body, request.headers)
+    except SlackSignatureError:
+        return Response(status_code=401)
+    except SlackError:
+        return Response(status_code=400)
+
+    if isinstance(parsed, SlackUrlVerification):
+        return PlainTextResponse(parsed.challenge)
+    if parsed is not None:
+        with anyio.move_on_after(2) as enqueue_scope:
+            await send_events.send(parsed)
+        if enqueue_scope.cancel_called:
+            return Response(status_code=503)
+    return Response(status_code=200)
 ```
 
-Call `accept_slack_request` with the untouched request bytes. Return its challenge for Slack URL
-verification, otherwise acknowledge the verified request immediately after enqueueing it. Run
-`consume_events` as a worker owned by your application.
+Run it:
 
-## Host contract
+```bash
+uv run uvicorn app:app --host 0.0.0.0 --port 8000
+```
 
-Adapters normalize five values into `ChannelEvent`: `event_id`, `conversation_id`, `sender_id`,
-`text`, and optional `reply_to_id`. `SlackChannel` requires the workspace's `team_id` and rejects
-events for other installations before normalization. Build a separate adapter for each provider
-installation or credential set.
+Expose port 8000 through your HTTPS host, invite the bot to a channel, and mention it. The endpoint verifies Slack's signature before enqueueing the event, returns the URL-verification challenge when Slack configures the endpoint, and replies in the original thread.
 
-The host loads the conversation's Pydantic AI messages, calls `AbstractAgent.run()`, sends the text
-result through `ChannelAdapter.reply()`, then saves `result.all_messages()`. Calls for one
-`conversation_id` are serialized within one `ChannelHost`; different conversations may run at the
-same time.
+## Things to ask
 
-`InMemoryConversationStore` is the default and loses history when the process exits. Implement
-`ConversationStore` for persistent history. Multiple workers must partition their queue by
-`conversation_id` or coordinate outside the host because host locks are process-local.
+- `@bot Summarize this update in three bullets.`
+- `@bot Rewrite this announcement for customers.`
+- `@bot List the decisions and open questions in this thread.`
+- Follow up in the same thread with `@bot Make it shorter` or `@bot Explain the second point`.
 
-The host does not claim events, acknowledge provider delivery, or retry. Claim `event_id` in the
-caller-owned queue before calling `handle()`. Duplicate calls run duplicate agent turns. Agent,
-reply, and store errors propagate. The host replies before saving history: a reply failure leaves
-history unchanged, while a save failure or cancellation can occur after the user has received the
-reply. A durable store should own its transaction and retry policy. Do not blindly retry the whole
-handler after an ambiguous delivery or save failure.
+## Operational notes
 
-## Slack behavior
+- Pass the untouched request bytes to `parse_request()`. Reading and re-encoding JSON first breaks signature verification.
+- Slack expects a response within three seconds and retries failed delivery. The example reserves two seconds for its bounded in-process queue and returns 503 when full. Use a durable queue for production.
+- Claim `event_id` before calling `handle()` if duplicate agent turns are unacceptable. The host does not claim, acknowledge, or retry events.
+- The default history store is process-local and loses history on restart. Pass a `ConversationStore` implementation for persistent history.
+- Events are serialized per Slack workspace, channel, and thread inside one `ChannelHost`. Coordinate workers outside the package when several processes share a store.
+- Signature verification authenticates Slack, not the sender. Check `sender_id` and `delivery_id` before enqueueing if only selected users or channels may invoke the agent.
+- The host sends the reply before saving history. A save failure can occur after Slack receives the reply, so do not blindly retry an ambiguous whole handler call.
+- The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
+- While Harness is on 0.x releases, minor releases may change this API. See the [version policy](index.md#version-policy).
 
-`SlackChannel.parse_request()` verifies `X-Slack-Request-Timestamp` and `X-Slack-Signature` against
-the raw body before decoding JSON. Requests more than five minutes from local time are rejected.
-It accepts `app_mention` and ordinary `message` callbacks, ignores bot messages and message
-subtypes, and returns `None` for unsupported events.
-
-Signature verification authenticates Slack, not the human sender. Apply channel and sender policy
-to the normalized IDs before enqueueing events when the app should serve only an allowlist.
-
-Root messages use their `ts` as `reply_to_id`. Thread replies keep the parent's `thread_ts`, so
-`SlackChannel.reply()` posts the response to the original thread with `chat.postMessage`.
-
-Pass an `httpx.AsyncClient` to reuse connections. The caller owns an injected client. Without one,
-each reply uses a short-lived client. `SlackChannel` stores its signing secret and bot token in
-private attributes and excludes them from `repr`; the caller remains responsible for secret
-storage and token selection.
-
-Slack requires an HTTP 2xx response within three seconds and may retry delivery. HTTP framework,
-queue, claim/ack, and retry policy remain application concerns.
-
-## API reference
-
-::: pydantic_ai_harness.channels.ChannelEvent
-
-::: pydantic_ai_harness.channels.ChannelHost
-
-::: pydantic_ai_harness.channels.ConversationStore
-
-::: pydantic_ai_harness.channels.InMemoryConversationStore
-
-::: pydantic_ai_harness.channels.slack.SlackChannel
+[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,0 +1,111 @@
+---
+title: Channels
+description: Run Pydantic AI agents from verified messages received through chat providers.
+---
+
+# Channels
+
+Channels run a text-output Pydantic AI agent for messages received from chat providers. Use them
+when an HTTP endpoint, queue consumer, or polling loop needs to preserve conversation history and
+send the agent's response through the provider that delivered the message.
+
+[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it
+> does, we follow the [version policy](../docs/index.md#version-policy).
+
+## Quick start
+
+`ChannelHost` sits outside `AbstractCapability`. It starts each turn through the agent's public
+`run()` method, so capabilities, tools, model settings, and output validation configured on the
+agent continue to apply.
+
+```python
+import os
+
+import anyio
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
+from pydantic_ai_harness.channels.slack import SlackChannel, SlackUrlVerification
+
+agent = Agent('openai:gpt-5.6-sol', output_type=str)
+slack = SlackChannel(
+    signing_secret=os.environ['SLACK_SIGNING_SECRET'],
+    bot_token=os.environ['SLACK_BOT_TOKEN'],
+)
+host = ChannelHost(agent, slack)
+send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
+
+
+def accept_slack_request(raw_body: bytes, headers: dict[str, str]) -> str | None:
+    request = slack.parse_request(raw_body, headers)
+    if isinstance(request, SlackUrlVerification):
+        return request.challenge
+    if request is not None:
+        send_events.send_nowait(request)
+    return None
+
+
+async def consume_events() -> None:
+    async with receive_events:
+        async for event in receive_events:
+            await host.handle(event)
+```
+
+Call `accept_slack_request` with the untouched request bytes. Return its challenge for Slack URL
+verification, otherwise acknowledge the verified request immediately after enqueueing it. Run
+`consume_events` as a worker owned by your application.
+
+## Host contract
+
+Adapters normalize five values into `ChannelEvent`: `event_id`, `conversation_id`, `sender_id`,
+`text`, and optional `reply_to_id`. IDs are scoped to one adapter installation. Build a separate
+adapter for each provider installation or credential set.
+
+The host loads the conversation's Pydantic AI messages, calls `AbstractAgent.run()`, sends the text
+result through `ChannelAdapter.reply()`, then saves `result.all_messages()`. Calls for one
+`conversation_id` are serialized within one `ChannelHost`; different conversations may run at the
+same time.
+
+`InMemoryConversationStore` is the default and loses history when the process exits. Implement
+`ConversationStore` for persistent history. Multiple workers must partition their queue by
+`conversation_id` or coordinate outside the host because host locks are process-local.
+
+The host does not claim events, acknowledge provider delivery, or retry. Claim `event_id` in the
+caller-owned queue before calling `handle()`. Duplicate calls run duplicate agent turns. Agent,
+reply, and store errors propagate. The host replies before saving history: a reply failure leaves
+history unchanged, while a save failure can occur after the user has received the reply.
+
+## Slack behavior
+
+`SlackChannel.parse_request()` verifies `X-Slack-Request-Timestamp` and `X-Slack-Signature` against
+the raw body before decoding JSON. Requests more than five minutes from local time are rejected.
+It accepts `app_mention` and ordinary `message` callbacks, ignores bot messages and message
+subtypes, and returns `None` for unsupported events.
+
+Signature verification authenticates Slack, not the human sender. Apply channel and sender policy
+to the normalized IDs before enqueueing events when the app should serve only an allowlist.
+
+Root messages use their `ts` as `reply_to_id`. Thread replies keep the parent's `thread_ts`, so
+`SlackChannel.reply()` posts the response to the original thread with `chat.postMessage`.
+
+Pass an `httpx.AsyncClient` to reuse connections. The caller owns an injected client. Without one,
+each reply uses a short-lived client. `SlackChannel` stores its signing secret and bot token in
+private attributes and excludes them from `repr`; the caller remains responsible for secret
+storage and token selection.
+
+Slack requires an HTTP 2xx response within three seconds and may retry delivery. HTTP framework,
+queue, claim/ack, and retry policy remain application concerns.
+
+## API reference
+
+::: pydantic_ai_harness.channels.ChannelEvent
+
+::: pydantic_ai_harness.channels.ChannelHost
+
+::: pydantic_ai_harness.channels.ConversationStore
+
+::: pydantic_ai_harness.channels.InMemoryConversationStore
+
+::: pydantic_ai_harness.channels.slack.SlackChannel

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -11,8 +11,7 @@ send the agent's response through the provider that delivered the message.
 
 [Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
 
-> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it
-> does, we follow the [version policy](../docs/index.md#version-policy).
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
 
 ## Quick start
 
@@ -33,6 +32,7 @@ agent = Agent('openai:gpt-5.6-sol', output_type=str)
 slack = SlackChannel(
     signing_secret=os.environ['SLACK_SIGNING_SECRET'],
     bot_token=os.environ['SLACK_BOT_TOKEN'],
+    team_id=os.environ['SLACK_TEAM_ID'],
 )
 host = ChannelHost(agent, slack)
 send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
@@ -60,8 +60,9 @@ verification, otherwise acknowledge the verified request immediately after enque
 ## Host contract
 
 Adapters normalize five values into `ChannelEvent`: `event_id`, `conversation_id`, `sender_id`,
-`text`, and optional `reply_to_id`. IDs are scoped to one adapter installation. Build a separate
-adapter for each provider installation or credential set.
+`text`, and optional `reply_to_id`. `SlackChannel` requires the workspace's `team_id` and rejects
+events for other installations before normalization. Build a separate adapter for each provider
+installation or credential set.
 
 The host loads the conversation's Pydantic AI messages, calls `AbstractAgent.run()`, sends the text
 result through `ChannelAdapter.reply()`, then saves `result.all_messages()`. Calls for one
@@ -75,7 +76,9 @@ same time.
 The host does not claim events, acknowledge provider delivery, or retry. Claim `event_id` in the
 caller-owned queue before calling `handle()`. Duplicate calls run duplicate agent turns. Agent,
 reply, and store errors propagate. The host replies before saving history: a reply failure leaves
-history unchanged, while a save failure can occur after the user has received the reply.
+history unchanged, while a save failure or cancellation can occur after the user has received the
+reply. A durable store should own its transaction and retry policy. Do not blindly retry the whole
+handler after an ambiguous delivery or save failure.
 
 ## Slack behavior
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -64,11 +64,15 @@ slack = SlackChannel(
     team_id=os.environ['SLACK_TEAM_ID'],
 )
 host = ChannelHost(agent, slack)
-send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
+worker_streams = [anyio.create_memory_object_stream[ChannelEvent](5) for _ in range(20)]
 
 
-async def consume_events() -> None:
-    async with receive_events:
+def worker_for(event: ChannelEvent) -> int:
+    return hash(event.conversation_id) % len(worker_streams)
+
+
+async def consume_events(worker: int) -> None:
+    async with worker_streams[worker][1] as receive_events:
         async for event in receive_events:
             try:
                 await host.handle(event)
@@ -79,7 +83,8 @@ async def consume_events() -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     async with anyio.create_task_group() as group:
-        group.start_soon(consume_events)
+        for worker in range(len(worker_streams)):
+            group.start_soon(consume_events, worker)
         yield
         group.cancel_scope.cancel()
 
@@ -100,6 +105,7 @@ async def receive_slack_event(request: Request) -> Response:
     if isinstance(parsed, SlackUrlVerification):
         return PlainTextResponse(parsed.challenge)
     if parsed is not None:
+        send_events = worker_streams[worker_for(parsed)][0]
         with anyio.move_on_after(2) as enqueue_scope:
             await send_events.send(parsed)
         if enqueue_scope.cancel_called:
@@ -126,14 +132,14 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 
 - Pass the untouched request bytes to `parse_request()`. Reading and re-encoding JSON first breaks signature verification.
 - Limit request-body size at the HTTPS server or proxy before FastAPI reads it. `parse_request()` verifies supplied bytes but does not own network admission.
-- Slack expects a response within three seconds and retries failed delivery. The example reserves two seconds for its bounded in-process queue and returns 503 when full. Use a durable queue for production.
+- Slack expects a response within three seconds and retries failed delivery. The example reserves two seconds for bounded, sharded in-process queues and returns 503 when one is full. Use a durable queue for production.
 - Claim `event_id` before calling `handle()` if duplicate agent turns are unacceptable. The host does not claim, acknowledge, or retry events.
 - The default history store is process-local and loses history on restart. Pass a `ConversationStore` implementation for persistent history.
 - Events are serialized per Slack workspace, channel, and thread inside one `ChannelHost`. Coordinate workers outside the package when several processes share a store.
 - Signature verification authenticates Slack, not the sender. Check `sender_id` and `delivery_id` before enqueueing if only selected users or channels may invoke the agent.
 - The host sends the reply before saving history. A save failure can occur after Slack receives the reply, so do not blindly retry an ambiguous whole handler call.
 - Slack may truncate replies over 40,000 characters. The adapter raises `SlackAPIError` when Slack reports that warning instead of treating a partial reply as success.
-- On the first HTTP 429, the adapter waits for `Retry-After` and retries the same generated reply once. A second 429 propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
+- On the first HTTP 429, this adapter instance pauses its replies in the current process, waits for `Retry-After`, and retries the same generated reply once. A second 429 waits again before it propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](index.md#version-policy).
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -119,18 +119,21 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 
 - `@bot Summarize this update in three bullets.`
 - `@bot Rewrite this announcement for customers.`
-- `@bot List the decisions and open questions in this thread.`
+- `@bot Turn these notes into a checklist.`
 - Follow up in the same thread with `@bot Make it shorter` or `@bot Explain the second point`.
 
 ## Operational notes
 
 - Pass the untouched request bytes to `parse_request()`. Reading and re-encoding JSON first breaks signature verification.
+- Limit request-body size at the HTTPS server or proxy before FastAPI reads it. `parse_request()` verifies supplied bytes but does not own network admission.
 - Slack expects a response within three seconds and retries failed delivery. The example reserves two seconds for its bounded in-process queue and returns 503 when full. Use a durable queue for production.
 - Claim `event_id` before calling `handle()` if duplicate agent turns are unacceptable. The host does not claim, acknowledge, or retry events.
 - The default history store is process-local and loses history on restart. Pass a `ConversationStore` implementation for persistent history.
 - Events are serialized per Slack workspace, channel, and thread inside one `ChannelHost`. Coordinate workers outside the package when several processes share a store.
 - Signature verification authenticates Slack, not the sender. Check `sender_id` and `delivery_id` before enqueueing if only selected users or channels may invoke the agent.
 - The host sends the reply before saving history. A save failure can occur after Slack receives the reply, so do not blindly retry an ambiguous whole handler call.
+- Slack may truncate replies over 40,000 characters. The adapter raises `SlackAPIError` when Slack reports that warning instead of treating a partial reply as success.
+- On the first HTTP 429, the adapter waits for `Retry-After` and retries the same generated reply once. A second 429 propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](index.md#version-policy).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -249,6 +249,9 @@ Core also ships loop-customization capabilities for production servers: [Select 
 
 And the agent plugs into any interface: [ACP](acp.md) *(experimental, Harness)* serves it to editors like Zed over the [Agent Client Protocol](https://agentclientprotocol.com), and core ships the [web chat UI](/ai/web/), [CLI](/ai/cli/), [frontend adapters](/ai/ui/overview/) (AG-UI, Vercel AI), and [realtime voice](/ai/realtime/overview/).
 
+Harness also ships [Channels](channels.md) for running text-output agents from verified Slack
+messages while caller-owned HTTP and queue infrastructure handles delivery.
+
 Community packages extend the same capability system further; see [third-party capabilities](/ai/capabilities/third-party/).
 
 ## When do you need the Harness?

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -6,8 +6,7 @@ send the agent's response through the provider that delivered the message.
 
 [Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
 
-> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it
-> does, we follow the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 
 ## Quick start
 
@@ -28,6 +27,7 @@ agent = Agent('openai:gpt-5.6-sol', output_type=str)
 slack = SlackChannel(
     signing_secret=os.environ['SLACK_SIGNING_SECRET'],
     bot_token=os.environ['SLACK_BOT_TOKEN'],
+    team_id=os.environ['SLACK_TEAM_ID'],
 )
 host = ChannelHost(agent, slack)
 send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
@@ -55,8 +55,9 @@ verification, otherwise acknowledge the verified request immediately after enque
 ## Host contract
 
 Adapters normalize five values into `ChannelEvent`: `event_id`, `conversation_id`, `sender_id`,
-`text`, and optional `reply_to_id`. IDs are scoped to one adapter installation. Build a separate
-adapter for each provider installation or credential set.
+`text`, and optional `reply_to_id`. `SlackChannel` requires the workspace's `team_id` and rejects
+events for other installations before normalization. Build a separate adapter for each provider
+installation or credential set.
 
 The host loads the conversation's Pydantic AI messages, calls `AbstractAgent.run()`, sends the text
 result through `ChannelAdapter.reply()`, then saves `result.all_messages()`. Calls for one
@@ -70,7 +71,9 @@ same time.
 The host does not claim events, acknowledge provider delivery, or retry. Claim `event_id` in the
 caller-owned queue before calling `handle()`. Duplicate calls run duplicate agent turns. Agent,
 reply, and store errors propagate. The host replies before saving history: a reply failure leaves
-history unchanged, while a save failure can occur after the user has received the reply.
+history unchanged, while a save failure or cancellation can occur after the user has received the
+reply. A durable store should own its transaction and retry policy. Do not blindly retry the whole
+handler after an ambiguous delivery or save failure.
 
 ## Slack behavior
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -114,18 +114,21 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 
 - `@bot Summarize this update in three bullets.`
 - `@bot Rewrite this announcement for customers.`
-- `@bot List the decisions and open questions in this thread.`
+- `@bot Turn these notes into a checklist.`
 - Follow up in the same thread with `@bot Make it shorter` or `@bot Explain the second point`.
 
 ## Operational notes
 
 - Pass the untouched request bytes to `parse_request()`. Reading and re-encoding JSON first breaks signature verification.
+- Limit request-body size at the HTTPS server or proxy before FastAPI reads it. `parse_request()` verifies supplied bytes but does not own network admission.
 - Slack expects a response within three seconds and retries failed delivery. The example reserves two seconds for its bounded in-process queue and returns 503 when full. Use a durable queue for production.
 - Claim `event_id` before calling `handle()` if duplicate agent turns are unacceptable. The host does not claim, acknowledge, or retry events.
 - The default history store is process-local and loses history on restart. Pass a `ConversationStore` implementation for persistent history.
 - Events are serialized per Slack workspace, channel, and thread inside one `ChannelHost`. Coordinate workers outside the package when several processes share a store.
 - Signature verification authenticates Slack, not the sender. Check `sender_id` and `delivery_id` before enqueueing if only selected users or channels may invoke the agent.
 - The host sends the reply before saving history. A save failure can occur after Slack receives the reply, so do not blindly retry an ambiguous whole handler call.
+- Slack may truncate replies over 40,000 characters. The adapter raises `SlackAPIError` when Slack reports that warning instead of treating a partial reply as success.
+- On the first HTTP 429, the adapter waits for `Retry-After` and retries the same generated reply once. A second 429 propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -1,27 +1,56 @@
 # Channels
 
-Channels run a text-output Pydantic AI agent for messages received from chat providers. Use them
-when an HTTP endpoint, queue consumer, or polling loop needs to preserve conversation history and
-send the agent's response through the provider that delivered the message.
+Channels let a Pydantic AI agent answer Slack mentions and continue each Slack thread with its own message history.
 
-[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
+## Install
 
-> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
+Channels uses the base Harness package. This example uses an OpenAI model and FastAPI:
 
-## Quick start
+```bash
+uv add pydantic-ai-harness "pydantic-ai-slim[openai]" fastapi uvicorn
+```
 
-`ChannelHost` sits outside `AbstractCapability`. It starts each turn through the agent's public
-`run()` method, so capabilities, tools, model settings, and output validation configured on the
-agent continue to apply.
+## Set up Slack
 
-```python
+1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps).
+2. Under **OAuth & Permissions**, add the bot scopes `app_mentions:read` and `chat:write`, then install the app to the workspace. Copy the bot token that starts with `xoxb-`.
+3. Under **Basic Information**, copy the signing secret.
+4. Start the example below on a public HTTPS URL, enable **Event Subscriptions**, set the request URL to `https://your-host/slack/events`, and subscribe to the `app_mention` bot event.
+5. Copy the workspace ID that starts with `T` from the Slack browser URL `app.slack.com/client/T.../`.
+
+Set the four required environment variables:
+
+```bash
+export OPENAI_API_KEY='your-openai-api-key'
+export SLACK_SIGNING_SECRET='your-slack-signing-secret'
+export SLACK_BOT_TOKEN='xoxb-your-bot-token'
+export SLACK_TEAM_ID='T-your-workspace-id'
+```
+
+Slack's installation screen handles OAuth. The package does not open a browser or implement an OAuth redirect. Browser interaction is required once to create, configure, and install the Slack app.
+
+## Run
+
+Save this as `app.py`:
+
+```python {names="defined"}
+import logging
 import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 import anyio
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import PlainTextResponse
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
-from pydantic_ai_harness.channels.slack import SlackChannel, SlackUrlVerification
+from pydantic_ai_harness.channels.slack import (
+    SlackChannel,
+    SlackError,
+    SlackSignatureError,
+    SlackUrlVerification,
+)
 
 agent = Agent('openai:gpt-5.6-sol', output_type=str)
 slack = SlackChannel(
@@ -33,77 +62,71 @@ host = ChannelHost(agent, slack)
 send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
 
 
-def accept_slack_request(raw_body: bytes, headers: dict[str, str]) -> str | None:
-    request = slack.parse_request(raw_body, headers)
-    if isinstance(request, SlackUrlVerification):
-        return request.challenge
-    if request is not None:
-        send_events.send_nowait(request)
-    return None
-
-
 async def consume_events() -> None:
     async with receive_events:
         async for event in receive_events:
-            await host.handle(event)
+            try:
+                await host.handle(event)
+            except Exception:
+                logging.exception('Slack event failed')
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    async with anyio.create_task_group() as group:
+        group.start_soon(consume_events)
+        yield
+        group.cancel_scope.cancel()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.post('/slack/events')
+async def receive_slack_event(request: Request) -> Response:
+    raw_body = await request.body()
+    try:
+        parsed = slack.parse_request(raw_body, request.headers)
+    except SlackSignatureError:
+        return Response(status_code=401)
+    except SlackError:
+        return Response(status_code=400)
+
+    if isinstance(parsed, SlackUrlVerification):
+        return PlainTextResponse(parsed.challenge)
+    if parsed is not None:
+        with anyio.move_on_after(2) as enqueue_scope:
+            await send_events.send(parsed)
+        if enqueue_scope.cancel_called:
+            return Response(status_code=503)
+    return Response(status_code=200)
 ```
 
-Call `accept_slack_request` with the untouched request bytes. Return its challenge for Slack URL
-verification, otherwise acknowledge the verified request immediately after enqueueing it. Run
-`consume_events` as a worker owned by your application.
+Run it:
 
-## Host contract
+```bash
+uv run uvicorn app:app --host 0.0.0.0 --port 8000
+```
 
-Adapters normalize five values into `ChannelEvent`: `event_id`, `conversation_id`, `sender_id`,
-`text`, and optional `reply_to_id`. `SlackChannel` requires the workspace's `team_id` and rejects
-events for other installations before normalization. Build a separate adapter for each provider
-installation or credential set.
+Expose port 8000 through your HTTPS host, invite the bot to a channel, and mention it. The endpoint verifies Slack's signature before enqueueing the event, returns the URL-verification challenge when Slack configures the endpoint, and replies in the original thread.
 
-The host loads the conversation's Pydantic AI messages, calls `AbstractAgent.run()`, sends the text
-result through `ChannelAdapter.reply()`, then saves `result.all_messages()`. Calls for one
-`conversation_id` are serialized within one `ChannelHost`; different conversations may run at the
-same time.
+## Things to ask
 
-`InMemoryConversationStore` is the default and loses history when the process exits. Implement
-`ConversationStore` for persistent history. Multiple workers must partition their queue by
-`conversation_id` or coordinate outside the host because host locks are process-local.
+- `@bot Summarize this update in three bullets.`
+- `@bot Rewrite this announcement for customers.`
+- `@bot List the decisions and open questions in this thread.`
+- Follow up in the same thread with `@bot Make it shorter` or `@bot Explain the second point`.
 
-The host does not claim events, acknowledge provider delivery, or retry. Claim `event_id` in the
-caller-owned queue before calling `handle()`. Duplicate calls run duplicate agent turns. Agent,
-reply, and store errors propagate. The host replies before saving history: a reply failure leaves
-history unchanged, while a save failure or cancellation can occur after the user has received the
-reply. A durable store should own its transaction and retry policy. Do not blindly retry the whole
-handler after an ambiguous delivery or save failure.
+## Operational notes
 
-## Slack behavior
+- Pass the untouched request bytes to `parse_request()`. Reading and re-encoding JSON first breaks signature verification.
+- Slack expects a response within three seconds and retries failed delivery. The example reserves two seconds for its bounded in-process queue and returns 503 when full. Use a durable queue for production.
+- Claim `event_id` before calling `handle()` if duplicate agent turns are unacceptable. The host does not claim, acknowledge, or retry events.
+- The default history store is process-local and loses history on restart. Pass a `ConversationStore` implementation for persistent history.
+- Events are serialized per Slack workspace, channel, and thread inside one `ChannelHost`. Coordinate workers outside the package when several processes share a store.
+- Signature verification authenticates Slack, not the sender. Check `sender_id` and `delivery_id` before enqueueing if only selected users or channels may invoke the agent.
+- The host sends the reply before saving history. A save failure can occur after Slack receives the reply, so do not blindly retry an ambiguous whole handler call.
+- The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
+- While Harness is on 0.x releases, minor releases may change this API. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 
-`SlackChannel.parse_request()` verifies `X-Slack-Request-Timestamp` and `X-Slack-Signature` against
-the raw body before decoding JSON. Requests more than five minutes from local time are rejected.
-It accepts `app_mention` and ordinary `message` callbacks, ignores bot messages and message
-subtypes, and returns `None` for unsupported events.
-
-Signature verification authenticates Slack, not the human sender. Apply channel and sender policy
-to the normalized IDs before enqueueing events when the app should serve only an allowlist.
-
-Root messages use their `ts` as `reply_to_id`. Thread replies keep the parent's `thread_ts`, so
-`SlackChannel.reply()` posts the response to the original thread with `chat.postMessage`.
-
-Pass an `httpx.AsyncClient` to reuse connections. The caller owns an injected client. Without one,
-each reply uses a short-lived client. `SlackChannel` stores its signing secret and bot token in
-private attributes and excludes them from `repr`; the caller remains responsible for secret
-storage and token selection.
-
-Slack requires an HTTP 2xx response within three seconds and may retry delivery. HTTP framework,
-queue, claim/ack, and retry policy remain application concerns.
-
-## API reference
-
-::: pydantic_ai_harness.channels.ChannelEvent
-
-::: pydantic_ai_harness.channels.ChannelHost
-
-::: pydantic_ai_harness.channels.ConversationStore
-
-::: pydantic_ai_harness.channels.InMemoryConversationStore
-
-::: pydantic_ai_harness.channels.slack.SlackChannel
+[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -59,11 +59,15 @@ slack = SlackChannel(
     team_id=os.environ['SLACK_TEAM_ID'],
 )
 host = ChannelHost(agent, slack)
-send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
+worker_streams = [anyio.create_memory_object_stream[ChannelEvent](5) for _ in range(20)]
 
 
-async def consume_events() -> None:
-    async with receive_events:
+def worker_for(event: ChannelEvent) -> int:
+    return hash(event.conversation_id) % len(worker_streams)
+
+
+async def consume_events(worker: int) -> None:
+    async with worker_streams[worker][1] as receive_events:
         async for event in receive_events:
             try:
                 await host.handle(event)
@@ -74,7 +78,8 @@ async def consume_events() -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     async with anyio.create_task_group() as group:
-        group.start_soon(consume_events)
+        for worker in range(len(worker_streams)):
+            group.start_soon(consume_events, worker)
         yield
         group.cancel_scope.cancel()
 
@@ -95,6 +100,7 @@ async def receive_slack_event(request: Request) -> Response:
     if isinstance(parsed, SlackUrlVerification):
         return PlainTextResponse(parsed.challenge)
     if parsed is not None:
+        send_events = worker_streams[worker_for(parsed)][0]
         with anyio.move_on_after(2) as enqueue_scope:
             await send_events.send(parsed)
         if enqueue_scope.cancel_called:
@@ -121,14 +127,14 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 
 - Pass the untouched request bytes to `parse_request()`. Reading and re-encoding JSON first breaks signature verification.
 - Limit request-body size at the HTTPS server or proxy before FastAPI reads it. `parse_request()` verifies supplied bytes but does not own network admission.
-- Slack expects a response within three seconds and retries failed delivery. The example reserves two seconds for its bounded in-process queue and returns 503 when full. Use a durable queue for production.
+- Slack expects a response within three seconds and retries failed delivery. The example reserves two seconds for bounded, sharded in-process queues and returns 503 when one is full. Use a durable queue for production.
 - Claim `event_id` before calling `handle()` if duplicate agent turns are unacceptable. The host does not claim, acknowledge, or retry events.
 - The default history store is process-local and loses history on restart. Pass a `ConversationStore` implementation for persistent history.
 - Events are serialized per Slack workspace, channel, and thread inside one `ChannelHost`. Coordinate workers outside the package when several processes share a store.
 - Signature verification authenticates Slack, not the sender. Check `sender_id` and `delivery_id` before enqueueing if only selected users or channels may invoke the agent.
 - The host sends the reply before saving history. A save failure can occur after Slack receives the reply, so do not blindly retry an ambiguous whole handler call.
 - Slack may truncate replies over 40,000 characters. The adapter raises `SlackAPIError` when Slack reports that warning instead of treating a partial reply as success.
-- On the first HTTP 429, the adapter waits for `Retry-After` and retries the same generated reply once. A second 429 propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
+- On the first HTTP 429, this adapter instance pauses its replies in the current process, waits for `Retry-After`, and retries the same generated reply once. A second 429 waits again before it propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -1,0 +1,106 @@
+# Channels
+
+Channels run a text-output Pydantic AI agent for messages received from chat providers. Use them
+when an HTTP endpoint, queue consumer, or polling loop needs to preserve conversation history and
+send the agent's response through the provider that delivered the message.
+
+[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it
+> does, we follow the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
+
+## Quick start
+
+`ChannelHost` sits outside `AbstractCapability`. It starts each turn through the agent's public
+`run()` method, so capabilities, tools, model settings, and output validation configured on the
+agent continue to apply.
+
+```python
+import os
+
+import anyio
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
+from pydantic_ai_harness.channels.slack import SlackChannel, SlackUrlVerification
+
+agent = Agent('openai:gpt-5.6-sol', output_type=str)
+slack = SlackChannel(
+    signing_secret=os.environ['SLACK_SIGNING_SECRET'],
+    bot_token=os.environ['SLACK_BOT_TOKEN'],
+)
+host = ChannelHost(agent, slack)
+send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
+
+
+def accept_slack_request(raw_body: bytes, headers: dict[str, str]) -> str | None:
+    request = slack.parse_request(raw_body, headers)
+    if isinstance(request, SlackUrlVerification):
+        return request.challenge
+    if request is not None:
+        send_events.send_nowait(request)
+    return None
+
+
+async def consume_events() -> None:
+    async with receive_events:
+        async for event in receive_events:
+            await host.handle(event)
+```
+
+Call `accept_slack_request` with the untouched request bytes. Return its challenge for Slack URL
+verification, otherwise acknowledge the verified request immediately after enqueueing it. Run
+`consume_events` as a worker owned by your application.
+
+## Host contract
+
+Adapters normalize five values into `ChannelEvent`: `event_id`, `conversation_id`, `sender_id`,
+`text`, and optional `reply_to_id`. IDs are scoped to one adapter installation. Build a separate
+adapter for each provider installation or credential set.
+
+The host loads the conversation's Pydantic AI messages, calls `AbstractAgent.run()`, sends the text
+result through `ChannelAdapter.reply()`, then saves `result.all_messages()`. Calls for one
+`conversation_id` are serialized within one `ChannelHost`; different conversations may run at the
+same time.
+
+`InMemoryConversationStore` is the default and loses history when the process exits. Implement
+`ConversationStore` for persistent history. Multiple workers must partition their queue by
+`conversation_id` or coordinate outside the host because host locks are process-local.
+
+The host does not claim events, acknowledge provider delivery, or retry. Claim `event_id` in the
+caller-owned queue before calling `handle()`. Duplicate calls run duplicate agent turns. Agent,
+reply, and store errors propagate. The host replies before saving history: a reply failure leaves
+history unchanged, while a save failure can occur after the user has received the reply.
+
+## Slack behavior
+
+`SlackChannel.parse_request()` verifies `X-Slack-Request-Timestamp` and `X-Slack-Signature` against
+the raw body before decoding JSON. Requests more than five minutes from local time are rejected.
+It accepts `app_mention` and ordinary `message` callbacks, ignores bot messages and message
+subtypes, and returns `None` for unsupported events.
+
+Signature verification authenticates Slack, not the human sender. Apply channel and sender policy
+to the normalized IDs before enqueueing events when the app should serve only an allowlist.
+
+Root messages use their `ts` as `reply_to_id`. Thread replies keep the parent's `thread_ts`, so
+`SlackChannel.reply()` posts the response to the original thread with `chat.postMessage`.
+
+Pass an `httpx.AsyncClient` to reuse connections. The caller owns an injected client. Without one,
+each reply uses a short-lived client. `SlackChannel` stores its signing secret and bot token in
+private attributes and excludes them from `repr`; the caller remains responsible for secret
+storage and token selection.
+
+Slack requires an HTTP 2xx response within three seconds and may retry delivery. HTTP framework,
+queue, claim/ack, and retry policy remain application concerns.
+
+## API reference
+
+::: pydantic_ai_harness.channels.ChannelEvent
+
+::: pydantic_ai_harness.channels.ChannelHost
+
+::: pydantic_ai_harness.channels.ConversationStore
+
+::: pydantic_ai_harness.channels.InMemoryConversationStore
+
+::: pydantic_ai_harness.channels.slack.SlackChannel

--- a/pydantic_ai_harness/channels/__init__.py
+++ b/pydantic_ai_harness/channels/__init__.py
@@ -1,0 +1,11 @@
+"""Run Pydantic AI agents from normalized messaging events."""
+
+from ._host import ChannelAdapter, ChannelEvent, ChannelHost, ConversationStore, InMemoryConversationStore
+
+__all__ = (
+    'ChannelAdapter',
+    'ChannelEvent',
+    'ChannelHost',
+    'ConversationStore',
+    'InMemoryConversationStore',
+)

--- a/pydantic_ai_harness/channels/_host.py
+++ b/pydantic_ai_harness/channels/_host.py
@@ -34,7 +34,7 @@ class ChannelAdapter(Protocol):
 
     async def reply(self, event: ChannelEvent, text: str) -> None:
         """Send `text` in response to `event`."""
-        ...
+        ...  # pragma: no cover - structural protocol
 
 
 class ConversationStore(Protocol):
@@ -42,11 +42,11 @@ class ConversationStore(Protocol):
 
     async def load(self, conversation_id: str) -> Sequence[ModelMessage]:
         """Load the conversation's messages, or an empty sequence for a new conversation."""
-        ...
+        ...  # pragma: no cover - structural protocol
 
     async def save(self, conversation_id: str, messages: Sequence[ModelMessage]) -> None:
         """Replace the conversation's stored messages."""
-        ...
+        ...  # pragma: no cover - structural protocol
 
 
 class InMemoryConversationStore:

--- a/pydantic_ai_harness/channels/_host.py
+++ b/pydantic_ai_harness/channels/_host.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Generic, Protocol
+from weakref import WeakValueDictionary
 
 import anyio
 from pydantic_ai.agent import AbstractAgent
@@ -80,8 +81,8 @@ class ChannelHost(Generic[AgentDepsT]):
     ) -> None:
         self._agent = agent
         self._adapter = adapter
-        self._store = store or InMemoryConversationStore()
-        self._conversation_locks: dict[str, anyio.Lock] = {}
+        self._store = store if store is not None else InMemoryConversationStore()
+        self._conversation_locks: WeakValueDictionary[str, anyio.Lock] = WeakValueDictionary()
 
     async def handle(self, event: ChannelEvent, *, deps: AgentDepsT = None) -> AgentRunResult[str]:
         """Run the agent for `event`, reply, then commit the resulting message history.

--- a/pydantic_ai_harness/channels/_host.py
+++ b/pydantic_ai_harness/channels/_host.py
@@ -20,6 +20,7 @@ class ChannelEvent:
 
     `reply_to_id` identifies the provider object that should receive the response. For a threaded
     provider this is the thread root; for a reply-based provider it is the source message.
+    `delivery_id` identifies the provider destination when it differs from `conversation_id`.
     """
 
     event_id: str
@@ -27,6 +28,7 @@ class ChannelEvent:
     sender_id: str
     text: str
     reply_to_id: str | None = None
+    delivery_id: str | None = None
 
 
 class ChannelAdapter(Protocol):

--- a/pydantic_ai_harness/channels/_host.py
+++ b/pydantic_ai_harness/channels/_host.py
@@ -1,0 +1,103 @@
+"""Provider-neutral channel event handling."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Generic, Protocol
+
+import anyio
+from pydantic_ai.agent import AbstractAgent
+from pydantic_ai.messages import ModelMessage
+from pydantic_ai.run import AgentRunResult
+from pydantic_ai.tools import AgentDepsT
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ChannelEvent:
+    """A text event normalized by a provider adapter.
+
+    `reply_to_id` identifies the provider object that should receive the response. For a threaded
+    provider this is the thread root; for a reply-based provider it is the source message.
+    """
+
+    event_id: str
+    conversation_id: str
+    sender_id: str
+    text: str
+    reply_to_id: str | None = None
+
+
+class ChannelAdapter(Protocol):
+    """The outbound half of a messaging provider adapter."""
+
+    async def reply(self, event: ChannelEvent, text: str) -> None:
+        """Send `text` in response to `event`."""
+        ...
+
+
+class ConversationStore(Protocol):
+    """Storage for Pydantic AI message history keyed by normalized conversation ID."""
+
+    async def load(self, conversation_id: str) -> Sequence[ModelMessage]:
+        """Load the conversation's messages, or an empty sequence for a new conversation."""
+        ...
+
+    async def save(self, conversation_id: str, messages: Sequence[ModelMessage]) -> None:
+        """Replace the conversation's stored messages."""
+        ...
+
+
+class InMemoryConversationStore:
+    """Keep conversation history in this Python process."""
+
+    def __init__(self) -> None:
+        self._messages: dict[str, list[ModelMessage]] = {}
+
+    async def load(self, conversation_id: str) -> Sequence[ModelMessage]:
+        """Load a copy of the current history."""
+        return list(self._messages.get(conversation_id, ()))
+
+    async def save(self, conversation_id: str, messages: Sequence[ModelMessage]) -> None:
+        """Store a copy of `messages`."""
+        self._messages[conversation_id] = list(messages)
+
+
+class ChannelHost(Generic[AgentDepsT]):
+    """Run an agent for inbound channel events and send its text response.
+
+    Events for one conversation run serially. Events for different conversations may overlap.
+    Serialization is local to this host instance; a multi-process receiver should partition its
+    queue by `conversation_id` or provide equivalent coordination.
+    """
+
+    def __init__(
+        self,
+        agent: AbstractAgent[AgentDepsT, str],
+        adapter: ChannelAdapter,
+        *,
+        store: ConversationStore | None = None,
+    ) -> None:
+        self._agent = agent
+        self._adapter = adapter
+        self._store = store or InMemoryConversationStore()
+        self._conversation_locks: dict[str, anyio.Lock] = {}
+
+    async def handle(self, event: ChannelEvent, *, deps: AgentDepsT = None) -> AgentRunResult[str]:
+        """Run the agent for `event`, reply, then commit the resulting message history.
+
+        The agent must produce text. Failures from the agent, adapter, or store are surfaced
+        without host-level retries.
+        """
+        lock = self._conversation_locks.setdefault(event.conversation_id, anyio.Lock())
+        async with lock:
+            history = await self._store.load(event.conversation_id)
+            result = await self._agent.run(
+                event.text,
+                message_history=history,
+                conversation_id=event.conversation_id,
+                deps=deps,
+            )
+            await self._adapter.reply(event, result.output)
+            await self._store.save(event.conversation_id, result.all_messages())
+            return result

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -100,6 +100,7 @@ class SlackChannel:
         if 'bot_id' in event or 'subtype' in event:
             return None
 
+        channel_id = _required_nonempty_string(event, 'channel')
         timestamp = _required_nonempty_string(event, 'ts')
         if 'thread_ts' in event:
             thread_timestamp = _required_nonempty_string(event, 'thread_ts')
@@ -107,15 +108,16 @@ class SlackChannel:
             thread_timestamp = timestamp
         return ChannelEvent(
             event_id=_required_nonempty_string(payload, 'event_id'),
-            conversation_id=_required_nonempty_string(event, 'channel'),
+            conversation_id=f'slack:{self._team_id}:{channel_id}:{thread_timestamp}',
             sender_id=_required_nonempty_string(event, 'user'),
             text=_required_string(event, 'text'),
             reply_to_id=thread_timestamp,
+            delivery_id=channel_id,
         )
 
     async def reply(self, event: ChannelEvent, text: str) -> None:
         """Post `text` to the Slack conversation and original thread for `event`."""
-        payload: dict[str, str] = {'channel': event.conversation_id, 'text': text}
+        payload: dict[str, str] = {'channel': event.delivery_id or event.conversation_id, 'text': text}
         if event.reply_to_id is not None:
             payload['thread_ts'] = event.reply_to_id
 

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -6,8 +6,12 @@ External assumptions verified 2026-09:
   more than five minutes from local time: https://docs.slack.dev/authentication/verifying-requests-from-slack/
 * `chat.postMessage` replies to a thread when passed its root `thread_ts`:
   https://docs.slack.dev/reference/methods/chat.postmessage
+* `chat.postMessage` reports truncation in `response_metadata.warnings`:
+  https://docs.slack.dev/changelog/2018-truncating-really-long-messages/
+* Slack returns HTTP 429 with a `Retry-After` delay:
+  https://docs.slack.dev/apis/web-api/rate-limits/
 
-Re-check both pages before changing request verification or reply mapping.
+Re-check these pages before changing request verification or reply mapping.
 """
 
 from __future__ import annotations
@@ -18,6 +22,7 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+import anyio
 import httpx
 from pydantic import TypeAdapter, ValidationError
 
@@ -28,6 +33,7 @@ __all__ = ('SlackAPIError', 'SlackChannel', 'SlackError', 'SlackSignatureError',
 _DEFAULT_API_URL = 'https://slack.com/api/chat.postMessage'
 _MAX_REQUEST_AGE_SECONDS = 60 * 5
 _JSON_OBJECT_ADAPTER = TypeAdapter(dict[str, object])
+_STRING_LIST_ADAPTER = TypeAdapter(list[str])
 
 
 class SlackError(Exception):
@@ -39,7 +45,7 @@ class SlackSignatureError(SlackError):
 
 
 class SlackAPIError(SlackError):
-    """Slack rejected an outbound reply."""
+    """An outbound Slack reply failed or was only partially delivered."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,7 +101,7 @@ class SlackChannel:
         event = _mapping(payload.get('event'))
         if event is None:
             raise SlackError("Slack payload field 'event' must be an object")
-        if _string(event, 'type') not in {'app_mention', 'message'}:
+        if _string(event, 'type') != 'app_mention':
             return None
         if 'bot_id' in event or 'subtype' in event:
             return None
@@ -152,6 +158,13 @@ class SlackChannel:
             headers={'Authorization': f'Bearer {self._bot_token}'},
             json=payload,
         )
+        if response.status_code == 429:
+            await anyio.sleep(_retry_after_seconds(response))
+            response = await client.post(
+                _DEFAULT_API_URL,
+                headers={'Authorization': f'Bearer {self._bot_token}'},
+                json=payload,
+            )
         response.raise_for_status()
         try:
             body = _json_object(response.content)
@@ -160,6 +173,31 @@ class SlackChannel:
         if body.get('ok') is not True:
             error = _string(body, 'error') or 'unknown_error'
             raise SlackAPIError(f'Slack chat.postMessage failed: {error}')
+        if 'response_metadata' not in body:
+            return
+        response_metadata = _mapping(body['response_metadata'])
+        if response_metadata is None:
+            raise SlackAPIError('Slack chat.postMessage returned an invalid response')
+        if 'warnings' in response_metadata:
+            try:
+                warnings = _STRING_LIST_ADAPTER.validate_python(response_metadata['warnings'])
+            except ValidationError as exc:
+                raise SlackAPIError('Slack chat.postMessage returned an invalid response') from exc
+            if 'message_truncated' in warnings:
+                raise SlackAPIError('Slack chat.postMessage truncated the reply')
+
+
+def _retry_after_seconds(response: httpx.Response) -> int:
+    value = response.headers.get('Retry-After')
+    if value is None:
+        raise SlackAPIError('Slack rate limit response has no Retry-After delay')
+    try:
+        seconds = int(value)
+    except ValueError as exc:
+        raise SlackAPIError('Slack rate limit response has an invalid Retry-After delay') from exc
+    if seconds < 0:
+        raise SlackAPIError('Slack rate limit response has an invalid Retry-After delay')
+    return seconds
 
 
 def _json_object(raw: bytes) -> dict[str, object]:

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -61,18 +61,20 @@ class SlackChannel:
         *,
         signing_secret: str,
         bot_token: str,
+        team_id: str,
         client: httpx.AsyncClient | None = None,
-        api_url: str = _DEFAULT_API_URL,
     ) -> None:
         """Configure one Slack app installation without taking ownership of `client`."""
         if not signing_secret:
             raise ValueError('signing_secret must not be empty')
         if not bot_token:
             raise ValueError('bot_token must not be empty')
+        if not team_id:
+            raise ValueError('team_id must not be empty')
         self._signing_secret = signing_secret.encode()
         self._bot_token = bot_token
+        self._team_id = team_id
         self._client = client
-        self._api_url = api_url
 
     def parse_request(self, raw_body: bytes, headers: Mapping[str, str]) -> ChannelEvent | SlackUrlVerification | None:
         """Verify a raw Slack request and normalize supported message events.
@@ -84,9 +86,11 @@ class SlackChannel:
         payload = _json_object(raw_body)
         request_type = _string(payload, 'type')
         if request_type == 'url_verification':
-            return SlackUrlVerification(_required_string(payload, 'challenge'))
+            return SlackUrlVerification(_required_nonempty_string(payload, 'challenge'))
         if request_type != 'event_callback':
             return None
+        if _required_nonempty_string(payload, 'team_id') != self._team_id:
+            raise SlackError('Slack event does not belong to this workspace installation')
 
         event = _mapping(payload.get('event'))
         if event is None:
@@ -96,13 +100,17 @@ class SlackChannel:
         if 'bot_id' in event or 'subtype' in event:
             return None
 
-        timestamp = _required_string(event, 'ts')
+        timestamp = _required_nonempty_string(event, 'ts')
+        if 'thread_ts' in event:
+            thread_timestamp = _required_nonempty_string(event, 'thread_ts')
+        else:
+            thread_timestamp = timestamp
         return ChannelEvent(
-            event_id=_required_string(payload, 'event_id'),
-            conversation_id=_required_string(event, 'channel'),
-            sender_id=_required_string(event, 'user'),
+            event_id=_required_nonempty_string(payload, 'event_id'),
+            conversation_id=_required_nonempty_string(event, 'channel'),
+            sender_id=_required_nonempty_string(event, 'user'),
             text=_required_string(event, 'text'),
-            reply_to_id=_string(event, 'thread_ts') or timestamp,
+            reply_to_id=thread_timestamp,
         )
 
     async def reply(self, event: ChannelEvent, text: str) -> None:
@@ -127,7 +135,8 @@ class SlackChannel:
             timestamp = int(timestamp_text)
         except ValueError as exc:
             raise SlackSignatureError('Invalid Slack request timestamp') from exc
-        if abs(time.time() - timestamp) > _MAX_REQUEST_AGE_SECONDS:
+        now = int(time.time())
+        if timestamp < now - _MAX_REQUEST_AGE_SECONDS or timestamp > now + _MAX_REQUEST_AGE_SECONDS:
             raise SlackSignatureError('Slack request timestamp is outside the five-minute window')
 
         signed = b'v0:' + timestamp_text.encode() + b':' + raw_body
@@ -137,7 +146,7 @@ class SlackChannel:
 
     async def _post(self, client: httpx.AsyncClient, payload: Mapping[str, str]) -> None:
         response = await client.post(
-            self._api_url,
+            _DEFAULT_API_URL,
             headers={'Authorization': f'Bearer {self._bot_token}'},
             json=payload,
         )
@@ -174,4 +183,11 @@ def _required_string(mapping: Mapping[str, object], key: str) -> str:
     value = _string(mapping, key)
     if value is None:
         raise SlackError(f'Slack payload field {key!r} must be a string')
+    return value
+
+
+def _required_nonempty_string(mapping: Mapping[str, object], key: str) -> str:
+    value = _required_string(mapping, key)
+    if not value:
+        raise SlackError(f'Slack payload field {key!r} must not be empty')
     return value

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -1,0 +1,177 @@
+"""Slack Events API adapter for the provider-neutral channel host.
+
+External assumptions verified 2026-09:
+
+* Slack signs `v0:{timestamp}:{raw_body}` with HMAC-SHA256 and recommends rejecting timestamps
+  more than five minutes from local time: https://docs.slack.dev/authentication/verifying-requests-from-slack/
+* `chat.postMessage` replies to a thread when passed its root `thread_ts`:
+  https://docs.slack.dev/reference/methods/chat.postmessage
+
+Re-check both pages before changing request verification or reply mapping.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import httpx
+from pydantic import TypeAdapter, ValidationError
+
+from ._host import ChannelEvent
+
+__all__ = ('SlackAPIError', 'SlackChannel', 'SlackError', 'SlackSignatureError', 'SlackUrlVerification')
+
+_DEFAULT_API_URL = 'https://slack.com/api/chat.postMessage'
+_MAX_REQUEST_AGE_SECONDS = 60 * 5
+_JSON_OBJECT_ADAPTER = TypeAdapter(dict[str, object])
+
+
+class SlackError(Exception):
+    """Base class for Slack adapter failures."""
+
+
+class SlackSignatureError(SlackError):
+    """The Slack request signature or timestamp is invalid."""
+
+
+class SlackAPIError(SlackError):
+    """Slack rejected an outbound reply."""
+
+
+@dataclass(frozen=True, slots=True)
+class SlackUrlVerification:
+    """A challenge that the caller's HTTP framework should return as plain text."""
+
+    challenge: str
+
+
+class SlackChannel:
+    """Verify and normalize Slack Events API requests and post threaded replies.
+
+    One instance represents one Slack app installation. The caller owns HTTP routing, prompt
+    acknowledgment, queueing, and the lifetime of any supplied `httpx.AsyncClient`.
+    """
+
+    def __init__(
+        self,
+        *,
+        signing_secret: str,
+        bot_token: str,
+        client: httpx.AsyncClient | None = None,
+        api_url: str = _DEFAULT_API_URL,
+    ) -> None:
+        """Configure one Slack app installation without taking ownership of `client`."""
+        if not signing_secret:
+            raise ValueError('signing_secret must not be empty')
+        if not bot_token:
+            raise ValueError('bot_token must not be empty')
+        self._signing_secret = signing_secret.encode()
+        self._bot_token = bot_token
+        self._client = client
+        self._api_url = api_url
+
+    def parse_request(self, raw_body: bytes, headers: Mapping[str, str]) -> ChannelEvent | SlackUrlVerification | None:
+        """Verify a raw Slack request and normalize supported message events.
+
+        URL verification returns a challenge. Unsupported events and bot-authored messages return
+        `None`, allowing the caller to acknowledge them without starting an agent run.
+        """
+        self._verify(raw_body, headers)
+        payload = _json_object(raw_body)
+        request_type = _string(payload, 'type')
+        if request_type == 'url_verification':
+            return SlackUrlVerification(_required_string(payload, 'challenge'))
+        if request_type != 'event_callback':
+            return None
+
+        event = _mapping(payload.get('event'))
+        if event is None:
+            raise SlackError("Slack payload field 'event' must be an object")
+        if _string(event, 'type') not in {'app_mention', 'message'}:
+            return None
+        if 'bot_id' in event or 'subtype' in event:
+            return None
+
+        timestamp = _required_string(event, 'ts')
+        return ChannelEvent(
+            event_id=_required_string(payload, 'event_id'),
+            conversation_id=_required_string(event, 'channel'),
+            sender_id=_required_string(event, 'user'),
+            text=_required_string(event, 'text'),
+            reply_to_id=_string(event, 'thread_ts') or timestamp,
+        )
+
+    async def reply(self, event: ChannelEvent, text: str) -> None:
+        """Post `text` to the Slack conversation and original thread for `event`."""
+        payload: dict[str, str] = {'channel': event.conversation_id, 'text': text}
+        if event.reply_to_id is not None:
+            payload['thread_ts'] = event.reply_to_id
+
+        if self._client is None:
+            async with httpx.AsyncClient() as client:
+                await self._post(client, payload)
+        else:
+            await self._post(self._client, payload)
+
+    def _verify(self, raw_body: bytes, headers: Mapping[str, str]) -> None:
+        normalized_headers = {name.lower(): value for name, value in headers.items()}
+        timestamp_text = normalized_headers.get('x-slack-request-timestamp')
+        signature = normalized_headers.get('x-slack-signature')
+        if timestamp_text is None or signature is None:
+            raise SlackSignatureError('Missing Slack signature headers')
+        try:
+            timestamp = int(timestamp_text)
+        except ValueError as exc:
+            raise SlackSignatureError('Invalid Slack request timestamp') from exc
+        if abs(time.time() - timestamp) > _MAX_REQUEST_AGE_SECONDS:
+            raise SlackSignatureError('Slack request timestamp is outside the five-minute window')
+
+        signed = b'v0:' + timestamp_text.encode() + b':' + raw_body
+        expected = 'v0=' + hmac.new(self._signing_secret, signed, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(expected, signature):
+            raise SlackSignatureError('Invalid Slack request signature')
+
+    async def _post(self, client: httpx.AsyncClient, payload: Mapping[str, str]) -> None:
+        response = await client.post(
+            self._api_url,
+            headers={'Authorization': f'Bearer {self._bot_token}'},
+            json=payload,
+        )
+        response.raise_for_status()
+        try:
+            body = _json_object(response.content)
+        except SlackError as exc:
+            raise SlackAPIError('Slack chat.postMessage returned an invalid response') from exc
+        if body.get('ok') is not True:
+            error = _string(body, 'error') or 'unknown_error'
+            raise SlackAPIError(f'Slack chat.postMessage failed: {error}')
+
+
+def _json_object(raw: bytes) -> dict[str, object]:
+    try:
+        return _JSON_OBJECT_ADAPTER.validate_json(raw)
+    except ValidationError as exc:
+        raise SlackError('Slack request body is not valid JSON') from exc
+
+
+def _mapping(value: object) -> dict[str, object] | None:
+    try:
+        return _JSON_OBJECT_ADAPTER.validate_python(value)
+    except ValidationError:
+        return None
+
+
+def _string(mapping: Mapping[str, object], key: str) -> str | None:
+    value = mapping.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _required_string(mapping: Mapping[str, object], key: str) -> str:
+    value = _string(mapping, key)
+    if value is None:
+        raise SlackError(f'Slack payload field {key!r} must be a string')
+    return value

--- a/pydantic_ai_harness/channels/slack.py
+++ b/pydantic_ai_harness/channels/slack.py
@@ -81,6 +81,7 @@ class SlackChannel:
         self._bot_token = bot_token
         self._team_id = team_id
         self._client = client
+        self._post_lock = anyio.Lock()
 
     def parse_request(self, raw_body: bytes, headers: Mapping[str, str]) -> ChannelEvent | SlackUrlVerification | None:
         """Verify a raw Slack request and normalize supported message events.
@@ -127,11 +128,12 @@ class SlackChannel:
         if event.reply_to_id is not None:
             payload['thread_ts'] = event.reply_to_id
 
-        if self._client is None:
-            async with httpx.AsyncClient() as client:
-                await self._post(client, payload)
-        else:
-            await self._post(self._client, payload)
+        async with self._post_lock:
+            if self._client is None:
+                async with httpx.AsyncClient() as client:
+                    await self._post(client, payload)
+            else:
+                await self._post(self._client, payload)
 
     def _verify(self, raw_body: bytes, headers: Mapping[str, str]) -> None:
         normalized_headers = {name.lower(): value for name, value in headers.items()}
@@ -165,6 +167,8 @@ class SlackChannel:
                 headers={'Authorization': f'Bearer {self._bot_token}'},
                 json=payload,
             )
+            if response.status_code == 429:
+                await anyio.sleep(_retry_after_seconds(response))
         response.raise_for_status()
         try:
             body = _json_object(response.content)

--- a/tests/channels/test_host.py
+++ b/tests/channels/test_host.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Sequence
 
 import anyio
@@ -36,10 +37,11 @@ class _RecordingAdapter:
 
 
 class _RecordingStore:
-    def __init__(self) -> None:
+    def __init__(self, *, save_error: Exception | None = None) -> None:
         self.delegate = InMemoryConversationStore()
         self.loads: list[str] = []
         self.saves: list[tuple[str, Sequence[ModelMessage]]] = []
+        self.save_error = save_error
 
     async def load(self, conversation_id: str) -> Sequence[ModelMessage]:
         self.loads.append(conversation_id)
@@ -47,6 +49,8 @@ class _RecordingStore:
 
     async def save(self, conversation_id: str, messages: Sequence[ModelMessage]) -> None:
         self.saves.append((conversation_id, messages))
+        if self.save_error is not None:
+            raise self.save_error
         await self.delegate.save(conversation_id, messages)
 
 
@@ -149,6 +153,72 @@ class TestChannelHost:
 
         assert calls == 1
         assert store.saves == []
+
+    async def test_store_failure_happens_after_reply_and_is_not_retried(self) -> None:
+        adapter = _RecordingAdapter()
+        store = _RecordingStore(save_error=RuntimeError('save failed'))
+        host = ChannelHost(Agent('test'), adapter, store=store)
+
+        with pytest.raises(RuntimeError, match='save failed'):
+            await host.handle(_event('one'))
+
+        assert len(adapter.replies) == 1
+        assert len(store.saves) == 1
+
+    async def test_duplicate_event_ids_are_caller_owned(self) -> None:
+        adapter = _RecordingAdapter()
+        host = ChannelHost(Agent('test'), adapter)
+        event = _event('duplicate')
+
+        await host.handle(event)
+        await host.handle(event)
+
+        assert len(adapter.replies) == 2
+
+    async def test_agent_failure_does_not_reply_or_save_and_releases_lock(self) -> None:
+        calls = 0
+
+        def model(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise RuntimeError('model failed')
+            return ModelResponse(parts=[TextPart('done')])
+
+        adapter = _RecordingAdapter()
+        store = _RecordingStore()
+        host = ChannelHost(Agent(FunctionModel(model)), adapter, store=store)
+
+        with pytest.raises(RuntimeError, match='model failed'):
+            await host.handle(_event('one'))
+        await host.handle(_event('two'))
+
+        assert len(adapter.replies) == 1
+        assert len(store.saves) == 1
+
+    async def test_cancellation_does_not_reply_or_save_and_releases_lock(self) -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def model(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            started.set()
+            await release.wait()
+            return ModelResponse(parts=[TextPart('done')])
+
+        adapter = _RecordingAdapter()
+        store = _RecordingStore()
+        host = ChannelHost(Agent(FunctionModel(model)), adapter, store=store)
+        task = asyncio.create_task(host.handle(_event('cancelled')))
+        await started.wait()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        release.set()
+        await host.handle(_event('next'))
+
+        assert len(adapter.replies) == 1
+        assert len(store.saves) == 1
 
 
 def test_conversation_store_protocol_is_runtime_structural() -> None:

--- a/tests/channels/test_host.py
+++ b/tests/channels/test_host.py
@@ -13,7 +13,6 @@ from pydantic_ai.run import AgentRunResult
 from pydantic_ai_harness.channels import (
     ChannelEvent,
     ChannelHost,
-    ConversationStore,
     InMemoryConversationStore,
 )
 
@@ -398,8 +397,3 @@ class TestChannelHost:
         assert len(adapter.replies) == 2
         assert [len(messages) for _, messages in store.saves] == [2, 2]
         assert len(result.all_messages()) == 2
-
-
-def test_conversation_store_protocol_is_runtime_structural() -> None:
-    store: ConversationStore = InMemoryConversationStore()
-    assert store is not None

--- a/tests/channels/test_host.py
+++ b/tests/channels/test_host.py
@@ -99,6 +99,7 @@ class TestChannelHost:
     async def test_uses_a_falsy_conversation_store(self) -> None:
         adapter = _RecordingAdapter()
         store = _FalsyStore()
+        assert not store
         host = ChannelHost(Agent('test'), adapter, store=store)
 
         await host.handle(_event('one'))

--- a/tests/channels/test_host.py
+++ b/tests/channels/test_host.py
@@ -147,14 +147,15 @@ class TestChannelHost:
             return ModelResponse(parts=[TextPart('done')])
 
         host = ChannelHost(Agent(FunctionModel(model)), _RecordingAdapter())
-        async with anyio.create_task_group() as group:
-            group.start_soon(host.handle, _event('same-1', 'same'))
-            group.start_soon(host.handle, _event('same-2', 'same'))
-            group.start_soon(host.handle, _event('other', 'other'))
-            await two_models_started.wait()
-            assert maximum_by_conversation == {'same': 1, 'other': 1}
-            assert maximum_total == 2
-            release_models.set()
+        with anyio.fail_after(5):
+            async with anyio.create_task_group() as group:
+                group.start_soon(host.handle, _event('same-1', 'same'))
+                group.start_soon(host.handle, _event('same-2', 'same'))
+                group.start_soon(host.handle, _event('other', 'other'))
+                await two_models_started.wait()
+                assert maximum_by_conversation == {'same': 1, 'other': 1}
+                assert maximum_total == 2
+                release_models.set()
 
         assert maximum_by_conversation == {'same': 1, 'other': 1}
         assert maximum_total == 2
@@ -269,13 +270,18 @@ class TestChannelHost:
         store = _RecordingStore()
         host = ChannelHost(Agent(FunctionModel(model)), adapter, store=store)
         task = asyncio.create_task(host.handle(_event('cancelled')))
-        await started.wait()
+        with anyio.fail_after(5):
+            await started.wait()
 
         task.cancel()
+        done, pending = await asyncio.wait({task}, timeout=5)
+        assert done == {task}
+        assert not pending
         with pytest.raises(asyncio.CancelledError):
             await task
         release.set()
-        await host.handle(_event('next'))
+        with anyio.fail_after(5):
+            await host.handle(_event('next'))
 
         assert len(adapter.replies) == 1
         assert len(store.saves) == 1
@@ -297,16 +303,21 @@ class TestChannelHost:
         store = _RecordingStore()
         host = ChannelHost(Agent(FunctionModel(model)), adapter, store=store)
         first = asyncio.create_task(host.handle(_event('first')))
-        await started.wait()
+        with anyio.fail_after(5):
+            await started.wait()
         waiting = asyncio.create_task(host.handle(_event('cancelled')))
         await asyncio.sleep(0)
 
         waiting.cancel()
+        done, pending = await asyncio.wait({waiting}, timeout=5)
+        assert done == {waiting}
+        assert not pending
         with pytest.raises(asyncio.CancelledError):
             await waiting
         release.set()
-        await first
-        await host.handle(_event('next'))
+        with anyio.fail_after(5):
+            await first
+            await host.handle(_event('next'))
 
         assert calls == 2
         assert len(adapter.replies) == 2
@@ -330,16 +341,21 @@ class TestChannelHost:
         store = BlockingLoadStore()
         host = ChannelHost(Agent('test'), adapter, store=store)
         task = asyncio.create_task(host.handle(_event('cancelled')))
-        await load_started.wait()
+        with anyio.fail_after(5):
+            await load_started.wait()
 
         task.cancel()
+        done, pending = await asyncio.wait({task}, timeout=5)
+        assert done == {task}
+        assert not pending
         with pytest.raises(asyncio.CancelledError):
             await task
         assert adapter.replies == []
         assert store.saves == []
 
         store.block = False
-        result = await host.handle(_event('next'))
+        with anyio.fail_after(5):
+            result = await host.handle(_event('next'))
         assert len(result.all_messages()) == 2
 
     async def test_cancellation_during_reply_leaves_history_uncommitted_and_releases_lock(self) -> None:
@@ -359,16 +375,21 @@ class TestChannelHost:
         store = _RecordingStore()
         host = ChannelHost(Agent('test'), adapter, store=store)
         task = asyncio.create_task(host.handle(_event('cancelled')))
-        await reply_started.wait()
+        with anyio.fail_after(5):
+            await reply_started.wait()
 
         task.cancel()
+        done, pending = await asyncio.wait({task}, timeout=5)
+        assert done == {task}
+        assert not pending
         with pytest.raises(asyncio.CancelledError):
             await task
         assert len(adapter.replies) == 1
         assert store.saves == []
 
         adapter.block = False
-        result = await host.handle(_event('next'))
+        with anyio.fail_after(5):
+            result = await host.handle(_event('next'))
         assert len(result.all_messages()) == 2
 
     async def test_cancellation_during_save_happens_after_reply_and_releases_lock(self) -> None:
@@ -386,13 +407,18 @@ class TestChannelHost:
         store = BlockingStore()
         host = ChannelHost(Agent('test'), adapter, store=store)
         task = asyncio.create_task(host.handle(_event('cancelled')))
-        await save_started.wait()
+        with anyio.fail_after(5):
+            await save_started.wait()
 
         task.cancel()
+        done, pending = await asyncio.wait({task}, timeout=5)
+        assert done == {task}
+        assert not pending
         with pytest.raises(asyncio.CancelledError):
             await task
         release_save.set()
-        result = await host.handle(_event('next'))
+        with anyio.fail_after(5):
+            result = await host.handle(_event('next'))
 
         assert len(adapter.replies) == 2
         assert [len(messages) for _, messages in store.saves] == [2, 2]

--- a/tests/channels/test_host.py
+++ b/tests/channels/test_host.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import anyio
+import pytest
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.run import AgentRunResult
+
+from pydantic_ai_harness.channels import (
+    ChannelEvent,
+    ChannelHost,
+    ConversationStore,
+    InMemoryConversationStore,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+class _RecordingAdapter:
+    def __init__(self, error: Exception | None = None) -> None:
+        self.replies: list[tuple[ChannelEvent, str]] = []
+        self.error = error
+
+    async def reply(self, event: ChannelEvent, text: str) -> None:
+        self.replies.append((event, text))
+        if self.error is not None:
+            raise self.error
+
+
+class _RecordingStore:
+    def __init__(self) -> None:
+        self.delegate = InMemoryConversationStore()
+        self.loads: list[str] = []
+        self.saves: list[tuple[str, Sequence[ModelMessage]]] = []
+
+    async def load(self, conversation_id: str) -> Sequence[ModelMessage]:
+        self.loads.append(conversation_id)
+        return await self.delegate.load(conversation_id)
+
+    async def save(self, conversation_id: str, messages: Sequence[ModelMessage]) -> None:
+        self.saves.append((conversation_id, messages))
+        await self.delegate.save(conversation_id, messages)
+
+
+def _event(event_id: str, conversation_id: str = 'conversation') -> ChannelEvent:
+    return ChannelEvent(
+        event_id=event_id,
+        conversation_id=conversation_id,
+        sender_id='sender',
+        text=f'prompt {event_id}',
+        reply_to_id=f'message {event_id}',
+    )
+
+
+class TestChannelHost:
+    async def test_runs_public_agent_replies_and_saves_history(self) -> None:
+        adapter = _RecordingAdapter()
+        store = _RecordingStore()
+        agent: Agent[None, str] = Agent('test', name='channel-agent')
+        host = ChannelHost(agent, adapter, store=store)
+
+        first = await host.handle(_event('one'))
+        second = await host.handle(_event('two'))
+
+        assert isinstance(first, AgentRunResult)
+        assert [text for _, text in adapter.replies] == ['success (no tool calls)', 'success (no tool calls)']
+        assert store.loads == ['conversation', 'conversation']
+        assert [len(messages) for _, messages in store.saves] == [2, 4]
+        assert len(second.all_messages()) == 4
+        assert all(message.conversation_id == 'conversation' for message in second.all_messages())
+
+    async def test_default_store_keeps_conversations_separate(self) -> None:
+        adapter = _RecordingAdapter()
+        host = ChannelHost(Agent('test'), adapter)
+
+        left = await host.handle(_event('left', 'left'))
+        right = await host.handle(_event('right', 'right'))
+
+        assert len(left.all_messages()) == 2
+        assert len(right.all_messages()) == 2
+
+    async def test_passes_per_event_dependencies(self) -> None:
+        adapter = _RecordingAdapter()
+        seen: list[str] = []
+
+        def instructions(ctx: RunContext[str]) -> str:
+            seen.append(ctx.deps)
+            return f'Dependency: {ctx.deps}'
+
+        agent = Agent('test', deps_type=str, instructions=instructions)
+        host = ChannelHost(agent, adapter)
+
+        await host.handle(_event('one'), deps='tenant-specific')
+
+        assert seen == ['tenant-specific']
+
+    async def test_serializes_one_conversation_but_allows_different_conversations(self) -> None:
+        active_by_conversation: dict[str, int] = {}
+        maximum_by_conversation: dict[str, int] = {}
+        total_active = 0
+        maximum_total = 0
+
+        async def model(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            nonlocal total_active, maximum_total
+            conversation_id = messages[-1].conversation_id
+            assert conversation_id is not None
+            active_by_conversation[conversation_id] = active_by_conversation.get(conversation_id, 0) + 1
+            maximum_by_conversation[conversation_id] = max(
+                maximum_by_conversation.get(conversation_id, 0), active_by_conversation[conversation_id]
+            )
+            total_active += 1
+            maximum_total = max(maximum_total, total_active)
+            await anyio.sleep(0.05)
+            active_by_conversation[conversation_id] -= 1
+            total_active -= 1
+            return ModelResponse(parts=[TextPart('done')])
+
+        host = ChannelHost(Agent(FunctionModel(model)), _RecordingAdapter())
+        async with anyio.create_task_group() as group:
+            group.start_soon(host.handle, _event('same-1', 'same'))
+            group.start_soon(host.handle, _event('same-2', 'same'))
+            group.start_soon(host.handle, _event('other', 'other'))
+
+        assert maximum_by_conversation == {'same': 1, 'other': 1}
+        assert maximum_total == 2
+
+    async def test_does_not_retry_adapter_failure_or_save_history(self) -> None:
+        calls = 0
+
+        def model(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            nonlocal calls
+            calls += 1
+            return ModelResponse(parts=[TextPart('done')])
+
+        adapter = _RecordingAdapter(RuntimeError('send failed'))
+        store = _RecordingStore()
+        host = ChannelHost(Agent(FunctionModel(model)), adapter, store=store)
+
+        with pytest.raises(RuntimeError, match='send failed'):
+            await host.handle(_event('one'))
+
+        assert calls == 1
+        assert store.saves == []
+
+
+def test_conversation_store_protocol_is_runtime_structural() -> None:
+    store: ConversationStore = InMemoryConversationStore()
+    assert store is not None

--- a/tests/channels/test_host.py
+++ b/tests/channels/test_host.py
@@ -54,6 +54,11 @@ class _RecordingStore:
         await self.delegate.save(conversation_id, messages)
 
 
+class _FalsyStore(_RecordingStore):
+    def __bool__(self) -> bool:
+        return False
+
+
 def _event(event_id: str, conversation_id: str = 'conversation') -> ChannelEvent:
     return ChannelEvent(
         event_id=event_id,
@@ -91,6 +96,16 @@ class TestChannelHost:
         assert len(left.all_messages()) == 2
         assert len(right.all_messages()) == 2
 
+    async def test_uses_a_falsy_conversation_store(self) -> None:
+        adapter = _RecordingAdapter()
+        store = _FalsyStore()
+        host = ChannelHost(Agent('test'), adapter, store=store)
+
+        await host.handle(_event('one'))
+
+        assert store.loads == ['conversation']
+        assert len(store.saves) == 1
+
     async def test_passes_per_event_dependencies(self) -> None:
         adapter = _RecordingAdapter()
         seen: list[str] = []
@@ -111,6 +126,8 @@ class TestChannelHost:
         maximum_by_conversation: dict[str, int] = {}
         total_active = 0
         maximum_total = 0
+        two_models_started = asyncio.Event()
+        release_models = asyncio.Event()
 
         async def model(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
             nonlocal total_active, maximum_total
@@ -122,7 +139,9 @@ class TestChannelHost:
             )
             total_active += 1
             maximum_total = max(maximum_total, total_active)
-            await anyio.sleep(0.05)
+            if total_active == 2:
+                two_models_started.set()
+            await release_models.wait()
             active_by_conversation[conversation_id] -= 1
             total_active -= 1
             return ModelResponse(parts=[TextPart('done')])
@@ -132,6 +151,10 @@ class TestChannelHost:
             group.start_soon(host.handle, _event('same-1', 'same'))
             group.start_soon(host.handle, _event('same-2', 'same'))
             group.start_soon(host.handle, _event('other', 'other'))
+            await two_models_started.wait()
+            assert maximum_by_conversation == {'same': 1, 'other': 1}
+            assert maximum_total == 2
+            release_models.set()
 
         assert maximum_by_conversation == {'same': 1, 'other': 1}
         assert maximum_total == 2
@@ -150,9 +173,12 @@ class TestChannelHost:
 
         with pytest.raises(RuntimeError, match='send failed'):
             await host.handle(_event('one'))
+        adapter.error = None
+        result = await host.handle(_event('two'))
 
-        assert calls == 1
-        assert store.saves == []
+        assert calls == 2
+        assert len(result.all_messages()) == 2
+        assert len(store.saves) == 1
 
     async def test_store_failure_happens_after_reply_and_is_not_retried(self) -> None:
         adapter = _RecordingAdapter()
@@ -161,9 +187,43 @@ class TestChannelHost:
 
         with pytest.raises(RuntimeError, match='save failed'):
             await host.handle(_event('one'))
+        store.save_error = None
+        result = await host.handle(_event('two'))
 
-        assert len(adapter.replies) == 1
-        assert len(store.saves) == 1
+        assert len(adapter.replies) == 2
+        assert [len(messages) for _, messages in store.saves] == [2, 2]
+        assert len(result.all_messages()) == 2
+
+    async def test_store_load_failure_stops_processing_and_releases_lock(self) -> None:
+        class FailingLoadStore(_RecordingStore):
+            load_error: Exception | None = RuntimeError('load failed')
+
+            async def load(self, conversation_id: str) -> Sequence[ModelMessage]:
+                self.loads.append(conversation_id)
+                if self.load_error is not None:
+                    raise self.load_error
+                return await self.delegate.load(conversation_id)
+
+        calls = 0
+
+        def model(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            nonlocal calls
+            calls += 1
+            return ModelResponse(parts=[TextPart('done')])
+
+        adapter = _RecordingAdapter()
+        store = FailingLoadStore()
+        host = ChannelHost(Agent(FunctionModel(model)), adapter, store=store)
+
+        with pytest.raises(RuntimeError, match='load failed'):
+            await host.handle(_event('one'))
+        assert calls == 0
+        assert adapter.replies == []
+        assert store.saves == []
+
+        store.load_error = None
+        result = await host.handle(_event('two'))
+        assert len(result.all_messages()) == 2
 
     async def test_duplicate_event_ids_are_caller_owned(self) -> None:
         adapter = _RecordingAdapter()
@@ -219,6 +279,124 @@ class TestChannelHost:
 
         assert len(adapter.replies) == 1
         assert len(store.saves) == 1
+
+    async def test_cancellation_while_waiting_for_lock_does_not_start_run(self) -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls = 0
+
+        async def model(_messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                started.set()
+                await release.wait()
+            return ModelResponse(parts=[TextPart('done')])
+
+        adapter = _RecordingAdapter()
+        store = _RecordingStore()
+        host = ChannelHost(Agent(FunctionModel(model)), adapter, store=store)
+        first = asyncio.create_task(host.handle(_event('first')))
+        await started.wait()
+        waiting = asyncio.create_task(host.handle(_event('cancelled')))
+        await asyncio.sleep(0)
+
+        waiting.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiting
+        release.set()
+        await first
+        await host.handle(_event('next'))
+
+        assert calls == 2
+        assert len(adapter.replies) == 2
+        assert len(store.saves) == 2
+
+    async def test_cancellation_during_load_stops_processing_and_releases_lock(self) -> None:
+        load_started = asyncio.Event()
+        release_load = asyncio.Event()
+
+        class BlockingLoadStore(_RecordingStore):
+            block = True
+
+            async def load(self, conversation_id: str) -> Sequence[ModelMessage]:
+                self.loads.append(conversation_id)
+                if self.block:
+                    load_started.set()
+                    await release_load.wait()
+                return await self.delegate.load(conversation_id)
+
+        adapter = _RecordingAdapter()
+        store = BlockingLoadStore()
+        host = ChannelHost(Agent('test'), adapter, store=store)
+        task = asyncio.create_task(host.handle(_event('cancelled')))
+        await load_started.wait()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert adapter.replies == []
+        assert store.saves == []
+
+        store.block = False
+        result = await host.handle(_event('next'))
+        assert len(result.all_messages()) == 2
+
+    async def test_cancellation_during_reply_leaves_history_uncommitted_and_releases_lock(self) -> None:
+        reply_started = asyncio.Event()
+        release_reply = asyncio.Event()
+
+        class BlockingAdapter(_RecordingAdapter):
+            block = True
+
+            async def reply(self, event: ChannelEvent, text: str) -> None:
+                self.replies.append((event, text))
+                if self.block:
+                    reply_started.set()
+                    await release_reply.wait()
+
+        adapter = BlockingAdapter()
+        store = _RecordingStore()
+        host = ChannelHost(Agent('test'), adapter, store=store)
+        task = asyncio.create_task(host.handle(_event('cancelled')))
+        await reply_started.wait()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert len(adapter.replies) == 1
+        assert store.saves == []
+
+        adapter.block = False
+        result = await host.handle(_event('next'))
+        assert len(result.all_messages()) == 2
+
+    async def test_cancellation_during_save_happens_after_reply_and_releases_lock(self) -> None:
+        save_started = asyncio.Event()
+        release_save = asyncio.Event()
+
+        class BlockingStore(_RecordingStore):
+            async def save(self, conversation_id: str, messages: Sequence[ModelMessage]) -> None:
+                self.saves.append((conversation_id, messages))
+                save_started.set()
+                await release_save.wait()
+                await self.delegate.save(conversation_id, messages)
+
+        adapter = _RecordingAdapter()
+        store = BlockingStore()
+        host = ChannelHost(Agent('test'), adapter, store=store)
+        task = asyncio.create_task(host.handle(_event('cancelled')))
+        await save_started.wait()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        release_save.set()
+        result = await host.handle(_event('next'))
+
+        assert len(adapter.replies) == 2
+        assert [len(messages) for _, messages in store.saves] == [2, 2]
+        assert len(result.all_messages()) == 2
 
 
 def test_conversation_store_protocol_is_runtime_structural() -> None:

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -72,21 +72,38 @@ class TestSlackRequestParsing:
             },
             event_id='Ev456',
         )
+        other_root_body = _body(
+            {
+                'type': 'message',
+                'channel': 'C123',
+                'user': 'U789',
+                'text': 'separate root',
+                'ts': '1700000099.000001',
+            },
+            event_id='Ev789',
+        )
 
-        assert channel.parse_request(root_body, _headers(root_body)) == ChannelEvent(
+        root = channel.parse_request(root_body, _headers(root_body))
+        thread = channel.parse_request(thread_body, _headers(thread_body))
+        other_root = channel.parse_request(other_root_body, _headers(other_root_body))
+        assert root == ChannelEvent(
             event_id='Ev123',
-            conversation_id='C123',
+            conversation_id='slack:T123:C123:1700000000.000001',
             sender_id='U123',
             text='<@BOT> hello',
             reply_to_id='1700000000.000001',
+            delivery_id='C123',
         )
-        assert channel.parse_request(thread_body, _headers(thread_body)) == ChannelEvent(
+        assert thread == ChannelEvent(
             event_id='Ev456',
-            conversation_id='C123',
+            conversation_id='slack:T123:C123:1700000000.000001',
             sender_id='U456',
             text='follow up',
             reply_to_id='1700000000.000001',
+            delivery_id='C123',
         )
+        assert isinstance(other_root, ChannelEvent)
+        assert other_root.conversation_id == 'slack:T123:C123:1700000099.000001'
 
     def test_rejects_event_for_another_workspace_installation(self) -> None:
         body = _body(team_id='T999')
@@ -94,6 +111,33 @@ class TestSlackRequestParsing:
 
         with pytest.raises(SlackError, match='workspace installation'):
             channel.parse_request(body, _headers(body))
+
+    def test_conversation_identity_isolated_by_workspace_and_channel(self) -> None:
+        original_body = _body()
+        other_workspace_body = _body(team_id='T999')
+        other_channel_body = _body(
+            {
+                'type': 'app_mention',
+                'channel': 'C999',
+                'user': 'U123',
+                'text': '<@BOT> hello',
+                'ts': '1700000000.000001',
+            }
+        )
+        original = SlackChannel(signing_secret='signing-secret', bot_token='token', team_id='T123').parse_request(
+            original_body, _headers(original_body)
+        )
+        other_workspace = SlackChannel(
+            signing_secret='signing-secret', bot_token='token', team_id='T999'
+        ).parse_request(other_workspace_body, _headers(other_workspace_body))
+        other_channel = SlackChannel(signing_secret='signing-secret', bot_token='token', team_id='T123').parse_request(
+            other_channel_body, _headers(other_channel_body)
+        )
+
+        assert isinstance(original, ChannelEvent)
+        assert isinstance(other_workspace, ChannelEvent)
+        assert isinstance(other_channel, ChannelEvent)
+        assert len({original.conversation_id, other_workspace.conversation_id, other_channel.conversation_id}) == 3
 
     def test_returns_url_verification_challenge(self) -> None:
         body = _body(type='url_verification', challenge='challenge-value')
@@ -204,10 +248,11 @@ class TestSlackReply:
             await channel.reply(
                 ChannelEvent(
                     event_id='Ev123',
-                    conversation_id='C123',
+                    conversation_id='slack:T123:C123:1700000000.000001',
                     sender_id='U123',
                     text='hello',
                     reply_to_id='1700000000.000001',
+                    delivery_id='C123',
                 ),
                 'agent reply',
             )
@@ -221,6 +266,21 @@ class TestSlackReply:
             'text': 'agent reply',
             'thread_ts': '1700000000.000001',
         }
+
+    async def test_uses_conversation_as_delivery_fallback(self) -> None:
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(200, json={'ok': True})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
+            await channel.reply(
+                ChannelEvent(event_id='e', conversation_id='C-fallback', sender_id='u', text='x'), 'reply'
+            )
+
+        assert json.loads(seen[0].content)['channel'] == 'C-fallback'
 
     async def test_surfaces_http_and_slack_api_errors(self) -> None:
         responses = iter(

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from collections.abc import Mapping
+
+import httpx
+import pytest
+
+from pydantic_ai_harness.channels import ChannelEvent
+from pydantic_ai_harness.channels.slack import (
+    SlackAPIError,
+    SlackChannel,
+    SlackError,
+    SlackSignatureError,
+    SlackUrlVerification,
+)
+
+
+def _body(event: object | None = None, **overrides: object) -> bytes:
+    payload: dict[str, object] = {
+        'type': 'event_callback',
+        'event_id': 'Ev123',
+        'event': {
+            'type': 'app_mention',
+            'channel': 'C123',
+            'user': 'U123',
+            'text': '<@BOT> hello',
+            'ts': '1700000000.000001',
+        },
+    }
+    if event is not None:
+        payload['event'] = event
+    payload.update(overrides)
+    return json.dumps(payload, separators=(',', ':')).encode()
+
+
+def _headers(body: bytes, *, secret: str = 'signing-secret', timestamp: int | None = None) -> dict[str, str]:
+    timestamp = int(time.time()) if timestamp is None else timestamp
+    timestamp_text = str(timestamp)
+    signed = b'v0:' + timestamp_text.encode() + b':' + body
+    signature = 'v0=' + hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+    return {'X-Slack-Request-Timestamp': timestamp_text, 'x-SLACK-signature': signature}
+
+
+class TestSlackRequestParsing:
+    @pytest.mark.parametrize('field', ['signing_secret', 'bot_token'])
+    def test_rejects_empty_credentials(self, field: str) -> None:
+        with pytest.raises(ValueError, match=field):
+            if field == 'signing_secret':
+                SlackChannel(signing_secret='', bot_token='token')
+            else:
+                SlackChannel(signing_secret='secret', bot_token='')
+
+    def test_normalizes_root_message_and_thread_reply(self) -> None:
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+        root_body = _body()
+        thread_body = _body(
+            {
+                'type': 'message',
+                'channel': 'C123',
+                'user': 'U456',
+                'text': 'follow up',
+                'ts': '1700000001.000001',
+                'thread_ts': '1700000000.000001',
+            },
+            event_id='Ev456',
+        )
+
+        assert channel.parse_request(root_body, _headers(root_body)) == ChannelEvent(
+            event_id='Ev123',
+            conversation_id='C123',
+            sender_id='U123',
+            text='<@BOT> hello',
+            reply_to_id='1700000000.000001',
+        )
+        assert channel.parse_request(thread_body, _headers(thread_body)) == ChannelEvent(
+            event_id='Ev456',
+            conversation_id='C123',
+            sender_id='U456',
+            text='follow up',
+            reply_to_id='1700000000.000001',
+        )
+
+    def test_returns_url_verification_challenge(self) -> None:
+        body = _body(type='url_verification', challenge='challenge-value')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+
+        assert channel.parse_request(body, _headers(body)) == SlackUrlVerification('challenge-value')
+
+    def test_ignores_unknown_request_type(self) -> None:
+        body = _body(type='unknown')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+
+        assert channel.parse_request(body, _headers(body)) is None
+
+    @pytest.mark.parametrize(
+        'event',
+        [
+            {'type': 'reaction_added'},
+            {'type': 'message', 'bot_id': 'B123'},
+            {'type': 'message', 'subtype': 'message_changed'},
+        ],
+    )
+    def test_ignores_unsupported_and_bot_events(self, event: Mapping[str, object]) -> None:
+        body = _body(event)
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+
+        assert channel.parse_request(body, _headers(body)) is None
+
+    def test_rejects_missing_malformed_stale_and_wrong_signatures(self) -> None:
+        body = _body()
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+
+        with pytest.raises(SlackSignatureError, match='Missing'):
+            channel.parse_request(body, {})
+        with pytest.raises(SlackSignatureError, match='timestamp'):
+            channel.parse_request(body, {'x-slack-request-timestamp': 'nope', 'x-slack-signature': 'v0=x'})
+        with pytest.raises(SlackSignatureError, match='five-minute'):
+            channel.parse_request(body, _headers(body, timestamp=int(time.time()) - 301))
+        with pytest.raises(SlackSignatureError, match='signature'):
+            channel.parse_request(body + b' ', _headers(body))
+
+    @pytest.mark.parametrize('body', [b'not-json', b'[]', _body(event_id=123), _body(event='bad')])
+    def test_rejects_malformed_payloads(self, body: bytes) -> None:
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+
+        with pytest.raises(SlackError):
+            channel.parse_request(body, _headers(body))
+
+
+@pytest.mark.anyio
+class TestSlackReply:
+    async def test_posts_to_configured_endpoint_with_original_thread(self) -> None:
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(200, json={'ok': True})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(
+                signing_secret='signing-secret',
+                bot_token='xoxb-secret',
+                client=client,
+                api_url='https://slack.invalid/custom-post',
+            )
+            await channel.reply(
+                ChannelEvent(
+                    event_id='Ev123',
+                    conversation_id='C123',
+                    sender_id='U123',
+                    text='hello',
+                    reply_to_id='1700000000.000001',
+                ),
+                'agent reply',
+            )
+
+        assert len(seen) == 1
+        assert seen[0].url == 'https://slack.invalid/custom-post'
+        assert seen[0].headers['authorization'] == 'Bearer xoxb-secret'
+        assert json.loads(seen[0].content) == {
+            'channel': 'C123',
+            'text': 'agent reply',
+            'thread_ts': '1700000000.000001',
+        }
+
+    async def test_surfaces_http_and_slack_api_errors(self) -> None:
+        responses = iter(
+            [
+                httpx.Response(503),
+                httpx.Response(200, json={'ok': False, 'error': 'not_in_channel'}),
+                httpx.Response(200, content=b'not-json'),
+            ]
+        )
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return next(responses)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(signing_secret='secret', bot_token='token', client=client)
+            event = ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x')
+
+            with pytest.raises(httpx.HTTPStatusError):
+                await channel.reply(event, 'first')
+            with pytest.raises(SlackAPIError, match='not_in_channel'):
+                await channel.reply(event, 'second')
+            with pytest.raises(SlackAPIError, match='invalid response'):
+                await channel.reply(event, 'third')
+
+    async def test_closes_short_lived_default_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clients: list[httpx.AsyncClient] = []
+        async_client_type = httpx.AsyncClient
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={'ok': True})
+
+        def client_factory() -> httpx.AsyncClient:
+            client = async_client_type(transport=httpx.MockTransport(handler))
+            clients.append(client)
+            return client
+
+        monkeypatch.setattr(httpx, 'AsyncClient', client_factory)
+        channel = SlackChannel(signing_secret='secret', bot_token='token')
+
+        await channel.reply(
+            ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x'),
+            'reply',
+        )
+
+        assert len(clients) == 1
+        assert clients[0].is_closed
+
+
+def test_secrets_are_absent_from_repr() -> None:
+    representation = repr(SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret'))
+    assert 'signing-secret' not in representation
+    assert 'xoxb-secret' not in representation

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -6,6 +6,7 @@ import json
 import time
 from collections.abc import Mapping
 
+import anyio
 import httpx
 import pytest
 
@@ -22,6 +23,7 @@ from pydantic_ai_harness.channels.slack import (
 def _body(event: object | None = None, **overrides: object) -> bytes:
     payload: dict[str, object] = {
         'type': 'event_callback',
+        'team_id': 'T123',
         'event_id': 'Ev123',
         'event': {
             'type': 'app_mention',
@@ -46,16 +48,18 @@ def _headers(body: bytes, *, secret: str = 'signing-secret', timestamp: int | No
 
 
 class TestSlackRequestParsing:
-    @pytest.mark.parametrize('field', ['signing_secret', 'bot_token'])
+    @pytest.mark.parametrize('field', ['signing_secret', 'bot_token', 'team_id'])
     def test_rejects_empty_credentials(self, field: str) -> None:
         with pytest.raises(ValueError, match=field):
             if field == 'signing_secret':
-                SlackChannel(signing_secret='', bot_token='token')
+                SlackChannel(signing_secret='', bot_token='token', team_id='team')
+            elif field == 'bot_token':
+                SlackChannel(signing_secret='secret', bot_token='', team_id='team')
             else:
-                SlackChannel(signing_secret='secret', bot_token='')
+                SlackChannel(signing_secret='secret', bot_token='token', team_id='')
 
     def test_normalizes_root_message_and_thread_reply(self) -> None:
-        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
         root_body = _body()
         thread_body = _body(
             {
@@ -84,15 +88,22 @@ class TestSlackRequestParsing:
             reply_to_id='1700000000.000001',
         )
 
+    def test_rejects_event_for_another_workspace_installation(self) -> None:
+        body = _body(team_id='T999')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
+
+        with pytest.raises(SlackError, match='workspace installation'):
+            channel.parse_request(body, _headers(body))
+
     def test_returns_url_verification_challenge(self) -> None:
         body = _body(type='url_verification', challenge='challenge-value')
-        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
 
         assert channel.parse_request(body, _headers(body)) == SlackUrlVerification('challenge-value')
 
     def test_ignores_unknown_request_type(self) -> None:
         body = _body(type='unknown')
-        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
 
         assert channel.parse_request(body, _headers(body)) is None
 
@@ -106,18 +117,22 @@ class TestSlackRequestParsing:
     )
     def test_ignores_unsupported_and_bot_events(self, event: Mapping[str, object]) -> None:
         body = _body(event)
-        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
 
         assert channel.parse_request(body, _headers(body)) is None
 
     def test_rejects_missing_malformed_stale_and_wrong_signatures(self) -> None:
         body = _body()
-        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
 
         with pytest.raises(SlackSignatureError, match='Missing'):
             channel.parse_request(body, {})
+        with pytest.raises(SlackSignatureError, match='Missing'):
+            channel.parse_request(body, {'x-slack-request-timestamp': str(int(time.time()))})
         with pytest.raises(SlackSignatureError, match='timestamp'):
             channel.parse_request(body, {'x-slack-request-timestamp': 'nope', 'x-slack-signature': 'v0=x'})
+        with pytest.raises(SlackSignatureError, match='five-minute'):
+            channel.parse_request(body, _headers(body) | {'x-slack-request-timestamp': '1' + '0' * 400})
         with pytest.raises(SlackSignatureError, match='five-minute'):
             channel.parse_request(body, _headers(body, timestamp=int(time.time()) - 301))
         with pytest.raises(SlackSignatureError, match='signature'):
@@ -125,15 +140,54 @@ class TestSlackRequestParsing:
 
     @pytest.mark.parametrize('body', [b'not-json', b'[]', _body(event_id=123), _body(event='bad')])
     def test_rejects_malformed_payloads(self, body: bytes) -> None:
-        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret')
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
 
         with pytest.raises(SlackError):
+            channel.parse_request(body, _headers(body))
+
+    @pytest.mark.parametrize('thread_timestamp', ['', 123])
+    def test_rejects_malformed_explicit_thread_timestamp(self, thread_timestamp: object) -> None:
+        body = _body(
+            {
+                'type': 'message',
+                'channel': 'C123',
+                'user': 'U123',
+                'text': 'hello',
+                'ts': '1700000000.000001',
+                'thread_ts': thread_timestamp,
+            }
+        )
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
+
+        with pytest.raises(SlackError, match='thread_ts'):
+            channel.parse_request(body, _headers(body))
+
+    @pytest.mark.parametrize(
+        ('body', 'field'),
+        [
+            (_body(team_id=''), 'team_id'),
+            (_body(event_id=''), 'event_id'),
+            (
+                _body({'type': 'message', 'channel': '', 'user': 'U123', 'text': 'hello', 'ts': '1700000000.1'}),
+                'channel',
+            ),
+            (
+                _body({'type': 'message', 'channel': 'C123', 'user': '', 'text': 'hello', 'ts': '1700000000.1'}),
+                'user',
+            ),
+            (_body({'type': 'message', 'channel': 'C123', 'user': 'U123', 'text': 'hello', 'ts': ''}), 'ts'),
+        ],
+    )
+    def test_rejects_empty_identity_fields(self, body: bytes, field: str) -> None:
+        channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
+
+        with pytest.raises(SlackError, match=field):
             channel.parse_request(body, _headers(body))
 
 
 @pytest.mark.anyio
 class TestSlackReply:
-    async def test_posts_to_configured_endpoint_with_original_thread(self) -> None:
+    async def test_posts_to_slack_endpoint_with_original_thread(self) -> None:
         seen: list[httpx.Request] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
@@ -144,8 +198,8 @@ class TestSlackReply:
             channel = SlackChannel(
                 signing_secret='signing-secret',
                 bot_token='xoxb-secret',
+                team_id='T123',
                 client=client,
-                api_url='https://slack.invalid/custom-post',
             )
             await channel.reply(
                 ChannelEvent(
@@ -157,9 +211,10 @@ class TestSlackReply:
                 ),
                 'agent reply',
             )
+            assert not client.is_closed
 
         assert len(seen) == 1
-        assert seen[0].url == 'https://slack.invalid/custom-post'
+        assert seen[0].url == 'https://slack.com/api/chat.postMessage'
         assert seen[0].headers['authorization'] == 'Bearer xoxb-secret'
         assert json.loads(seen[0].content) == {
             'channel': 'C123',
@@ -173,6 +228,7 @@ class TestSlackReply:
                 httpx.Response(503),
                 httpx.Response(200, json={'ok': False, 'error': 'not_in_channel'}),
                 httpx.Response(200, content=b'not-json'),
+                httpx.Response(200, json={'ok': False}),
             ]
         )
 
@@ -180,7 +236,7 @@ class TestSlackReply:
             return next(responses)
 
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-            channel = SlackChannel(signing_secret='secret', bot_token='token', client=client)
+            channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
             event = ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x')
 
             with pytest.raises(httpx.HTTPStatusError):
@@ -189,6 +245,8 @@ class TestSlackReply:
                 await channel.reply(event, 'second')
             with pytest.raises(SlackAPIError, match='invalid response'):
                 await channel.reply(event, 'third')
+            with pytest.raises(SlackAPIError, match='unknown_error'):
+                await channel.reply(event, 'fourth')
 
     async def test_closes_short_lived_default_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
         clients: list[httpx.AsyncClient] = []
@@ -203,7 +261,7 @@ class TestSlackReply:
             return client
 
         monkeypatch.setattr(httpx, 'AsyncClient', client_factory)
-        channel = SlackChannel(signing_secret='secret', bot_token='token')
+        channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team')
 
         await channel.reply(
             ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x'),
@@ -213,8 +271,61 @@ class TestSlackReply:
         assert len(clients) == 1
         assert clients[0].is_closed
 
+    async def test_closes_short_lived_default_client_after_http_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clients: list[httpx.AsyncClient] = []
+        async_client_type = httpx.AsyncClient
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503)
+
+        def client_factory() -> httpx.AsyncClient:
+            client = async_client_type(transport=httpx.MockTransport(handler))
+            clients.append(client)
+            return client
+
+        monkeypatch.setattr(httpx, 'AsyncClient', client_factory)
+        channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team')
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await channel.reply(ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x'), 'reply')
+
+        assert len(clients) == 1
+        assert clients[0].is_closed
+
+    async def test_closes_short_lived_default_client_after_cancellation(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clients: list[httpx.AsyncClient] = []
+        async_client_type = httpx.AsyncClient
+        started = anyio.Event()
+
+        async def handler(_request: httpx.Request) -> httpx.Response:
+            started.set()
+            await anyio.Event().wait()
+            return httpx.Response(200, json={'ok': True})
+
+        def client_factory() -> httpx.AsyncClient:
+            client = async_client_type(transport=httpx.MockTransport(handler))
+            clients.append(client)
+            return client
+
+        monkeypatch.setattr(httpx, 'AsyncClient', client_factory)
+        channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team')
+
+        cancel_scope = anyio.CancelScope()
+
+        async def run_reply() -> None:
+            with cancel_scope:
+                await channel.reply(ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x'), 'reply')
+
+        async with anyio.create_task_group() as group:
+            group.start_soon(run_reply)
+            await started.wait()
+            cancel_scope.cancel()
+
+        assert len(clients) == 1
+        assert clients[0].is_closed
+
 
 def test_secrets_are_absent_from_repr() -> None:
-    representation = repr(SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret'))
+    representation = repr(SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123'))
     assert 'signing-secret' not in representation
     assert 'xoxb-secret' not in representation

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -360,7 +360,7 @@ class TestSlackReply:
         async def handler(_request: httpx.Request) -> httpx.Response:
             started.set()
             await anyio.Event().wait()
-            return httpx.Response(200, json={'ok': True})
+            return httpx.Response(200, json={'ok': True})  # pragma: no cover - cancellation prevents return
 
         def client_factory() -> httpx.AsyncClient:
             client = async_client_type(transport=httpx.MockTransport(handler))

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import hmac
 import json
@@ -369,7 +370,8 @@ class TestSlackReply:
         assert [request.headers['authorization'] for request in seen] == ['Bearer token'] * 2
         assert seen[0].content == seen[1].content
 
-    async def test_does_not_retry_a_second_rate_limit(self) -> None:
+    async def test_does_not_retry_a_second_rate_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        delays: list[float] = []
         responses = iter(
             [
                 httpx.Response(429, headers={'Retry-After': '0'}),
@@ -380,6 +382,11 @@ class TestSlackReply:
         def handler(_request: httpx.Request) -> httpx.Response:
             return next(responses)
 
+        async def record_delay(seconds: float) -> None:
+            delays.append(seconds)
+
+        monkeypatch.setattr(anyio, 'sleep', record_delay)
+
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
             event = ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x')
@@ -389,6 +396,117 @@ class TestSlackReply:
 
         assert rate_limit.value.response.status_code == 429
         assert rate_limit.value.response.headers['Retry-After'] == '3'
+        assert delays == [0, 3]
+
+    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
+    async def test_rate_limit_wait_blocks_other_replies_for_the_installation(
+        self, anyio_backend: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        requests: list[httpx.Request] = []
+        retry_waiting = anyio.Event()
+        release_retry = anyio.Event()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if len(requests) == 1:
+                return httpx.Response(429, headers={'Retry-After': '7'})
+            return httpx.Response(200, json={'ok': True})
+
+        async def wait_for_retry(seconds: float) -> None:
+            assert seconds == 7
+            retry_waiting.set()
+            await release_retry.wait()
+
+        monkeypatch.setattr(anyio, 'sleep', wait_for_retry)
+        first_event = ChannelEvent(
+            event_id='e1', conversation_id='c1', sender_id='u', text='x', reply_to_id='1', delivery_id='C1'
+        )
+        second_event = ChannelEvent(
+            event_id='e2', conversation_id='c2', sender_id='u', text='x', reply_to_id='2', delivery_id='C2'
+        )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
+            with anyio.fail_after(5):
+                async with anyio.create_task_group() as group:
+                    group.start_soon(channel.reply, first_event, 'first')
+                    await retry_waiting.wait()
+                    group.start_soon(channel.reply, second_event, 'second')
+                    await asyncio.sleep(0)
+                    assert len(requests) == 1
+                    release_retry.set()
+
+        assert anyio_backend == 'asyncio'
+        payloads = [json.loads(request.content) for request in requests]
+        assert [(payload['channel'], payload['thread_ts'], payload['text']) for payload in payloads] == [
+            ('C1', '1', 'first'),
+            ('C1', '1', 'first'),
+            ('C2', '2', 'second'),
+        ]
+
+    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
+    async def test_second_rate_limit_keeps_other_replies_waiting(
+        self, anyio_backend: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        requests: list[httpx.Request] = []
+        delays: list[float] = []
+        cooldown_started = [anyio.Event(), anyio.Event()]
+        release_cooldown = [anyio.Event(), anyio.Event()]
+        errors: list[httpx.HTTPStatusError] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if len(requests) == 1:
+                return httpx.Response(429, headers={'Retry-After': '7'})
+            if len(requests) == 2:
+                return httpx.Response(429, headers={'Retry-After': '11'})
+            return httpx.Response(200, json={'ok': True})
+
+        async def wait_for_retry(seconds: float) -> None:
+            index = len(delays)
+            delays.append(seconds)
+            cooldown_started[index].set()
+            await release_cooldown[index].wait()
+
+        async def record_first_failure(channel: SlackChannel, event: ChannelEvent) -> None:
+            try:
+                await channel.reply(event, 'first')
+            except httpx.HTTPStatusError as exc:
+                errors.append(exc)
+
+        monkeypatch.setattr(anyio, 'sleep', wait_for_retry)
+        first_event = ChannelEvent(
+            event_id='e1', conversation_id='c1', sender_id='u', text='x', reply_to_id='1', delivery_id='C1'
+        )
+        second_event = ChannelEvent(
+            event_id='e2', conversation_id='c2', sender_id='u', text='x', reply_to_id='2', delivery_id='C2'
+        )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
+            with anyio.fail_after(5):
+                async with anyio.create_task_group() as group:
+                    group.start_soon(record_first_failure, channel, first_event)
+                    await cooldown_started[0].wait()
+                    group.start_soon(channel.reply, second_event, 'second')
+                    await asyncio.sleep(0)
+                    assert len(requests) == 1
+                    release_cooldown[0].set()
+                    await cooldown_started[1].wait()
+                    await asyncio.sleep(0)
+                    assert len(requests) == 2
+                    release_cooldown[1].set()
+
+        assert anyio_backend == 'asyncio'
+        assert delays == [7, 11]
+        assert len(errors) == 1
+        assert errors[0].response.status_code == 429
+        payloads = [json.loads(request.content) for request in requests]
+        assert [(payload['channel'], payload['thread_ts'], payload['text']) for payload in payloads] == [
+            ('C1', '1', 'first'),
+            ('C1', '1', 'first'),
+            ('C2', '2', 'second'),
+        ]
 
     @pytest.mark.parametrize('headers', [{}, {'Retry-After': 'invalid'}, {'Retry-After': '-1'}])
     async def test_rejects_invalid_rate_limit_delay(self, headers: Mapping[str, str]) -> None:
@@ -412,7 +530,9 @@ class TestSlackReply:
 
         def handler(request: httpx.Request) -> httpx.Response:
             requests.append(request)
-            return httpx.Response(429, headers={'Retry-After': '60'})
+            if len(requests) == 1:
+                return httpx.Response(429, headers={'Retry-After': '60'})
+            return httpx.Response(200, json={'ok': True})
 
         def client_factory() -> httpx.AsyncClient:
             client = async_client_type(transport=httpx.MockTransport(handler))
@@ -432,14 +552,18 @@ class TestSlackReply:
             with cancel_scope:
                 await channel.reply(ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x'), 'reply')
 
-        async with anyio.create_task_group() as group:
-            group.start_soon(run_reply)
-            await waiting.wait()
-            cancel_scope.cancel()
+        with anyio.fail_after(5):
+            async with anyio.create_task_group() as group:
+                group.start_soon(run_reply)
+                await waiting.wait()
+                cancel_scope.cancel()
 
-        assert len(requests) == 1
-        assert len(clients) == 1
-        assert clients[0].is_closed
+        with anyio.fail_after(5):
+            await channel.reply(ChannelEvent(event_id='next', conversation_id='next', sender_id='u', text='x'), 'next')
+
+        assert len(requests) == 2
+        assert len(clients) == 2
+        assert all(client.is_closed for client in clients)
 
     async def test_closes_short_lived_default_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
         clients: list[httpx.AsyncClient] = []
@@ -489,8 +613,13 @@ class TestSlackReply:
         clients: list[httpx.AsyncClient] = []
         async_client_type = httpx.AsyncClient
         started = anyio.Event()
+        requests = 0
 
         async def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal requests
+            requests += 1
+            if requests > 1:
+                return httpx.Response(200, json={'ok': True})
             started.set()
             await anyio.Event().wait()
             return httpx.Response(200, json={'ok': True})  # pragma: no cover - cancellation prevents return
@@ -509,13 +638,18 @@ class TestSlackReply:
             with cancel_scope:
                 await channel.reply(ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x'), 'reply')
 
-        async with anyio.create_task_group() as group:
-            group.start_soon(run_reply)
-            await started.wait()
-            cancel_scope.cancel()
+        with anyio.fail_after(5):
+            async with anyio.create_task_group() as group:
+                group.start_soon(run_reply)
+                await started.wait()
+                cancel_scope.cancel()
 
-        assert len(clients) == 1
-        assert clients[0].is_closed
+        with anyio.fail_after(5):
+            await channel.reply(ChannelEvent(event_id='next', conversation_id='next', sender_id='u', text='x'), 'next')
+
+        assert requests == 2
+        assert len(clients) == 2
+        assert all(client.is_closed for client in clients)
 
 
 def test_secrets_are_absent_from_repr() -> None:

--- a/tests/channels/test_slack.py
+++ b/tests/channels/test_slack.py
@@ -9,8 +9,9 @@ from collections.abc import Mapping
 import anyio
 import httpx
 import pytest
+from pydantic_ai import Agent
 
-from pydantic_ai_harness.channels import ChannelEvent
+from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
 from pydantic_ai_harness.channels.slack import (
     SlackAPIError,
     SlackChannel,
@@ -58,15 +59,15 @@ class TestSlackRequestParsing:
             else:
                 SlackChannel(signing_secret='secret', bot_token='token', team_id='')
 
-    def test_normalizes_root_message_and_thread_reply(self) -> None:
+    def test_normalizes_root_mention_and_thread_reply(self) -> None:
         channel = SlackChannel(signing_secret='signing-secret', bot_token='xoxb-secret', team_id='T123')
         root_body = _body()
         thread_body = _body(
             {
-                'type': 'message',
+                'type': 'app_mention',
                 'channel': 'C123',
                 'user': 'U456',
-                'text': 'follow up',
+                'text': '<@BOT> follow up',
                 'ts': '1700000001.000001',
                 'thread_ts': '1700000000.000001',
             },
@@ -74,10 +75,10 @@ class TestSlackRequestParsing:
         )
         other_root_body = _body(
             {
-                'type': 'message',
+                'type': 'app_mention',
                 'channel': 'C123',
                 'user': 'U789',
-                'text': 'separate root',
+                'text': '<@BOT> separate root',
                 'ts': '1700000099.000001',
             },
             event_id='Ev789',
@@ -98,7 +99,7 @@ class TestSlackRequestParsing:
             event_id='Ev456',
             conversation_id='slack:T123:C123:1700000000.000001',
             sender_id='U456',
-            text='follow up',
+            text='<@BOT> follow up',
             reply_to_id='1700000000.000001',
             delivery_id='C123',
         )
@@ -155,8 +156,9 @@ class TestSlackRequestParsing:
         'event',
         [
             {'type': 'reaction_added'},
-            {'type': 'message', 'bot_id': 'B123'},
-            {'type': 'message', 'subtype': 'message_changed'},
+            {'type': 'message', 'channel': 'C123', 'user': 'U123', 'text': 'hello', 'ts': '1700000000.1'},
+            {'type': 'app_mention', 'bot_id': 'B123'},
+            {'type': 'app_mention', 'subtype': 'message_changed'},
         ],
     )
     def test_ignores_unsupported_and_bot_events(self, event: Mapping[str, object]) -> None:
@@ -193,7 +195,7 @@ class TestSlackRequestParsing:
     def test_rejects_malformed_explicit_thread_timestamp(self, thread_timestamp: object) -> None:
         body = _body(
             {
-                'type': 'message',
+                'type': 'app_mention',
                 'channel': 'C123',
                 'user': 'U123',
                 'text': 'hello',
@@ -212,14 +214,14 @@ class TestSlackRequestParsing:
             (_body(team_id=''), 'team_id'),
             (_body(event_id=''), 'event_id'),
             (
-                _body({'type': 'message', 'channel': '', 'user': 'U123', 'text': 'hello', 'ts': '1700000000.1'}),
+                _body({'type': 'app_mention', 'channel': '', 'user': 'U123', 'text': 'hello', 'ts': '1700000000.1'}),
                 'channel',
             ),
             (
-                _body({'type': 'message', 'channel': 'C123', 'user': '', 'text': 'hello', 'ts': '1700000000.1'}),
+                _body({'type': 'app_mention', 'channel': 'C123', 'user': '', 'text': 'hello', 'ts': '1700000000.1'}),
                 'user',
             ),
-            (_body({'type': 'message', 'channel': 'C123', 'user': 'U123', 'text': 'hello', 'ts': ''}), 'ts'),
+            (_body({'type': 'app_mention', 'channel': 'C123', 'user': 'U123', 'text': 'hello', 'ts': ''}), 'ts'),
         ],
     )
     def test_rejects_empty_identity_fields(self, body: bytes, field: str) -> None:
@@ -299,14 +301,145 @@ class TestSlackReply:
             channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
             event = ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x')
 
-            with pytest.raises(httpx.HTTPStatusError):
+            with pytest.raises(httpx.HTTPStatusError) as unavailable:
                 await channel.reply(event, 'first')
+            assert unavailable.value.response.status_code == 503
             with pytest.raises(SlackAPIError, match='not_in_channel'):
                 await channel.reply(event, 'second')
             with pytest.raises(SlackAPIError, match='invalid response'):
                 await channel.reply(event, 'third')
             with pytest.raises(SlackAPIError, match='unknown_error'):
                 await channel.reply(event, 'fourth')
+
+    async def test_surfaces_truncated_and_malformed_warning_responses(self) -> None:
+        responses = iter(
+            [
+                httpx.Response(200, json={'ok': True, 'response_metadata': {}}),
+                httpx.Response(200, json={'ok': True, 'response_metadata': {'warnings': ['missing_charset']}}),
+                httpx.Response(200, json={'ok': True, 'response_metadata': {'warnings': ['message_truncated']}}),
+                httpx.Response(200, json={'ok': True, 'response_metadata': {'warnings': 'message_truncated'}}),
+                httpx.Response(200, json={'ok': True, 'response_metadata': 'invalid'}),
+            ]
+        )
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return next(responses)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
+            event = ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x')
+
+            await channel.reply(event, 'accepted empty metadata')
+            await channel.reply(event, 'accepted warning')
+            with pytest.raises(SlackAPIError, match='truncated'):
+                await channel.reply(event, 'truncated warning')
+            with pytest.raises(SlackAPIError, match='invalid response'):
+                await channel.reply(event, 'malformed warning')
+            with pytest.raises(SlackAPIError, match='invalid response'):
+                await channel.reply(event, 'malformed metadata')
+
+    @pytest.mark.parametrize('anyio_backend', ['asyncio'])
+    async def test_retries_one_rate_limited_reply_without_rerunning_agent(
+        self, anyio_backend: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[httpx.Request] = []
+        delays: list[float] = []
+        responses = iter([httpx.Response(429, headers={'Retry-After': '7'}), httpx.Response(200, json={'ok': True})])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return next(responses)
+
+        async def record_delay(seconds: float) -> None:
+            delays.append(seconds)
+
+        monkeypatch.setattr(anyio, 'sleep', record_delay)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
+            event = ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x')
+
+            result = await ChannelHost(Agent('test'), channel).handle(event)
+
+        assert anyio_backend == 'asyncio'
+        assert result.usage.requests == 1
+        assert delays == [7]
+        assert len(seen) == 2
+        assert [str(request.url) for request in seen] == ['https://slack.com/api/chat.postMessage'] * 2
+        assert [request.headers['authorization'] for request in seen] == ['Bearer token'] * 2
+        assert seen[0].content == seen[1].content
+
+    async def test_does_not_retry_a_second_rate_limit(self) -> None:
+        responses = iter(
+            [
+                httpx.Response(429, headers={'Retry-After': '0'}),
+                httpx.Response(429, headers={'Retry-After': '3'}),
+            ]
+        )
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return next(responses)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
+            event = ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x')
+
+            with pytest.raises(httpx.HTTPStatusError) as rate_limit:
+                await channel.reply(event, 'reply')
+
+        assert rate_limit.value.response.status_code == 429
+        assert rate_limit.value.response.headers['Retry-After'] == '3'
+
+    @pytest.mark.parametrize('headers', [{}, {'Retry-After': 'invalid'}, {'Retry-After': '-1'}])
+    async def test_rejects_invalid_rate_limit_delay(self, headers: Mapping[str, str]) -> None:
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers=headers)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team', client=client)
+            event = ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x')
+
+            with pytest.raises(SlackAPIError, match='Retry-After'):
+                await channel.reply(event, 'reply')
+
+    async def test_cancellation_during_rate_limit_wait_closes_default_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        clients: list[httpx.AsyncClient] = []
+        requests: list[httpx.Request] = []
+        async_client_type = httpx.AsyncClient
+        waiting = anyio.Event()
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(429, headers={'Retry-After': '60'})
+
+        def client_factory() -> httpx.AsyncClient:
+            client = async_client_type(transport=httpx.MockTransport(handler))
+            clients.append(client)
+            return client
+
+        async def wait_for_retry(_seconds: float) -> None:
+            waiting.set()
+            await anyio.Event().wait()
+
+        monkeypatch.setattr(httpx, 'AsyncClient', client_factory)
+        monkeypatch.setattr(anyio, 'sleep', wait_for_retry)
+        channel = SlackChannel(signing_secret='secret', bot_token='token', team_id='team')
+        cancel_scope = anyio.CancelScope()
+
+        async def run_reply() -> None:
+            with cancel_scope:
+                await channel.reply(ChannelEvent(event_id='e', conversation_id='c', sender_id='u', text='x'), 'reply')
+
+        async with anyio.create_task_group() as group:
+            group.start_soon(run_reply)
+            await waiting.wait()
+            cancel_scope.cancel()
+
+        assert len(requests) == 1
+        assert len(clients) == 1
+        assert clients[0].is_closed
 
     async def test_closes_short_lived_default_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
         clients: list[httpx.AsyncClient] = []

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -37,7 +37,7 @@ def _is_deprecation_shim(package: Path) -> bool:
 # capability tables per review. `media` exports the content-addressed stores Step Persistence
 # uses; its docs placement is being reworked in
 # https://github.com/pydantic/pydantic-ai-harness/issues/625.
-_NOT_A_CAPABILITY = frozenset({'media'})
+_NOT_A_CAPABILITY = frozenset({'channels', 'media'})
 
 
 def _capability_packages() -> list[Path]:
@@ -139,6 +139,7 @@ _CAPABILITY_PAGE_META = {
     'youdotcom.md': ('youdotcom', 'You.com'),
     'macroscope.md': ('macroscope', 'Macroscope'),
     'browser-use.md': ('browser_use', 'Browser Use'),
+    'channels.md': ('channels', 'Channels'),
     'compaction.md': ('compaction', 'Compaction'),
     'tool-output-limits.md': ('tool_output_limits', 'Tool Output Limits'),
     'warn-on-cache-busts.md': ('warn_on_cache_busts', 'Warn On Cache Busts'),


### PR DESCRIPTION
## What this adds

This lets a Pydantic AI text agent receive verified Slack app mentions, keep separate history for each workspace, channel, and thread, and reply in the original thread. The same small host contract can be used by other chat providers.

## How to run it

Install with `uv add pydantic-ai-harness "pydantic-ai-slim[openai]" fastapi uvicorn`. Create a Slack app with `app_mentions:read` and `chat:write`, subscribe to `app_mention`, and provide `SLACK_SIGNING_SECRET`, `SLACK_BOT_TOKEN`, `SLACK_TEAM_ID`, and the model credential. Slack handles browser OAuth when the app is installed. The package does not open a browser or host an OAuth callback.

Create `SlackChannel(signing_secret=..., bot_token=..., team_id=...)`, pass it with an `Agent` to `ChannelHost`, call `parse_request(raw_body, headers)` at the HTTP boundary, enqueue the returned `ChannelEvent`, then call `await host.handle(event)`. See the [complete Channels guide](https://github.com/pydantic/pydantic-ai-harness/blob/codex/channels-slack-787/docs/channels.md).

## Access and changes

- The adapter reads only the signed event body supplied by the caller. It does not fetch channels, users, files, or Slack history, and it has no pagination.
- It accepts only user-authored `app_mention` callbacks. Ordinary messages, bot-authored events, subtypes, and unsupported events are ignored.
- Its only Slack write is `chat.postMessage` to the authenticated event channel and original thread. It exposes no Slack tools to the model and performs no arbitrary create, edit, delete, archive, or file operation.
- Replies are automatic after a verified mention is admitted by the caller. There is no approval prompt for that reply. The caller must enforce any sender or channel allowlist before enqueueing.

## Maintainer attention

- **Durable ingress and duplicates.** Slack retries deliveries. The example uses bounded, sharded queues but they are process-local, so a crash can lose an acknowledged event. Production callers must durably enqueue and atomically claim `event_id` before `handle()` to prevent lost or duplicate turns across restarts and workers. The five-minute signature window rejects stale requests but does not deduplicate current retries. Maintainer decision required: no, unless this package should own application storage.
- **Sender and channel admission.** A valid signature authenticates Slack and the configured workspace, not an individual sender. Without a caller check, any user who can mention the app can spend model tokens and trigger its tools. Callers must check `sender_id` and `delivery_id` before enqueueing when access is restricted. Maintainer decision required: no, unless policy should move into this provider adapter.
- **Request size.** `parse_request()` verifies supplied bytes but does not limit what the HTTPS server reads. An oversized request can consume application memory before verification. The guide requires a server or proxy body-size limit. Maintainer decision required: no, unless this package should own HTTP admission.
- **History and concurrency.** The default history store and per-conversation locks are process-local. Restarts lose history, and multiple workers can overlap unless the application provides a shared store and coordination. The package exposes a store protocol and documents that boundary. Maintainer decision required: no.
- **Reply-before-save.** The host posts the Slack reply before saving new history. Cancellation or a save failure can leave a delivered reply with unsaved history, so retrying the whole handler can duplicate output and model/tool work. The exception propagates and the guide calls out the ambiguity. Maintainer decision required: yes only if save-before-reply is preferred despite the risk of saving a reply that was never delivered.
- **Rate limits and unknown outcomes.** After the first 429, one `SlackChannel` instance pauses its replies, waits for `Retry-After`, and retries the identical generated reply once without rerunning the agent. If the retry is also rate-limited, it waits again before propagating the second 429 so queued replies do not bypass the cooldown. Coordination remains process-local. Timeouts and 5xx responses are not retried because delivery may be ambiguous; callers must not retry the whole agent run blindly. Maintainer decision required: no, unless a different retry or cross-process policy is wanted.
- **Truncation.** Slack may truncate text over 40,000 characters after accepting it. The adapter detects `message_truncated` and raises, but part of the reply may already be visible, so retrying can duplicate output. It does not split messages because multi-message delivery can fail partway. Maintainer decision required: yes only if automatic splitting is preferred.
- **Client timeouts and lifetime.** A supplied `httpx.AsyncClient`, including its timeout policy and lifecycle, is caller-owned and is not closed here. Without one, each reply uses and closes a short-lived client with HTTPX defaults, including after failure or cancellation. Slow calls occupy the handler until that timeout, and per-call clients do not pool connections. Inject a shared client with deployment-specific timeouts when needed. Maintainer decision required: no, unless the package should expose timeout settings or own a pooled client.
- **Provider setup.** This is an HTTP Events API adapter, not Socket Mode. The user supplies a public HTTPS endpoint and installs a Slack app once in a browser; runtime is headless. The package requires no hosted service or paid plan and uses Slack's current signing and `chat.postMessage` APIs. Maintainer decision required: no.
- **API maturity.** Harness is on 0.x releases, so minor releases may adjust this new public API. Maintainer decision required: accept this maturity level or request changes before merge.

## Why this design

- `ChannelHost` calls public `AbstractAgent.run()` so Harness does not create a second agent runtime.
- History identity is separate from delivery identity. Slack history is isolated by verified workspace, channel, and thread root, while replies use the raw authenticated channel ID.
- Duplicate claims, durable queues, OAuth, and sender policy stay outside the package because they depend on application storage and deployment topology.
- Only Slack's explicit 429 is retried. Ambiguous send failures propagate without an automatic replay.
- The adapter uses `httpx` already present in the project and avoids a Slack SDK dependency for one verified webhook and one API method.

## Evidence

- Focused Channels tests: `uv run --no-sync coverage run --branch --source=pydantic_ai_harness/channels -m pytest -p no:cacheprovider tests/channels` produced 67 passing tests.
- Focused Channels coverage: 190 production statements and 52 branches at 100%.
- Explicit changed-path Pyright: 0 errors, 0 warnings, 0 information messages.
- Ruff format and lint passed across the repository. Paired-doc parity passed 289 tests; four Channels snippet tests passed; the complete documented example import-ran with the documented dependencies and environment variables.
- Independent Sol reviews covered specification and scope, design and maintainability, public API, tests and branch coverage, authentication and security, failure and cancellation behavior, ecosystem precedents, docs parity, and this PR body. All valid findings were fixed and the code, docs, security, and test reviews report no remaining findings.
- Current unresolved review threads: 0 after replying to and validating all five findings.
- Required CI for final SHA `0857a15894626a294f7b73b603a2c91b09ec95b2`: [green](https://github.com/pydantic/pydantic-ai-harness/actions/runs/33945015118). Lint, every Python matrix job, the base-install import, aggregate coverage, and the final `check` job passed. Five not-applicable jobs were skipped, including provider integration jobs.

No repository-wide Pyright or pytest was run locally.

## Dependencies and related PRs

- New dependencies: none. `pyproject.toml` and `uv.lock` are unchanged.
- Program issue: #787.
- Shared Pydantic AI docs navigation partner: [pydantic/pydantic-ai#7939](https://github.com/pydantic/pydantic-ai/pull/7939).
- Telegram [#802](https://github.com/pydantic/pydantic-ai-harness/pull/802) and Discord [#804](https://github.com/pydantic/pydantic-ai-harness/pull/804) target upstream branch `codex/channels-slack-787` and depend on this PR.
- This PR targets `main`. The fork head and upstream stacking branch both point to final SHA `0857a15894626a294f7b73b603a2c91b09ec95b2`; no `main` ref was modified.
