### PR TITLE
Add a Discord adapter to the `Channels` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ Core also ships loop-customization capabilities for production servers: [Select 
 And the agent plugs into any interface: [ACP](pydantic_ai_harness/experimental/acp/) *(experimental, Harness)* serves it to editors like Zed over the [Agent Client Protocol](https://agentclientprotocol.com), and core ships the [web chat UI](https://ai.pydantic.dev/web/), [CLI](https://ai.pydantic.dev/cli/), [frontend adapters](https://ai.pydantic.dev/ui/) (AG-UI, Vercel AI), and [realtime voice](https://ai.pydantic.dev/realtime/).
 
 Harness also ships [Channels](pydantic_ai_harness/channels/) for running text-output agents from
-verified Slack messages while caller-owned HTTP and queue infrastructure handles delivery.
+verified Slack messages and Discord Gateway events while caller-owned infrastructure handles
+delivery and event claims.
 
 Community packages extend the same capability system further; see [third-party capabilities](https://ai.pydantic.dev/capabilities/third-party/).
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,15 +1,15 @@
 ---
 title: Channels
-description: Run Pydantic AI agents from verified Slack messages.
+description: Run Pydantic AI agents from Slack and Discord messages.
 ---
 
 # Channels
 
-Channels let a Pydantic AI agent answer Slack mentions and continue each Slack thread with its own message history.
+Channels let a Pydantic AI agent answer messages in Slack and Discord while keeping conversation history separate.
 
 ## Install
 
-Channels uses the base Harness package. This example uses an OpenAI model and FastAPI:
+The Slack example uses the base Harness package, an OpenAI model, and FastAPI:
 
 ```bash
 uv add pydantic-ai-harness "pydantic-ai-slim[openai]" fastapi uvicorn
@@ -142,5 +142,104 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 - On the first HTTP 429, this adapter instance pauses its replies in the current process, waits for `Retry-After`, and retries the same generated reply once. A second 429 waits again before it propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](index.md#version-policy).
+
+## Discord
+
+The Discord adapter lets an agent answer direct messages and mentioned messages in allowed servers and threads.
+
+Install the Gateway transport and the OpenAI model provider used below:
+
+```bash
+uv add "pydantic-ai-harness[discord]" "pydantic-ai-slim[openai]"
+```
+
+In Discord's browser-based developer portal, create an application and add a bot. Use the OAuth2
+URL Generator to install the bot with the `bot` scope and the View Channels, Read Message History,
+Send Messages, and Send Messages in Threads permissions. Discord handles this one-time browser
+authorization; the adapter does not implement OAuth. On the application's **Bot** page, use
+**Reset Token** to copy the bot token. In Discord, enable **Developer Mode** under **User Settings >
+Advanced**, then right-click your user and server and choose **Copy ID**.
+
+Set the required credentials and admitted IDs:
+
+```bash
+export OPENAI_API_KEY='your-openai-api-key'
+export DISCORD_BOT_TOKEN='your-discord-bot-token'
+export DISCORD_USER_ID='your-discord-user-id'
+export DISCORD_GUILD_ID='your-discord-server-id'
+```
+
+Save this as `discord_bot.py`:
+
+```python {names="defined"}
+import logging
+import os
+
+import anyio
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelHost
+from pydantic_ai_harness.channels.discord import DiscordChannel
+
+
+async def main() -> None:
+    channel = DiscordChannel(
+        os.environ['DISCORD_BOT_TOKEN'],
+        allowed_user_ids={os.environ['DISCORD_USER_ID']},
+        allowed_guild_ids={os.environ['DISCORD_GUILD_ID']},
+    )
+    agent = Agent('openai:gpt-5.6-sol', instructions='Answer questions clearly and briefly.')
+    host = ChannelHost(agent, channel)
+    async with channel:
+        async for event in channel.events():
+            try:
+                await host.handle(event)
+            except Exception:
+                logging.exception('Discord event failed')
+
+
+anyio.run(main)
+```
+
+Run it:
+
+```bash
+uv run python discord_bot.py
+```
+
+Users can ask the agent to:
+
+- answer questions in a direct message;
+- respond when mentioned in an allowed server channel or thread;
+- continue a conversation in the same channel or thread;
+- use any tools and capabilities configured on the `Agent`.
+
+Discord may deliver the same event more than once. Atomically claim `event.event_id` in durable
+storage before `host.handle()` when duplicate turns are unacceptable. The default conversation
+store also loses history on restart. The sequential example bounds pending work and continues after
+a failed event; run a bounded worker pool when different conversations need to overlap.
+
+A long reply can post earlier chunks before a later request fails, and a transport timeout can
+leave a chunk's outcome unknown. Do not blindly retry the whole `host.handle()` call. Retrying
+`channel.reply(event, same_text)` promptly uses the same nonce, but Discord only retains nonce
+deduplication for a few minutes. Replies over 20,000 characters fail before the first chunk is sent
+to bound the number of automatic writes.
+
+The adapter admits only `allowed_user_ids`. Server messages also require an
+`allowed_guild_ids` match and a bot mention unless `require_mention=False`. Passing `None`
+explicitly for either allowlist admits every ID in that category. There is no channel allowlist: an
+allowed user can invoke the bot in any bot-visible channel or thread in an allowed guild, so use
+Discord channel permission overrides to limit channel access. A Discord thread ID is globally
+unique and is both the conversation identity and reply destination, so `delivery_id` remains
+unset. With the default `intents`, setting `require_mention=False` requests the privileged Message
+Content intent, which must also be enabled in Discord's developer portal. A custom `intents` value
+must include Message Content to receive unmentioned server text.
+
+Run the adapter on asyncio with one active `events()` iterator per `DiscordChannel`. Identify pacing,
+the reconnect circuit breaker, and REST rate-limit state are process-local, while Discord's 1,000
+Identify calls per 24 hours limit applies across the bot and can reset its token. Run one adapter per
+bot. This adapter is unsharded, so Discord close code 4011 means the bot has outgrown this transport.
+The adapter serializes replies in one process and retries HTTP 429 twice when each requested delay is
+at most 60 seconds. Longer delays and other HTTP failures surface to the caller.
 
 [Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -250,7 +250,8 @@ Core also ships loop-customization capabilities for production servers: [Select 
 And the agent plugs into any interface: [ACP](acp.md) *(experimental, Harness)* serves it to editors like Zed over the [Agent Client Protocol](https://agentclientprotocol.com), and core ships the [web chat UI](/ai/web/), [CLI](/ai/cli/), [frontend adapters](/ai/ui/overview/) (AG-UI, Vercel AI), and [realtime voice](/ai/realtime/overview/).
 
 Harness also ships [Channels](channels.md) for running text-output agents from verified Slack
-messages while caller-owned HTTP and queue infrastructure handles delivery.
+messages and Discord Gateway events while caller-owned infrastructure handles delivery and event
+claims.
 
 Community packages extend the same capability system further; see [third-party capabilities](/ai/capabilities/third-party/).
 

--- a/pydantic_ai_harness/channels/README.md
+++ b/pydantic_ai_harness/channels/README.md
@@ -1,10 +1,10 @@
 # Channels
 
-Channels let a Pydantic AI agent answer Slack mentions and continue each Slack thread with its own message history.
+Channels let a Pydantic AI agent answer messages in Slack and Discord while keeping conversation history separate.
 
 ## Install
 
-Channels uses the base Harness package. This example uses an OpenAI model and FastAPI:
+The Slack example uses the base Harness package, an OpenAI model, and FastAPI:
 
 ```bash
 uv add pydantic-ai-harness "pydantic-ai-slim[openai]" fastapi uvicorn
@@ -137,5 +137,104 @@ Expose port 8000 through your HTTPS host, invite the bot to a channel, and menti
 - On the first HTTP 429, this adapter instance pauses its replies in the current process, waits for `Retry-After`, and retries the same generated reply once. A second 429 waits again before it propagates; timeouts and 5xx responses are not retried because their delivery outcome can be ambiguous.
 - The caller owns FastAPI, the queue, OAuth, and any injected `httpx.AsyncClient`.
 - While Harness is on 0.x releases, minor releases may change this API. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
+
+## Discord
+
+The Discord adapter lets an agent answer direct messages and mentioned messages in allowed servers and threads.
+
+Install the Gateway transport and the OpenAI model provider used below:
+
+```bash
+uv add "pydantic-ai-harness[discord]" "pydantic-ai-slim[openai]"
+```
+
+In Discord's browser-based developer portal, create an application and add a bot. Use the OAuth2
+URL Generator to install the bot with the `bot` scope and the View Channels, Read Message History,
+Send Messages, and Send Messages in Threads permissions. Discord handles this one-time browser
+authorization; the adapter does not implement OAuth. On the application's **Bot** page, use
+**Reset Token** to copy the bot token. In Discord, enable **Developer Mode** under **User Settings >
+Advanced**, then right-click your user and server and choose **Copy ID**.
+
+Set the required credentials and admitted IDs:
+
+```bash
+export OPENAI_API_KEY='your-openai-api-key'
+export DISCORD_BOT_TOKEN='your-discord-bot-token'
+export DISCORD_USER_ID='your-discord-user-id'
+export DISCORD_GUILD_ID='your-discord-server-id'
+```
+
+Save this as `discord_bot.py`:
+
+```python {names="defined"}
+import logging
+import os
+
+import anyio
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.channels import ChannelHost
+from pydantic_ai_harness.channels.discord import DiscordChannel
+
+
+async def main() -> None:
+    channel = DiscordChannel(
+        os.environ['DISCORD_BOT_TOKEN'],
+        allowed_user_ids={os.environ['DISCORD_USER_ID']},
+        allowed_guild_ids={os.environ['DISCORD_GUILD_ID']},
+    )
+    agent = Agent('openai:gpt-5.6-sol', instructions='Answer questions clearly and briefly.')
+    host = ChannelHost(agent, channel)
+    async with channel:
+        async for event in channel.events():
+            try:
+                await host.handle(event)
+            except Exception:
+                logging.exception('Discord event failed')
+
+
+anyio.run(main)
+```
+
+Run it:
+
+```bash
+uv run python discord_bot.py
+```
+
+Users can ask the agent to:
+
+- answer questions in a direct message;
+- respond when mentioned in an allowed server channel or thread;
+- continue a conversation in the same channel or thread;
+- use any tools and capabilities configured on the `Agent`.
+
+Discord may deliver the same event more than once. Atomically claim `event.event_id` in durable
+storage before `host.handle()` when duplicate turns are unacceptable. The default conversation
+store also loses history on restart. The sequential example bounds pending work and continues after
+a failed event; run a bounded worker pool when different conversations need to overlap.
+
+A long reply can post earlier chunks before a later request fails, and a transport timeout can
+leave a chunk's outcome unknown. Do not blindly retry the whole `host.handle()` call. Retrying
+`channel.reply(event, same_text)` promptly uses the same nonce, but Discord only retains nonce
+deduplication for a few minutes. Replies over 20,000 characters fail before the first chunk is sent
+to bound the number of automatic writes.
+
+The adapter admits only `allowed_user_ids`. Server messages also require an
+`allowed_guild_ids` match and a bot mention unless `require_mention=False`. Passing `None`
+explicitly for either allowlist admits every ID in that category. There is no channel allowlist: an
+allowed user can invoke the bot in any bot-visible channel or thread in an allowed guild, so use
+Discord channel permission overrides to limit channel access. A Discord thread ID is globally
+unique and is both the conversation identity and reply destination, so `delivery_id` remains
+unset. With the default `intents`, setting `require_mention=False` requests the privileged Message
+Content intent, which must also be enabled in Discord's developer portal. A custom `intents` value
+must include Message Content to receive unmentioned server text.
+
+Run the adapter on asyncio with one active `events()` iterator per `DiscordChannel`. Identify pacing,
+the reconnect circuit breaker, and REST rate-limit state are process-local, while Discord's 1,000
+Identify calls per 24 hours limit applies across the bot and can reset its token. Run one adapter per
+bot. This adapter is unsharded, so Discord close code 4011 means the bot has outgrown this transport.
+The adapter serializes replies in one process and retries HTTP 429 twice when each requested delay is
+at most 60 seconds. Longer delays and other HTTP failures surface to the caller.
 
 [Source code](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/channels/)

--- a/pydantic_ai_harness/channels/discord.py
+++ b/pydantic_ai_harness/channels/discord.py
@@ -1,0 +1,528 @@
+"""Discord Gateway and REST adapter for the Channels API."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import math
+import random
+from collections.abc import AsyncGenerator, Collection
+from types import TracebackType
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+import anyio
+import httpx
+from pydantic import TypeAdapter, ValidationError
+from websockets.asyncio.client import ClientConnection, connect
+from websockets.exceptions import ConnectionClosed, InvalidStatus
+
+from ._host import ChannelEvent
+
+# Discord protocol assumptions, verified 2026-09-05:
+# - Gateway v10 heartbeats, resume state, Identify limits, and session-invalidating close codes:
+#   https://docs.discord.com/developers/events/gateway
+#   https://docs.discord.com/developers/topics/opcodes-and-status-codes
+# - Bot authentication, message length, nonce idempotency, and REST rate-limit retry fields:
+#   https://docs.discord.com/developers/reference
+#   https://docs.discord.com/developers/resources/message#create-message
+#   https://docs.discord.com/developers/topics/rate-limits
+# - Default and reply message types are the user-authored text events admitted here:
+#   https://docs.discord.com/developers/resources/message#message-object-message-types
+# Re-check these pages before changing Gateway opcodes, intents, message types, authentication, or retry policy.
+_API_BASE_URL = 'https://discord.com/api/v10'
+_GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json'
+_DEFAULT_INTENTS = (1 << 9) | (1 << 12)
+_MESSAGE_CONTENT_INTENT = 1 << 15
+_USER_MESSAGE_TYPES = {0, 19}
+_MAX_REPLY_LENGTH = 20_000
+_MAX_RETRY_AFTER = 60.0
+_FATAL_CLOSE_CODES = {4004, 4010, 4011, 4012, 4013, 4014}
+_SESSION_INVALIDATING_CLOSE_CODES = {1000, 1001, 4003, 4007, 4009}
+_HELLO_TIMEOUT = 30.0
+_MAX_CONSECUTIVE_IDENTIFY_ATTEMPTS = 100
+_JSON_OBJECT = TypeAdapter(dict[str, object])
+_JSON_OBJECTS = TypeAdapter(list[dict[str, object]])
+_GATEWAY_LOGGER = logging.Logger('pydantic_ai_harness.channels.discord.gateway', level=logging.CRITICAL + 1)
+
+
+class DiscordChannelError(RuntimeError):
+    """A Discord Gateway or REST operation failed."""
+
+
+class DiscordChannel:
+    """Translate Discord messages and replies at the provider-neutral Channels boundary.
+
+    The async event iterator reconnects and resumes Gateway sessions when Discord permits it.
+    Durable event claiming remains the caller's responsibility; repeated Discord deliveries
+    retain the same `ChannelEvent.event_id`.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        allowed_user_ids: Collection[str] | None,
+        allowed_guild_ids: Collection[str] | None = (),
+        require_mention: bool = True,
+        intents: int | None = None,
+        api_base_url: str = _API_BASE_URL,
+        gateway_url: str = _GATEWAY_URL,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Configure Discord authentication, admission policy, and transport endpoints.
+
+        Passing `None` for an allowlist explicitly admits every ID in that category. Guild
+        messages are denied by default, while direct messages follow `allowed_user_ids`.
+        """
+        if not token:
+            raise ValueError('Discord bot token must not be empty')
+        self._token = token
+        self._allowed_user_ids = None if allowed_user_ids is None else frozenset(allowed_user_ids)
+        self._allowed_guild_ids = None if allowed_guild_ids is None else frozenset(allowed_guild_ids)
+        self._require_mention = require_mention
+        self._intents = (
+            _DEFAULT_INTENTS | (_MESSAGE_CONTENT_INTENT if not require_mention else 0) if intents is None else intents
+        )
+        self._api_base_url = api_base_url.rstrip('/')
+        self._gateway_url = gateway_url
+        self._http_client = http_client
+        self._owns_http_client = http_client is None
+        self._sequence: int | None = None
+        self._session_id: str | None = None
+        self._resume_gateway_url: str | None = None
+        self._bot_user_id: str | None = None
+        self._heartbeat_acknowledged = True
+        self._last_identify_at: float | None = None
+        self._identify_attempts = 0
+        self._rest_lock = anyio.Lock()
+        self._rest_blocked_until = 0.0
+        self._events_active = False
+        self._gateway_task: asyncio.Task[None] | None = None
+
+    async def __aenter__(self) -> DiscordChannel:
+        """Enter the adapter lifecycle."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Leave the adapter lifecycle and close owned resources."""
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close active Gateway and adapter-owned HTTP resources."""
+        gateway_task = self._gateway_task
+        if gateway_task is not None:
+            gateway_task.cancel()
+        with anyio.CancelScope(shield=True):
+            if gateway_task is not None:
+                await asyncio.gather(gateway_task, return_exceptions=True)
+                if self._gateway_task is gateway_task:
+                    self._gateway_task = None
+                    self._clear_session()
+                    self._events_active = False
+            if self._owns_http_client and self._http_client is not None:
+                await self._http_client.aclose()
+                self._http_client = None
+
+    async def events(self) -> AsyncGenerator[ChannelEvent, None]:
+        """Yield admitted text messages while maintaining the Discord Gateway session."""
+        if self._events_active:
+            raise DiscordChannelError('DiscordChannel supports one active event iterator')
+        self._events_active = True
+        queue: asyncio.Queue[ChannelEvent] = asyncio.Queue(maxsize=100)
+        gateway_task = asyncio.create_task(self._gateway_loop(queue))
+        self._gateway_task = gateway_task
+        next_event: asyncio.Task[ChannelEvent] | None = None
+        try:
+            while True:
+                next_event = asyncio.create_task(queue.get())
+                done, _ = await asyncio.wait((gateway_task, next_event), return_when=asyncio.FIRST_COMPLETED)
+                if gateway_task in done:
+                    next_event.cancel()
+                    await asyncio.gather(next_event, return_exceptions=True)
+                    next_event = None
+                    await gateway_task
+                    raise DiscordChannelError('Discord Gateway event loop stopped unexpectedly')  # pragma: no cover
+                event = next_event.result()
+                next_event = None
+                yield event
+        finally:
+            if next_event is not None:
+                next_event.cancel()
+            gateway_task.cancel()
+            with anyio.CancelScope(shield=True):
+                if next_event is not None:
+                    await asyncio.gather(next_event, return_exceptions=True)
+                await asyncio.gather(gateway_task, return_exceptions=True)
+                if self._gateway_task is gateway_task:
+                    self._gateway_task = None
+                    self._clear_session()
+                    self._events_active = False
+
+    async def _gateway_loop(self, queue: asyncio.Queue[ChannelEvent]) -> None:
+        reconnect_delay = 1.0
+        while True:
+            established = asyncio.Event()
+            using_resume_gateway = self._resume_gateway_url is not None
+            try:
+                gateway_url = self._gateway_connection_url()
+                async with connect(
+                    gateway_url, ping_interval=None, close_timeout=1, max_size=None, logger=_GATEWAY_LOGGER
+                ) as websocket:
+                    await self._read_connection(websocket, queue, established)
+            except ConnectionClosed as exc:
+                close = exc.rcvd or exc.sent
+                close_code = close.code if close is not None else None
+                if close_code in _FATAL_CLOSE_CODES:
+                    raise DiscordChannelError(
+                        f'Discord Gateway rejected the connection (close code {close_code})'
+                    ) from exc
+                if close_code in _SESSION_INVALIDATING_CLOSE_CODES:
+                    self._clear_session()
+            except (OSError, TimeoutError):
+                if using_resume_gateway:
+                    self._clear_session()
+            except InvalidStatus as exc:
+                status_code = exc.response.status_code
+                if using_resume_gateway:
+                    self._clear_session()
+                elif status_code < 500:
+                    raise DiscordChannelError(f'Discord Gateway handshake failed with HTTP {status_code}') from exc
+            if established.is_set():
+                reconnect_delay = 1.0
+            await anyio.sleep(reconnect_delay)
+            reconnect_delay = min(reconnect_delay * 2, 30)
+
+    async def reply(self, event: ChannelEvent, text: str) -> None:
+        """Post a reply to the source Discord message, honoring REST rate limits."""
+        if not text:
+            raise DiscordChannelError('Discord replies must not be empty')
+        if len(text) > _MAX_REPLY_LENGTH:
+            raise DiscordChannelError('Discord replies must not exceed 20,000 characters')
+        chunks = [text[index : index + 2000] for index in range(0, len(text), 2000)]
+        reply_digest = hashlib.blake2s(text.encode()).digest()
+        async with self._rest_lock:
+            for index, chunk in enumerate(chunks):
+                await self._send_chunk(event, chunk, index, reply_digest)
+
+    def _gateway_connection_url(self) -> str:
+        base = self._resume_gateway_url or self._gateway_url
+        parts = urlsplit(base)
+        query = [
+            (key, value)
+            for key, value in parse_qsl(parts.query, keep_blank_values=True)
+            if key not in {'v', 'encoding', 'compress'}
+        ]
+        query.extend((('v', '10'), ('encoding', 'json')))
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+
+    async def _read_connection(
+        self,
+        websocket: ClientConnection,
+        queue: asyncio.Queue[ChannelEvent],
+        established: asyncio.Event,
+    ) -> None:
+        heartbeat_task = await self._gateway_handshake(websocket)
+        if heartbeat_task is None:
+            return
+        try:
+            while True:
+                raw_message = await websocket.recv()
+                payload = self._parse_payload(raw_message)
+                if payload is None:
+                    continue
+                opcode = self._integer(payload.get('op'))
+                if opcode == 10:
+                    self._hello_interval(payload, repeated=True)
+                elif opcode == 0:
+                    if not await self._handle_dispatch(websocket, queue, established, payload):
+                        return
+                elif opcode == 1:
+                    await self._send_heartbeat(websocket, expect_ack=False)
+                elif opcode == 7:
+                    await websocket.close(code=4000)
+                elif opcode == 9:
+                    if payload.get('d') is not True:
+                        self._clear_session()
+                    await websocket.close(code=4000)
+                elif opcode == 11:
+                    self._heartbeat_acknowledged = True
+        finally:
+            heartbeat_task.cancel()
+            await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+    async def _gateway_handshake(self, websocket: ClientConnection) -> asyncio.Task[None] | None:
+        with anyio.fail_after(_HELLO_TIMEOUT):
+            while True:
+                payload = self._parse_payload(await websocket.recv())
+                if payload is None:
+                    continue
+                opcode = self._integer(payload.get('op'))
+                if opcode == 10:
+                    interval = self._hello_interval(payload, repeated=False)
+                    self._heartbeat_acknowledged = True
+                    await self._authenticate(websocket)
+                    return asyncio.create_task(self._heartbeat(websocket, interval))
+                if opcode == 7:
+                    await websocket.close(code=4000)
+                    return None
+                if opcode == 9:
+                    if payload.get('d') is not True:
+                        self._clear_session()
+                    await websocket.close(code=4000)
+                    return None
+
+    async def _handle_dispatch(
+        self,
+        websocket: ClientConnection,
+        queue: asyncio.Queue[ChannelEvent],
+        established: asyncio.Event,
+        payload: dict[str, object],
+    ) -> bool:
+        sequence = self._integer(payload.get('s'))
+        event = self._dispatch_event(payload)
+        event_name = payload.get('t')
+        if event_name == 'RESUMED' or (
+            event_name == 'READY'
+            and self._session_id is not None
+            and self._resume_gateway_url is not None
+            and self._bot_user_id is not None
+        ):
+            established.set()
+        if event is not None:
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                await websocket.close(code=4000)
+                return False
+        if sequence is not None:
+            self._sequence = sequence
+        return True
+
+    def _hello_interval(self, payload: dict[str, object], *, repeated: bool) -> float:
+        if repeated:
+            raise DiscordChannelError('Discord Gateway sent more than one Hello')
+        data = self._object(payload.get('d'))
+        interval_ms = self._integer(data.get('heartbeat_interval'))
+        if interval_ms is None or interval_ms <= 0:
+            raise DiscordChannelError('Discord Gateway Hello omitted a valid heartbeat interval')
+        try:
+            return interval_ms / 1000
+        except OverflowError:
+            raise DiscordChannelError('Discord Gateway Hello omitted a valid heartbeat interval') from None
+
+    async def _authenticate(self, websocket: ClientConnection) -> None:
+        if self._session_id is not None and self._sequence is not None:
+            await websocket.send(
+                json.dumps(
+                    {
+                        'op': 6,
+                        'd': {'token': self._token, 'session_id': self._session_id, 'seq': self._sequence},
+                    }
+                )
+            )
+            return
+        now = anyio.current_time()
+        if self._identify_attempts >= _MAX_CONSECUTIVE_IDENTIFY_ATTEMPTS:
+            raise DiscordChannelError('Discord Gateway stopped after 100 consecutive Identify attempts without READY')
+        if self._last_identify_at is not None:
+            await anyio.sleep(max(0, 5 - (now - self._last_identify_at)))
+        self._last_identify_at = anyio.current_time()
+        self._identify_attempts += 1
+        await websocket.send(
+            json.dumps(
+                {
+                    'op': 2,
+                    'd': {
+                        'token': self._token,
+                        'intents': self._intents,
+                        'properties': {
+                            'os': 'pydantic-ai-harness',
+                            'browser': 'pydantic-ai-harness',
+                            'device': 'pydantic-ai-harness',
+                        },
+                    },
+                }
+            )
+        )
+
+    async def _heartbeat(self, websocket: ClientConnection, interval: float) -> None:
+        await anyio.sleep(interval * random.random())
+        while self._heartbeat_acknowledged:
+            await self._send_heartbeat(websocket)
+            await anyio.sleep(interval)
+        await websocket.close(code=4000)
+
+    async def _send_heartbeat(self, websocket: ClientConnection, *, expect_ack: bool = True) -> None:
+        if expect_ack:
+            self._heartbeat_acknowledged = False
+        await websocket.send(json.dumps({'op': 1, 'd': self._sequence}))
+
+    def _dispatch_event(self, payload: dict[str, object]) -> ChannelEvent | None:
+        event_name = payload.get('t')
+        data = self._object(payload.get('d'))
+        if event_name == 'READY':
+            self._session_id = self._string(data.get('session_id'))
+            self._resume_gateway_url = self._string(data.get('resume_gateway_url'))
+            user = self._object(data.get('user'))
+            self._bot_user_id = self._string(user.get('id'))
+            if not self._session_id or not self._resume_gateway_url or not self._bot_user_id:
+                self._clear_session()
+                raise DiscordChannelError('Discord Gateway READY omitted required session fields')
+            self._identify_attempts = 0
+            return None
+        if event_name != 'MESSAGE_CREATE':
+            return None
+        return self._message_event(data)
+
+    def _message_event(self, data: dict[str, object]) -> ChannelEvent | None:
+        if self._integer(data.get('type')) not in _USER_MESSAGE_TYPES:
+            return None
+        message_id = self._string(data.get('id'))
+        channel_id = self._string(data.get('channel_id'))
+        content = self._string(data.get('content'))
+        author = self._object(data.get('author'))
+        author_id = self._string(author.get('id'))
+        if not message_id or not channel_id or not content or not author_id:
+            return None
+        bot = author.get('bot')
+        if ('bot' in author and not isinstance(bot, bool)) or bot is True:
+            return None
+        if 'webhook_id' in data or author_id == self._bot_user_id:
+            return None
+        if self._allowed_user_ids is not None and author_id not in self._allowed_user_ids:
+            return None
+
+        guild_id = self._string(data.get('guild_id'))
+        if 'guild_id' in data and not guild_id:
+            return None
+        if guild_id is not None:
+            if self._allowed_guild_ids is not None and guild_id not in self._allowed_guild_ids:
+                return None
+            if self._require_mention:
+                bot_user_id = self._bot_user_id
+                mentions = data.get('mentions')
+                if bot_user_id is None or not self._mentions_user(mentions, bot_user_id):
+                    return None
+                content = content.replace(f'<@{bot_user_id}>', '').replace(f'<@!{bot_user_id}>', '').strip()
+                if not content:
+                    return None
+        return ChannelEvent(
+            event_id=message_id,
+            conversation_id=channel_id,
+            sender_id=author_id,
+            text=content,
+            reply_to_id=message_id,
+        )
+
+    @classmethod
+    def _mentions_user(cls, value: object, user_id: str) -> bool:
+        try:
+            mentions = _JSON_OBJECTS.validate_python(value)
+        except ValidationError:
+            return False
+        return any(cls._string(item.get('id')) == user_id for item in mentions)
+
+    async def _send_chunk(self, event: ChannelEvent, text: str, index: int, reply_digest: bytes) -> None:
+        client = self._http_client
+        if client is None:
+            client = httpx.AsyncClient()
+            self._http_client = client
+        nonce_input = event.event_id.encode() + b'\0' + str(index).encode() + b'\0' + reply_digest
+        nonce = hashlib.blake2s(nonce_input, digest_size=12).hexdigest()
+        body: dict[str, object] = {
+            'content': text,
+            'allowed_mentions': {'parse': [], 'replied_user': False},
+            'nonce': nonce,
+            'enforce_nonce': True,
+        }
+        if event.reply_to_id is not None:
+            body['message_reference'] = {'message_id': event.reply_to_id, 'fail_if_not_exists': False}
+
+        url = f'{self._api_base_url}/channels/{event.conversation_id}/messages'
+        for attempt in range(3):  # pragma: no branch
+            blocked_for = self._rest_blocked_until - anyio.current_time()
+            if blocked_for > 0:
+                await anyio.sleep(blocked_for)
+                self._rest_blocked_until = 0
+            response = await client.post(
+                url,
+                json=body,
+                headers={
+                    'Authorization': f'Bot {self._token}',
+                    'User-Agent': 'DiscordBot (https://github.com/pydantic/pydantic-ai-harness, 1)',
+                },
+            )
+            if response.status_code != 429:
+                try:
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    raise DiscordChannelError(
+                        f'Discord Create Message failed with HTTP {response.status_code}'
+                    ) from exc
+                return
+            retry_after = self._retry_after(response)
+            self._rest_blocked_until = anyio.current_time() + retry_after
+            if attempt == 2:
+                break
+            await anyio.sleep(retry_after)
+            self._rest_blocked_until = 0
+        raise DiscordChannelError('Discord Create Message remained rate limited after 3 attempts')
+
+    @classmethod
+    def _retry_after(cls, response: httpx.Response) -> float:
+        value = response.headers.get('Retry-After')
+        if value is None:
+            try:
+                payload = _JSON_OBJECT.validate_json(response.content)
+                retry_after = payload.get('retry_after')
+                if not isinstance(retry_after, str | int | float) or isinstance(retry_after, bool):
+                    raise DiscordChannelError('Discord rate-limit response omitted a valid retry delay')
+                value = str(retry_after)
+            except ValidationError:
+                raise DiscordChannelError('Discord rate-limit response omitted a valid retry delay') from None
+        try:
+            delay = float(value)
+        except ValueError:
+            raise DiscordChannelError('Discord rate-limit response omitted a valid retry delay') from None
+        if not math.isfinite(delay) or delay < 0 or delay > _MAX_RETRY_AFTER:
+            raise DiscordChannelError('Discord rate-limit retry delay must be between 0 and 60 seconds')
+        return delay
+
+    def _clear_session(self) -> None:
+        self._sequence = None
+        self._session_id = None
+        self._resume_gateway_url = None
+
+    @staticmethod
+    def _parse_payload(raw_message: str | bytes) -> dict[str, object] | None:
+        if not isinstance(raw_message, str):
+            return None
+        try:
+            return _JSON_OBJECT.validate_json(raw_message)
+        except ValidationError:
+            return None
+
+    @staticmethod
+    def _object(value: object) -> dict[str, object]:
+        try:
+            return _JSON_OBJECT.validate_python(value)
+        except ValidationError:
+            return {}
+
+    @staticmethod
+    def _string(value: object) -> str | None:
+        return value if isinstance(value, str) else None
+
+    @staticmethod
+    def _integer(value: object) -> int | None:
+        return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+__all__ = ('DiscordChannel', 'DiscordChannelError')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,9 @@ prompt-injection-defender = [
 prompt-injection-defender-ml = [
     "stackone-defender[onnx]>=0.7.3,<0.8 ; python_full_version >= '3.11'",
 ]
+discord = [
+    "websockets>=13,<17",
+]
 
 [project.urls]
 Homepage = 'https://github.com/pydantic/pydantic-ai-harness'

--- a/tests/channels/test_discord.py
+++ b/tests/channels/test_discord.py
@@ -1,0 +1,1483 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import anyio
+import httpx
+import pytest
+
+pytest.importorskip('websockets')
+
+from pydantic import TypeAdapter
+from pydantic_ai import Agent
+from websockets.asyncio.server import Server, ServerConnection, serve
+from websockets.datastructures import Headers
+from websockets.exceptions import ConnectionClosed, InvalidStatus
+from websockets.http11 import Response
+
+from pydantic_ai_harness.channels import ChannelEvent, ChannelHost
+from pydantic_ai_harness.channels.discord import DiscordChannel, DiscordChannelError
+
+pytestmark = pytest.mark.anyio
+
+_JSON_OBJECT = TypeAdapter(dict[str, object])
+_SOCKET_ADDRESS = TypeAdapter(tuple[str, int])
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+@asynccontextmanager
+async def _gateway(handler: Callable[[ServerConnection], Awaitable[None]]) -> AsyncGenerator[str, None]:
+    failures: list[Exception] = []
+
+    async def checked_handler(connection: ServerConnection) -> None:
+        if failures:
+            await connection.close(code=4014)
+            return
+        try:
+            await handler(connection)
+        except Exception as exc:
+            failures.append(exc)
+            raise
+
+    server: Server = await serve(checked_handler, '127.0.0.1', 0)
+    socket = next(iter(server.sockets))
+    host, port = _SOCKET_ADDRESS.validate_python(socket.getsockname()[:2])
+    try:
+        yield f'ws://{host}:{port}'
+    finally:
+        server.close()
+        await server.wait_closed()
+        if failures:
+            raise failures[0]
+
+
+def _message(*, content: str = 'hello', guild_id: str | None = None, message_type: int = 0) -> dict[str, object]:
+    data: dict[str, object] = {
+        'id': 'message-1',
+        'channel_id': 'thread-1',
+        'content': content,
+        'type': message_type,
+        'author': {'id': 'user-1', 'bot': False},
+        'mentions': [{'id': 'bot-1'}],
+    }
+    if guild_id is not None:
+        data['guild_id'] = guild_id
+    return {'op': 0, 't': 'MESSAGE_CREATE', 's': 2, 'd': data}
+
+
+class TestDiscordChannel:
+    async def test_gateway_fixture_propagates_handler_failure(self) -> None:
+        async def handler(_connection: ServerConnection) -> None:
+            raise RuntimeError('sentinel gateway failure')
+
+        with pytest.raises(RuntimeError, match='sentinel gateway failure'):
+            async with _gateway(handler) as gateway_url:
+                channel = DiscordChannel('token', allowed_user_ids=None, gateway_url=gateway_url)
+                with pytest.raises(DiscordChannelError, match='4014'):  # pragma: no branch
+                    await anext(channel.events())
+
+    async def test_identifies_and_maps_guild_thread_message(self) -> None:
+        identified: list[dict[str, object]] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            identified.append(_JSON_OBJECT.validate_json(await connection.recv()))
+            await connection.send(
+                json.dumps(
+                    {
+                        'op': 0,
+                        't': 'READY',
+                        's': 1,
+                        'd': {
+                            'session_id': 'session-1',
+                            'resume_gateway_url': 'ws://unused',
+                            'user': {'id': 'bot-1'},
+                        },
+                    }
+                )
+            )
+            await connection.send(json.dumps(_message(content='<@bot-1> explain this', guild_id='guild-1')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel(
+                'secret-token',
+                allowed_user_ids={'user-1'},
+                allowed_guild_ids={'guild-1'},
+                gateway_url=gateway_url,
+            )
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        identify_data = _JSON_OBJECT.validate_python(identified[0]['d'])
+        assert identified[0]['op'] == 2
+        assert identify_data['token'] == 'secret-token'
+        assert identify_data['intents'] == 4_608
+        assert event == ChannelEvent(
+            event_id='message-1',
+            conversation_id='thread-1',
+            sender_id='user-1',
+            text='explain this',
+            reply_to_id='message-1',
+        )
+        assert event.delivery_id is None
+
+    async def test_unmentioned_guild_messages_request_message_content_intent(self) -> None:
+        identified: dict[str, object] = {}
+
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            identified.update(_JSON_OBJECT.validate_json(await connection.recv()))
+            await connection.send(json.dumps(_message(content='unmentioned', guild_id='guild-1')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel(
+                'token',
+                allowed_user_ids={'user-1'},
+                allowed_guild_ids={'guild-1'},
+                require_mention=False,
+                gateway_url=gateway_url,
+            )
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        identify_data = _JSON_OBJECT.validate_python(identified['d'])
+        assert identify_data['intents'] == 37_376
+        assert event.text == 'unmentioned'
+
+    async def test_explicit_intents_override_defaults(self) -> None:
+        identified: dict[str, object] = {}
+
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            identified.update(_JSON_OBJECT.validate_json(await connection.recv()))
+            await connection.send(json.dumps(_message(content='event')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, intents=1, gateway_url=gateway_url)
+            events = channel.events()
+            await anext(events)
+            await events.aclose()
+
+        identify_data = _JSON_OBJECT.validate_python(identified['d'])
+        assert identify_data['intents'] == 1
+
+    async def test_forces_json_gateway_encoding_without_compression(self) -> None:
+        request_path = ''
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal request_path
+            assert connection.request is not None
+            request_path = connection.request.path
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(json.dumps(_message(content='json event')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel(
+                'token',
+                allowed_user_ids={'user-1'},
+                gateway_url=f'{gateway_url}?v=9&encoding=etf&compress=zlib-stream&trace=kept',
+            )
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'json event'
+        assert request_path == '/?trace=kept&v=10&encoding=json'
+
+    async def test_handshake_ignores_malformed_payloads_before_hello(self) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(b'{}')
+            await connection.send('{not json')
+            await connection.send(json.dumps({'op': 'unknown'}))
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(json.dumps(_message(content='after malformed handshake payloads')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'after malformed handshake payloads'
+
+    @pytest.mark.parametrize('reconnect_payload', [{'op': 7, 'd': None}, {'op': 9, 'd': True}, {'op': 9, 'd': False}])
+    async def test_reconnect_request_before_hello_starts_new_connection(
+        self, reconnect_payload: dict[str, object]
+    ) -> None:
+        connections = 0
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            if connections == 1:
+                await connection.send(json.dumps(reconnect_payload))
+                await connection.wait_closed()
+                return
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(json.dumps(_message(content='after reconnect request')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert connections == 2
+        assert event.text == 'after reconnect request'
+
+    async def test_gateway_http_failures_retry_server_error_then_surface_client_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        statuses = iter((503, 401))
+
+        class RejectedConnection:
+            async def __aenter__(self) -> None:
+                status = next(statuses)
+                raise InvalidStatus(Response(status, 'rejected', Headers()))
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc_value: BaseException | None,
+                traceback: object,
+            ) -> None:
+                return None  # pragma: no cover
+
+        def reject_connection(*_args: object, **_kwargs: object) -> RejectedConnection:
+            return RejectedConnection()
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.connect', reject_connection)
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.sleep', AsyncMock())
+        channel = DiscordChannel('token', allowed_user_ids=None)
+
+        with pytest.raises(DiscordChannelError, match='HTTP 401'):
+            await anext(channel.events())
+
+    @pytest.mark.parametrize('failure', ['network', 'http'])
+    async def test_failed_resume_endpoint_falls_back_to_fresh_identify(
+        self, failure: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        authentications: list[dict[str, object]] = []
+        connections = 0
+
+        async def reject_handshake(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            await reader.readuntil(b'\r\n\r\n')
+            writer.write(b'HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n')
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        rejection_server = await asyncio.start_server(reject_handshake, '127.0.0.1', 0)
+        rejection_socket = rejection_server.sockets[0]
+        rejection_host, rejection_port = _SOCKET_ADDRESS.validate_python(rejection_socket.getsockname()[:2])
+        resume_gateway_url = 'ws://127.0.0.1:1' if failure == 'network' else f'ws://{rejection_host}:{rejection_port}'
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            authentications.append(_JSON_OBJECT.validate_json(await connection.recv()))
+            if connections == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            'op': 0,
+                            't': 'READY',
+                            's': 1,
+                            'd': {
+                                'session_id': 'session',
+                                'resume_gateway_url': resume_gateway_url,
+                                'user': {'id': 'bot-1'},
+                            },
+                        }
+                    )
+                )
+                await connection.close(code=4000)
+            else:
+                await connection.send(json.dumps(_message(content='fresh connection')))
+                await connection.wait_closed()
+
+        never_release = asyncio.Event()
+
+        async def skip_transport_delays(delay: float) -> None:
+            if delay >= 60:
+                await never_release.wait()
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.sleep', skip_transport_delays)
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.random.random', lambda: 1.0)
+        try:
+            async with _gateway(handler) as gateway_url:
+                channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+                events = channel.events()
+                event = await anext(events)
+                await events.aclose()
+        finally:
+            rejection_server.close()
+            await rejection_server.wait_closed()
+
+        assert event.text == 'fresh connection'
+        assert [authentication['op'] for authentication in authentications] == [2, 2]
+
+    @pytest.mark.parametrize(
+        'ready_data',
+        [
+            {'resume_gateway_url': 'ws://resume', 'user': {'id': 'bot'}},
+            {'session_id': '', 'resume_gateway_url': 'ws://resume', 'user': {'id': 'bot'}},
+            {'session_id': 'session', 'user': {'id': 'bot'}},
+            {'session_id': 'session', 'resume_gateway_url': '', 'user': {'id': 'bot'}},
+            {'session_id': 'session', 'resume_gateway_url': 'ws://resume'},
+            {'session_id': 'session', 'resume_gateway_url': 'ws://resume', 'user': {'id': ''}},
+        ],
+    )
+    async def test_rejects_ready_without_required_session_fields(self, ready_data: dict[str, object]) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(json.dumps({'op': 0, 't': 'READY', 's': 1, 'd': ready_data}))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids=None, gateway_url=gateway_url)
+            with pytest.raises(DiscordChannelError, match='READY omitted required'):
+                await anext(channel.events())
+
+    async def test_ignores_large_gateway_event_before_message(self) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(
+                json.dumps(
+                    {
+                        'op': 0,
+                        't': 'READY',
+                        's': 1,
+                        'd': {
+                            'session_id': 'session-1',
+                            'resume_gateway_url': 'ws://unused',
+                            'user': {'id': 'bot-1'},
+                        },
+                    }
+                )
+            )
+            await connection.send(json.dumps({'op': 0, 't': 'GUILD_CREATE', 's': 2, 'd': {'x': 'x' * 1_100_000}}))
+            await connection.send(json.dumps(_message(content='after large event')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'after large event'
+
+    async def test_buffer_overload_resumes_without_losing_events(self) -> None:
+        total_messages = 110
+        connections = 0
+        overflowed = asyncio.Event()
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            connection_number = connections
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            authentication = _JSON_OBJECT.validate_json(await connection.recv())
+            if connection_number == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            'op': 0,
+                            't': 'READY',
+                            's': 0,
+                            'd': {
+                                'session_id': 'session',
+                                'resume_gateway_url': gateway_url,
+                                'user': {'id': 'bot-1'},
+                            },
+                        }
+                    )
+                )
+                first_sequence = 1
+            else:
+                resume = _JSON_OBJECT.validate_python(authentication['d'])
+                first_sequence = int(str(resume['seq'])) + 1
+            try:
+                for sequence in range(first_sequence, total_messages + 1):
+                    payload = _message(content=f'message {sequence}')
+                    data = _JSON_OBJECT.validate_python(payload['d'])
+                    data['id'] = f'message-{sequence}'
+                    payload['d'] = data
+                    payload['s'] = sequence
+                    await connection.send(json.dumps(payload))
+                await connection.wait_closed()
+            except ConnectionClosed:  # pragma: no cover -- close timing varies by event loop
+                pass
+            finally:
+                if connection_number == 1:
+                    overflowed.set()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            received = [(await anext(events)).event_id]
+            await asyncio.wait_for(overflowed.wait(), timeout=3)
+            while len(received) < total_messages:
+                received.append((await anext(events)).event_id)
+            await events.aclose()
+
+        assert received == [f'message-{sequence}' for sequence in range(1, total_messages + 1)]
+        assert connections >= 2
+
+    async def test_rejects_a_second_active_event_iterator(self) -> None:
+        identified = asyncio.Event()
+
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            identified.set()
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids=None, gateway_url=gateway_url)
+            first_events = channel.events()
+            first_consumer = asyncio.create_task(anext(first_events))
+            await asyncio.wait_for(identified.wait(), timeout=1)
+            with pytest.raises(DiscordChannelError, match='one active event iterator'):
+                await anext(channel.events())
+            first_consumer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first_consumer
+            await first_events.aclose()
+
+    @pytest.mark.parametrize('reconnect_payload', [{'op': 7, 'd': None}, {'op': 9, 'd': True}])
+    async def test_resumes_with_latest_sequence_and_preserves_event_identity(
+        self, reconnect_payload: dict[str, object]
+    ) -> None:
+        connections = 0
+        gateway_url = ''
+        authentications: list[dict[str, object]] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            authentications.append(_JSON_OBJECT.validate_json(await connection.recv()))
+            if connections == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            'op': 0,
+                            't': 'READY',
+                            's': 8,
+                            'd': {
+                                'session_id': 'session-1',
+                                'resume_gateway_url': gateway_url,
+                                'user': {'id': 'bot-1'},
+                            },
+                        }
+                    )
+                )
+                await connection.send(json.dumps(_message(content='first')))
+                await connection.send(json.dumps(reconnect_payload))
+                await connection.wait_closed()
+            else:
+                await connection.send(json.dumps(_message(content='replayed')))
+                await connection.wait_closed()
+
+        async with _gateway(handler) as running_gateway_url:
+            gateway_url = running_gateway_url
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            first = await anext(events)
+            second = await anext(events)
+            await events.aclose()
+
+        resume_data = _JSON_OBJECT.validate_python(authentications[1]['d'])
+        assert first.event_id == second.event_id == 'message-1'
+        assert authentications[1]['op'] == 6
+        assert resume_data == {'token': 'token', 'session_id': 'session-1', 'seq': 2}
+
+    async def test_invalid_session_starts_a_new_session(self) -> None:
+        connections = 0
+        authentications: list[dict[str, object]] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            authentications.append(_JSON_OBJECT.validate_json(await connection.recv()))
+            if connections == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            'op': 0,
+                            't': 'READY',
+                            's': 1,
+                            'd': {
+                                'session_id': 'stale',
+                                'resume_gateway_url': gateway_url,
+                                'user': {'id': 'bot-1'},
+                            },
+                        }
+                    )
+                )
+                await connection.send(json.dumps({'op': 9, 'd': False}))
+                await connection.wait_closed()
+            else:
+                await connection.send(json.dumps(_message(content='new session')))
+                await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'new session'
+        assert [authentication['op'] for authentication in authentications] == [2, 2]
+
+    @pytest.mark.parametrize('close_code', [1000, 1001])
+    async def test_clean_close_reidentifies(self, close_code: int, monkeypatch: pytest.MonkeyPatch) -> None:
+        times = iter((0.0, 0.0, 10.0, 10.0))
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.current_time', lambda: next(times))
+        connections = 0
+        authentications: list[dict[str, object]] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            authentications.append(_JSON_OBJECT.validate_json(await connection.recv()))
+            if connections == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            'op': 0,
+                            't': 'READY',
+                            's': 1,
+                            'd': {
+                                'session_id': 'stale',
+                                'resume_gateway_url': gateway_url,
+                                'user': {'id': 'bot-1'},
+                            },
+                        }
+                    )
+                )
+                await connection.close(code=close_code)
+            else:
+                await connection.send(json.dumps(_message(content='new session')))
+                await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            await anext(events)
+            await events.aclose()
+
+        assert [authentication['op'] for authentication in authentications] == [2, 2]
+
+    @pytest.mark.parametrize('close_code', [4007, 4009])
+    async def test_stale_session_close_codes_reidentify(self, close_code: int, monkeypatch: pytest.MonkeyPatch) -> None:
+        times = iter((0.0, 0.0, 10.0, 10.0))
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.current_time', lambda: next(times))
+        connections = 0
+        authentications: list[dict[str, object]] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            authentications.append(_JSON_OBJECT.validate_json(await connection.recv()))
+            if connections == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            'op': 0,
+                            't': 'READY',
+                            's': 1,
+                            'd': {
+                                'session_id': 'stale',
+                                'resume_gateway_url': gateway_url,
+                                'user': {'id': 'bot-1'},
+                            },
+                        }
+                    )
+                )
+                await connection.close(code=close_code)
+            else:
+                await connection.send(json.dumps(_message(content='new session')))
+                await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            await anext(events)
+            await events.aclose()
+
+        assert [authentication['op'] for authentication in authentications] == [2, 2]
+
+    async def test_answers_server_heartbeat_with_latest_sequence(self) -> None:
+        heartbeat: dict[str, object] = {}
+
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(
+                json.dumps(
+                    {
+                        'op': 0,
+                        't': 'READY',
+                        's': 7,
+                        'd': {'session_id': 's', 'resume_gateway_url': 'ws://unused', 'user': {'id': 'bot-1'}},
+                    }
+                )
+            )
+            await connection.send(json.dumps({'op': 1, 'd': None}))
+            heartbeat.update(_JSON_OBJECT.validate_json(await connection.recv()))
+            await connection.send(json.dumps({'op': 11, 'd': None}))
+            await connection.send(json.dumps(_message(content='after heartbeat')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            await anext(events)
+            await events.aclose()
+
+        assert heartbeat == {'op': 1, 'd': 7}
+
+    async def test_server_requested_heartbeat_does_not_consume_periodic_ack(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.random.random', lambda: 1)
+
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 20}}))
+            await connection.recv()
+            await connection.send(json.dumps({'op': 1, 'd': None}))
+            requested = _JSON_OBJECT.validate_json(await connection.recv())
+            periodic = _JSON_OBJECT.validate_json(await connection.recv())
+            await connection.send(json.dumps({'op': 11, 'd': None}))
+            await connection.send(json.dumps(_message(content='connection stayed healthy')))
+            await connection.wait_closed()
+            assert requested['op'] == periodic['op'] == 1
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'connection stayed healthy'
+
+    async def test_reads_heartbeat_ack_while_event_consumer_is_paused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.random.random', lambda: 0)
+        heartbeat_count = 0
+        received_multiple_heartbeats = asyncio.Event()
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal heartbeat_count
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 20}}))
+            await connection.recv()
+            await connection.send(
+                json.dumps(
+                    {
+                        'op': 0,
+                        't': 'READY',
+                        's': 1,
+                        'd': {'session_id': 's', 'resume_gateway_url': gateway_url, 'user': {'id': 'bot-1'}},
+                    }
+                )
+            )
+            await connection.send(json.dumps(_message(content='pause consumer')))
+            while heartbeat_count < 2:
+                payload = _JSON_OBJECT.validate_json(await connection.recv())
+                assert payload.get('op') == 1
+                heartbeat_count += 1
+                await connection.send(json.dumps({'op': 11, 'd': None}))
+            received_multiple_heartbeats.set()
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            await anext(events)
+            await asyncio.wait_for(received_multiple_heartbeats.wait(), timeout=1)
+            await events.aclose()
+
+        assert heartbeat_count >= 2
+
+    async def test_first_heartbeat_uses_gateway_jitter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.random.random', lambda: 0.25)
+        requested_delays: list[float] = []
+        original_sleep = anyio.sleep
+
+        async def recording_sleep(delay: float) -> None:
+            requested_delays.append(delay)
+            await original_sleep(delay)
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.sleep', recording_sleep)
+
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 100}}))
+            await connection.recv()
+            heartbeat = _JSON_OBJECT.validate_json(await connection.recv())
+            assert heartbeat['op'] == 1
+            await connection.send(json.dumps({'op': 11, 'd': None}))
+            await connection.send(json.dumps(_message(content='after jitter')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            await anext(events)
+            await events.aclose()
+
+        assert abs(requested_delays[0] - 0.025) < 1e-9
+
+    @pytest.mark.parametrize('heartbeat_interval', ['false', '1e309', '1' + '0' * 1000])
+    async def test_rejects_invalid_gateway_hello(self, heartbeat_interval: str) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(f'{{"op":10,"d":{{"heartbeat_interval":{heartbeat_interval}}}}}')
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids=None, gateway_url=gateway_url)
+            with pytest.raises(DiscordChannelError, match='valid heartbeat interval'):
+                await anext(channel.events())
+
+    async def test_rejects_repeated_gateway_hello(self) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            hello = json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}})
+            await connection.send(hello)
+            await connection.recv()
+            await connection.send(hello)
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids=None, gateway_url=gateway_url)
+            with pytest.raises(DiscordChannelError, match='more than one Hello'):
+                await anext(channel.events())
+
+    async def test_reconnects_when_gateway_omits_hello(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord._HELLO_TIMEOUT', 0.01)
+        connections = 0
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            if connections == 1:
+                await connection.wait_closed()
+                return
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(json.dumps(_message(content='after timeout')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'after timeout'
+        assert connections == 2
+
+    async def test_cancelling_waiting_consumer_closes_gateway_tasks(self) -> None:
+        identified = asyncio.Event()
+        connections = 0
+        authentications: list[dict[str, object]] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            authentications.append(_JSON_OBJECT.validate_json(await connection.recv()))
+            if connections == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            'op': 0,
+                            't': 'READY',
+                            's': 1,
+                            'd': {
+                                'session_id': 'session',
+                                'resume_gateway_url': gateway_url,
+                                'user': {'id': 'bot-1'},
+                            },
+                        }
+                    )
+                )
+                identified.set()
+            else:
+                await connection.send(json.dumps(_message(content='fresh connection')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids=None, gateway_url=gateway_url)
+            events = channel.events()
+            consumer = asyncio.create_task(anext(events))
+            await asyncio.wait_for(identified.wait(), timeout=1)
+            consumer.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await consumer
+            await events.aclose()
+            next_events = channel.events()
+            event = await anext(next_events)
+            await next_events.aclose()
+
+        assert consumer.done()
+        assert event.text == 'fresh connection'
+        assert [authentication['op'] for authentication in authentications] == [2, 2]
+
+    async def test_anyio_cancellation_closes_gateway_and_allows_reuse(self) -> None:
+        first_connected = asyncio.Event()
+        first_disconnected = asyncio.Event()
+        connections = 0
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            connection_number = connections
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            if connection_number == 1:
+                first_connected.set()
+                await connection.wait_closed()
+                first_disconnected.set()
+                return
+            await connection.send(json.dumps(_message(content='after cancellation')))
+            await connection.wait_closed()
+
+        async def consume(channel: DiscordChannel) -> None:
+            async for _event in channel.events():
+                pass  # pragma: no cover
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            async with anyio.create_task_group() as group:
+                group.start_soon(consume, channel)
+                await first_connected.wait()
+                group.cancel_scope.cancel()
+            await asyncio.wait_for(first_disconnected.wait(), timeout=1)
+
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert connections == 2
+        assert event.text == 'after cancellation'
+
+    async def test_context_exit_closes_a_paused_event_connection(self) -> None:
+        disconnected = asyncio.Event()
+        connections = 0
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            content = 'pause iterator' if connections == 1 else 'replacement iterator'
+            await connection.send(json.dumps(_message(content=content)))
+            await connection.wait_closed()
+            if connections == 1:
+                disconnected.set()
+
+        async with _gateway(handler) as gateway_url:
+            async with DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url) as channel:
+                events = channel.events()
+                event = await anext(events)
+            await asyncio.wait_for(disconnected.wait(), timeout=1)
+            replacement_events = channel.events()
+            replacement_event = await anext(replacement_events)
+            await replacement_events.aclose()
+            await events.aclose()
+
+        assert event.text == 'pause iterator'
+        assert replacement_event.text == 'replacement iterator'
+
+    async def test_aclose_blocks_replacement_until_gateway_cleanup_finishes(self) -> None:
+        gateway_started = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        release_cleanup = asyncio.Event()
+
+        class SlowCleanupChannel(DiscordChannel):
+            async def _gateway_loop(self, queue: asyncio.Queue[ChannelEvent]) -> None:
+                gateway_started.set()
+                try:
+                    await asyncio.Event().wait()
+                finally:
+                    cleanup_started.set()
+                    await asyncio.shield(release_cleanup.wait())
+
+        channel = SlowCleanupChannel('token', allowed_user_ids=None)
+        events = channel.events()
+        pending_event = asyncio.create_task(anext(events))
+        await gateway_started.wait()
+
+        close_task = asyncio.create_task(channel.aclose())
+        await cleanup_started.wait()
+        concurrent_close_task = asyncio.create_task(channel.aclose())
+        await asyncio.sleep(0)
+        replacement_events = channel.events()
+        with pytest.raises(DiscordChannelError, match='one active event iterator'):
+            await anext(replacement_events)
+
+        release_cleanup.set()
+        await asyncio.gather(close_task, concurrent_close_task)
+        await asyncio.gather(pending_event, return_exceptions=True)
+        await events.aclose()
+
+    async def test_missing_heartbeat_ack_reconnects_and_resumes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.random.random', lambda: 0)
+        connections = 0
+        authentications: list[dict[str, object]] = []
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 10}}))
+            authentications.append(_JSON_OBJECT.validate_json(await connection.recv()))
+            if connections == 1:
+                await connection.send(
+                    json.dumps(
+                        {
+                            'op': 0,
+                            't': 'READY',
+                            's': 4,
+                            'd': {
+                                'session_id': 'session',
+                                'resume_gateway_url': gateway_url,
+                                'user': {'id': 'bot-1'},
+                            },
+                        }
+                    )
+                )
+                await connection.recv()
+                await connection.wait_closed()
+            else:
+                await connection.send(json.dumps(_message(content='after reconnect')))
+                await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'after reconnect'
+        assert [authentication['op'] for authentication in authentications] == [2, 6]
+
+    async def test_pre_ready_disconnects_back_off_exponentially(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        original_sleep = anyio.sleep
+        reconnect_sleeps: list[float] = []
+        connections = 0
+
+        async def controlled_sleep(delay: float) -> None:
+            if 0 < delay < 60:
+                reconnect_sleeps.append(delay)
+                await original_sleep(0)
+            elif delay >= 60:
+                await asyncio.Event().wait()
+
+        times = iter(float(value) for value in range(0, 1000, 10))
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.sleep', controlled_sleep)
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.current_time', lambda: next(times))
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.random.random', lambda: 1)
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            if connections < 3:
+                await connection.close(code=4000)
+                return
+            await connection.send(json.dumps(_message(content='eventually ready')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'eventually ready'
+        assert reconnect_sleeps[:2] == [1, 2]
+
+    async def test_stops_after_consecutive_identifies_without_ready(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        original_sleep = anyio.sleep
+        connections = 0
+        authentications: list[dict[str, object]] = []
+
+        async def controlled_sleep(delay: float) -> None:
+            if delay < 60:
+                await original_sleep(0)
+            else:
+                await asyncio.Event().wait()
+
+        times = iter(float(value) for value in range(0, 1000, 10))
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord._MAX_CONSECUTIVE_IDENTIFY_ATTEMPTS', 2)
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.sleep', controlled_sleep)
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.current_time', lambda: next(times))
+
+        async def handler(connection: ServerConnection) -> None:
+            nonlocal connections
+            connections += 1
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            try:
+                authentications.append(_JSON_OBJECT.validate_json(await connection.recv()))
+                await connection.close(code=4000)
+            except ConnectionClosed:
+                pass
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('token', allowed_user_ids=None, gateway_url=gateway_url)
+            with pytest.raises(DiscordChannelError, match='consecutive Identify'):
+                await anext(channel.events())
+
+        assert connections == 3
+        assert [authentication['op'] for authentication in authentications] == [2, 2]
+
+    async def test_surfaces_fatal_gateway_close_without_logging_token(self, caplog: pytest.LogCaptureFixture) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.close(code=4014, reason='privileged intent denied')
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel('do-not-leak', allowed_user_ids=None, gateway_url=gateway_url)
+            with caplog.at_level(logging.DEBUG, logger='websockets.client'):
+                with pytest.raises(DiscordChannelError, match='4014') as exc_info:  # pragma: no branch
+                    await anext(channel.events())
+
+        assert 'do-not-leak' not in str(exc_info.value)
+        assert 'do-not-leak' not in caplog.text
+
+    async def test_ignores_unadmitted_and_looping_messages(self) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(
+                json.dumps(
+                    {
+                        'op': 0,
+                        't': 'READY',
+                        's': 1,
+                        'd': {'session_id': 's', 'resume_gateway_url': 'ws://unused', 'user': {'id': 'bot-1'}},
+                    }
+                )
+            )
+            await connection.send(b'{}')
+            await connection.send('{not json')
+            await connection.send(json.dumps({'op': 'unknown'}))
+            await connection.send(json.dumps({'op': 0, 't': 'MESSAGE_CREATE', 's': None, 'd': {}}))
+            await connection.send(json.dumps({'op': 0, 't': 'MESSAGE_CREATE', 's': None, 'd': {'type': 0}}))
+            bot_message = _message()
+            bot_data = _JSON_OBJECT.validate_python(bot_message['d'])
+            bot_data['author'] = {'id': 'other-bot', 'bot': True}
+            bot_message['d'] = bot_data
+            await connection.send(json.dumps(bot_message))
+            malformed_bot_message = _message()
+            malformed_bot_data = _JSON_OBJECT.validate_python(malformed_bot_message['d'])
+            malformed_bot_data['author'] = {'id': 'user-1', 'bot': 1}
+            malformed_bot_message['d'] = malformed_bot_data
+            await connection.send(json.dumps(malformed_bot_message))
+            self_message = _message()
+            self_data = _JSON_OBJECT.validate_python(self_message['d'])
+            self_data['author'] = {'id': 'bot-1', 'bot': False}
+            self_message['d'] = self_data
+            await connection.send(json.dumps(self_message))
+            webhook_message = _message()
+            webhook_data = _JSON_OBJECT.validate_python(webhook_message['d'])
+            webhook_data['webhook_id'] = 'webhook-1'
+            webhook_message['d'] = webhook_data
+            await connection.send(json.dumps(webhook_message))
+            null_webhook_message = _message()
+            null_webhook_data = _JSON_OBJECT.validate_python(null_webhook_message['d'])
+            null_webhook_data['webhook_id'] = None
+            null_webhook_message['d'] = null_webhook_data
+            await connection.send(json.dumps(null_webhook_message))
+            disallowed_user = _message()
+            disallowed_user_data = _JSON_OBJECT.validate_python(disallowed_user['d'])
+            disallowed_user_data['author'] = {'id': 'user-2', 'bot': False}
+            disallowed_user['d'] = disallowed_user_data
+            await connection.send(json.dumps(disallowed_user))
+            await connection.send(json.dumps(_message(content='<@bot-1> wrong guild', guild_id='guild-2')))
+            malformed_guild = _message(content='invalid guild identity')
+            malformed_guild_data = _JSON_OBJECT.validate_python(malformed_guild['d'])
+            malformed_guild_data['guild_id'] = 1
+            malformed_guild['d'] = malformed_guild_data
+            await connection.send(json.dumps(malformed_guild))
+            await connection.send(json.dumps(_message(content='system message', message_type=21)))
+            malformed_type = _message(content='malformed message type')
+            malformed_type_data = _JSON_OBJECT.validate_python(malformed_type['d'])
+            malformed_type_data['type'] = '0'
+            malformed_type['d'] = malformed_type_data
+            await connection.send(json.dumps(malformed_type))
+            unmentioned = _message(content='no mention', guild_id='guild-1')
+            unmentioned_data = _JSON_OBJECT.validate_python(unmentioned['d'])
+            unmentioned_data['mentions'] = []
+            unmentioned['d'] = unmentioned_data
+            await connection.send(json.dumps(unmentioned))
+            malformed_mentions = _message(content='bad mentions', guild_id='guild-1')
+            malformed_mentions_data = _JSON_OBJECT.validate_python(malformed_mentions['d'])
+            malformed_mentions_data['mentions'] = 'not a list'
+            malformed_mentions['d'] = malformed_mentions_data
+            await connection.send(json.dumps(malformed_mentions))
+            await connection.send(json.dumps(_message(content='<@bot-1>', guild_id='guild-1')))
+            await connection.send(json.dumps(_message(content='accepted DM', message_type=19)))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel(
+                'token', allowed_user_ids={'user-1'}, allowed_guild_ids={'guild-1'}, gateway_url=gateway_url
+            )
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'accepted DM'
+
+    async def test_can_explicitly_accept_unmentioned_guild_messages(self) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(
+                json.dumps(
+                    {
+                        'op': 0,
+                        't': 'READY',
+                        's': 1,
+                        'd': {'session_id': 's', 'resume_gateway_url': 'ws://unused', 'user': {'id': 'bot-1'}},
+                    }
+                )
+            )
+            message = _message(content='no mention required', guild_id='guild-1')
+            data = _JSON_OBJECT.validate_python(message['d'])
+            data['mentions'] = []
+            message['d'] = data
+            await connection.send(json.dumps(message))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            channel = DiscordChannel(
+                'token',
+                allowed_user_ids={'user-1'},
+                allowed_guild_ids={'guild-1'},
+                require_mention=False,
+                gateway_url=gateway_url,
+            )
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == 'no mention required'
+
+    @pytest.mark.parametrize(('admit_all_guilds', 'expected'), [(False, 'accepted DM'), (True, 'guild message')])
+    async def test_guild_allowlist_default_and_explicit_wildcard(self, admit_all_guilds: bool, expected: str) -> None:
+        async def handler(connection: ServerConnection) -> None:
+            await connection.send(json.dumps({'op': 10, 'd': {'heartbeat_interval': 60_000}}))
+            await connection.recv()
+            await connection.send(
+                json.dumps(
+                    {
+                        'op': 0,
+                        't': 'READY',
+                        's': 1,
+                        'd': {'session_id': 's', 'resume_gateway_url': 'ws://unused', 'user': {'id': 'bot-1'}},
+                    }
+                )
+            )
+            await connection.send(json.dumps(_message(content='<@bot-1> guild message', guild_id='guild-1')))
+            await connection.send(json.dumps(_message(content='accepted DM')))
+            await connection.wait_closed()
+
+        async with _gateway(handler) as gateway_url:
+            if admit_all_guilds:
+                channel = DiscordChannel(
+                    'token', allowed_user_ids={'user-1'}, allowed_guild_ids=None, gateway_url=gateway_url
+                )
+            else:
+                channel = DiscordChannel('token', allowed_user_ids={'user-1'}, gateway_url=gateway_url)
+            events = channel.events()
+            event = await anext(events)
+            await events.aclose()
+
+        assert event.text == expected
+
+    async def test_public_host_path_posts_reply_with_safe_retry(self) -> None:
+        requests: list[httpx.Request] = []
+        bodies: list[dict[str, object]] = []
+
+        async def send(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            bodies.append(_JSON_OBJECT.validate_json(request.content))
+            if len(requests) == 1:
+                return httpx.Response(429, headers={'Retry-After': '0'}, request=request)
+            return httpx.Response(200, json={'id': 'reply'}, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+        channel = DiscordChannel(
+            'secret-token',
+            allowed_user_ids={'user-1'},
+            api_base_url='https://discord.test/api/v10',
+            http_client=client,
+        )
+        host = ChannelHost(Agent('test'), channel)
+        event = ChannelEvent(
+            event_id='message-1',
+            conversation_id='channel-1',
+            sender_id='user-1',
+            text='question',
+            reply_to_id='message-1',
+        )
+
+        result = await host.handle(event)
+        await client.aclose()
+
+        assert result.output == 'success (no tool calls)'
+        assert len(requests) == 2
+        assert requests[0].url == 'https://discord.test/api/v10/channels/channel-1/messages'
+        assert requests[0].headers['authorization'] == 'Bot secret-token'
+        assert requests[0].headers['user-agent'].startswith('DiscordBot (')
+        assert bodies[0] == bodies[1]
+        assert bodies[0]['allowed_mentions'] == {'parse': [], 'replied_user': False}
+        assert bodies[0]['message_reference'] == {'message_id': 'message-1', 'fail_if_not_exists': False}
+        assert bodies[0]['enforce_nonce'] is True
+        assert len(str(bodies[0]['nonce'])) <= 25
+
+    async def test_adapter_owned_http_client_is_created_and_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def send(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+
+        def client_factory() -> httpx.AsyncClient:
+            return client
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.httpx.AsyncClient', client_factory)
+        event = ChannelEvent(event_id='event', conversation_id='channel', sender_id='user', text='in')
+
+        channel = DiscordChannel('token', allowed_user_ids=None)
+        await channel.reply(event, 'reply')
+        with anyio.CancelScope() as cancel_scope:
+            cancel_scope.cancel()
+            await channel.aclose()
+
+        assert client.is_closed
+
+    async def test_splits_long_replies_without_retrying_http_errors(self) -> None:
+        contents: list[str] = []
+
+        def send(request: httpx.Request) -> httpx.Response:
+            body = _JSON_OBJECT.validate_json(request.content)
+            contents.append(str(body['content']))
+            status = 404 if len(contents) == 2 else 200
+            return httpx.Response(status, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+        channel = DiscordChannel('token', allowed_user_ids=None, http_client=client)
+        event = ChannelEvent(event_id='event', conversation_id='channel', sender_id='user', text='in')
+
+        with pytest.raises(DiscordChannelError, match='HTTP 404'):
+            await channel.reply(event, 'a' * 2001 + 'b' * 2000)
+        await client.aclose()
+
+        assert contents == ['a' * 2000, 'a' + 'b' * 1999]
+
+    async def test_sends_all_long_reply_chunks_in_order_with_distinct_nonces(self) -> None:
+        bodies: list[dict[str, object]] = []
+
+        def send(request: httpx.Request) -> httpx.Response:
+            bodies.append(_JSON_OBJECT.validate_json(request.content))
+            return httpx.Response(200, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+        channel = DiscordChannel('token', allowed_user_ids=None, http_client=client)
+        event = ChannelEvent(event_id='event', conversation_id='channel', sender_id='user', text='in')
+
+        await channel.reply(event, 'a' * 2000 + 'b' * 2000 + 'c')
+        await client.aclose()
+
+        assert [body['content'] for body in bodies] == ['a' * 2000, 'b' * 2000, 'c']
+        nonces = [str(body['nonce']) for body in bodies]
+        assert len(set(nonces)) == 3
+        assert all(len(nonce) <= 25 for nonce in nonces)
+
+    async def test_manual_retry_reuses_nonce_without_retrying_unknown_outcome(self) -> None:
+        bodies: list[dict[str, object]] = []
+
+        def send(request: httpx.Request) -> httpx.Response:
+            bodies.append(_JSON_OBJECT.validate_json(request.content))
+            if len(bodies) == 1:
+                raise httpx.ReadTimeout('unknown send outcome', request=request)
+            return httpx.Response(200, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+        channel = DiscordChannel('token', allowed_user_ids=None, http_client=client)
+        event = ChannelEvent(event_id='event', conversation_id='channel', sender_id='user', text='in')
+
+        with pytest.raises(httpx.ReadTimeout, match='unknown send outcome'):
+            await channel.reply(event, 'reply')
+        assert len(bodies) == 1
+
+        await channel.reply(event, 'reply')
+        await channel.reply(event, 'different reply')
+        await client.aclose()
+
+        assert bodies[0]['nonce'] == bodies[1]['nonce']
+        assert bodies[1]['nonce'] != bodies[2]['nonce']
+
+    async def test_rate_limit_wait_blocks_concurrent_replies(self) -> None:
+        contents: list[str] = []
+        first_request_started = asyncio.Event()
+
+        async def send(request: httpx.Request) -> httpx.Response:
+            body = _JSON_OBJECT.validate_json(request.content)
+            contents.append(str(body['content']))
+            if len(contents) == 1:
+                first_request_started.set()
+                return httpx.Response(429, json={'retry_after': 0, 'global': True}, request=request)
+            return httpx.Response(200, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+        channel = DiscordChannel('token', allowed_user_ids=None, http_client=client)
+        first = ChannelEvent(event_id='first', conversation_id='one', sender_id='user', text='in')
+        second = ChannelEvent(event_id='second', conversation_id='two', sender_id='user', text='in')
+
+        async def send_second() -> None:
+            await first_request_started.wait()
+            await channel.reply(second, 'second reply')
+
+        async with anyio.create_task_group() as group:
+            group.start_soon(channel.reply, first, 'first reply')
+            group.start_soon(send_second)
+        await client.aclose()
+
+        assert contents == ['first reply', 'first reply', 'second reply']
+
+    async def test_exhausted_rate_limit_does_not_sleep_without_another_attempt(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sleeps: list[float] = []
+
+        async def record_sleep(delay: float) -> None:
+            sleeps.append(delay)
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.sleep', record_sleep)
+        requests = 0
+
+        def send(request: httpx.Request) -> httpx.Response:
+            nonlocal requests
+            requests += 1
+            return httpx.Response(429, headers={'Retry-After': '2'}, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+        channel = DiscordChannel('token', allowed_user_ids=None, http_client=client)
+        event = ChannelEvent(event_id='event', conversation_id='channel', sender_id='user', text='in')
+
+        with pytest.raises(DiscordChannelError, match='remained rate limited'):
+            await channel.reply(event, 'reply')
+        await client.aclose()
+
+        assert requests == 3
+        assert sleeps == [2, 2]
+
+    async def test_cancelled_rate_limit_wait_blocks_the_next_reply(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sleeps: list[float] = []
+        first_sleep_started = asyncio.Event()
+        never_release = asyncio.Event()
+
+        async def controlled_sleep(delay: float) -> None:
+            sleeps.append(delay)
+            if len(sleeps) == 1:
+                first_sleep_started.set()
+                await never_release.wait()
+
+        monkeypatch.setattr('pydantic_ai_harness.channels.discord.anyio.sleep', controlled_sleep)
+        contents: list[str] = []
+
+        def send(request: httpx.Request) -> httpx.Response:
+            body = _JSON_OBJECT.validate_json(request.content)
+            contents.append(str(body['content']))
+            if len(contents) == 1:
+                return httpx.Response(429, headers={'Retry-After': '2'}, request=request)
+            return httpx.Response(200, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+        channel = DiscordChannel('token', allowed_user_ids=None, http_client=client)
+        first = ChannelEvent(event_id='first', conversation_id='one', sender_id='user', text='in')
+        second = ChannelEvent(event_id='second', conversation_id='two', sender_id='user', text='in')
+
+        first_reply = asyncio.create_task(channel.reply(first, 'first reply'))
+        await first_sleep_started.wait()
+        first_reply.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first_reply
+        await channel.reply(second, 'second reply')
+        await client.aclose()
+
+        assert contents == ['first reply', 'second reply']
+        assert len(sleeps) == 2
+        assert sleeps[1] > 0
+
+    @pytest.mark.parametrize(
+        ('headers', 'content'),
+        [
+            ({'Retry-After': 'nan'}, b''),
+            ({'Retry-After': '-1'}, b''),
+            ({'Retry-After': '61'}, b''),
+            ({'Retry-After': 'not-a-number'}, b''),
+            ({}, b'{not json'),
+            ({}, b'{"retry_after": false}'),
+        ],
+    )
+    async def test_rejects_invalid_rate_limit_delay_and_redacts_token(
+        self, headers: dict[str, str], content: bytes
+    ) -> None:
+        def send(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, headers=headers, content=content, request=request)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(send))
+        channel = DiscordChannel('do-not-leak', allowed_user_ids=None, http_client=client)
+        event = ChannelEvent(event_id='event', conversation_id='channel', sender_id='user', text='in')
+
+        with pytest.raises(DiscordChannelError, match='retry delay') as exc_info:
+            await channel.reply(event, 'reply')
+        await client.aclose()
+
+        assert 'do-not-leak' not in repr(channel)
+        assert 'do-not-leak' not in str(exc_info.value)
+
+    async def test_requires_explicit_nonempty_credentials_and_reply(self) -> None:
+        with pytest.raises(ValueError, match='must not be empty'):
+            DiscordChannel('', allowed_user_ids=None)
+
+        channel = DiscordChannel('token', allowed_user_ids=None)
+        event = ChannelEvent(event_id='event', conversation_id='channel', sender_id='user', text='in')
+        with pytest.raises(DiscordChannelError, match='must not be empty'):
+            await channel.reply(event, '')
+        with pytest.raises(DiscordChannelError, match='must not exceed 20,000'):
+            await channel.reply(event, 'x' * 20_001)
+        await channel.aclose()

--- a/uv.lock
+++ b/uv.lock
@@ -3955,6 +3955,10 @@ codemode = [
 dbos = [
     { name = "pydantic-ai-slim", extra = ["dbos"] },
 ]
+discord = [
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+]
 dynamic-workflow = [
     { name = "pydantic-monty" },
 ]
@@ -4051,9 +4055,10 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'skills'", specifier = ">=6.0.2" },
     { name = "stackone-defender", marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender'", specifier = ">=0.7.3,<0.8" },
     { name = "stackone-defender", extras = ["onnx"], marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender-ml'", specifier = ">=0.7.3,<0.8" },
+    { name = "websockets", marker = "extra == 'discord'", specifier = ">=13,<17" },
     { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.1,<4" },
 ]
-provides-extras = ["acp", "anthropic", "aws-lambda", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
+provides-extras = ["acp", "anthropic", "aws-lambda", "browser-use", "cli", "code-mode", "codemode", "dbos", "discord", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What this adds

This lets a text agent receive Discord direct messages and allowed server messages through the Gateway, then reply in the same channel or thread. Conversation history stays separate by Discord's globally unique channel or thread ID.

## How a user runs it

Install with `uv add "pydantic-ai-harness[discord]" "pydantic-ai-slim[openai]"`. Create and install a Discord bot in the browser, then pass its token and admission allowlists to `DiscordChannel`. Pass the adapter and an `Agent` to `ChannelHost`, then consume `channel.events()`. The [Channels guide](https://github.com/adtyavrdhn/pydantic-ai-harness/blob/codex/discord-channel-787/docs/channels.md#discord) has the complete runnable example and exact environment variables.

## What it can access or change

The adapter reads user-authored default and reply text from `MESSAGE_CREATE` events. It admits only configured user IDs. Server messages also need an allowed guild ID and, by default, a bot mention. It ignores bot, self, webhook, empty, and malformed messages. It does not read message history, attachments, reactions, edits, member lists, or channel topics.

Each admitted message may post one text reply, split into Discord-sized chunks, in the source channel or thread. Replies reference the source message and suppress generated mentions. The adapter exposes no Discord administration, search, delete, moderation, or thread-creation tools. The ordinary reply needs no extra approval because the user triggered it. Additional tools and approvals are controlled by the separately configured `Agent`.

## Maintainer attention

- **Direct Gateway implementation.** The adapter owns v10 Hello, heartbeat, ACK, Identify, Resume, reconnect, close-code, and timeout behavior instead of using a full Discord SDK. Tests cover these paths, including clean-close re-identification and fallback from a failed resume endpoint, and source comments link the current specification. Impact: protocol changes require maintenance here. Mitigation: the implementation forces JSON without compression and keeps the public API transport-focused. Maintainer decision: accept the smaller dependency or request a larger SDK.
- **Authentication and installation.** A bot token is sent in Gateway authentication and the REST `Authorization` header. Token-bearing WebSocket frame logging is disabled, and public errors omit the token. Discord handles the one-time browser installation; runtime is headless and has no user OAuth flow. No paid Discord plan is known to be required. Model-provider use may cost money. No maintainer decision is required.
- **Message Content.** The default mention-only server mode and direct messages do not request the privileged Message Content intent. Setting `require_mention=False` with default intents requests it and requires enabling it in Discord. Verified bots in 100 or more guilds need Discord approval. A custom `intents` value is caller-owned. No maintainer decision is required.
- **Channel scope.** Python policy allowlists users and guilds, not channels. An allowed user can trigger the bot in any visible channel or thread in an allowed guild when the mention rule passes. Discord channel permission overrides are the channel-level control. Maintainer decision: accept this small policy surface or request an adapter channel allowlist with a rule for dynamic threads.
- **Automatic write.** Each admitted event may post a reply. The bot needs View Channels, Read Message History, Send Messages, and Send Messages in Threads. Mention suppression prevents reply notifications. No further approval prompt is added because no Discord tools are exposed. No maintainer decision is required.
- **Claiming, history, and coordination.** Discord can replay events after Resume. `event_id` is stable, but callers must atomically claim it before `host.handle()` when duplicate turns matter. The example does not pretend an in-memory set is durable. History is also in memory unless callers provide a store. Cross-process claims, ordering, and coordination remain caller-owned. Maintainer decision: accept the existing `ChannelHost` boundary.
- **Partial and unknown delivery.** A long reply can post earlier chunks before a later request fails. A transport timeout can leave a send outcome unknown. Non-429 failures surface and are not automatically replayed. Retrying the same `reply(event, text)` promptly reuses deterministic chunk nonces bound to the complete reply text, but Discord retains nonce deduplication for only a few minutes. Replies over 20,000 characters fail before the first send. Retrying the entire agent turn is not recommended. No maintainer decision is required.
- **Backpressure and lifecycle.** One adapter permits one active asyncio event iterator and one Gateway connection. A 100-event buffer separates Gateway reading from model latency. Overflow reconnects with Resume. The docs process sequentially and explain bounded concurrency. Context exit cancels and awaits active Gateway work. The adapter is not sharded and supports one adapter process per bot; Discord close code 4011 surfaces when sharding is required. A hosted process must remain running. No maintainer decision is required for this initial scope.
- **Rate and session limits.** REST sends use one process-local lock and make at most three total attempts, retrying HTTP 429 at most twice only when each requested delay is at most 60 seconds. Gateway reconnect delay grows to 30 seconds. Fresh Identify is spaced by five seconds and stops after 100 consecutive attempts without `READY`. This is a reconnect circuit breaker, not enforcement of Discord's global 1,000-per-24-hour session-start quota. There is no cross-process bucket or session-limit coordinator. Maintainer decision: accept the process-local limits.
- **Provider payloads and drift.** Replies are split into 2,000-character chunks and capped at 20,000 total characters. Valid large authenticated Gateway frames are accepted because guild state events may exceed the WebSocket library's 1 MiB default, then ignored unless they are relevant message events. This trades a fixed frame cap for compatibility with Discord's event stream. There is no pagination because the adapter does not list or search. Webhook signatures do not apply because inbound events use the authenticated Gateway. API v10 is fixed. Maintainer decision: accept authenticated Gateway frame sizing and recheck first-party docs when protocol constants change.
- **Ecosystem audit.** The [source-linked ecosystem audit](https://github.com/pydantic/pydantic-ai-harness/pull/804#issuecomment-5545695869) of Hermes Agent, OpenClaw, and Nanobot found duplicate-client, zombie-session, listener-blocking, permission, and cleanup failures. The adapter enforces one iterator, isolates Gateway reading from model work, bounds handoff, checks admission and message type on every event, awaits cleanup, and uses exact IDs. A later first-party review corrected the audit's standard-close interpretation: codes 1000 and 1001 invalidate the session and now trigger fresh Identify. Their read/search/admin prompts were not adopted because this adapter exposes none of those tools. No maintainer decision is required.

## Why this design

- Discord channel and thread snowflakes are globally unique and are also REST destinations, so `conversation_id` is the raw ID and `delivery_id` stays unset.
- Gateway reading runs independently of agent work so model latency does not block heartbeat ACK processing.
- `websockets` is the only new package. A full Discord SDK would add a larger surface for one inbound event and one outbound action.
- Admission, intent selection, mention suppression, retry state, and identity are enforced in code. A provider prompt would not control any exposed Discord tool.

## Evidence

- `uv run --no-sync ruff format --check .`: passed.
- `uv run --no-sync ruff check .`: passed.
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/channels/discord.py tests/channels/test_discord.py`: 0 errors.
- `uv run --no-sync pytest -p no:cacheprovider tests/channels/test_discord.py`: 64 passed.
- `uv run --no-sync pytest -p no:cacheprovider tests/channels/test_discord.py tests/channels/test_host.py tests/test_docs_parity.py`: 368 passed.
- Repository-wide Pyright, pytest, and coverage were not run locally. Focused coverage was run only after CI reported a Discord-specific gap.
- Focused coverage: `DISCORD_COV_DIR=$(mktemp -d); COVERAGE_FILE="$DISCORD_COV_DIR/.coverage" uv run --no-sync coverage run --branch -m pytest -p no:cacheprovider tests/channels/test_discord.py; COVERAGE_FILE="$DISCORD_COV_DIR/.coverage" uv run --no-sync coverage report -m pydantic_ai_harness/channels/discord.py tests/channels/test_discord.py`: 100%, 1,350 statements and 200 branches. Required CI and combined coverage are green on `45be8349` in [run 33973912091](https://github.com/pydantic/pydantic-ai-harness/actions/runs/33973912091).
- Independent specification, standards/design, public API, security/authentication, failure behavior, tests, and docs/prompt reviews found no remaining actionable implementation finding after fixes. A final skeptical maintainer review found no remaining body gap after the linked research and retry wording were corrected.
- All 13 inline review threads were evaluated, fixed, replied to, reacted to, and resolved. Unresolved thread count: 0.

## Dependencies and PR relationships

The optional `discord` extra adds `websockets>=13,<17` for Discord's Gateway. `httpx` remains the existing REST client. The current `dependencies:approved` label records dependency approval; #790 records the original dependency rationale.

This PR is stacked on #794 through upstream base `codex/channels-slack-787` at `0857a15894626a294f7b73b603a2c91b09ec95b2`. The navigation companion is [pydantic-ai#7939](https://github.com/pydantic/pydantic-ai/pull/7939). Part of #787.