### PR TITLE
Handle instruction updates in token estimates and conversation search

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -35,6 +35,8 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 
 ## Triggers
 
+Instruction replacement and withdrawal records contribute their full rendered system text to token estimates.
+
 Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`. Token counts anchor on the provider-reported usage of the most recent model response when one is available. That provider usage includes the instructions, tool definitions, and `FilePart` payloads sent in the anchored request; only the messages added since are estimated. The suffix after the anchor, or a history with no usage anchor, uses `tokenizer` or a ~4-chars-per-token heuristic and cannot see `FilePart` payloads. Pending tool schemas newly revealed for the request are conservatively estimated by the implementation. `DeduplicateFileReads` runs on every request when no trigger is set (it is cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` / `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` / `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a large total.
 
 ### `max_fraction`: one setting for every model

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -35,7 +35,7 @@ An agent that runs for many turns accumulates history: tool outputs, file reads,
 
 ## Triggers
 
-Instruction replacement and withdrawal records contribute their full rendered system text to token estimates.
+Instruction replacement and withdrawal records contribute their full rendered system text to token estimates. Superseded updates before a new instruction baseline are excluded.
 
 Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`. Token counts anchor on the provider-reported usage of the most recent model response when one is available. That provider usage includes the instructions, tool definitions, and `FilePart` payloads sent in the anchored request; only the messages added since are estimated. The suffix after the anchor, or a history with no usage anchor, uses `tokenizer` or a ~4-chars-per-token heuristic and cannot see `FilePart` payloads. Pending tool schemas newly revealed for the request are conservatively estimated by the implementation. `DeduplicateFileReads` runs on every request when no trigger is set (it is cheap and near-lossless). `TieredCompaction` triggers and stops on a single `target_tokens` / `target_fraction` budget. `ClampOversizedMessages` triggers per *part* (`max_part_tokens` / `max_part_chars`), not on the whole history -- the failure it targets is one oversized part, not a large total.
 

--- a/docs/conversation-search.md
+++ b/docs/conversation-search.md
@@ -117,6 +117,8 @@ warnings.filterwarnings('ignore', category=HarnessDeprecationWarning)
 | `add_instructions` | `True` | Emit a short note telling the model the recall tool exists. |
 | `tool_id` | `conversation-search` | Toolset id for the search tool. |
 
+Persisted instruction replacements and withdrawals are searchable as system text. Their displayed excerpts are limited to 200 characters; the search index retains the full text.
+
 ## Limitations
 
 - Search only reaches what was persisted: history inherited from runs that never ran with `StepPersistence` (for example a long `message_history` passed in from an unpersisted session) cannot be recovered if compaction drops it before the first snapshot.

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -32,7 +32,7 @@ alternative: they work with every model and keep the compaction logic (and its c
 
 ## Triggers
 
-Instruction replacement and withdrawal records contribute their full rendered system text to token estimates.
+Instruction replacement and withdrawal records contribute their full rendered system text to token estimates. Superseded updates before a new instruction baseline are excluded.
 
 Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`.
 Token counts anchor on the provider-reported usage of the most recent model response when one is

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -32,6 +32,8 @@ alternative: they work with every model and keep the compaction logic (and its c
 
 ## Triggers
 
+Instruction replacement and withdrawal records contribute their full rendered system text to token estimates.
+
 Every size-based strategy triggers on `max_messages`, `max_tokens` (estimated), or `max_fraction`.
 Token counts anchor on the provider-reported usage of the most recent model response when one is
 available: its `input_tokens` measured the whole request that produced it (instructions, tool

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -78,10 +78,24 @@ def _collect_message_text(messages: Sequence[ModelMessage]) -> list[str]:
     `FilePart` is deliberately absent: its payload is binary, and counting its length as
     characters would be a number with no relation to what the provider bills.
     """
+    # Core omits earlier updates after an instruction baseline is replaced. The attribute
+    # guard keeps this compatible with core releases that predate instruction updates.
+    baseline_index = max(
+        (
+            index
+            for index, message in enumerate(messages)
+            if isinstance(message, ModelRequest)
+            and hasattr(message, 'instruction_baseline')
+            and message.instruction_baseline is not None  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]  # pragma: lax no cover
+        ),
+        default=0,
+    )
     segments: list[str] = []
-    for msg in messages:
+    for index, msg in enumerate(messages):
         if isinstance(msg, ModelRequest):
             for request_part in msg.parts:
+                if request_part.part_kind == 'instruction-delta' and index < baseline_index:  # pyright: ignore[reportUnnecessaryComparison]
+                    continue  # pragma: lax no cover
                 segments.extend(_request_part_text(request_part))
         else:
             for response_part in msg.parts:

--- a/pydantic_ai_harness/compaction/_shared.py
+++ b/pydantic_ai_harness/compaction/_shared.py
@@ -102,6 +102,9 @@ def _request_part_text(part: ModelRequestPart) -> list[str]:
         return [_user_prompt_text_for_counting(part)]
     elif isinstance(part, SystemPromptPart):
         return [part.content]
+    # Match the discriminator so this remains importable before the new core part is released.
+    elif part.part_kind == 'instruction-delta':  # pyright: ignore[reportUnnecessaryComparison]
+        return [part.render()]  # pragma: lax no cover - requires core instruction updates
     elif isinstance(part, (ToolReturnPart, RetryPromptPart)):
         # Both are sent in full. The tool-search and capability-load returns subclass
         # `ToolReturnPart`, so they arrive here too.

--- a/pydantic_ai_harness/conversation_search/README.md
+++ b/pydantic_ai_harness/conversation_search/README.md
@@ -110,6 +110,8 @@ warnings.filterwarnings('ignore', category=HarnessDeprecationWarning)
 | `add_instructions` | `True` | Emit a short note telling the model the recall tool exists. |
 | `tool_id` | `conversation-search` | Toolset id for the search tool. |
 
+Persisted instruction replacements and withdrawals are searchable as system text. Their displayed excerpts are limited to 200 characters; the search index retains the full text.
+
 ## Limitations
 
 - Search only reaches what was persisted: history inherited from runs that never ran with `StepPersistence` (for example a long `message_history` passed in from an unpersisted session) cannot be recovered if compaction drops it before the first snapshot.

--- a/pydantic_ai_harness/conversation_search/_toolset.py
+++ b/pydantic_ai_harness/conversation_search/_toolset.py
@@ -194,6 +194,10 @@ def _format_request_part(part: ModelRequestPart, *, truncate: bool) -> str | Non
         if truncate:
             content = content[:200]
         return f'System: {content}'
+    # Match the discriminator so this remains importable before the new core part is released.
+    if part.part_kind == 'instruction-delta':  # pyright: ignore[reportUnnecessaryComparison]
+        content = part.render()  # pragma: lax no cover - requires core instruction updates
+        return f'System: {content[:200] if truncate else content}'  # pragma: lax no cover
     if isinstance(part, ToolReturnPart):
         content = str(part.content)
         if truncate and len(content) > 500:

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -7,12 +7,14 @@ from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import pydantic_ai.messages as messages_module
 import pytest
 from opentelemetry.trace import NoOpTracer, Tracer, get_tracer
 from pydantic_ai import Agent
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.messages import (
     ModelMessage,
+    ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
     SpeechPart,
@@ -1378,6 +1380,27 @@ class TestManualCompactionSemantics:
 # ---------------------------------------------------------------------------
 # Realtime models (#585)
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not hasattr(messages_module, 'InstructionDeltaPart'), reason='requires core instruction updates')
+class TestInstructionDeltaCounting:
+    @pytest.mark.parametrize(
+        ('content', 'rendered'),
+        [
+            ('New state', "Instruction block 'agent:state' is replaced from this point onward by:\n\nNew state"),
+            (None, "Instruction block 'agent:state' is withdrawn. Its previous instructions no longer apply."),
+        ],
+    )
+    def test_rendered_updates_count(self, content: str | None, rendered: str) -> None:  # pragma: lax no cover
+        history = ModelMessagesTypeAdapter.validate_python(
+            [
+                {
+                    'kind': 'request',
+                    'parts': [{'part_kind': 'instruction-delta', 'id': 'agent:state', 'content': content}],
+                }
+            ]
+        )
+        assert estimate_token_count(history, len) == len(rendered)
 
 
 class TestSpeechPartCounting:

--- a/tests/compaction/test_context_budget.py
+++ b/tests/compaction/test_context_budget.py
@@ -1384,6 +1384,24 @@ class TestManualCompactionSemantics:
 
 @pytest.mark.skipif(not hasattr(messages_module, 'InstructionDeltaPart'), reason='requires core instruction updates')
 class TestInstructionDeltaCounting:
+    def test_superseded_updates_do_not_count(self) -> None:  # pragma: lax no cover
+        history = ModelMessagesTypeAdapter.validate_python(
+            [
+                {
+                    'kind': 'request',
+                    'parts': [{'part_kind': 'instruction-delta', 'id': 'agent:state', 'content': 'B' * 400}],
+                },
+                {'kind': 'response', 'parts': [{'part_kind': 'text', 'content': 'done'}]},
+                {
+                    'kind': 'request',
+                    'parts': [{'part_kind': 'user-prompt', 'content': 'Continue.'}],
+                    'instruction_baseline': {},
+                    'instructions': 'C',
+                },
+            ]
+        )
+        assert estimate_token_count(history, len) == estimate_token_count(TestModel().prepare_messages(history), len)
+
     @pytest.mark.parametrize(
         ('content', 'rendered'),
         [

--- a/tests/conversation_search/test_conversation_search.py
+++ b/tests/conversation_search/test_conversation_search.py
@@ -13,11 +13,13 @@ import re
 import warnings
 from pathlib import Path
 
+import pydantic_ai.messages as messages_module
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.messages import (
     BinaryContent,
     ModelMessage,
+    ModelMessagesTypeAdapter,
     ModelRequest,
     ModelResponse,
     RetryPromptPart,
@@ -799,6 +801,25 @@ class TestSearchScope:
         assert 'Found 1 match(es)' in rendered
         assert 'TEXTTAIL' not in excerpts
         assert '...' in excerpts
+
+    @pytest.mark.skipif(
+        not hasattr(messages_module, 'InstructionDeltaPart'), reason='requires core instruction updates'
+    )
+    async def test_instruction_updates_stay_searchable_past_display_cutoff(self) -> None:  # pragma: lax no cover
+        history = ModelMessagesTypeAdapter.validate_python(
+            [
+                {
+                    'kind': 'request',
+                    'parts': [
+                        {'part_kind': 'instruction-delta', 'id': 'agent:state', 'content': 'cedar ' * 50 + 'DELTATAIL'}
+                    ],
+                }
+            ]
+        )
+        rendered = await _search(_StubSource({'r1': history}), 'DELTATAIL')
+        assert 'Found 1 match(es)' in rendered
+        assert "System: Instruction block 'agent:state' is replaced" in rendered
+        assert 'DELTATAIL' not in rendered.split(':\n\n', 1)[1]
 
     async def test_max_matches_and_context_lines_honored(self) -> None:
         store = InMemoryStepStore()


### PR DESCRIPTION
> This pull request was posted by Codex Desktop using gpt-6-astra on behalf of David.

## Summary

Account for `InstructionDeltaPart` in compaction token estimates and conversation search. The exhaustive handlers currently fail the [core PR's harness compatibility check](https://github.com/pydantic/pydantic-ai/actions/runs/34157819825/job/101853190662).

Token estimates count the complete rendered replacement or withdrawal and exclude updates superseded by a new instruction baseline. Search indexes that system text in full and limits its displayed excerpt to 200 characters. Matching the discriminator keeps this importable with released Pydantic AI before the new class exists.

Targeted estimator/search tests and type checks pass against released core 2.38.0 and the core PR branch. New-part tests skip on releases without the class; version-dependent coverage exclusions cover those unreachable paths. Dependencies are unchanged.

## Linked Issue

Related to pydantic/pydantic-ai#7900. Companion to pydantic/pydantic-ai#8188; this can land first so that PR's harness compatibility check can pass.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (targeted checks and full precommit pass; full tests run in CI)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)
