### PR TITLE
Cover the corrupt-snapshot skip in `_sync_save_snapshot` without depending on `glob` order

### DIFF
--- a/tests/step_persistence/test_step_persistence.py
+++ b/tests/step_persistence/test_step_persistence.py
@@ -368,6 +368,20 @@ class TestFileStepStore:
 
         assert await store.list_snapshots(run_id='r1') == [snapshot]
 
+    async def test_snapshot_scan_skips_a_partially_written_snapshot_file(self, tmp_path: Path) -> None:
+        # The corrupt file is the only one in the directory on purpose: the key scan returns as soon as
+        # it reads a snapshot carrying the same key, so a directory that also held a good one would only
+        # reach the corrupt file when `glob` happened to yield it first, which is filesystem order.
+        store = FileStepStore(tmp_path)
+        snapshot = ContinuableSnapshot(run_id='r1', step_index=1, messages=[], idempotency_key='0:1:complete')
+        snap_dir = tmp_path / 'r1' / 'snapshots'
+        snap_dir.mkdir(parents=True)
+        (snap_dir / 'broken.json').write_text('{', encoding='utf-8')
+
+        await store.save_snapshot(snapshot)
+
+        assert await store.list_snapshots(run_id='r1') == [snapshot]
+
     async def test_snapshot_key_line_separator_does_not_suppress_distinct_key(self, tmp_path: Path) -> None:
         store = FileStepStore(tmp_path)
         first = ContinuableSnapshot(run_id='r1', step_index=1, messages=[], idempotency_key='first\nsecond')


### PR DESCRIPTION
`_sync_save_snapshot` scans a run's existing snapshot files for a matching idempotency key, skipping any it cannot parse:

```python
for path in snap_dir.glob('*.json'):
    try:
        prior = _load_json_object(path.read_text(encoding='utf-8'))
    except (FileNotFoundError, ValueError, ValidationError):
        continue                                    # <- these two lines
    if prior.get('idempotency_key') == snapshot.idempotency_key:
        return
```

The only test that reaches the skip, `test_snapshot_record_suppresses_retry_if_key_ledger_write_was_interrupted`, leaves *both* a good snapshot and a corrupt `broken.json` in the directory. The scan `return`s as soon as it reads the good one, so whether the corrupt file is visited at all depends on which `glob` yields first.

`Path.glob` does not sort — it is `os.scandir` order, which on ext4 is the directory hash order, and **the hash seed is generated per filesystem at mkfs time**. So the same test, on the same commit, takes the skip on one machine and not on another. It takes it on our laptops; it does not on the CI runner, where `coverage` reports `_store.py:627-628` uncovered and fails `fail-under=100`.

That is why #714 — which does not touch `step_persistence` at all — has a red `coverage` job, while #712 was green: different runner, different seed. Any PR is one unlucky runner away from the same failure.

## The fix

A test whose run directory holds *only* the corrupt file, so the scan cannot return early and must take the skip in any order. It also states a property worth having on its own: a partially written snapshot file left behind by an interrupted write does not block later snapshots from being saved.

## Verification

- Forced sorted `glob` order via a `Path.glob` shim and re-measured: `627-628` covered under **both** the native and the sorted order (before this change, covered under native only).
- Mutated `continue` to `raise AssertionError` — the new test fails, so the branch is genuinely reached rather than incidentally counted.
