### PR TITLE
Add `TelegramChannel` to Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Core also ships loop-customization capabilities for production servers: [Select 
 And the agent plugs into any interface: [ACP](pydantic_ai_harness/experimental/acp/) *(experimental, Harness)* serves it to editors like Zed over the [Agent Client Protocol](https://agentclientprotocol.com), and core ships the [web chat UI](https://ai.pydantic.dev/web/), [CLI](https://ai.pydantic.dev/cli/), [frontend adapters](https://ai.pydantic.dev/ui/) (AG-UI, Vercel AI), and [realtime voice](https://ai.pydantic.dev/realtime/).
 
 Harness also ships [Channels](pydantic_ai_harness/channels/) for running text-output agents from
-verified Slack messages while caller-owned HTTP and queue infrastructure handles delivery.
+verified Slack and Telegram messages while caller-owned HTTP and queue infrastructure handles delivery.
 
 Community packages extend the same capability system further; see [third-party capabilities](https://ai.pydantic.dev/capabilities/third-party/).
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -297,10 +297,10 @@ uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
   claims, and returns 204 after enqueue. It loses state on restart, and a later handler failure is not retried. Use a
   durable queue with an atomic `event_id` claim and explicit retry policy when duplicate or lost turns are
   unacceptable.
-- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Larger or
-  repeated delays raise `TelegramRateLimitError` with Telegram's `retry_after` value. Transport and other provider
-  failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many earlier chunks
-  Telegram confirmed.
+- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Before any
+  confirmed chunk, larger or repeated delays raise `TelegramRateLimitError` with Telegram's `retry_after` value.
+  After partial delivery, `TelegramPartialDeliveryError` preserves both `sent_chunks` and any `retry_after` value.
+  Transport and other provider failures are not retried because delivery may be ambiguous.
 - The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
   secret as application secrets. Telegram puts the bot token in the Bot API request URL; custom clients, proxies,
   and API URLs must not log or forward it to an untrusted service.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -141,7 +141,6 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 - Slack may truncate replies over 40,000 characters. The adapter raises `SlackAPIError` when Slack reports that warning instead of treating a partial reply as success.
 - On the first HTTP 429, this adapter instance pauses its replies in the current process, waits for `Retry-After`, and retries the same generated reply once. A second 429 waits again before it propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
-- While Harness is on 0.x releases, minor releases may change this API. See the [version policy](index.md#version-policy).
 
 ## Telegram webhook
 
@@ -157,12 +156,14 @@ uv add pydantic-ai-harness "pydantic-ai-slim[openai]" starlette uvicorn
 
 1. Create a bot in Telegram with BotFather and copy its token.
 2. Call `getMe` with that token and copy the numeric `result.id` as `TELEGRAM_BOT_ID`.
-3. Choose the numeric Telegram user or sender-chat ID allowed to invoke the agent.
+3. Before setting the webhook, send the bot a direct message and call `getUpdates`. Copy `message.from.id` as the
+   allowed user ID. To allow a message sent on behalf of a chat, copy `message.sender_chat.id` from that update.
 4. Set a public HTTPS webhook URL and register it with `setWebhook`.
 
 ```bash
 export TELEGRAM_BOT_TOKEN='your-botfather-token'
 curl --fail "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe"
+curl --fail "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates"
 
 export TELEGRAM_BOT_ID='your-numeric-result-id'
 export TELEGRAM_ALLOWED_SENDER_ID='your-numeric-user-or-sender-chat-id'
@@ -180,6 +181,9 @@ curl --fail --request POST \
 Telegram bot authentication does not use OAuth. No browser interaction is required by this integration, though
 you use the Telegram app to talk to BotFather and your bot.
 
+For ordinary group messages, disable Privacy Mode with BotFather or make the bot a group administrator. Re-add the
+bot after changing Privacy Mode so Telegram applies the new setting.
+
 ### Run
 
 Save this as `telegram_bot.py`:
@@ -187,6 +191,7 @@ Save this as `telegram_bot.py`:
 ```python {names="defined"}
 import logging
 import os
+from collections import deque
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -208,15 +213,21 @@ telegram = TelegramChannel(
 )
 host = ChannelHost(Agent('openai:gpt-5.6-sol', output_type=str), telegram)
 send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
+MAX_CLAIMED_EVENTS = 10_000
+MAX_WEBHOOK_BODY_BYTES = 1_000_000
 
 
 async def consume_events() -> None:
     claimed: set[str] = set()
+    claim_order: deque[str] = deque()
     async with receive_events:
         async for event in receive_events:
             if event.event_id in claimed:
                 continue
+            if len(claim_order) == MAX_CLAIMED_EVENTS:
+                claimed.remove(claim_order.popleft())
             claimed.add(event.event_id)
+            claim_order.append(event.event_id)
             try:
                 await host.handle(event)
             except Exception:
@@ -232,8 +243,17 @@ async def lifespan(_app: Starlette) -> AsyncIterator[None]:
 
 
 async def telegram_webhook(request: Request) -> Response:
+    body = bytearray()
+    with anyio.move_on_after(5) as body_scope:
+        async for chunk in request.stream():
+            if len(body) + len(chunk) > MAX_WEBHOOK_BODY_BYTES:
+                return Response(status_code=413)
+            body.extend(chunk)
+    if body_scope.cancel_called:
+        return Response(status_code=408)
+
     try:
-        event = telegram.parse_request(await request.body(), request.headers)
+        event = telegram.parse_request(bytes(body), request.headers)
     except TelegramWebhookError:
         return Response(status_code=401)
     except TelegramError:
@@ -271,12 +291,18 @@ uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
   unsupported update types, and ephemeral messages.
 - History is isolated by bot, chat, and forum or direct-message topic. Replies go to the original chat, topic, and
   source message.
-- Telegram may retry webhook delivery. The example uses a bounded in-process queue and claim set, which lose work
-  and claims on restart. Use a durable queue with an atomic `event_id` claim when duplicate turns are unacceptable.
+- The example rejects webhook bodies over 1,000,000 bytes, stops reading after five seconds, and returns 503 when
+  its bounded queue cannot accept an event within two seconds.
+- Telegram may retry webhook delivery. The example uses a bounded in-process queue, retains the latest 10,000
+  claims, and returns 204 after enqueue. It loses state on restart, and a later handler failure is not retried. Use a
+  durable queue with an atomic `event_id` claim and explicit retry policy when duplicate or lost turns are
+  unacceptable.
 - Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Transport and
   other provider failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many
   earlier chunks Telegram confirmed.
 - The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
-  secret as application secrets.
+  secret as application secrets. Telegram puts the bot token in the Bot API request URL; custom clients, proxies,
+  and API URLs must not log or forward it to an untrusted service.
+- While Harness is on 0.x releases, minor releases may change this API. See the [version policy](index.md#version-policy).
 
 [Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -144,3 +144,139 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](index.md#version-policy).
 
 [Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
+## Telegram webhook
+
+Telegram lets a text-output agent answer allowed users in Telegram chats and topics through Bot API webhooks.
+
+### Install
+
+```bash
+uv add pydantic-ai-harness "pydantic-ai-slim[openai]" starlette uvicorn
+```
+
+### Set up Telegram
+
+1. Create a bot in Telegram with BotFather and copy its token.
+2. Call `getMe` with that token and copy the numeric `result.id` as `TELEGRAM_BOT_ID`.
+3. Choose the numeric Telegram user or sender-chat ID allowed to invoke the agent.
+4. Set a public HTTPS webhook URL and register it with `setWebhook`.
+
+```bash
+export TELEGRAM_BOT_TOKEN='your-botfather-token'
+curl --fail "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe"
+
+export TELEGRAM_BOT_ID='your-numeric-result-id'
+export TELEGRAM_ALLOWED_SENDER_ID='your-numeric-user-or-sender-chat-id'
+export TELEGRAM_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+export TELEGRAM_WEBHOOK_URL='https://your-host/telegram'
+export OPENAI_API_KEY='your-openai-api-key'
+
+curl --fail --request POST \
+  "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+  --data-urlencode "url=${TELEGRAM_WEBHOOK_URL}" \
+  --data-urlencode "secret_token=${TELEGRAM_WEBHOOK_SECRET}" \
+  --data-urlencode 'allowed_updates=["message"]'
+```
+
+Telegram bot authentication does not use OAuth. No browser interaction is required by this integration, though
+you use the Telegram app to talk to BotFather and your bot.
+
+### Run
+
+Save this as `telegram_bot.py`:
+
+```python {names="defined"}
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import anyio
+from pydantic_ai import Agent
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
+
+from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
+from pydantic_ai_harness.channels.telegram import TelegramChannel, TelegramError, TelegramWebhookError
+
+telegram = TelegramChannel(
+    bot_id=int(os.environ['TELEGRAM_BOT_ID']),
+    bot_token=os.environ['TELEGRAM_BOT_TOKEN'],
+    webhook_secret=os.environ['TELEGRAM_WEBHOOK_SECRET'],
+    allowed_senders={int(os.environ['TELEGRAM_ALLOWED_SENDER_ID'])},
+)
+host = ChannelHost(Agent('openai:gpt-5.6-sol', output_type=str), telegram)
+send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
+
+
+async def consume_events() -> None:
+    claimed: set[str] = set()
+    async with receive_events:
+        async for event in receive_events:
+            if event.event_id in claimed:
+                continue
+            claimed.add(event.event_id)
+            try:
+                await host.handle(event)
+            except Exception:
+                logging.exception('Telegram event failed')
+
+
+@asynccontextmanager
+async def lifespan(_app: Starlette) -> AsyncIterator[None]:
+    async with anyio.create_task_group() as tasks:
+        tasks.start_soon(consume_events)
+        yield
+        tasks.cancel_scope.cancel()
+
+
+async def telegram_webhook(request: Request) -> Response:
+    try:
+        event = telegram.parse_request(await request.body(), request.headers)
+    except TelegramWebhookError:
+        return Response(status_code=401)
+    except TelegramError:
+        return Response(status_code=400)
+
+    if event is not None:
+        with anyio.move_on_after(2) as enqueue_scope:
+            await send_events.send(event)
+        if enqueue_scope.cancel_called:
+            return Response(status_code=503)
+    return Response(status_code=204)
+
+
+app = Starlette(routes=[Route('/telegram', telegram_webhook, methods=['POST'])], lifespan=lifespan)
+```
+
+Run it behind the public HTTPS URL registered with `setWebhook`:
+
+```bash
+uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
+```
+
+### Things to ask
+
+- `Summarize this update in three bullets.`
+- `Rewrite this announcement for customers.`
+- `List the decisions and open questions in this topic.`
+- Reply with `Make it shorter` to continue the same conversation.
+
+### Operational notes
+
+- The webhook secret authenticates possession of the configured secret. The required sender allowlist separately
+  controls which Telegram users or sender chats may invoke the agent.
+- The adapter accepts text `message` updates. It ignores bot messages, media-only messages, disallowed senders,
+  unsupported update types, and ephemeral messages.
+- History is isolated by bot, chat, and forum or direct-message topic. Replies go to the original chat, topic, and
+  source message.
+- Telegram may retry webhook delivery. The example uses a bounded in-process queue and claim set, which lose work
+  and claims on restart. Use a durable queue with an atomic `event_id` claim when duplicate turns are unacceptable.
+- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Transport and
+  other provider failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many
+  earlier chunks Telegram confirmed.
+- The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
+  secret as application secrets.
+

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -297,9 +297,10 @@ uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
   claims, and returns 204 after enqueue. It loses state on restart, and a later handler failure is not retried. Use a
   durable queue with an atomic `event_id` claim and explicit retry policy when duplicate or lost turns are
   unacceptable.
-- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Transport and
-  other provider failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many
-  earlier chunks Telegram confirmed.
+- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Larger or
+  repeated delays raise `TelegramRateLimitError` with Telegram's `retry_after` value. Transport and other provider
+  failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many earlier chunks
+  Telegram confirmed.
 - The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
   secret as application secrets. Telegram puts the bot token in the Bot API request URL; custom clients, proxies,
   and API URLs must not log or forward it to an untrusted service.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,11 +1,11 @@
 ---
 title: Channels
-description: Run Pydantic AI agents from verified Slack messages.
+description: Run Pydantic AI agents from verified Slack and Telegram messages.
 ---
 
 # Channels
 
-Channels let a Pydantic AI agent answer Slack mentions and continue each Slack thread with its own message history.
+Channels let a Pydantic AI agent answer verified Slack and Telegram messages while keeping separate history for each conversation.
 
 ## Install
 
@@ -143,7 +143,6 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](index.md#version-policy).
 
-[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
 ## Telegram webhook
 
 Telegram lets a text-output agent answer allowed users in Telegram chats and topics through Bot API webhooks.
@@ -280,3 +279,4 @@ uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
 - The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
   secret as application secrets.
 
+[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -249,8 +249,8 @@ Core also ships loop-customization capabilities for production servers: [Select 
 
 And the agent plugs into any interface: [ACP](acp.md) *(experimental, Harness)* serves it to editors like Zed over the [Agent Client Protocol](https://agentclientprotocol.com), and core ships the [web chat UI](/ai/web/), [CLI](/ai/cli/), [frontend adapters](/ai/ui/overview/) (AG-UI, Vercel AI), and [realtime voice](/ai/realtime/overview/).
 
-Harness also ships [Channels](channels.md) for running text-output agents from verified Slack
-messages while caller-owned HTTP and queue infrastructure handles delivery.
+Harness also ships [Channels](channels.md) for running text-output agents from verified Slack and
+Telegram messages while caller-owned HTTP and queue infrastructure handles delivery.
 
 Community packages extend the same capability system further; see [third-party capabilities](/ai/capabilities/third-party/).
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -292,9 +292,10 @@ uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
   claims, and returns 204 after enqueue. It loses state on restart, and a later handler failure is not retried. Use a
   durable queue with an atomic `event_id` claim and explicit retry policy when duplicate or lost turns are
   unacceptable.
-- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Transport and
-  other provider failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many
-  earlier chunks Telegram confirmed.
+- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Larger or
+  repeated delays raise `TelegramRateLimitError` with Telegram's `retry_after` value. Transport and other provider
+  failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many earlier chunks
+  Telegram confirmed.
 - The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
   secret as application secrets. Telegram puts the bot token in the Bot API request URL; custom clients, proxies,
   and API URLs must not log or forward it to an untrusted service.

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -1,6 +1,6 @@
 # Channels
 
-Channels let a Pydantic AI agent answer Slack mentions and continue each Slack thread with its own message history.
+Channels let a Pydantic AI agent answer verified Slack and Telegram messages while keeping separate history for each conversation.
 
 ## Install
 
@@ -138,7 +138,6 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 
-[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
 ## Telegram webhook
 
 Telegram lets a text-output agent answer allowed users in Telegram chats and topics through Bot API webhooks.
@@ -275,3 +274,4 @@ uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
 - The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
   secret as application secrets.
 
+[Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -136,7 +136,6 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 - Slack may truncate replies over 40,000 characters. The adapter raises `SlackAPIError` when Slack reports that warning instead of treating a partial reply as success.
 - On the first HTTP 429, this adapter instance pauses its replies in the current process, waits for `Retry-After`, and retries the same generated reply once. A second 429 waits again before it propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
-- While Harness is on 0.x releases, minor releases may change this API. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 
 ## Telegram webhook
 
@@ -152,12 +151,14 @@ uv add pydantic-ai-harness "pydantic-ai-slim[openai]" starlette uvicorn
 
 1. Create a bot in Telegram with BotFather and copy its token.
 2. Call `getMe` with that token and copy the numeric `result.id` as `TELEGRAM_BOT_ID`.
-3. Choose the numeric Telegram user or sender-chat ID allowed to invoke the agent.
+3. Before setting the webhook, send the bot a direct message and call `getUpdates`. Copy `message.from.id` as the
+   allowed user ID. To allow a message sent on behalf of a chat, copy `message.sender_chat.id` from that update.
 4. Set a public HTTPS webhook URL and register it with `setWebhook`.
 
 ```bash
 export TELEGRAM_BOT_TOKEN='your-botfather-token'
 curl --fail "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe"
+curl --fail "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getUpdates"
 
 export TELEGRAM_BOT_ID='your-numeric-result-id'
 export TELEGRAM_ALLOWED_SENDER_ID='your-numeric-user-or-sender-chat-id'
@@ -175,6 +176,9 @@ curl --fail --request POST \
 Telegram bot authentication does not use OAuth. No browser interaction is required by this integration, though
 you use the Telegram app to talk to BotFather and your bot.
 
+For ordinary group messages, disable Privacy Mode with BotFather or make the bot a group administrator. Re-add the
+bot after changing Privacy Mode so Telegram applies the new setting.
+
 ### Run
 
 Save this as `telegram_bot.py`:
@@ -182,6 +186,7 @@ Save this as `telegram_bot.py`:
 ```python {names="defined"}
 import logging
 import os
+from collections import deque
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -203,15 +208,21 @@ telegram = TelegramChannel(
 )
 host = ChannelHost(Agent('openai:gpt-5.6-sol', output_type=str), telegram)
 send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
+MAX_CLAIMED_EVENTS = 10_000
+MAX_WEBHOOK_BODY_BYTES = 1_000_000
 
 
 async def consume_events() -> None:
     claimed: set[str] = set()
+    claim_order: deque[str] = deque()
     async with receive_events:
         async for event in receive_events:
             if event.event_id in claimed:
                 continue
+            if len(claim_order) == MAX_CLAIMED_EVENTS:
+                claimed.remove(claim_order.popleft())
             claimed.add(event.event_id)
+            claim_order.append(event.event_id)
             try:
                 await host.handle(event)
             except Exception:
@@ -227,8 +238,17 @@ async def lifespan(_app: Starlette) -> AsyncIterator[None]:
 
 
 async def telegram_webhook(request: Request) -> Response:
+    body = bytearray()
+    with anyio.move_on_after(5) as body_scope:
+        async for chunk in request.stream():
+            if len(body) + len(chunk) > MAX_WEBHOOK_BODY_BYTES:
+                return Response(status_code=413)
+            body.extend(chunk)
+    if body_scope.cancel_called:
+        return Response(status_code=408)
+
     try:
-        event = telegram.parse_request(await request.body(), request.headers)
+        event = telegram.parse_request(bytes(body), request.headers)
     except TelegramWebhookError:
         return Response(status_code=401)
     except TelegramError:
@@ -266,12 +286,18 @@ uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
   unsupported update types, and ephemeral messages.
 - History is isolated by bot, chat, and forum or direct-message topic. Replies go to the original chat, topic, and
   source message.
-- Telegram may retry webhook delivery. The example uses a bounded in-process queue and claim set, which lose work
-  and claims on restart. Use a durable queue with an atomic `event_id` claim when duplicate turns are unacceptable.
+- The example rejects webhook bodies over 1,000,000 bytes, stops reading after five seconds, and returns 503 when
+  its bounded queue cannot accept an event within two seconds.
+- Telegram may retry webhook delivery. The example uses a bounded in-process queue, retains the latest 10,000
+  claims, and returns 204 after enqueue. It loses state on restart, and a later handler failure is not retried. Use a
+  durable queue with an atomic `event_id` claim and explicit retry policy when duplicate or lost turns are
+  unacceptable.
 - Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Transport and
   other provider failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many
   earlier chunks Telegram confirmed.
 - The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
-  secret as application secrets.
+  secret as application secrets. Telegram puts the bot token in the Bot API request URL; custom clients, proxies,
+  and API URLs must not log or forward it to an untrusted service.
+- While Harness is on 0.x releases, minor releases may change this API. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 
 [Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -139,3 +139,139 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
 
 [Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)
+## Telegram webhook
+
+Telegram lets a text-output agent answer allowed users in Telegram chats and topics through Bot API webhooks.
+
+### Install
+
+```bash
+uv add pydantic-ai-harness "pydantic-ai-slim[openai]" starlette uvicorn
+```
+
+### Set up Telegram
+
+1. Create a bot in Telegram with BotFather and copy its token.
+2. Call `getMe` with that token and copy the numeric `result.id` as `TELEGRAM_BOT_ID`.
+3. Choose the numeric Telegram user or sender-chat ID allowed to invoke the agent.
+4. Set a public HTTPS webhook URL and register it with `setWebhook`.
+
+```bash
+export TELEGRAM_BOT_TOKEN='your-botfather-token'
+curl --fail "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/getMe"
+
+export TELEGRAM_BOT_ID='your-numeric-result-id'
+export TELEGRAM_ALLOWED_SENDER_ID='your-numeric-user-or-sender-chat-id'
+export TELEGRAM_WEBHOOK_SECRET="$(openssl rand -hex 32)"
+export TELEGRAM_WEBHOOK_URL='https://your-host/telegram'
+export OPENAI_API_KEY='your-openai-api-key'
+
+curl --fail --request POST \
+  "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/setWebhook" \
+  --data-urlencode "url=${TELEGRAM_WEBHOOK_URL}" \
+  --data-urlencode "secret_token=${TELEGRAM_WEBHOOK_SECRET}" \
+  --data-urlencode 'allowed_updates=["message"]'
+```
+
+Telegram bot authentication does not use OAuth. No browser interaction is required by this integration, though
+you use the Telegram app to talk to BotFather and your bot.
+
+### Run
+
+Save this as `telegram_bot.py`:
+
+```python {names="defined"}
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import anyio
+from pydantic_ai import Agent
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Route
+
+from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
+from pydantic_ai_harness.channels.telegram import TelegramChannel, TelegramError, TelegramWebhookError
+
+telegram = TelegramChannel(
+    bot_id=int(os.environ['TELEGRAM_BOT_ID']),
+    bot_token=os.environ['TELEGRAM_BOT_TOKEN'],
+    webhook_secret=os.environ['TELEGRAM_WEBHOOK_SECRET'],
+    allowed_senders={int(os.environ['TELEGRAM_ALLOWED_SENDER_ID'])},
+)
+host = ChannelHost(Agent('openai:gpt-5.6-sol', output_type=str), telegram)
+send_events, receive_events = anyio.create_memory_object_stream[ChannelEvent](100)
+
+
+async def consume_events() -> None:
+    claimed: set[str] = set()
+    async with receive_events:
+        async for event in receive_events:
+            if event.event_id in claimed:
+                continue
+            claimed.add(event.event_id)
+            try:
+                await host.handle(event)
+            except Exception:
+                logging.exception('Telegram event failed')
+
+
+@asynccontextmanager
+async def lifespan(_app: Starlette) -> AsyncIterator[None]:
+    async with anyio.create_task_group() as tasks:
+        tasks.start_soon(consume_events)
+        yield
+        tasks.cancel_scope.cancel()
+
+
+async def telegram_webhook(request: Request) -> Response:
+    try:
+        event = telegram.parse_request(await request.body(), request.headers)
+    except TelegramWebhookError:
+        return Response(status_code=401)
+    except TelegramError:
+        return Response(status_code=400)
+
+    if event is not None:
+        with anyio.move_on_after(2) as enqueue_scope:
+            await send_events.send(event)
+        if enqueue_scope.cancel_called:
+            return Response(status_code=503)
+    return Response(status_code=204)
+
+
+app = Starlette(routes=[Route('/telegram', telegram_webhook, methods=['POST'])], lifespan=lifespan)
+```
+
+Run it behind the public HTTPS URL registered with `setWebhook`:
+
+```bash
+uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
+```
+
+### Things to ask
+
+- `Summarize this update in three bullets.`
+- `Rewrite this announcement for customers.`
+- `List the decisions and open questions in this topic.`
+- Reply with `Make it shorter` to continue the same conversation.
+
+### Operational notes
+
+- The webhook secret authenticates possession of the configured secret. The required sender allowlist separately
+  controls which Telegram users or sender chats may invoke the agent.
+- The adapter accepts text `message` updates. It ignores bot messages, media-only messages, disallowed senders,
+  unsupported update types, and ephemeral messages.
+- History is isolated by bot, chat, and forum or direct-message topic. Replies go to the original chat, topic, and
+  source message.
+- Telegram may retry webhook delivery. The example uses a bounded in-process queue and claim set, which lose work
+  and claims on restart. Use a durable queue with an atomic `event_id` claim when duplicate turns are unacceptable.
+- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Transport and
+  other provider failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many
+  earlier chunks Telegram confirmed.
+- The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
+  secret as application secrets.
+

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -292,10 +292,10 @@ uv run uvicorn telegram_bot:app --host 0.0.0.0 --port 8000
   claims, and returns 204 after enqueue. It loses state on restart, and a later handler failure is not retried. Use a
   durable queue with an atomic `event_id` claim and explicit retry policy when duplicate or lost turns are
   unacceptable.
-- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Larger or
-  repeated delays raise `TelegramRateLimitError` with Telegram's `retry_after` value. Transport and other provider
-  failures are not retried because delivery may be ambiguous. A later-chunk failure reports how many earlier chunks
-  Telegram confirmed.
+- Replies are split at 4096 characters. A valid HTTP 429 delay of at most 60 seconds is retried once. Before any
+  confirmed chunk, larger or repeated delays raise `TelegramRateLimitError` with Telegram's `retry_after` value.
+  After partial delivery, `TelegramPartialDeliveryError` preserves both `sent_chunks` and any `retry_after` value.
+  Transport and other provider failures are not retried because delivery may be ambiguous.
 - The caller owns Starlette, the queue, and any injected `httpx.AsyncClient`. Store the BotFather token and webhook
   secret as application secrets. Telegram puts the bot token in the Bot API request URL; custom clients, proxies,
   and API URLs must not log or forward it to an untrusted service.

--- a/pydantic_ai_harness/channels/__init__.py
+++ b/pydantic_ai_harness/channels/__init__.py
@@ -1,7 +1,7 @@
 """Run Pydantic AI agents from normalized messaging events."""
 
 from ._host import ChannelAdapter, ChannelEvent, ChannelHost, ConversationStore, InMemoryConversationStore
-from .telegram import TelegramChannel, TelegramError, TelegramWebhookError
+from .telegram import TelegramChannel, TelegramError, TelegramPartialDeliveryError, TelegramWebhookError
 
 __all__ = (
     'ChannelAdapter',
@@ -11,5 +11,6 @@ __all__ = (
     'InMemoryConversationStore',
     'TelegramChannel',
     'TelegramError',
+    'TelegramPartialDeliveryError',
     'TelegramWebhookError',
 )

--- a/pydantic_ai_harness/channels/__init__.py
+++ b/pydantic_ai_harness/channels/__init__.py
@@ -1,7 +1,6 @@
 """Run Pydantic AI agents from normalized messaging events."""
 
 from ._host import ChannelAdapter, ChannelEvent, ChannelHost, ConversationStore, InMemoryConversationStore
-from .telegram import TelegramChannel, TelegramError, TelegramPartialDeliveryError, TelegramWebhookError
 
 __all__ = (
     'ChannelAdapter',
@@ -9,8 +8,4 @@ __all__ = (
     'ChannelHost',
     'ConversationStore',
     'InMemoryConversationStore',
-    'TelegramChannel',
-    'TelegramError',
-    'TelegramPartialDeliveryError',
-    'TelegramWebhookError',
 )

--- a/pydantic_ai_harness/channels/__init__.py
+++ b/pydantic_ai_harness/channels/__init__.py
@@ -1,6 +1,7 @@
 """Run Pydantic AI agents from normalized messaging events."""
 
 from ._host import ChannelAdapter, ChannelEvent, ChannelHost, ConversationStore, InMemoryConversationStore
+from .telegram import TelegramChannel, TelegramError, TelegramWebhookError
 
 __all__ = (
     'ChannelAdapter',
@@ -8,4 +9,7 @@ __all__ = (
     'ChannelHost',
     'ConversationStore',
     'InMemoryConversationStore',
+    'TelegramChannel',
+    'TelegramError',
+    'TelegramWebhookError',
 )

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -34,6 +34,7 @@ _SECRET_PATTERN = re.compile(r'[A-Za-z0-9_-]{1,256}')
 _CONVERSATION_PATTERN = re.compile(
     r'telegram:bot:([1-9][0-9]*):chat:(-?[1-9][0-9]*)(?::(topic|direct-topic):([1-9][0-9]*))?'
 )
+_DELIVERY_PATTERN = re.compile(r'-?[1-9][0-9]*')
 _MESSAGE_PATTERN = re.compile(r'telegram:message:([1-9][0-9]*)')
 _TELEGRAM_URL_PATTERN = re.compile(r'(https?://[^\s]*?/bot)[^/\s]+(/[^\s]+)')
 _JSON_ADAPTER: TypeAdapter[object] = TypeAdapter(object)
@@ -109,6 +110,8 @@ class TelegramChannel:
         sender_values: Collection[object] = allowed_senders
         if any(not _is_integer_id(sender_id) for sender_id in sender_values):
             raise TypeError('allowed_senders must contain only integer Telegram IDs')
+        if any(sender_id == 0 for sender_id in allowed_senders):
+            raise ValueError('allowed_senders must contain only nonzero Telegram IDs')
         sender_ids = frozenset(allowed_senders)
         if not sender_ids:
             raise ValueError('allowed_senders must contain at least one Telegram ID')
@@ -162,6 +165,7 @@ class TelegramChannel:
             sender_id=f'telegram:{sender_kind}:{sender_id}',
             text=text,
             reply_to_id=f'telegram:message:{message_id}',
+            delivery_id=str(chat_id),
         )
 
     def _sender(self, message: Mapping[str, object]) -> tuple[str, int] | None:
@@ -171,7 +175,7 @@ class TelegramChannel:
             if sender_chat is None:
                 raise TelegramError('Telegram webhook payload has invalid sender-chat identity')
             sender_chat_id = sender_chat.get('id')
-            if not _is_integer_id(sender_chat_id):
+            if not _is_integer_id(sender_chat_id) or sender_chat_id == 0:
                 raise TelegramError('Telegram webhook payload has invalid sender-chat identity')
             return 'chat', sender_chat_id
 
@@ -181,7 +185,7 @@ class TelegramChannel:
             raise TelegramError('Telegram webhook payload has no sender identity')
         sender_id = sender.get('id')
         is_bot = sender.get('is_bot')
-        if not _is_integer_id(sender_id) or not isinstance(is_bot, bool):
+        if not _is_integer_id(sender_id) or sender_id == 0 or not isinstance(is_bot, bool):
             raise TelegramError('Telegram webhook payload has invalid sender identity')
         if is_bot:
             return None
@@ -197,7 +201,10 @@ class TelegramChannel:
         """
         if not text:
             raise ValueError('text must not be empty')
-        chat_id, topic_kind, topic_id = _decode_conversation(event.conversation_id, bot_id=self._bot_id)
+        conversation_chat_id, topic_kind, topic_id = _decode_conversation(event.conversation_id, bot_id=self._bot_id)
+        chat_id = _decode_delivery(event.delivery_id)
+        if chat_id != conversation_chat_id:
+            raise TelegramError('event delivery_id does not match its Telegram conversation_id')
         message_id = _decode_message(event.reply_to_id)
 
         chunks = [text[start : start + _MAX_TEXT_CHARS] for start in range(0, len(text), _MAX_TEXT_CHARS)]
@@ -326,7 +333,7 @@ def _message_identity(message: Mapping[str, object]) -> tuple[int, str | None, i
     if chat is None or message_id < 0:
         raise TelegramError('Telegram webhook payload has invalid message identity')
     chat_id = chat.get('id')
-    if not _is_integer_id(chat_id):
+    if not _is_integer_id(chat_id) or chat_id == 0:
         raise TelegramError('Telegram webhook payload has invalid chat identity')
 
     topic_id = message.get('message_thread_id')
@@ -377,6 +384,12 @@ def _decode_message(reply_to_id: str | None) -> int | None:
     if match is None:
         raise TelegramError('event reply_to_id is not a Telegram message identity')
     return int(match.group(1))
+
+
+def _decode_delivery(delivery_id: str | None) -> int:
+    if delivery_id is None or _DELIVERY_PATTERN.fullmatch(delivery_id) is None:
+        raise TelegramError('event delivery_id is not a Telegram chat identity')
+    return int(delivery_id)
 
 
 def _retry_after(envelope: Mapping[str, object]) -> float | None:

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -17,7 +17,9 @@ import hmac
 import logging
 import re
 from collections.abc import Collection, Mapping
+from threading import Lock
 from typing import TypeGuard
+from weakref import finalize
 
 import anyio
 import httpx
@@ -36,7 +38,6 @@ _CONVERSATION_PATTERN = re.compile(
 )
 _DELIVERY_PATTERN = re.compile(r'-?[1-9][0-9]*')
 _MESSAGE_PATTERN = re.compile(r'telegram:message:([1-9][0-9]*)')
-_TELEGRAM_URL_PATTERN = re.compile(r'(https?://[^\s]*?/bot)[^/\s]+(/[^\s]+)')
 _JSON_ADAPTER: TypeAdapter[object] = TypeAdapter(object)
 _MAPPING_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
 
@@ -59,11 +60,37 @@ class TelegramPartialDeliveryError(TelegramError):
 
 
 class _TelegramTokenFilter(logging.Filter):
+    def __init__(self) -> None:
+        super().__init__()
+        self._lock = Lock()
+        self._prefixes: dict[str, tuple[str, int]] = {}
+
+    def register(self, token_url_prefix: str, redacted_url_prefix: str) -> None:
+        with self._lock:
+            current = self._prefixes.get(token_url_prefix)
+            count = current[1] + 1 if current is not None else 1
+            self._prefixes[token_url_prefix] = redacted_url_prefix, count
+
+    def unregister(self, token_url_prefix: str) -> None:
+        with self._lock:
+            redacted_url_prefix, count = self._prefixes[token_url_prefix]
+            if count == 1:
+                del self._prefixes[token_url_prefix]
+            else:
+                self._prefixes[token_url_prefix] = redacted_url_prefix, count - 1
+
     def filter(self, record: logging.LogRecord) -> bool:
         if record.name == 'httpx' and record.msg == 'HTTP Request: %s %s "%s %d %s"':
             args = record.args
             if isinstance(args, tuple):  # pragma: no branch - HTTPX supplies positional logging arguments
-                record.args = tuple(_redact_log_argument(value) for value in args)
+                with self._lock:
+                    replacements = tuple(
+                        (token_url_prefix, redacted_url_prefix)
+                        for token_url_prefix, (redacted_url_prefix, _count) in sorted(
+                            self._prefixes.items(), key=lambda item: len(item[0]), reverse=True
+                        )
+                    )
+                record.args = tuple(_redact_log_argument(value, replacements) for value in args)
         return True
 
 
@@ -126,8 +153,11 @@ class TelegramChannel:
         self._api_url = api_url.rstrip('/')
 
         httpx_logger = logging.getLogger('httpx')
+        token_url_prefix = str(httpx.URL(f'{self._api_url}/bot{self._bot_token}/'))
+        _TOKEN_FILTER.register(token_url_prefix, f'{token_url_prefix.rpartition("/bot")[0]}/bot<redacted>/')
         if _TOKEN_FILTER not in httpx_logger.filters:
             httpx_logger.addFilter(_TOKEN_FILTER)
+        finalize(self, _TOKEN_FILTER.unregister, token_url_prefix)
 
     def parse_request(self, raw_body: bytes, headers: Mapping[str, str]) -> ChannelEvent | None:
         """Verify and normalize one caller-owned Telegram webhook request.
@@ -339,6 +369,12 @@ def _message_identity(message: Mapping[str, object]) -> tuple[int, str | None, i
     topic_id = message.get('message_thread_id')
     if topic_id is not None and (not _is_integer_id(topic_id) or topic_id <= 0):
         raise TelegramError('Telegram webhook payload has invalid topic identity')
+    is_topic_message = message.get('is_topic_message')
+    if is_topic_message is not None and is_topic_message is not True:
+        raise TelegramError('Telegram webhook payload has invalid topic identity')
+    if is_topic_message is True and topic_id is None:
+        raise TelegramError('Telegram webhook payload has invalid topic identity')
+    forum_topic_id = topic_id if is_topic_message is True else None
     direct_topic = message.get('direct_messages_topic')
     direct_topic_id: int | None = None
     if direct_topic is not None:
@@ -349,10 +385,10 @@ def _message_identity(message: Mapping[str, object]) -> tuple[int, str | None, i
         if not _is_integer_id(raw_direct_topic_id) or raw_direct_topic_id <= 0:
             raise TelegramError('Telegram webhook payload has invalid direct-topic identity')
         direct_topic_id = raw_direct_topic_id
-    if topic_id is not None and direct_topic_id is not None:
+    if forum_topic_id is not None and direct_topic_id is not None:
         raise TelegramError('Telegram webhook payload has ambiguous topic identity')
-    if topic_id is not None:
-        return chat_id, 'topic', topic_id, message_id
+    if forum_topic_id is not None:
+        return chat_id, 'topic', forum_topic_id, message_id
     if direct_topic_id is not None:
         return chat_id, 'direct-topic', direct_topic_id, message_id
     return chat_id, None, None, message_id
@@ -362,10 +398,12 @@ def _is_integer_id(value: object) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def _redact_log_argument(value: object) -> object:
+def _redact_log_argument(value: object, replacements: tuple[tuple[str, str], ...]) -> object:
     if isinstance(value, (str, httpx.URL)):
         text = str(value)
-        return _TELEGRAM_URL_PATTERN.sub(r'\1<redacted>\2', text)
+        for token_url_prefix, redacted_url_prefix in replacements:
+            text = text.replace(token_url_prefix, redacted_url_prefix)
+        return text
     return value
 
 

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -1,0 +1,310 @@
+"""Telegram Bot API adapter for the provider-neutral Channels host.
+
+External assumptions verified 2026-09-04 against https://core.telegram.org/bots/api:
+
+* webhook requests carry the configured secret in `X-Telegram-Bot-Api-Secret-Token`;
+* `update_id` identifies deliveries, while messages identify their chat, optional topic, and source message;
+* Bot API requests use `https://api.telegram.org/bot<token>/METHOD_NAME`;
+* `sendMessage` accepts 1 to 4096 characters and supports topics and reply parameters;
+* flood-control responses may include an integer `parameters.retry_after` delay.
+
+Re-check the linked primary documentation before changing authentication, identity, or retry policy.
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import re
+from collections.abc import Collection, Mapping
+from typing import TypeGuard
+
+import anyio
+import httpx
+from pydantic import TypeAdapter, ValidationError
+
+from ._host import ChannelEvent
+
+_DEFAULT_API_URL = 'https://api.telegram.org'
+_MAX_TEXT_CHARS = 4096
+_MAX_RETRY_AFTER_SECONDS = 60
+_SECRET_PATTERN = re.compile(r'[A-Za-z0-9_-]{1,256}')
+_CONVERSATION_PATTERN = re.compile(r'telegram:chat:(-?[0-9]+)(?::topic:([0-9]+))?')
+_MESSAGE_PATTERN = re.compile(r'telegram:message:([0-9]+)')
+_TELEGRAM_URL_PATTERN = re.compile(r'(https?://[^/\s]+/bot)[^/\s]+(/[^\s]*)?')
+_JSON_ADAPTER: TypeAdapter[object] = TypeAdapter(object)
+_MAPPING_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
+
+
+class TelegramError(RuntimeError):
+    """A Telegram webhook payload or Bot API request is invalid."""
+
+
+class TelegramWebhookError(TelegramError):
+    """A Telegram webhook request fails secret-token verification."""
+
+
+class _TelegramTokenFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        redacted = _TELEGRAM_URL_PATTERN.sub(r'\1<redacted>\2', message)
+        if redacted != message:
+            record.msg = redacted
+            record.args = ()
+        return True
+
+
+_TOKEN_FILTER = _TelegramTokenFilter()
+
+
+class _RateLimited(TelegramError):
+    def __init__(self, message: str, *, retry_after: float) -> None:
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class TelegramChannel:
+    """Translate verified Telegram updates and send replies through the Bot API."""
+
+    def __init__(
+        self,
+        *,
+        bot_token: str,
+        webhook_secret: str,
+        allowed_senders: Collection[int],
+        client: httpx.AsyncClient | None = None,
+        api_url: str = _DEFAULT_API_URL,
+    ) -> None:
+        """Configure Telegram authentication, admission, and HTTP transport.
+
+        Args:
+            bot_token: Token issued by BotFather for Bot API requests.
+            webhook_secret: Secret configured through Telegram's `setWebhook` method.
+            allowed_senders: Telegram user or sender-chat IDs allowed to start runs.
+            client: Optional pooled HTTP client. The caller retains ownership.
+            api_url: Bot API server base URL.
+        """
+        if not bot_token:
+            raise ValueError('bot_token must not be empty')
+        if _SECRET_PATTERN.fullmatch(webhook_secret) is None:
+            raise ValueError('webhook_secret must contain 1-256 ASCII letters, digits, underscores, or hyphens')
+        if isinstance(allowed_senders, str):
+            raise TypeError('allowed_senders must be a collection of integer Telegram IDs')
+        sender_values: Collection[object] = allowed_senders
+        if any(not _is_integer_id(sender_id) for sender_id in sender_values):
+            raise TypeError('allowed_senders must contain only integer Telegram IDs')
+        sender_ids = frozenset(allowed_senders)
+        if not sender_ids:
+            raise ValueError('allowed_senders must contain at least one Telegram ID')
+        if not api_url:
+            raise ValueError('api_url must not be empty')
+
+        self._bot_token = bot_token
+        self._webhook_secret = webhook_secret
+        self._allowed_senders = sender_ids
+        self._client = client
+        self._api_url = api_url.rstrip('/')
+
+        httpx_logger = logging.getLogger('httpx')
+        if _TOKEN_FILTER not in httpx_logger.filters:
+            httpx_logger.addFilter(_TOKEN_FILTER)
+
+    def parse_request(self, raw_body: bytes, headers: Mapping[str, str]) -> ChannelEvent | None:
+        """Verify and normalize one caller-owned Telegram webhook request.
+
+        Unsupported update types, non-text messages, bot messages, and disallowed senders return
+        `None`. The caller should atomically claim the returned `event_id` before passing the event
+        to [`ChannelHost.handle`][pydantic_ai_harness.channels.ChannelHost.handle].
+        """
+        secret_values = [
+            value for name, value in headers.items() if name.casefold() == 'x-telegram-bot-api-secret-token'
+        ]
+        if len(secret_values) > 1:
+            raise TelegramWebhookError('Telegram webhook has ambiguous secret token headers')
+        if len(secret_values) != 1 or not hmac.compare_digest(secret_values[0], self._webhook_secret):
+            raise TelegramWebhookError('Telegram webhook secret token is missing or invalid')
+
+        try:
+            payload = _mapping(_JSON_ADAPTER.validate_json(raw_body))
+        except ValidationError:
+            payload = None
+        if payload is None:
+            raise TelegramError('Telegram webhook payload must be a JSON object')
+
+        update_id = payload.get('update_id')
+        if isinstance(update_id, bool) or not isinstance(update_id, int) or update_id < 0:
+            raise TelegramError('Telegram webhook payload has an invalid update_id')
+
+        raw_message = payload.get('message')
+        if raw_message is None:
+            return None
+        message = _mapping(raw_message)
+        if message is None:
+            raise TelegramError('Telegram webhook payload has an invalid message')
+
+        text = message.get('text')
+        if not isinstance(text, str) or not text:
+            return None
+
+        chat = _mapping(message.get('chat'))
+        message_id = message.get('message_id')
+        if chat is None or not _is_integer_id(message_id) or message_id <= 0:
+            raise TelegramError('Telegram webhook payload has invalid message identity')
+        chat_id = chat.get('id')
+        if not _is_integer_id(chat_id):
+            raise TelegramError('Telegram webhook payload has invalid chat identity')
+
+        topic_id = message.get('message_thread_id')
+        if topic_id is not None and (not _is_integer_id(topic_id) or topic_id <= 0):
+            raise TelegramError('Telegram webhook payload has invalid topic identity')
+
+        sender = self._sender(message)
+        if sender is None:
+            return None
+        sender_kind, sender_id = sender
+        if sender_id not in self._allowed_senders:
+            return None
+
+        conversation_id = f'telegram:chat:{chat_id}'
+        if topic_id is not None:
+            conversation_id += f':topic:{topic_id}'
+        return ChannelEvent(
+            event_id=f'telegram:update:{update_id}',
+            conversation_id=conversation_id,
+            sender_id=f'telegram:{sender_kind}:{sender_id}',
+            text=text,
+            reply_to_id=f'telegram:message:{message_id}',
+        )
+
+    def _sender(self, message: Mapping[str, object]) -> tuple[str, int] | None:
+        raw_sender_chat = message.get('sender_chat')
+        if raw_sender_chat is not None:
+            sender_chat = _mapping(raw_sender_chat)
+            if sender_chat is None:
+                raise TelegramError('Telegram webhook payload has invalid sender-chat identity')
+            sender_chat_id = sender_chat.get('id')
+            if not _is_integer_id(sender_chat_id):
+                raise TelegramError('Telegram webhook payload has invalid sender-chat identity')
+            return 'chat', sender_chat_id
+
+        raw_sender = message.get('from')
+        sender = _mapping(raw_sender)
+        if sender is None:
+            raise TelegramError('Telegram webhook payload has no sender identity')
+        sender_id = sender.get('id')
+        is_bot = sender.get('is_bot')
+        if not _is_integer_id(sender_id) or not isinstance(is_bot, bool):
+            raise TelegramError('Telegram webhook payload has invalid sender identity')
+        if is_bot:
+            return None
+        return 'user', sender_id
+
+    async def reply(self, event: ChannelEvent, text: str) -> None:
+        """Reply once in Telegram, splitting text at the provider limit.
+
+        A flood-control response is retried once after Telegram's `retry_after` delay. Transport
+        failures and other provider errors are surfaced without retry because delivery may already
+        have happened.
+        """
+        if not text:
+            raise ValueError('text must not be empty')
+        chat_id, topic_id = _decode_conversation(event.conversation_id)
+        message_id = _decode_message(event.reply_to_id)
+
+        for start in range(0, len(text), _MAX_TEXT_CHARS):
+            payload: dict[str, object] = {
+                'chat_id': chat_id,
+                'text': text[start : start + _MAX_TEXT_CHARS],
+            }
+            if topic_id is not None:
+                payload['message_thread_id'] = topic_id
+            if message_id is not None:
+                payload['reply_parameters'] = {'message_id': message_id}
+            await self._send_with_one_flood_retry(payload)
+
+    async def _send_with_one_flood_retry(self, payload: Mapping[str, object]) -> None:
+        try:
+            await self._send(payload)
+        except _RateLimited as exc:
+            await anyio.sleep(exc.retry_after)
+            try:
+                await self._send(payload)
+            except _RateLimited as second:
+                raise TelegramError(str(second)) from None
+
+    async def _send(self, payload: Mapping[str, object]) -> None:
+        if self._client is not None:
+            await self._post(self._client, payload)
+            return
+        async with httpx.AsyncClient() as client:
+            await self._post(client, payload)
+
+    async def _post(self, client: httpx.AsyncClient, payload: Mapping[str, object]) -> None:
+        method = 'sendMessage'
+        try:
+            response = await client.post(
+                f'{self._api_url}/bot{self._bot_token}/{method}',
+                json=dict(payload),
+            )
+        except httpx.RequestError:
+            raise TelegramError(f'Telegram Bot API request failed: {method}') from None
+
+        try:
+            envelope = _mapping(_JSON_ADAPTER.validate_json(response.content))
+        except ValidationError:
+            envelope = None
+        if envelope is None:
+            raise TelegramError(f'Telegram Bot API returned an invalid response: {method}')
+        if response.is_success and envelope.get('ok') is True:
+            return
+
+        description = envelope.get('description')
+        message = description if isinstance(description, str) else f'Telegram Bot API rejected {method}'
+        message = message.replace(self._bot_token, '<redacted>')
+        retry_after = _retry_after(envelope)
+        if retry_after is not None:
+            raise _RateLimited(message, retry_after=retry_after)
+        raise TelegramError(message)
+
+
+def _mapping(value: object) -> dict[str, object] | None:
+    try:
+        return _MAPPING_ADAPTER.validate_python(value)
+    except ValidationError:
+        return None
+
+
+def _is_integer_id(value: object) -> TypeGuard[int]:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _decode_conversation(conversation_id: str) -> tuple[int, int | None]:
+    match = _CONVERSATION_PATTERN.fullmatch(conversation_id)
+    if match is None:
+        raise TelegramError('event conversation_id is not a Telegram chat identity')
+    topic = match.group(2)
+    return int(match.group(1)), int(topic) if topic is not None else None
+
+
+def _decode_message(reply_to_id: str | None) -> int | None:
+    if reply_to_id is None:
+        return None
+    match = _MESSAGE_PATTERN.fullmatch(reply_to_id)
+    if match is None:
+        raise TelegramError('event reply_to_id is not a Telegram message identity')
+    return int(match.group(1))
+
+
+def _retry_after(envelope: Mapping[str, object]) -> float | None:
+    parameters = _mapping(envelope.get('parameters'))
+    if parameters is None:
+        return None
+    retry_after = parameters.get('retry_after')
+    if (
+        isinstance(retry_after, bool)
+        or not isinstance(retry_after, int)
+        or retry_after < 0
+        or retry_after > _MAX_RETRY_AFTER_SECONDS
+    ):
+        return None
+    return float(retry_after)

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -29,9 +29,9 @@ _DEFAULT_API_URL = 'https://api.telegram.org'
 _MAX_TEXT_CHARS = 4096
 _MAX_RETRY_AFTER_SECONDS = 60
 _SECRET_PATTERN = re.compile(r'[A-Za-z0-9_-]{1,256}')
-_CONVERSATION_PATTERN = re.compile(r'telegram:chat:(-?[0-9]+)(?::topic:([0-9]+))?')
-_MESSAGE_PATTERN = re.compile(r'telegram:message:([0-9]+)')
-_TELEGRAM_URL_PATTERN = re.compile(r'(https?://[^/\s]+/bot)[^/\s]+(/[^\s]*)?')
+_CONVERSATION_PATTERN = re.compile(r'telegram:chat:(-?[1-9][0-9]*)(?::(topic|direct-topic):([1-9][0-9]*))?')
+_MESSAGE_PATTERN = re.compile(r'telegram:message:([1-9][0-9]*)')
+_TELEGRAM_URL_PATTERN = re.compile(r'(https?://[^\s]*?/bot)[^/\s]+(/[^\s]+)')
 _JSON_ADAPTER: TypeAdapter[object] = TypeAdapter(object)
 _MAPPING_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
 
@@ -44,13 +44,21 @@ class TelegramWebhookError(TelegramError):
     """A Telegram webhook request fails secret-token verification."""
 
 
+class TelegramPartialDeliveryError(TelegramError):
+    """A multi-message reply fails after at least one chunk is confirmed."""
+
+    def __init__(self, message: str, *, sent_chunks: int) -> None:
+        """Record how many chunks Telegram confirmed before the failure."""
+        super().__init__(message)
+        self.sent_chunks = sent_chunks
+
+
 class _TelegramTokenFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
-        message = record.getMessage()
-        redacted = _TELEGRAM_URL_PATTERN.sub(r'\1<redacted>\2', message)
-        if redacted != message:
-            record.msg = redacted
-            record.args = ()
+        if record.name == 'httpx' and record.msg == 'HTTP Request: %s %s "%s %d %s"':
+            args = record.args
+            if isinstance(args, tuple):  # pragma: no branch - HTTPX supplies positional logging arguments
+                record.args = tuple(_redact_log_argument(value) for value in args)
         return True
 
 
@@ -116,47 +124,18 @@ class TelegramChannel:
         `None`. The caller should atomically claim the returned `event_id` before passing the event
         to [`ChannelHost.handle`][pydantic_ai_harness.channels.ChannelHost.handle].
         """
-        secret_values = [
-            value for name, value in headers.items() if name.casefold() == 'x-telegram-bot-api-secret-token'
-        ]
-        if len(secret_values) > 1:
-            raise TelegramWebhookError('Telegram webhook has ambiguous secret token headers')
-        if len(secret_values) != 1 or not hmac.compare_digest(secret_values[0], self._webhook_secret):
-            raise TelegramWebhookError('Telegram webhook secret token is missing or invalid')
-
-        try:
-            payload = _mapping(_JSON_ADAPTER.validate_json(raw_body))
-        except ValidationError:
-            payload = None
-        if payload is None:
-            raise TelegramError('Telegram webhook payload must be a JSON object')
-
-        update_id = payload.get('update_id')
-        if isinstance(update_id, bool) or not isinstance(update_id, int) or update_id < 0:
-            raise TelegramError('Telegram webhook payload has an invalid update_id')
-
-        raw_message = payload.get('message')
-        if raw_message is None:
-            return None
-        message = _mapping(raw_message)
+        update_id, message = _verified_update(raw_body, headers, self._webhook_secret)
         if message is None:
-            raise TelegramError('Telegram webhook payload has an invalid message')
+            return None
 
         text = message.get('text')
         if not isinstance(text, str) or not text:
             return None
 
-        chat = _mapping(message.get('chat'))
-        message_id = message.get('message_id')
-        if chat is None or not _is_integer_id(message_id) or message_id <= 0:
-            raise TelegramError('Telegram webhook payload has invalid message identity')
-        chat_id = chat.get('id')
-        if not _is_integer_id(chat_id):
-            raise TelegramError('Telegram webhook payload has invalid chat identity')
-
-        topic_id = message.get('message_thread_id')
-        if topic_id is not None and (not _is_integer_id(topic_id) or topic_id <= 0):
-            raise TelegramError('Telegram webhook payload has invalid topic identity')
+        identity = _message_identity(message)
+        if identity is None:
+            return None
+        chat_id, topic_kind, topic_id, message_id = identity
 
         sender = self._sender(message)
         if sender is None:
@@ -166,8 +145,8 @@ class TelegramChannel:
             return None
 
         conversation_id = f'telegram:chat:{chat_id}'
-        if topic_id is not None:
-            conversation_id += f':topic:{topic_id}'
+        if topic_kind is not None:
+            conversation_id += f':{topic_kind}:{topic_id}'
         return ChannelEvent(
             event_id=f'telegram:update:{update_id}',
             conversation_id=conversation_id,
@@ -200,27 +179,39 @@ class TelegramChannel:
         return 'user', sender_id
 
     async def reply(self, event: ChannelEvent, text: str) -> None:
-        """Reply once in Telegram, splitting text at the provider limit.
+        """Reply in Telegram, splitting text at the provider limit.
 
         A flood-control response is retried once after Telegram's `retry_after` delay. Transport
         failures and other provider errors are surfaced without retry because delivery may already
-        have happened.
+        have happened. If a later chunk fails, `TelegramPartialDeliveryError.sent_chunks` reports
+        how many preceding chunks Telegram confirmed.
         """
         if not text:
             raise ValueError('text must not be empty')
-        chat_id, topic_id = _decode_conversation(event.conversation_id)
+        chat_id, topic_kind, topic_id = _decode_conversation(event.conversation_id)
         message_id = _decode_message(event.reply_to_id)
 
-        for start in range(0, len(text), _MAX_TEXT_CHARS):
+        chunks = [text[start : start + _MAX_TEXT_CHARS] for start in range(0, len(text), _MAX_TEXT_CHARS)]
+        for index, chunk in enumerate(chunks):
             payload: dict[str, object] = {
                 'chat_id': chat_id,
-                'text': text[start : start + _MAX_TEXT_CHARS],
+                'text': chunk,
             }
-            if topic_id is not None:
+            if topic_kind == 'topic':
                 payload['message_thread_id'] = topic_id
+            elif topic_kind == 'direct-topic':
+                payload['direct_messages_topic_id'] = topic_id
             if message_id is not None:
                 payload['reply_parameters'] = {'message_id': message_id}
-            await self._send_with_one_flood_retry(payload)
+            try:
+                await self._send_with_one_flood_retry(payload)
+            except TelegramError as exc:
+                if index == 0:
+                    raise
+                raise TelegramPartialDeliveryError(
+                    f'Telegram reply failed after {index} of {len(chunks)} chunks were confirmed: {exc}',
+                    sent_chunks=index,
+                ) from None
 
     async def _send_with_one_flood_retry(self, payload: Mapping[str, object]) -> None:
         try:
@@ -256,12 +247,16 @@ class TelegramChannel:
         if envelope is None:
             raise TelegramError(f'Telegram Bot API returned an invalid response: {method}')
         if response.is_success and envelope.get('ok') is True:
-            return
+            result = _mapping(envelope.get('result'))
+            sent_message_id = result.get('message_id') if result is not None else None
+            if _is_integer_id(sent_message_id) and sent_message_id >= 0:
+                return
+            raise TelegramError(f'Telegram Bot API returned an invalid response: {method}')
 
         description = envelope.get('description')
         message = description if isinstance(description, str) else f'Telegram Bot API rejected {method}'
         message = message.replace(self._bot_token, '<redacted>')
-        retry_after = _retry_after(envelope)
+        retry_after = _retry_after(envelope) if response.status_code == 429 else None
         if retry_after is not None:
             raise _RateLimited(message, retry_after=retry_after)
         raise TelegramError(message)
@@ -274,16 +269,91 @@ def _mapping(value: object) -> dict[str, object] | None:
         return None
 
 
+def _verified_update(
+    raw_body: bytes, headers: Mapping[str, str], webhook_secret: str
+) -> tuple[int, dict[str, object] | None]:
+    secret_values = [value for name, value in headers.items() if name.casefold() == 'x-telegram-bot-api-secret-token']
+    if len(secret_values) > 1:
+        raise TelegramWebhookError('Telegram webhook has ambiguous secret token headers')
+    if (
+        len(secret_values) != 1
+        or _SECRET_PATTERN.fullmatch(secret_values[0]) is None
+        or not hmac.compare_digest(secret_values[0], webhook_secret)
+    ):
+        raise TelegramWebhookError('Telegram webhook secret token is missing or invalid')
+
+    try:
+        payload = _mapping(_JSON_ADAPTER.validate_json(raw_body))
+    except ValidationError:
+        payload = None
+    if payload is None:
+        raise TelegramError('Telegram webhook payload must be a JSON object')
+
+    update_id = payload.get('update_id')
+    if isinstance(update_id, bool) or not isinstance(update_id, int) or update_id <= 0:
+        raise TelegramError('Telegram webhook payload has an invalid update_id')
+
+    raw_message = payload.get('message')
+    if raw_message is None:
+        return update_id, None
+    message = _mapping(raw_message)
+    if message is None:
+        raise TelegramError('Telegram webhook payload has an invalid message')
+    return update_id, message
+
+
+def _message_identity(message: Mapping[str, object]) -> tuple[int, str | None, int | None, int] | None:
+    message_id = message.get('message_id')
+    if not _is_integer_id(message_id):
+        raise TelegramError('Telegram webhook payload has invalid message identity')
+    if message_id == 0 or message.get('ephemeral_message_id') is not None:
+        return None
+    chat = _mapping(message.get('chat'))
+    if chat is None or message_id < 0:
+        raise TelegramError('Telegram webhook payload has invalid message identity')
+    chat_id = chat.get('id')
+    if not _is_integer_id(chat_id):
+        raise TelegramError('Telegram webhook payload has invalid chat identity')
+
+    topic_id = message.get('message_thread_id')
+    if topic_id is not None and (not _is_integer_id(topic_id) or topic_id <= 0):
+        raise TelegramError('Telegram webhook payload has invalid topic identity')
+    direct_topic = message.get('direct_messages_topic')
+    direct_topic_id: int | None = None
+    if direct_topic is not None:
+        direct_topic_mapping = _mapping(direct_topic)
+        if direct_topic_mapping is None:
+            raise TelegramError('Telegram webhook payload has invalid direct-topic identity')
+        raw_direct_topic_id = direct_topic_mapping.get('topic_id')
+        if not _is_integer_id(raw_direct_topic_id) or raw_direct_topic_id <= 0:
+            raise TelegramError('Telegram webhook payload has invalid direct-topic identity')
+        direct_topic_id = raw_direct_topic_id
+    if topic_id is not None and direct_topic_id is not None:
+        raise TelegramError('Telegram webhook payload has ambiguous topic identity')
+    if topic_id is not None:
+        return chat_id, 'topic', topic_id, message_id
+    if direct_topic_id is not None:
+        return chat_id, 'direct-topic', direct_topic_id, message_id
+    return chat_id, None, None, message_id
+
+
 def _is_integer_id(value: object) -> TypeGuard[int]:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def _decode_conversation(conversation_id: str) -> tuple[int, int | None]:
+def _redact_log_argument(value: object) -> object:
+    if isinstance(value, (str, httpx.URL)):
+        text = str(value)
+        return _TELEGRAM_URL_PATTERN.sub(r'\1<redacted>\2', text)
+    return value
+
+
+def _decode_conversation(conversation_id: str) -> tuple[int, str | None, int | None]:
     match = _CONVERSATION_PATTERN.fullmatch(conversation_id)
     if match is None:
         raise TelegramError('event conversation_id is not a Telegram chat identity')
-    topic = match.group(2)
-    return int(match.group(1)), int(topic) if topic is not None else None
+    topic = match.group(3)
+    return int(match.group(1)), match.group(2), int(topic) if topic is not None else None
 
 
 def _decode_message(reply_to_id: str | None) -> int | None:

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -59,10 +59,11 @@ class TelegramWebhookError(TelegramError):
 class TelegramPartialDeliveryError(TelegramError):
     """A multi-message reply fails after at least one chunk is confirmed."""
 
-    def __init__(self, message: str, *, sent_chunks: int) -> None:
-        """Record how many chunks Telegram confirmed before the failure."""
+    def __init__(self, message: str, *, sent_chunks: int, retry_after: int | None = None) -> None:
+        """Record confirmed chunks and any Telegram-provided retry delay."""
         super().__init__(message)
         self.sent_chunks = sent_chunks
+        self.retry_after = retry_after
 
 
 class TelegramRateLimitError(TelegramError):
@@ -233,10 +234,10 @@ class TelegramChannel:
     async def reply(self, event: ChannelEvent, text: str) -> None:
         """Reply in Telegram, splitting text at the provider limit.
 
-        A flood-control response is retried once after Telegram's `retry_after` delay. Transport
-        failures and other provider errors are surfaced without retry because delivery may already
+        A flood-control delay of at most 60 seconds is retried once. Larger and repeated delays are
+        surfaced without retry. Transport failures are also surfaced because delivery may already
         have happened. If a later chunk fails, `TelegramPartialDeliveryError.sent_chunks` reports
-        how many preceding chunks Telegram confirmed.
+        how many preceding chunks Telegram confirmed and `retry_after` preserves a rate-limit delay.
         """
         if not text:
             raise ValueError('text must not be empty')
@@ -266,6 +267,7 @@ class TelegramChannel:
                 raise TelegramPartialDeliveryError(
                     f'Telegram reply failed after {index} of {len(chunks)} chunks were confirmed: {exc}',
                     sent_chunks=index,
+                    retry_after=exc.retry_after if isinstance(exc, TelegramRateLimitError) else None,
                 ) from None
 
     async def _send_with_one_flood_retry(self, payload: Mapping[str, object]) -> None:

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -400,10 +400,11 @@ def _is_integer_id(value: object) -> TypeGuard[int]:
 
 def _redact_log_argument(value: object, replacements: tuple[tuple[str, str], ...]) -> object:
     if isinstance(value, (str, httpx.URL)):
-        text = str(value)
+        original_text = str(value)
+        text = original_text
         for token_url_prefix, redacted_url_prefix in replacements:
             text = text.replace(token_url_prefix, redacted_url_prefix)
-        return text
+        return text if text != original_text else value
     return value
 
 

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -27,7 +27,13 @@ from pydantic import TypeAdapter, ValidationError
 
 from ._host import ChannelEvent
 
-__all__ = ('TelegramChannel', 'TelegramError', 'TelegramPartialDeliveryError', 'TelegramWebhookError')
+__all__ = (
+    'TelegramChannel',
+    'TelegramError',
+    'TelegramPartialDeliveryError',
+    'TelegramRateLimitError',
+    'TelegramWebhookError',
+)
 
 _DEFAULT_API_URL = 'https://api.telegram.org'
 _MAX_TEXT_CHARS = 4096
@@ -57,6 +63,15 @@ class TelegramPartialDeliveryError(TelegramError):
         """Record how many chunks Telegram confirmed before the failure."""
         super().__init__(message)
         self.sent_chunks = sent_chunks
+
+
+class TelegramRateLimitError(TelegramError):
+    """Telegram rate-limits a reply with a caller-visible retry delay."""
+
+    def __init__(self, message: str, *, retry_after: int) -> None:
+        """Record Telegram's requested delay without forcing an unbounded wait."""
+        super().__init__(message)
+        self.retry_after = retry_after
 
 
 class _TelegramTokenFilter(logging.Filter):
@@ -95,12 +110,6 @@ class _TelegramTokenFilter(logging.Filter):
 
 
 _TOKEN_FILTER = _TelegramTokenFilter()
-
-
-class _RateLimited(TelegramError):
-    def __init__(self, message: str, *, retry_after: float) -> None:
-        super().__init__(message)
-        self.retry_after = retry_after
 
 
 class TelegramChannel:
@@ -262,12 +271,14 @@ class TelegramChannel:
     async def _send_with_one_flood_retry(self, payload: Mapping[str, object]) -> None:
         try:
             await self._send(payload)
-        except _RateLimited as exc:
+        except TelegramRateLimitError as exc:
+            if exc.retry_after > _MAX_RETRY_AFTER_SECONDS:
+                raise
             await anyio.sleep(exc.retry_after)
             try:
                 await self._send(payload)
-            except _RateLimited as second:
-                raise TelegramError(str(second)) from None
+            except TelegramRateLimitError:
+                raise
 
     async def _send(self, payload: Mapping[str, object]) -> None:
         if self._client is not None:
@@ -309,7 +320,7 @@ class TelegramChannel:
         message = message.replace(self._bot_token, '<redacted>')
         retry_after = _retry_after(envelope) if response.status_code == 429 else None
         if retry_after is not None:
-            raise _RateLimited(message, retry_after=retry_after)
+            raise TelegramRateLimitError(message, retry_after=retry_after)
         raise TelegramError(message)
 
 
@@ -431,16 +442,11 @@ def _decode_delivery(delivery_id: str | None) -> int:
     return int(delivery_id)
 
 
-def _retry_after(envelope: Mapping[str, object]) -> float | None:
+def _retry_after(envelope: Mapping[str, object]) -> int | None:
     parameters = _mapping(envelope.get('parameters'))
     if parameters is None:
         return None
     retry_after = parameters.get('retry_after')
-    if (
-        isinstance(retry_after, bool)
-        or not isinstance(retry_after, int)
-        or retry_after < 0
-        or retry_after > _MAX_RETRY_AFTER_SECONDS
-    ):
+    if isinstance(retry_after, bool) or not isinstance(retry_after, int) or retry_after < 0:
         return None
-    return float(retry_after)
+    return retry_after

--- a/pydantic_ai_harness/channels/telegram.py
+++ b/pydantic_ai_harness/channels/telegram.py
@@ -25,11 +25,15 @@ from pydantic import TypeAdapter, ValidationError
 
 from ._host import ChannelEvent
 
+__all__ = ('TelegramChannel', 'TelegramError', 'TelegramPartialDeliveryError', 'TelegramWebhookError')
+
 _DEFAULT_API_URL = 'https://api.telegram.org'
 _MAX_TEXT_CHARS = 4096
 _MAX_RETRY_AFTER_SECONDS = 60
 _SECRET_PATTERN = re.compile(r'[A-Za-z0-9_-]{1,256}')
-_CONVERSATION_PATTERN = re.compile(r'telegram:chat:(-?[1-9][0-9]*)(?::(topic|direct-topic):([1-9][0-9]*))?')
+_CONVERSATION_PATTERN = re.compile(
+    r'telegram:bot:([1-9][0-9]*):chat:(-?[1-9][0-9]*)(?::(topic|direct-topic):([1-9][0-9]*))?'
+)
 _MESSAGE_PATTERN = re.compile(r'telegram:message:([1-9][0-9]*)')
 _TELEGRAM_URL_PATTERN = re.compile(r'(https?://[^\s]*?/bot)[^/\s]+(/[^\s]+)')
 _JSON_ADAPTER: TypeAdapter[object] = TypeAdapter(object)
@@ -77,6 +81,7 @@ class TelegramChannel:
     def __init__(
         self,
         *,
+        bot_id: int,
         bot_token: str,
         webhook_secret: str,
         allowed_senders: Collection[int],
@@ -86,12 +91,15 @@ class TelegramChannel:
         """Configure Telegram authentication, admission, and HTTP transport.
 
         Args:
+            bot_id: Public Telegram user ID of the bot, used to scope stored identities.
             bot_token: Token issued by BotFather for Bot API requests.
             webhook_secret: Secret configured through Telegram's `setWebhook` method.
             allowed_senders: Telegram user or sender-chat IDs allowed to start runs.
             client: Optional pooled HTTP client. The caller retains ownership.
             api_url: Bot API server base URL.
         """
+        if not _is_integer_id(bot_id) or bot_id <= 0:
+            raise ValueError('bot_id must be a positive integer Telegram ID')
         if not bot_token:
             raise ValueError('bot_token must not be empty')
         if _SECRET_PATTERN.fullmatch(webhook_secret) is None:
@@ -107,6 +115,7 @@ class TelegramChannel:
         if not api_url:
             raise ValueError('api_url must not be empty')
 
+        self._bot_id = bot_id
         self._bot_token = bot_token
         self._webhook_secret = webhook_secret
         self._allowed_senders = sender_ids
@@ -144,11 +153,11 @@ class TelegramChannel:
         if sender_id not in self._allowed_senders:
             return None
 
-        conversation_id = f'telegram:chat:{chat_id}'
+        conversation_id = f'telegram:bot:{self._bot_id}:chat:{chat_id}'
         if topic_kind is not None:
             conversation_id += f':{topic_kind}:{topic_id}'
         return ChannelEvent(
-            event_id=f'telegram:update:{update_id}',
+            event_id=f'telegram:bot:{self._bot_id}:update:{update_id}',
             conversation_id=conversation_id,
             sender_id=f'telegram:{sender_kind}:{sender_id}',
             text=text,
@@ -188,7 +197,7 @@ class TelegramChannel:
         """
         if not text:
             raise ValueError('text must not be empty')
-        chat_id, topic_kind, topic_id = _decode_conversation(event.conversation_id)
+        chat_id, topic_kind, topic_id = _decode_conversation(event.conversation_id, bot_id=self._bot_id)
         message_id = _decode_message(event.reply_to_id)
 
         chunks = [text[start : start + _MAX_TEXT_CHARS] for start in range(0, len(text), _MAX_TEXT_CHARS)]
@@ -246,11 +255,16 @@ class TelegramChannel:
             envelope = None
         if envelope is None:
             raise TelegramError(f'Telegram Bot API returned an invalid response: {method}')
-        if response.is_success and envelope.get('ok') is True:
+        ok = envelope.get('ok')
+        if not isinstance(ok, bool):
+            raise TelegramError(f'Telegram Bot API returned an invalid response: {method}')
+        if response.is_success and ok:
             result = _mapping(envelope.get('result'))
             sent_message_id = result.get('message_id') if result is not None else None
             if _is_integer_id(sent_message_id) and sent_message_id >= 0:
                 return
+            raise TelegramError(f'Telegram Bot API returned an invalid response: {method}')
+        if ok:
             raise TelegramError(f'Telegram Bot API returned an invalid response: {method}')
 
         description = envelope.get('description')
@@ -348,12 +362,12 @@ def _redact_log_argument(value: object) -> object:
     return value
 
 
-def _decode_conversation(conversation_id: str) -> tuple[int, str | None, int | None]:
+def _decode_conversation(conversation_id: str, *, bot_id: int) -> tuple[int, str | None, int | None]:
     match = _CONVERSATION_PATTERN.fullmatch(conversation_id)
-    if match is None:
+    if match is None or int(match.group(1)) != bot_id:
         raise TelegramError('event conversation_id is not a Telegram chat identity')
-    topic = match.group(3)
-    return int(match.group(1)), match.group(2), int(topic) if topic is not None else None
+    topic = match.group(4)
+    return int(match.group(2)), match.group(3), int(topic) if topic is not None else None
 
 
 def _decode_message(reply_to_id: str | None) -> int | None:

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -848,6 +848,14 @@ class TestTelegramChannel:
 
     async def test_uses_custom_api_url(self, caplog: pytest.LogCaptureFixture) -> None:
         requests: list[httpx.Request] = []
+        unrelated_log_arguments: list[object] = []
+
+        class ObserveUnrelatedUrl(logging.Filter):
+            def filter(self, record: logging.LogRecord) -> bool:
+                args = record.args
+                if isinstance(args, tuple) and len(args) > 1:  # pragma: no branch - the test emits positional args
+                    unrelated_log_arguments.append(args[1])
+                return True
 
         def handler(request: httpx.Request) -> httpx.Response:
             requests.append(request)
@@ -867,21 +875,26 @@ class TestTelegramChannel:
 
         await channel.reply(event, 'answer')
 
+        observer = ObserveUnrelatedUrl()
+        logging.getLogger('httpx').addFilter(observer)
         with caplog.at_level(logging.INFO, logger='httpx'):
             await channel.reply(event, 'second')
+            unrelated_url = httpx.URL('https://example.com/botinventory/items')
             logging.getLogger('httpx').info(
                 'HTTP Request: %s %s "%s %d %s"',
                 'GET',
-                httpx.URL('https://example.com/botinventory/items'),
+                unrelated_url,
                 'HTTP/1.1',
                 200,
                 'OK',
             )
+        logging.getLogger('httpx').removeFilter(observer)
 
         assert str(requests[0].url) == 'https://telegram.test/bot-decoy/root/botbot-secret/sendMessage'
         assert 'bot-secret' not in caplog.text
         assert '<redacted>' in caplog.text
         assert 'https://example.com/botinventory/items' in caplog.text
+        assert unrelated_log_arguments[-1] is unrelated_url
         await client.aclose()
 
     async def test_redacts_overlapping_active_bot_tokens(self, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -588,6 +588,38 @@ class TestTelegramChannel:
             await channel.reply(event, 'a' * 4097)
 
         assert exc_info.value.sent_chunks == 1
+        assert exc_info.value.retry_after is None
+        assert calls == 2
+        await client.aclose()
+
+    async def test_preserves_rate_limit_after_partial_delivery(self) -> None:
+        calls = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                return _response(
+                    {
+                        'ok': False,
+                        'error_code': 429,
+                        'description': 'Too Many Requests',
+                        'parameters': {'retry_after': 2_282},
+                    },
+                    status_code=429,
+                )
+            return _response({'ok': True, 'result': {'message_id': calls}})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        with pytest.raises(TelegramPartialDeliveryError, match='1 of 2') as exc_info:
+            await channel.reply(event, 'a' * 4097)
+
+        assert exc_info.value.sent_chunks == 1
+        assert exc_info.value.retry_after == 2_282
         assert calls == 2
         await client.aclose()
 

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -10,7 +10,12 @@ from pydantic import TypeAdapter
 from pydantic_ai import Agent
 
 from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
-from pydantic_ai_harness.channels.telegram import TelegramChannel, TelegramError, TelegramWebhookError
+from pydantic_ai_harness.channels.telegram import (
+    TelegramChannel,
+    TelegramError,
+    TelegramPartialDeliveryError,
+    TelegramWebhookError,
+)
 
 pytestmark = pytest.mark.anyio
 
@@ -79,9 +84,16 @@ class TestTelegramChannel:
     async def test_rejects_unverified_or_malformed_webhook(self) -> None:
         channel = _channel()
 
-        for headers in ({}, _headers('wrong'), {'X-Telegram-Bot-Api-Secret-Token': 'wrong'}):
+        for headers in (
+            {},
+            _headers('wrong'),
+            {'X-Telegram-Bot-Api-Secret-Token': 'wrong'},
+            {'X-Telegram-Bot-Api-Secret-Token': 'é'},
+        ):
             with pytest.raises(TelegramWebhookError, match='secret token'):
                 channel.parse_request(_update(), headers)
+            with pytest.raises(TelegramWebhookError, match='secret token'):
+                channel.parse_request(b'not json', headers)
 
         with pytest.raises(TelegramWebhookError, match='ambiguous'):
             channel.parse_request(
@@ -92,7 +104,15 @@ class TestTelegramChannel:
                 },
             )
 
-        for body in (b'not json', b'[]', b'{"update_id":true}', b'{"update_id":-1}', b'{"message":{}}'):
+        for body in (
+            b'not json',
+            b'[]',
+            b'{"update_id":true}',
+            b'{"update_id":0}',
+            b'{"update_id":-1}',
+            b'{"message":{}}',
+            b'{"update_id":1,"message":"invalid"}',
+        ):
             with pytest.raises(TelegramError, match='payload'):
                 channel.parse_request(body, _headers())
 
@@ -137,7 +157,8 @@ class TestTelegramChannel:
         channel = _channel()
 
         malformed_messages = (
-            {'message_id': 0, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
+            {'message_id': True, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
+            {'message_id': -1, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
             {'message_id': 1, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': True}, 'text': 'hello'},
             {
                 'message_id': 1,
@@ -155,12 +176,91 @@ class TestTelegramChannel:
                 'chat': {'id': 1},
                 'text': 'hello',
             },
+            {
+                'message_id': 1,
+                'sender_chat': {'id': True},
+                'from': {'id': 22, 'is_bot': False},
+                'chat': {'id': 1},
+                'text': 'hello',
+            },
+            {'message_id': 1, 'chat': {'id': 1}, 'text': 'hello'},
+            {
+                'message_id': 1,
+                'direct_messages_topic': 'invalid',
+                'from': {'id': 22, 'is_bot': False},
+                'chat': {'id': 1},
+                'text': 'hello',
+            },
+            {
+                'message_id': 1,
+                'direct_messages_topic': {'topic_id': 0},
+                'from': {'id': 22, 'is_bot': False},
+                'chat': {'id': 1},
+                'text': 'hello',
+            },
         )
 
         for message in malformed_messages:
             body = json.dumps({'update_id': 1, 'message': message}).encode()
             with pytest.raises(TelegramError, match='identity'):
                 channel.parse_request(body, _headers())
+
+        ephemeral = {
+            'message_id': 0,
+            'ephemeral_message_id': 9,
+            'from': {'id': 22, 'is_bot': False},
+            'chat': {'id': 1},
+            'text': 'hello',
+        }
+        assert channel.parse_request(json.dumps({'update_id': 1, 'message': ephemeral}).encode(), _headers()) is None
+
+        scheduled = {**ephemeral, 'ephemeral_message_id': None}
+        assert channel.parse_request(json.dumps({'update_id': 2, 'message': scheduled}).encode(), _headers()) is None
+
+        plain_event = channel.parse_request(_update(topic_id=None), _headers())
+        assert plain_event is not None
+        assert plain_event.conversation_id == 'telegram:chat:-100123'
+
+    async def test_preserves_direct_message_topic_identity(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            return _response({'ok': True, 'result': {'message_id': 1}})
+
+        body = _BODY_ADAPTER.validate_python(json.loads(_update(topic_id=None)))
+        message = _BODY_ADAPTER.validate_python(body['message'])
+        message['direct_messages_topic'] = {'topic_id': 55, 'user': {'id': 22, 'is_bot': False}}
+        body['message'] = message
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+
+        event = channel.parse_request(json.dumps(body).encode(), _headers())
+
+        assert event is not None
+        assert event.conversation_id == 'telegram:chat:-100123:direct-topic:55'
+        await channel.reply(event, 'answer')
+        assert requests == [
+            {
+                'chat_id': -100123,
+                'direct_messages_topic_id': 55,
+                'reply_parameters': {'message_id': 33},
+                'text': 'answer',
+            }
+        ]
+
+        message['message_thread_id'] = 44
+        with pytest.raises(TelegramError, match='ambiguous topic'):
+            channel.parse_request(json.dumps(body).encode(), _headers())
+
+        message.pop('message_thread_id')
+        direct_topic = _BODY_ADAPTER.validate_python(message['direct_messages_topic'])
+        direct_topic['topic_id'] = 56
+        message['direct_messages_topic'] = direct_topic
+        other_event = channel.parse_request(json.dumps(body).encode(), _headers())
+        assert other_event is not None
+        assert other_event.conversation_id != event.conversation_id
+        await client.aclose()
 
     async def test_duplicate_update_is_idempotent_at_admission_boundary(self) -> None:
         requests: list[dict[str, object]] = []
@@ -208,6 +308,7 @@ class TestTelegramChannel:
                 'text': 'answer',
             }
         ]
+        assert not client.is_closed
         await client.aclose()
 
     async def test_chunks_text_at_telegram_limit(self) -> None:
@@ -233,6 +334,28 @@ class TestTelegramChannel:
         assert all('message_thread_id' not in request and 'reply_parameters' not in request for request in requests)
         with pytest.raises(ValueError, match='text must not be empty'):
             await channel.reply(event, '')
+        await client.aclose()
+
+    async def test_reports_confirmed_chunks_after_partial_delivery(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise httpx.ReadError('connection lost', request=request)
+            return _response({'ok': True, 'result': {'message_id': calls}})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        with pytest.raises(TelegramPartialDeliveryError, match='1 of 2') as exc_info:
+            await channel.reply(event, 'a' * 4097)
+
+        assert exc_info.value.sent_chunks == 1
+        assert calls == 2
         await client.aclose()
 
     async def test_retry_policy(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -300,15 +423,14 @@ class TestTelegramChannel:
         def handler(_request: httpx.Request) -> httpx.Response:
             nonlocal calls
             calls += 1
-            return _response(
-                {
-                    'ok': False,
-                    'error_code': 429,
-                    'description': 'Too Many Requests',
-                    'parameters': {'retry_after': retry_after},
-                },
-                status_code=429,
-            )
+            payload: dict[str, object] = {
+                'ok': False,
+                'error_code': 429,
+                'description': 'Too Many Requests',
+            }
+            if retry_after is not None:
+                payload['parameters'] = {'retry_after': retry_after}
+            return _response(payload, status_code=429)
 
         monkeypatch.setattr('pydantic_ai_harness.channels.telegram.anyio.sleep', sleep)
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
@@ -329,6 +451,11 @@ class TestTelegramChannel:
         with pytest.raises(TelegramError, match='Too Many Requests'):
             await channel.reply(event, 'third')
         assert calls == 4
+
+        retry_after = None
+        with pytest.raises(TelegramError, match='Too Many Requests'):
+            await channel.reply(event, 'fourth')
+        assert calls == 5
         await client.aclose()
 
     async def test_rejects_invalid_provider_responses_and_event_identity(self) -> None:
@@ -338,6 +465,7 @@ class TestTelegramChannel:
                 _response([], status_code=500),
                 _response({'ok': False}, status_code=401),
                 _response({'ok': True}, status_code=500),
+                _response({'ok': True}),
             )
         )
 
@@ -353,7 +481,7 @@ class TestTelegramChannel:
             text='prompt',
         )
 
-        for _ in range(4):
+        for _ in range(5):
             with pytest.raises(TelegramError):
                 await channel.reply(event, 'answer')
 
@@ -362,6 +490,16 @@ class TestTelegramChannel:
                 ChannelEvent(
                     event_id='telegram:update:1',
                     conversation_id='slack:channel:7',
+                    sender_id='telegram:user:22',
+                    text='prompt',
+                ),
+                'answer',
+            )
+        with pytest.raises(TelegramError, match='conversation_id'):
+            await channel.reply(
+                ChannelEvent(
+                    event_id='telegram:update:1',
+                    conversation_id='telegram:chat:7:topic:0',
                     sender_id='telegram:user:22',
                     text='prompt',
                 ),
@@ -378,14 +516,58 @@ class TestTelegramChannel:
                 ),
                 'answer',
             )
+        with pytest.raises(TelegramError, match='reply_to_id'):
+            await channel.reply(
+                ChannelEvent(
+                    event_id='telegram:update:1',
+                    conversation_id='telegram:chat:7',
+                    sender_id='telegram:user:22',
+                    text='prompt',
+                    reply_to_id='telegram:message:0',
+                ),
+                'answer',
+            )
         await client.aclose()
 
-    async def test_uses_custom_api_url(self) -> None:
+    async def test_does_not_retry_authentication_failure_with_retry_after(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = 0
+
+        async def sleep(_delay: float) -> None:
+            pytest.fail('authentication failure must not sleep')
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            return _response(
+                {
+                    'ok': False,
+                    'error_code': 401,
+                    'description': 'Unauthorized',
+                    'parameters': {'retry_after': 1},
+                },
+                status_code=401,
+            )
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.anyio.sleep', sleep)
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        with pytest.raises(TelegramError, match='Unauthorized'):
+            await channel.reply(event, 'answer')
+
+        assert calls == 1
+        await client.aclose()
+
+    async def test_uses_custom_api_url(self, caplog: pytest.LogCaptureFixture) -> None:
         requests: list[httpx.Request] = []
 
         def handler(request: httpx.Request) -> httpx.Response:
             requests.append(request)
-            return _response({'ok': True})
+            return _response({'ok': True, 'result': {'message_id': 1}})
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = TelegramChannel(
@@ -400,8 +582,33 @@ class TestTelegramChannel:
 
         await channel.reply(event, 'answer')
 
+        with caplog.at_level(logging.INFO, logger='httpx'):
+            await channel.reply(event, 'second')
+
         assert str(requests[0].url) == 'https://telegram.test/root/botbot-secret/sendMessage'
+        assert 'bot-secret' not in caplog.text
+        assert '<redacted>' in caplog.text
         await client.aclose()
+
+    async def test_closes_short_lived_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        clients: list[TrackingClient] = []
+
+        class TrackingClient(httpx.AsyncClient):
+            def __init__(self) -> None:
+                super().__init__(
+                    transport=httpx.MockTransport(lambda _request: _response({'ok': True, 'result': {'message_id': 1}}))
+                )
+                clients.append(self)
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.httpx.AsyncClient', TrackingClient)
+        channel = _channel()
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        await channel.reply(event, 'answer')
+
+        assert len(clients) == 1
+        assert clients[0].is_closed
 
     async def test_bot_token_is_redacted(self, caplog: pytest.LogCaptureFixture) -> None:
         calls = 0
@@ -426,12 +633,11 @@ class TestTelegramChannel:
         assert event is not None
 
         with caplog.at_level(logging.INFO, logger='httpx'):
+            logging.getLogger('httpx').info('unrelated %s', 'request')
             await channel.reply(event, 'first')
             with pytest.raises(TelegramError, match='Unauthorized') as exc_info:
                 await channel.reply(event, 'second')
 
-        assert 'bot-secret' not in repr(channel)
-        assert 'webhook-secret' not in repr(channel)
         assert 'bot-secret' not in str(exc_info.value)
         assert 'bot-secret' not in caplog.text
         assert '<redacted>' in caplog.text

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Mapping
+from collections.abc import Awaitable, Callable, Iterator, Mapping
+from pathlib import Path
+from types import TracebackType
+from typing import TypeGuard
 
+import anyio
 import httpx
 import pytest
+from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from pydantic import TypeAdapter
 from pydantic_ai import Agent
+from starlette.applications import Starlette
 
 from pydantic_ai_harness.channels import ChannelEvent, ChannelHost, InMemoryConversationStore
 from pydantic_ai_harness.channels.telegram import (
@@ -52,6 +58,7 @@ def _update(
     }
     if topic_id is not None:
         message['message_thread_id'] = topic_id
+        message['is_topic_message'] = True
     return json.dumps({'update_id': update_id, 'message': message}).encode()
 
 
@@ -63,6 +70,16 @@ def _channel(client: httpx.AsyncClient | None = None) -> TelegramChannel:
         allowed_senders={22},
         client=client,
     )
+
+
+def _telegram_docs_example() -> str:
+    readme = Path(__file__).parents[2] / 'pydantic_ai_harness' / 'channels' / 'README.md'
+    telegram_section = readme.read_text(encoding='utf-8').split('Save this as `telegram_bot.py`:', 1)[1]
+    return telegram_section.split('```python {names="defined"}', 1)[1].split('```', 1)[0]
+
+
+def _is_async_no_arg(value: object) -> TypeGuard[Callable[[], Awaitable[None]]]:
+    return callable(value)
 
 
 class TestTelegramChannel:
@@ -181,6 +198,7 @@ class TestTelegramChannel:
             {
                 'message_id': 1,
                 'message_thread_id': 0,
+                'is_topic_message': True,
                 'from': {'id': 22, 'is_bot': False},
                 'chat': {'id': 1},
                 'text': 'hello',
@@ -247,6 +265,44 @@ class TestTelegramChannel:
         assert plain_event is not None
         assert plain_event.conversation_id == 'telegram:bot:9001:chat:-100123'
 
+    async def test_keeps_generic_message_thread_in_chat_conversation(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            return _response({'ok': True, 'result': {'message_id': 1}})
+
+        body = _BODY_ADAPTER.validate_python(json.loads(_update(topic_id=None)))
+        message = _BODY_ADAPTER.validate_python(body['message'])
+        message['message_thread_id'] = 2
+        body['message'] = message
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+
+        event = channel.parse_request(json.dumps(body).encode(), _headers())
+
+        assert event is not None
+        assert event.conversation_id == 'telegram:bot:9001:chat:-100123'
+        await channel.reply(event, 'answer')
+        assert requests == [
+            {
+                'chat_id': -100123,
+                'reply_parameters': {'message_id': 33},
+                'text': 'answer',
+            }
+        ]
+        await client.aclose()
+
+    async def test_rejects_forum_topic_marker_without_thread_id(self) -> None:
+        for topic_fields in ({'is_topic_message': True}, {'is_topic_message': False, 'message_thread_id': 2}):
+            body = _BODY_ADAPTER.validate_python(json.loads(_update(topic_id=None)))
+            message = _BODY_ADAPTER.validate_python(body['message'])
+            message.update(topic_fields)
+            body['message'] = message
+
+            with pytest.raises(TelegramError, match='invalid topic identity'):
+                _channel().parse_request(json.dumps(body).encode(), _headers())
+
     async def test_preserves_direct_message_topic_identity(self) -> None:
         requests: list[dict[str, object]] = []
 
@@ -276,10 +332,12 @@ class TestTelegramChannel:
         ]
 
         message['message_thread_id'] = 44
+        message['is_topic_message'] = True
         with pytest.raises(TelegramError, match='ambiguous topic'):
             channel.parse_request(json.dumps(body).encode(), _headers())
 
         message.pop('message_thread_id')
+        message.pop('is_topic_message')
         direct_topic = _BODY_ADAPTER.validate_python(message['direct_messages_topic'])
         direct_topic['topic_id'] = 56
         message['direct_messages_topic'] = direct_topic
@@ -311,6 +369,111 @@ class TestTelegramChannel:
         assert claimed == {'telegram:bot:9001:update:11'}
         assert len(requests) == 1
         await client.aclose()
+
+    async def test_documented_server_bounds_ingress_and_claims(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv('TELEGRAM_BOT_ID', '9001')
+        monkeypatch.setenv('TELEGRAM_BOT_TOKEN', 'bot-secret')
+        monkeypatch.setenv('TELEGRAM_ALLOWED_SENDER_ID', '22')
+        monkeypatch.setenv('TELEGRAM_WEBHOOK_SECRET', 'webhook-secret')
+        monkeypatch.setenv('OPENAI_API_KEY', 'test-key')
+        namespace: dict[str, object] = {}
+        exec(compile(_telegram_docs_example(), 'telegram_bot.py', 'exec'), namespace)
+        app = namespace.get('app')
+        assert isinstance(app, Starlette)
+
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url='https://example.test') as client:
+            oversized = await client.post('/telegram', content=b'x' * 1_000_001, headers=_headers())
+            unauthorized = await client.post('/telegram', content=b'{}')
+            malformed = await client.post('/telegram', content=b'not json', headers=_headers())
+            ignored = await client.post('/telegram', content=b'{"update_id":1}', headers=_headers())
+
+            assert [oversized.status_code, unauthorized.status_code, malformed.status_code, ignored.status_code] == [
+                413,
+                401,
+                400,
+                204,
+            ]
+
+            move_on_after = anyio.move_on_after
+
+            def expire_body_read(delay: float | None) -> anyio.CancelScope:
+                return move_on_after(0 if delay == 5 else delay)
+
+            monkeypatch.setattr(anyio, 'move_on_after', expire_body_read)
+            timed_out = await client.post('/telegram', content=b'{}', headers=_headers())
+            assert timed_out.status_code == 408
+            monkeypatch.setattr(anyio, 'move_on_after', move_on_after)
+
+            for update_id in range(100):
+                queued = await client.post('/telegram', content=_update(update_id=update_id + 1), headers=_headers())
+                assert queued.status_code == 204
+
+            def expire_enqueue(delay: float | None) -> anyio.CancelScope:
+                return move_on_after(0 if delay == 2 else delay)
+
+            monkeypatch.setattr(anyio, 'move_on_after', expire_enqueue)
+            full = await client.post('/telegram', content=_update(update_id=101), headers=_headers())
+            assert full.status_code == 503
+
+        send_events = namespace.get('send_events')
+        receive_events = namespace.get('receive_events')
+        assert isinstance(send_events, MemoryObjectSendStream)
+        assert isinstance(receive_events, MemoryObjectReceiveStream)
+        await send_events.aclose()
+        await receive_events.aclose()
+
+        events = [
+            ChannelEvent(
+                event_id=f'telegram:bot:9001:update:{update_id}',
+                conversation_id='telegram:bot:9001:chat:1',
+                sender_id='telegram:user:22',
+                text='hello',
+            )
+            for update_id in range(10_001)
+        ]
+        events.append(events[0])
+
+        class FakeHost:
+            def __init__(self) -> None:
+                self.handled: list[str] = []
+
+            async def handle(self, event: ChannelEvent) -> None:
+                self.handled.append(event.event_id)
+
+        class FakeReceive:
+            def __init__(self, values: list[ChannelEvent]) -> None:
+                self._values: Iterator[ChannelEvent] = iter(values)
+
+            async def __aenter__(self) -> FakeReceive:
+                return self
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                return None
+
+            def __aiter__(self) -> FakeReceive:
+                return self
+
+            async def __anext__(self) -> ChannelEvent:
+                try:
+                    return next(self._values)
+                except StopIteration:
+                    raise StopAsyncIteration from None
+
+        host = FakeHost()
+        namespace['host'] = host
+        namespace['receive_events'] = FakeReceive(events)
+        consume_events = namespace.get('consume_events')
+        assert _is_async_no_arg(consume_events)
+
+        await consume_events()
+
+        assert len(host.handled) == 10_002
+        assert host.handled.count(events[0].event_id) == 2
 
     async def test_sends_to_original_topic_and_message(self) -> None:
         requests: list[dict[str, object]] = []
@@ -629,7 +792,7 @@ class TestTelegramChannel:
     ) -> None:
         calls = 0
 
-        async def sleep(_delay: float) -> None:
+        async def sleep(_delay: float) -> None:  # pragma: no cover - this test asserts no retry
             pytest.fail('authentication failure must not sleep')
 
         def handler(_request: httpx.Request) -> httpx.Response:
@@ -660,7 +823,7 @@ class TestTelegramChannel:
     async def test_does_not_retry_malformed_rate_limit_envelope(self, monkeypatch: pytest.MonkeyPatch) -> None:
         calls = 0
 
-        async def sleep(_delay: float) -> None:
+        async def sleep(_delay: float) -> None:  # pragma: no cover - this test asserts no retry
             pytest.fail('malformed response must not sleep')
 
         def handler(_request: httpx.Request) -> httpx.Response:
@@ -697,7 +860,7 @@ class TestTelegramChannel:
             webhook_secret='webhook-secret',
             allowed_senders={22},
             client=client,
-            api_url='https://telegram.test/root/',
+            api_url='https://telegram.test/bot-decoy/root/',
         )
         event = channel.parse_request(_update(), _headers())
         assert event is not None
@@ -706,10 +869,50 @@ class TestTelegramChannel:
 
         with caplog.at_level(logging.INFO, logger='httpx'):
             await channel.reply(event, 'second')
+            logging.getLogger('httpx').info(
+                'HTTP Request: %s %s "%s %d %s"',
+                'GET',
+                httpx.URL('https://example.com/botinventory/items'),
+                'HTTP/1.1',
+                200,
+                'OK',
+            )
 
-        assert str(requests[0].url) == 'https://telegram.test/root/botbot-secret/sendMessage'
+        assert str(requests[0].url) == 'https://telegram.test/bot-decoy/root/botbot-secret/sendMessage'
         assert 'bot-secret' not in caplog.text
         assert '<redacted>' in caplog.text
+        assert 'https://example.com/botinventory/items' in caplog.text
+        await client.aclose()
+
+    async def test_redacts_overlapping_active_bot_tokens(self, caplog: pytest.LogCaptureFixture) -> None:
+        client = httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda _request: _response({'ok': True, 'result': {'message_id': 1}}))
+        )
+        _first = TelegramChannel(
+            bot_id=9001,
+            bot_token='first-secret',
+            webhook_secret='webhook-secret',
+            allowed_senders={22},
+            client=client,
+            api_url='https://proxy.test',
+        )
+        second = TelegramChannel(
+            bot_id=9002,
+            bot_token='second-secret',
+            webhook_secret='webhook-secret',
+            allowed_senders={22},
+            client=client,
+            api_url='https://proxy.test/botfirst-secret/tenant',
+        )
+        event = second.parse_request(_update(), _headers())
+        assert event is not None
+
+        with caplog.at_level(logging.INFO, logger='httpx'):
+            await second.reply(event, 'answer')
+
+        assert 'first-secret' not in caplog.text
+        assert 'second-secret' not in caplog.text
+        assert caplog.text.count('<redacted>') == 2
         await client.aclose()
 
     async def test_closes_short_lived_client(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -20,6 +20,7 @@ from pydantic_ai_harness.channels.telegram import (
     TelegramChannel,
     TelegramError,
     TelegramPartialDeliveryError,
+    TelegramRateLimitError,
     TelegramWebhookError,
 )
 
@@ -645,12 +646,15 @@ class TestTelegramChannel:
         assert 'bot-secret' not in str(exc_info.value)
         await client.aclose()
 
-    async def test_rejects_second_rate_limit_and_malformed_retry_control(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_surfaces_unretried_rate_limits_and_rejects_malformed_retry_control(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         retry_after: object = 0
         calls = 0
+        sleeps: list[float] = []
 
-        async def sleep(_delay: float) -> None:
-            return None
+        async def sleep(delay: float) -> None:
+            sleeps.append(delay)
 
         def handler(_request: httpx.Request) -> httpx.Response:
             nonlocal calls
@@ -670,24 +674,38 @@ class TestTelegramChannel:
         event = channel.parse_request(_update(), _headers())
         assert event is not None
 
-        with pytest.raises(TelegramError, match='Too Many Requests'):
+        with pytest.raises(TelegramRateLimitError, match='Too Many Requests') as repeated:
             await channel.reply(event, 'first')
         assert calls == 2
+        assert repeated.value.retry_after == 0
+        assert sleeps == [0]
 
         retry_after = False
         with pytest.raises(TelegramError, match='Too Many Requests'):
             await channel.reply(event, 'second')
         assert calls == 3
 
-        retry_after = 61
+        retry_after = -1
         with pytest.raises(TelegramError, match='Too Many Requests'):
             await channel.reply(event, 'third')
         assert calls == 4
 
-        retry_after = None
+        retry_after = 1.5
         with pytest.raises(TelegramError, match='Too Many Requests'):
             await channel.reply(event, 'fourth')
         assert calls == 5
+
+        retry_after = None
+        with pytest.raises(TelegramError, match='Too Many Requests'):
+            await channel.reply(event, 'fifth')
+        assert calls == 6
+
+        retry_after = 2_282
+        with pytest.raises(TelegramRateLimitError, match='Too Many Requests') as long_delay:
+            await channel.reply(event, 'sixth')
+        assert calls == 7
+        assert long_delay.value.retry_after == 2_282
+        assert sleeps == [0]
         await client.aclose()
 
     async def test_rejects_invalid_provider_responses_and_event_identity(self) -> None:

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -57,6 +57,7 @@ def _update(
 
 def _channel(client: httpx.AsyncClient | None = None) -> TelegramChannel:
     return TelegramChannel(
+        bot_id=9001,
         bot_token='bot-secret',
         webhook_secret='webhook-secret',
         allowed_senders={22},
@@ -74,12 +75,26 @@ class TestTelegramChannel:
         )
 
         assert event == ChannelEvent(
-            event_id='telegram:update:11',
-            conversation_id='telegram:chat:-100123:topic:44',
+            event_id='telegram:bot:9001:update:11',
+            conversation_id='telegram:bot:9001:chat:-100123:topic:44',
             sender_id='telegram:user:22',
             text='hello',
             reply_to_id='telegram:message:33',
         )
+
+    async def test_scopes_claims_and_history_to_bot(self) -> None:
+        first = _channel().parse_request(_update(), _headers())
+        second = TelegramChannel(
+            bot_id=9002,
+            bot_token='other-secret',
+            webhook_secret='webhook-secret',
+            allowed_senders={22},
+        ).parse_request(_update(), _headers())
+
+        assert first is not None
+        assert second is not None
+        assert first.event_id != second.event_id
+        assert first.conversation_id != second.conversation_id
 
     async def test_rejects_unverified_or_malformed_webhook(self) -> None:
         channel = _channel()
@@ -143,6 +158,7 @@ class TestTelegramChannel:
         message['sender_chat'] = {'id': -100999}
         body['message'] = message
         channel = TelegramChannel(
+            bot_id=9001,
             bot_token='bot-secret',
             webhook_secret='webhook-secret',
             allowed_senders={-100999},
@@ -219,7 +235,7 @@ class TestTelegramChannel:
 
         plain_event = channel.parse_request(_update(topic_id=None), _headers())
         assert plain_event is not None
-        assert plain_event.conversation_id == 'telegram:chat:-100123'
+        assert plain_event.conversation_id == 'telegram:bot:9001:chat:-100123'
 
     async def test_preserves_direct_message_topic_identity(self) -> None:
         requests: list[dict[str, object]] = []
@@ -238,7 +254,7 @@ class TestTelegramChannel:
         event = channel.parse_request(json.dumps(body).encode(), _headers())
 
         assert event is not None
-        assert event.conversation_id == 'telegram:chat:-100123:direct-topic:55'
+        assert event.conversation_id == 'telegram:bot:9001:chat:-100123:direct-topic:55'
         await channel.reply(event, 'answer')
         assert requests == [
             {
@@ -282,7 +298,7 @@ class TestTelegramChannel:
             claimed.add(event.event_id)
             await host.handle(event)
 
-        assert claimed == {'telegram:update:11'}
+        assert claimed == {'telegram:bot:9001:update:11'}
         assert len(requests) == 1
         await client.aclose()
 
@@ -321,8 +337,8 @@ class TestTelegramChannel:
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = _channel(client)
         event = ChannelEvent(
-            event_id='telegram:update:1',
-            conversation_id='telegram:chat:7',
+            event_id='telegram:bot:9001:update:1',
+            conversation_id='telegram:bot:9001:chat:7',
             sender_id='telegram:user:22',
             text='prompt',
         )
@@ -463,6 +479,7 @@ class TestTelegramChannel:
             (
                 httpx.Response(200, content=b'not json'),
                 _response([], status_code=500),
+                _response({}),
                 _response({'ok': False}, status_code=401),
                 _response({'ok': True}, status_code=500),
                 _response({'ok': True}),
@@ -475,20 +492,20 @@ class TestTelegramChannel:
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = _channel(client)
         event = ChannelEvent(
-            event_id='telegram:update:1',
-            conversation_id='telegram:chat:7',
+            event_id='telegram:bot:9001:update:1',
+            conversation_id='telegram:bot:9001:chat:7',
             sender_id='telegram:user:22',
             text='prompt',
         )
 
-        for _ in range(5):
+        for _ in range(6):
             with pytest.raises(TelegramError):
                 await channel.reply(event, 'answer')
 
         with pytest.raises(TelegramError, match='conversation_id'):
             await channel.reply(
                 ChannelEvent(
-                    event_id='telegram:update:1',
+                    event_id='telegram:bot:9001:update:1',
                     conversation_id='slack:channel:7',
                     sender_id='telegram:user:22',
                     text='prompt',
@@ -498,8 +515,18 @@ class TestTelegramChannel:
         with pytest.raises(TelegramError, match='conversation_id'):
             await channel.reply(
                 ChannelEvent(
-                    event_id='telegram:update:1',
-                    conversation_id='telegram:chat:7:topic:0',
+                    event_id='telegram:bot:9002:update:1',
+                    conversation_id='telegram:bot:9002:chat:7',
+                    sender_id='telegram:user:22',
+                    text='prompt',
+                ),
+                'answer',
+            )
+        with pytest.raises(TelegramError, match='conversation_id'):
+            await channel.reply(
+                ChannelEvent(
+                    event_id='telegram:bot:9001:update:1',
+                    conversation_id='telegram:bot:9001:chat:7:topic:0',
                     sender_id='telegram:user:22',
                     text='prompt',
                 ),
@@ -508,8 +535,8 @@ class TestTelegramChannel:
         with pytest.raises(TelegramError, match='reply_to_id'):
             await channel.reply(
                 ChannelEvent(
-                    event_id='telegram:update:1',
-                    conversation_id='telegram:chat:7',
+                    event_id='telegram:bot:9001:update:1',
+                    conversation_id='telegram:bot:9001:chat:7',
                     sender_id='telegram:user:22',
                     text='prompt',
                     reply_to_id='slack:message:2',
@@ -519,8 +546,8 @@ class TestTelegramChannel:
         with pytest.raises(TelegramError, match='reply_to_id'):
             await channel.reply(
                 ChannelEvent(
-                    event_id='telegram:update:1',
-                    conversation_id='telegram:chat:7',
+                    event_id='telegram:bot:9001:update:1',
+                    conversation_id='telegram:bot:9001:chat:7',
                     sender_id='telegram:user:22',
                     text='prompt',
                     reply_to_id='telegram:message:0',
@@ -562,6 +589,32 @@ class TestTelegramChannel:
         assert calls == 1
         await client.aclose()
 
+    async def test_does_not_retry_malformed_rate_limit_envelope(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = 0
+
+        async def sleep(_delay: float) -> None:
+            pytest.fail('malformed response must not sleep')
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            return _response(
+                {'ok': True, 'parameters': {'retry_after': 1}},
+                status_code=429,
+            )
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.anyio.sleep', sleep)
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        with pytest.raises(TelegramError, match='invalid response'):
+            await channel.reply(event, 'answer')
+
+        assert calls == 1
+        await client.aclose()
+
     async def test_uses_custom_api_url(self, caplog: pytest.LogCaptureFixture) -> None:
         requests: list[httpx.Request] = []
 
@@ -571,6 +624,7 @@ class TestTelegramChannel:
 
         client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         channel = TelegramChannel(
+            bot_id=9001,
             bot_token='bot-secret',
             webhook_secret='webhook-secret',
             allowed_senders={22},
@@ -663,17 +717,24 @@ class TestTelegramChannel:
         await client.aclose()
 
     async def test_validates_configuration(self) -> None:
+        with pytest.raises(ValueError, match='bot_id'):
+            TelegramChannel(bot_id=0, bot_token='token', webhook_secret='secret', allowed_senders={22})
         with pytest.raises(ValueError, match='bot_token'):
-            TelegramChannel(bot_token='', webhook_secret='secret', allowed_senders={22})
+            TelegramChannel(bot_id=9001, bot_token='', webhook_secret='secret', allowed_senders={22})
         with pytest.raises(ValueError, match='webhook_secret'):
-            TelegramChannel(bot_token='token', webhook_secret='', allowed_senders={22})
+            TelegramChannel(bot_id=9001, bot_token='token', webhook_secret='', allowed_senders={22})
         with pytest.raises(ValueError, match='webhook_secret'):
-            TelegramChannel(bot_token='token', webhook_secret='contains spaces', allowed_senders={22})
+            TelegramChannel(bot_id=9001, bot_token='token', webhook_secret='contains spaces', allowed_senders={22})
         with pytest.raises(ValueError, match='allowed_senders'):
-            TelegramChannel(bot_token='token', webhook_secret='secret', allowed_senders=set())
+            TelegramChannel(bot_id=9001, bot_token='token', webhook_secret='secret', allowed_senders=set())
         with pytest.raises(TypeError, match='allowed_senders'):
-            TelegramChannel(bot_token='token', webhook_secret='secret', allowed_senders='22')  # type: ignore[arg-type]
+            TelegramChannel(
+                bot_id=9001,
+                bot_token='token',
+                webhook_secret='secret',
+                allowed_senders='22',  # type: ignore[arg-type]
+            )
         with pytest.raises(TypeError, match='allowed_senders'):
-            TelegramChannel(bot_token='token', webhook_secret='secret', allowed_senders={True})
+            TelegramChannel(bot_id=9001, bot_token='token', webhook_secret='secret', allowed_senders={True})
         with pytest.raises(ValueError, match='api_url'):
-            TelegramChannel(bot_token='token', webhook_secret='secret', allowed_senders={22}, api_url='')
+            TelegramChannel(bot_id=9001, bot_token='token', webhook_secret='secret', allowed_senders={22}, api_url='')

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+
+import httpx
+import pytest
+from pydantic import TypeAdapter
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
+from pydantic_ai_harness.channels.telegram import TelegramChannel, TelegramError, TelegramWebhookError
+
+pytestmark = pytest.mark.anyio
+
+_BODY_ADAPTER = TypeAdapter(dict[str, object])
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+def _response(payload: object, *, status_code: int = 200) -> httpx.Response:
+    return httpx.Response(status_code, json=payload)
+
+
+def _headers(secret: str = 'webhook-secret') -> Mapping[str, str]:
+    return {'x-telegram-bot-api-secret-token': secret}
+
+
+def _update(
+    *,
+    update_id: int = 11,
+    chat_id: int = -100123,
+    sender_id: int = 22,
+    message_id: int = 33,
+    topic_id: int | None = 44,
+    text: str = 'hello',
+) -> bytes:
+    message: dict[str, object] = {
+        'message_id': message_id,
+        'from': {'id': sender_id, 'is_bot': False},
+        'chat': {'id': chat_id, 'type': 'supergroup'},
+        'text': text,
+    }
+    if topic_id is not None:
+        message['message_thread_id'] = topic_id
+    return json.dumps({'update_id': update_id, 'message': message}).encode()
+
+
+def _channel(client: httpx.AsyncClient | None = None) -> TelegramChannel:
+    return TelegramChannel(
+        bot_token='bot-secret',
+        webhook_secret='webhook-secret',
+        allowed_senders={22},
+        client=client,
+    )
+
+
+class TestTelegramChannel:
+    async def test_maps_verified_topic_reply_update(self) -> None:
+        channel = _channel()
+
+        event = channel.parse_request(
+            _update(),
+            {'X-TELEGRAM-BOT-API-SECRET-TOKEN': 'webhook-secret'},
+        )
+
+        assert event == ChannelEvent(
+            event_id='telegram:update:11',
+            conversation_id='telegram:chat:-100123:topic:44',
+            sender_id='telegram:user:22',
+            text='hello',
+            reply_to_id='telegram:message:33',
+        )
+
+    async def test_rejects_unverified_or_malformed_webhook(self) -> None:
+        channel = _channel()
+
+        for headers in ({}, _headers('wrong'), {'X-Telegram-Bot-Api-Secret-Token': 'wrong'}):
+            with pytest.raises(TelegramWebhookError, match='secret token'):
+                channel.parse_request(_update(), headers)
+
+        with pytest.raises(TelegramWebhookError, match='ambiguous'):
+            channel.parse_request(
+                _update(),
+                {
+                    'X-Telegram-Bot-Api-Secret-Token': 'webhook-secret',
+                    'x-telegram-bot-api-secret-token': 'webhook-secret',
+                },
+            )
+
+        for body in (b'not json', b'[]', b'{"update_id":true}', b'{"update_id":-1}', b'{"message":{}}'):
+            with pytest.raises(TelegramError, match='payload'):
+                channel.parse_request(body, _headers())
+
+    async def test_ignores_unsupported_or_disallowed_updates(self) -> None:
+        channel = _channel()
+
+        assert channel.parse_request(b'{"update_id":1,"callback_query":{}}', _headers()) is None
+        assert (
+            channel.parse_request(
+                b'{"update_id":2,"message":{"message_id":3,"from":{"id":22},"chat":{"id":4},"photo":[]}}',
+                _headers(),
+            )
+            is None
+        )
+        assert channel.parse_request(_update(update_id=3, sender_id=99), _headers()) is None
+
+        bot_message = _BODY_ADAPTER.validate_python(json.loads(_update(update_id=4)))
+        message = _BODY_ADAPTER.validate_python(bot_message['message'])
+        sender = _BODY_ADAPTER.validate_python(message['from'])
+        sender['is_bot'] = True
+        message['from'] = sender
+        bot_message['message'] = message
+        assert channel.parse_request(json.dumps(bot_message).encode(), _headers()) is None
+
+    async def test_maps_anonymous_chat_sender_without_trusting_fake_user(self) -> None:
+        body = _BODY_ADAPTER.validate_python(json.loads(_update()))
+        message = _BODY_ADAPTER.validate_python(body['message'])
+        message['sender_chat'] = {'id': -100999}
+        body['message'] = message
+        channel = TelegramChannel(
+            bot_token='bot-secret',
+            webhook_secret='webhook-secret',
+            allowed_senders={-100999},
+        )
+
+        event = channel.parse_request(json.dumps(body).encode(), _headers())
+
+        assert event is not None
+        assert event.sender_id == 'telegram:chat:-100999'
+
+    async def test_rejects_malformed_message_identities(self) -> None:
+        channel = _channel()
+
+        malformed_messages = (
+            {'message_id': 0, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
+            {'message_id': 1, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': True}, 'text': 'hello'},
+            {
+                'message_id': 1,
+                'message_thread_id': 0,
+                'from': {'id': 22, 'is_bot': False},
+                'chat': {'id': 1},
+                'text': 'hello',
+            },
+            {'message_id': 1, 'from': {'id': True, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
+            {'message_id': 1, 'from': {'id': 22}, 'chat': {'id': 1}, 'text': 'hello'},
+            {
+                'message_id': 1,
+                'sender_chat': 'invalid',
+                'from': {'id': 22, 'is_bot': False},
+                'chat': {'id': 1},
+                'text': 'hello',
+            },
+        )
+
+        for message in malformed_messages:
+            body = json.dumps({'update_id': 1, 'message': message}).encode()
+            with pytest.raises(TelegramError, match='identity'):
+                channel.parse_request(body, _headers())
+
+    async def test_duplicate_update_is_idempotent_at_admission_boundary(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            return _response({'ok': True, 'result': {'message_id': 1}})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        host = ChannelHost(Agent('test'), channel)
+        claimed: set[str] = set()
+
+        for _ in range(2):
+            event = channel.parse_request(_update(), _headers())
+            assert event is not None
+            if event.event_id in claimed:
+                continue
+            claimed.add(event.event_id)
+            await host.handle(event)
+
+        assert claimed == {'telegram:update:11'}
+        assert len(requests) == 1
+        await client.aclose()
+
+    async def test_sends_to_original_topic_and_message(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            return _response({'ok': True, 'result': {'message_id': 1}})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        await channel.reply(event, 'answer')
+
+        assert requests == [
+            {
+                'chat_id': -100123,
+                'message_thread_id': 44,
+                'reply_parameters': {'message_id': 33},
+                'text': 'answer',
+            }
+        ]
+        await client.aclose()
+
+    async def test_chunks_text_at_telegram_limit(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            return _response({'ok': True, 'result': {'message_id': len(requests)}})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = ChannelEvent(
+            event_id='telegram:update:1',
+            conversation_id='telegram:chat:7',
+            sender_id='telegram:user:22',
+            text='prompt',
+        )
+
+        await channel.reply(event, 'a' * 4097)
+        await channel.reply(event, '😀' * 2049)
+
+        assert [request['text'] for request in requests] == ['a' * 4096, 'a', '😀' * 2049]
+        assert all('message_thread_id' not in request and 'reply_parameters' not in request for request in requests)
+        with pytest.raises(ValueError, match='text must not be empty'):
+            await channel.reply(event, '')
+        await client.aclose()
+
+    async def test_retry_policy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = 0
+        sleeps: list[float] = []
+
+        async def sleep(delay: float) -> None:
+            sleeps.append(delay)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return _response(
+                    {
+                        'ok': False,
+                        'error_code': 429,
+                        'description': 'Too Many Requests',
+                        'parameters': {'retry_after': 2},
+                    },
+                    status_code=429,
+                )
+            return _response({'ok': True, 'result': {'message_id': 1}})
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.anyio.sleep', sleep)
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        await channel.reply(event, 'answer')
+
+        assert calls == 2
+        assert sleeps == [2.0]
+        await client.aclose()
+
+    async def test_does_not_retry_ambiguous_transport_failure(self) -> None:
+        calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            raise httpx.ReadError('connection lost', request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        with pytest.raises(TelegramError, match='request failed') as exc_info:
+            await channel.reply(event, 'answer')
+
+        assert calls == 1
+        assert exc_info.value.__cause__ is None
+        assert 'bot-secret' not in str(exc_info.value)
+        await client.aclose()
+
+    async def test_rejects_second_rate_limit_and_malformed_retry_control(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        retry_after: object = 0
+        calls = 0
+
+        async def sleep(_delay: float) -> None:
+            return None
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            return _response(
+                {
+                    'ok': False,
+                    'error_code': 429,
+                    'description': 'Too Many Requests',
+                    'parameters': {'retry_after': retry_after},
+                },
+                status_code=429,
+            )
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.telegram.anyio.sleep', sleep)
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        with pytest.raises(TelegramError, match='Too Many Requests'):
+            await channel.reply(event, 'first')
+        assert calls == 2
+
+        retry_after = False
+        with pytest.raises(TelegramError, match='Too Many Requests'):
+            await channel.reply(event, 'second')
+        assert calls == 3
+
+        retry_after = 61
+        with pytest.raises(TelegramError, match='Too Many Requests'):
+            await channel.reply(event, 'third')
+        assert calls == 4
+        await client.aclose()
+
+    async def test_rejects_invalid_provider_responses_and_event_identity(self) -> None:
+        responses = iter(
+            (
+                httpx.Response(200, content=b'not json'),
+                _response([], status_code=500),
+                _response({'ok': False}, status_code=401),
+                _response({'ok': True}, status_code=500),
+            )
+        )
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return next(responses)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = ChannelEvent(
+            event_id='telegram:update:1',
+            conversation_id='telegram:chat:7',
+            sender_id='telegram:user:22',
+            text='prompt',
+        )
+
+        for _ in range(4):
+            with pytest.raises(TelegramError):
+                await channel.reply(event, 'answer')
+
+        with pytest.raises(TelegramError, match='conversation_id'):
+            await channel.reply(
+                ChannelEvent(
+                    event_id='telegram:update:1',
+                    conversation_id='slack:channel:7',
+                    sender_id='telegram:user:22',
+                    text='prompt',
+                ),
+                'answer',
+            )
+        with pytest.raises(TelegramError, match='reply_to_id'):
+            await channel.reply(
+                ChannelEvent(
+                    event_id='telegram:update:1',
+                    conversation_id='telegram:chat:7',
+                    sender_id='telegram:user:22',
+                    text='prompt',
+                    reply_to_id='slack:message:2',
+                ),
+                'answer',
+            )
+        await client.aclose()
+
+    async def test_uses_custom_api_url(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return _response({'ok': True})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = TelegramChannel(
+            bot_token='bot-secret',
+            webhook_secret='webhook-secret',
+            allowed_senders={22},
+            client=client,
+            api_url='https://telegram.test/root/',
+        )
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        await channel.reply(event, 'answer')
+
+        assert str(requests[0].url) == 'https://telegram.test/root/botbot-secret/sendMessage'
+        await client.aclose()
+
+    async def test_bot_token_is_redacted(self, caplog: pytest.LogCaptureFixture) -> None:
+        calls = 0
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return _response({'ok': True, 'result': {'message_id': 1}})
+            return _response(
+                {
+                    'ok': False,
+                    'error_code': 401,
+                    'description': 'Unauthorized https://api.telegram.org/botbot-secret/sendMessage',
+                },
+                status_code=401,
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(), _headers())
+        assert event is not None
+
+        with caplog.at_level(logging.INFO, logger='httpx'):
+            await channel.reply(event, 'first')
+            with pytest.raises(TelegramError, match='Unauthorized') as exc_info:
+                await channel.reply(event, 'second')
+
+        assert 'bot-secret' not in repr(channel)
+        assert 'webhook-secret' not in repr(channel)
+        assert 'bot-secret' not in str(exc_info.value)
+        assert 'bot-secret' not in caplog.text
+        assert '<redacted>' in caplog.text
+        await client.aclose()
+
+    async def test_agent_integration(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            return _response({'ok': True, 'result': {'message_id': 1}})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        event = channel.parse_request(_update(text='run the agent'), _headers())
+        assert event is not None
+
+        result = await ChannelHost(Agent('test'), channel).handle(event)
+
+        assert result.output == 'success (no tool calls)'
+        assert requests[0]['text'] == result.output
+        assert all(message.conversation_id == event.conversation_id for message in result.all_messages())
+        await client.aclose()
+
+    async def test_validates_configuration(self) -> None:
+        with pytest.raises(ValueError, match='bot_token'):
+            TelegramChannel(bot_token='', webhook_secret='secret', allowed_senders={22})
+        with pytest.raises(ValueError, match='webhook_secret'):
+            TelegramChannel(bot_token='token', webhook_secret='', allowed_senders={22})
+        with pytest.raises(ValueError, match='webhook_secret'):
+            TelegramChannel(bot_token='token', webhook_secret='contains spaces', allowed_senders={22})
+        with pytest.raises(ValueError, match='allowed_senders'):
+            TelegramChannel(bot_token='token', webhook_secret='secret', allowed_senders=set())
+        with pytest.raises(TypeError, match='allowed_senders'):
+            TelegramChannel(bot_token='token', webhook_secret='secret', allowed_senders='22')  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match='allowed_senders'):
+            TelegramChannel(bot_token='token', webhook_secret='secret', allowed_senders={True})
+        with pytest.raises(ValueError, match='api_url'):
+            TelegramChannel(bot_token='token', webhook_secret='secret', allowed_senders={22}, api_url='')

--- a/tests/channels/test_telegram.py
+++ b/tests/channels/test_telegram.py
@@ -9,7 +9,7 @@ import pytest
 from pydantic import TypeAdapter
 from pydantic_ai import Agent
 
-from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
+from pydantic_ai_harness.channels import ChannelEvent, ChannelHost, InMemoryConversationStore
 from pydantic_ai_harness.channels.telegram import (
     TelegramChannel,
     TelegramError,
@@ -80,6 +80,7 @@ class TestTelegramChannel:
             sender_id='telegram:user:22',
             text='hello',
             reply_to_id='telegram:message:33',
+            delivery_id='-100123',
         )
 
     async def test_scopes_claims_and_history_to_bot(self) -> None:
@@ -176,6 +177,7 @@ class TestTelegramChannel:
             {'message_id': True, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
             {'message_id': -1, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
             {'message_id': 1, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': True}, 'text': 'hello'},
+            {'message_id': 1, 'from': {'id': 22, 'is_bot': False}, 'chat': {'id': 0}, 'text': 'hello'},
             {
                 'message_id': 1,
                 'message_thread_id': 0,
@@ -184,6 +186,7 @@ class TestTelegramChannel:
                 'text': 'hello',
             },
             {'message_id': 1, 'from': {'id': True, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
+            {'message_id': 1, 'from': {'id': 0, 'is_bot': False}, 'chat': {'id': 1}, 'text': 'hello'},
             {'message_id': 1, 'from': {'id': 22}, 'chat': {'id': 1}, 'text': 'hello'},
             {
                 'message_id': 1,
@@ -195,6 +198,13 @@ class TestTelegramChannel:
             {
                 'message_id': 1,
                 'sender_chat': {'id': True},
+                'from': {'id': 22, 'is_bot': False},
+                'chat': {'id': 1},
+                'text': 'hello',
+            },
+            {
+                'message_id': 1,
+                'sender_chat': {'id': 0},
                 'from': {'id': 22, 'is_bot': False},
                 'chat': {'id': 1},
                 'text': 'hello',
@@ -327,6 +337,48 @@ class TestTelegramChannel:
         assert not client.is_closed
         await client.aclose()
 
+    async def test_topics_keep_separate_history_and_share_raw_chat_delivery(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(_BODY_ADAPTER.validate_python(json.loads(request.content)))
+            return _response({'ok': True, 'result': {'message_id': len(requests)}})
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        channel = _channel(client)
+        store = InMemoryConversationStore()
+        host = ChannelHost(Agent('test'), channel, store=store)
+        first = channel.parse_request(_update(topic_id=44, text='first topic'), _headers())
+        second = channel.parse_request(
+            _update(update_id=12, message_id=34, topic_id=45, text='second topic'), _headers()
+        )
+        assert first is not None
+        assert second is not None
+
+        first_result = await host.handle(first)
+        second_result = await host.handle(second)
+
+        assert first.conversation_id != second.conversation_id
+        assert first.delivery_id == second.delivery_id == '-100123'
+        assert await store.load(first.conversation_id) == first_result.all_messages()
+        assert await store.load(second.conversation_id) == second_result.all_messages()
+        assert len(first_result.all_messages()) == len(second_result.all_messages())
+        assert requests == [
+            {
+                'chat_id': -100123,
+                'message_thread_id': 44,
+                'reply_parameters': {'message_id': 33},
+                'text': first_result.output,
+            },
+            {
+                'chat_id': -100123,
+                'message_thread_id': 45,
+                'reply_parameters': {'message_id': 34},
+                'text': second_result.output,
+            },
+        ]
+        await client.aclose()
+
     async def test_chunks_text_at_telegram_limit(self) -> None:
         requests: list[dict[str, object]] = []
 
@@ -341,6 +393,7 @@ class TestTelegramChannel:
             conversation_id='telegram:bot:9001:chat:7',
             sender_id='telegram:user:22',
             text='prompt',
+            delivery_id='7',
         )
 
         await channel.reply(event, 'a' * 4097)
@@ -496,6 +549,7 @@ class TestTelegramChannel:
             conversation_id='telegram:bot:9001:chat:7',
             sender_id='telegram:user:22',
             text='prompt',
+            delivery_id='7',
         )
 
         for _ in range(6):
@@ -540,6 +594,7 @@ class TestTelegramChannel:
                     sender_id='telegram:user:22',
                     text='prompt',
                     reply_to_id='slack:message:2',
+                    delivery_id='7',
                 ),
                 'answer',
             )
@@ -551,9 +606,22 @@ class TestTelegramChannel:
                     sender_id='telegram:user:22',
                     text='prompt',
                     reply_to_id='telegram:message:0',
+                    delivery_id='7',
                 ),
                 'answer',
             )
+        for delivery_id in (None, '0', 'not-a-chat', '8'):
+            with pytest.raises(TelegramError, match='delivery_id'):
+                await channel.reply(
+                    ChannelEvent(
+                        event_id='telegram:bot:9001:update:1',
+                        conversation_id='telegram:bot:9001:chat:7',
+                        sender_id='telegram:user:22',
+                        text='prompt',
+                        delivery_id=delivery_id,
+                    ),
+                    'answer',
+                )
         await client.aclose()
 
     async def test_does_not_retry_authentication_failure_with_retry_after(
@@ -736,5 +804,7 @@ class TestTelegramChannel:
             )
         with pytest.raises(TypeError, match='allowed_senders'):
             TelegramChannel(bot_id=9001, bot_token='token', webhook_secret='secret', allowed_senders={True})
+        with pytest.raises(ValueError, match='allowed_senders'):
+            TelegramChannel(bot_id=9001, bot_token='token', webhook_secret='secret', allowed_senders={0})
         with pytest.raises(ValueError, match='api_url'):
             TelegramChannel(bot_id=9001, bot_token='token', webhook_secret='secret', allowed_senders={22}, api_url='')


### PR DESCRIPTION
## What this adds

`TelegramChannel` lets a text-output agent answer allowed Telegram users in chats, forum topics, and direct-message topics through verified webhooks.

## How a user runs it

Install `pydantic-ai-harness`, a Pydantic AI model extra, Starlette, and Uvicorn. Create a BotFather bot, register a public HTTPS webhook with a secret, then pass `TelegramChannel` to `ChannelHost`. Telegram uses a bot token and webhook secret, not OAuth. No browser flow is required. See the [runnable guide](https://github.com/adtyavrdhn/pydantic-ai-harness/blob/codex/telegram-channel-737/docs/channels.md#telegram-webhook).

## Access and changes

- Reads text `message` updates from configured numeric user or sender-chat IDs.
- Ignores bot messages, media-only messages, unsupported update types, disallowed senders, and ephemeral messages.
- Sends text replies to the original chat, topic, and source message. It does not edit, delete, archive, or manage Telegram resources.
- An allowed sender triggers a reply without an interactive approval step. The application owns the sender allowlist and agent behavior.

## Maintainer attention

- **Webhook delivery and replay:** Telegram retries non-2xx deliveries. The package verifies and normalizes requests but does not own HTTP acknowledgment, durable queues, atomic duplicate claims, concurrency limits, or failed-auth rate limiting. The example bounds request size, read time, queue size, and retained claims, then returns 204 after enqueue. While an `event_id` remains in the current process's 10,000-claim window, it is handled at most once and remains claimed after handler failure. Older duplicates can run again after eviction, and queued events plus claims are lost on restart. Production deployments that cannot tolerate duplicate or lost runs need durable admission keyed by `event_id`, an explicit retry policy, and endpoint rate limiting. No maintainer decision is required unless Harness should own a web server or durable queue.
- **Partial and ambiguous sends:** Replies over 4096 characters use multiple `sendMessage` calls. A later failure can leave a partial reply. Transport failure may occur after Telegram accepted a send, so it is surfaced without retry. The error reports confirmed earlier chunks. No maintainer decision is required.
- **Rate limits:** One valid HTTP 429 response is retried once when `retry_after` is at most 60 seconds. Before any confirmed chunk, larger or repeated valid delays raise `TelegramRateLimitError`. After partial delivery, `TelegramPartialDeliveryError` preserves both `sent_chunks` and Telegram's `retry_after` value. Malformed, authentication, and transport failures surface without retry. With concurrent `ChannelHost.handle()` calls, only that conversation waits; the single-consumer example pauses all queued events during the delay. No maintainer decision is required.
- **History ordering:** The shared host sends the reply before saving history. A save failure can therefore occur after Telegram received the message. Retrying the whole handler can duplicate the reply. No maintainer decision is required.
- **Identity:** History is isolated by bot, chat, and forum or direct-message topic. Outbound delivery separately validates the raw chat ID and source message ID. Malformed topic fields are rejected. No maintainer decision is required.
- **Authentication and secrets:** The bot token authorizes Bot API sends and appears in the required request URL. The adapter redacts its exact token URL from errors and HTTPX request logs, including custom API base paths, without rewriting unrelated URLs. A custom `api_url` receives the token and must be trusted. The webhook secret verifies ingress, and the sender allowlist is a separate authorization check. The adapter treats the token as opaque and relies on the documented `getMe` setup step to validate it. Applications must store both values as secrets. No maintainer decision is required.
- **Telegram setup:** A public HTTPS endpoint and BotFather are required. Privacy Mode hides ordinary group messages unless disabled or the bot is a group administrator; Telegram requires re-adding the bot after changing Privacy Mode. Telegram Bot API has no required paid plan. Model-provider usage may cost money. No maintainer decision is required.
- **Supported behavior:** This is text-only webhook ingress. It does not add polling, edited messages, channel posts, media, reactions, streaming edits, or business-bot behavior. Unknown response fields are tolerated, while malformed required fields are rejected. No maintainer decision is required.
- **Original issue scope:** #737 originally requested long polling, `/new`, static error replies, and no group support. Maintainer direction for the coordinated Channels program replaced those points with verified webhooks, caller-owned commands and failures, and bot/chat/topic identity. This is recorded on #737. Practical impact: this PR intentionally does not implement those older bullets. No further maintainer decision is required.
- **Maturity:** This is a new public provider adapter built on the new Channels API in #794. Its API may change during Harness 0.x releases. A maintainer should review the stacked API relationship before merging.

## Why this design

- The caller owns webhook acknowledgment, redelivery policy, event claims, and durability because those policies depend on its HTTP server and queue.
- `conversation_id` includes bot, chat, and topic for history isolation. `delivery_id` remains the raw chat destination. `reply_to_id` remains the source message.
- Ambiguous transport failures are not retried because Telegram `sendMessage` has no Bot API idempotency key.
- No provider prompt or Telegram tool description is added. Provider text enters as user input, while authentication, sender admission, and routing are enforced in code.

## Evidence

- `uv run --no-sync pytest -p no:cacheprovider tests/channels`: `95 passed`, including `28` Telegram tests.
- `COVERAGE_FILE=/tmp/codex-telegram-737.coverage uv run --no-sync coverage run --branch -m pytest -p no:cacheprovider tests/channels/test_telegram.py` followed by a report limited to `telegram.py` and `test_telegram.py`: `862` statements and `164` branches, `100%`.
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/channels/telegram.py tests/channels/test_telegram.py`: `0 errors`.
- `uv run --no-sync ruff format --check .` and `uv run --no-sync ruff check .`: passed across `347` files.
- `uv run --no-sync pytest -p no:cacheprovider tests/test_docs_parity.py -k channels`: `4 passed`.
- `uv run --no-sync pytest -p no:cacheprovider tests/test_doc_snippets.py -k channels`: `8 passed`.
- Independent specification/API, standards/design, tests/security, and skeptical docs/PR-body reviews passed on the final rebased head.
- Unresolved review threads: `0`. All three prior findings were validated, fixed, answered, and resolved.
- Required CI is green on the final rebased head: [run 33972343956](https://github.com/pydantic/pydantic-ai-harness/actions/runs/33972343956), including lint, all Python matrices, aggregate coverage, and the final check.

Only the listed focused pytest and explicit-file Pyright commands were run locally. Repository-wide pytest and Pyright were not run.

## Dependencies and PR relationships

- New dependencies: none.
- Closes #737 and tracks the integration program in #787.
- Stacked on #794 at upstream base `codex/channels-slack-787`, exact reviewed SHA `0857a15894626a294f7b73b603a2c91b09ec95b2`.
- Shared navigation partner: pydantic/pydantic-ai#7939.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests cover public behavior and fake network boundaries
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks
