### PR TITLE
Count truncation markers within `Truncate.max_chars`

### DIFF
--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -137,8 +137,11 @@ a `warnings.warn`, since it cannot be safely truncated.
 Thresholds are measured in characters by default. Set `over_tokens=True` to measure in
 estimated tokens (the same ~4-chars-per-token heuristic as [compaction](compaction.md)); pass a
 `tokenizer` callable for accuracy. `Truncate.max_chars` is always characters -- truncation is a
-character operation regardless of the threshold unit. Set `strip_ansi=True` to strip ANSI
-escape sequences from text returns before measuring and reducing.
+character operation regardless of the threshold unit. The cap includes the truncation marker
+and applies separately to each reduced text value. If no content and complete marker fit,
+truncation keeps the selected slice without a marker; a non-positive cap returns an empty
+string. Set `strip_ansi=True` to strip ANSI escape sequences from text returns before
+measuring and reducing.
 
 ## Pageable structured spills
 

--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -124,6 +124,55 @@ agent = Agent(
 schemas), `tail` (keep the last characters, good for build and test output where errors land
 last), and `head_tail` (keep both ends, elide the middle -- the default).
 
+## Layering with Shell
+
+Keep Shell's native `max_output_chars` above the `ToolOutputLimits` thresholds. Use
+`tail` truncation for moderate command output and `Spill` for large output:
+
+```python
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.shell import Shell
+from pydantic_ai_harness.tool_output_limits import (
+    Band,
+    Spill,
+    ToolOutputLimits,
+    Truncate,
+    TruncationStrategy,
+)
+
+tail = Truncate(max_chars=4_000, strategy=TruncationStrategy.tail)
+agent = Agent(
+    'openai:gpt-5.6-sol',
+    capabilities=[
+        Shell(allowed_commands=['git', 'rg', 'pytest'], max_output_chars=100_000),
+        ToolOutputLimits(
+            bands=[],
+            per_tool={
+                'run_command': [
+                    Band(over=20_000, action=Spill(then=tail)),
+                    Band(over=4_000, action=tail),
+                ],
+            },
+        ),
+    ],
+)
+```
+
+Only `run_command` uses these bands; `bands=[]` leaves other tools to their native limits.
+A tail slice retains an exit-code trailer when it fits in the retained suffix. It does not
+guarantee that an entire line survives a small budget; `head` can remove the trailer.
+
+Shell applies its native cap before `ToolOutputLimits` sees the result. With the spill
+threshold below that cap, a natively truncated result is stored instead of being truncated
+again, unless the store fails. The spill preview shows both ends and the model can use
+`read_tool_result` to inspect the stored text.
+
+Spilling preserves only the result received from Shell. It cannot recover content already
+removed by the native cap. A preview can contain both spill and native truncation notices;
+a native notice describes the stored result, not the shorter preview. `Spill.preview_chars`
+controls the preview's content budget; its header and omission marker add to that length.
+
 ## Both `return_value` and `content` are reduced
 
 A `ToolReturn` carries a `return_value` and an optional `content` that core renders as a

--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -170,8 +170,9 @@ again, unless the store fails. The spill preview shows both ends and the model c
 
 Spilling preserves only the result received from Shell. It cannot recover content already
 removed by the native cap. A preview can contain both spill and native truncation notices;
-a native notice describes the stored result, not the shorter preview. `Spill.preview_chars`
-controls the preview's content budget; its header and omission marker add to that length.
+a native notice describes the stored result, not the shorter preview. A positive
+`Spill.preview_chars` value controls the preview's content budget; its header and omission
+marker add to that length.
 
 ## Both `return_value` and `content` are reduced
 
@@ -187,10 +188,10 @@ Thresholds are measured in characters by default. Set `over_tokens=True` to meas
 estimated tokens (the same ~4-chars-per-token heuristic as [compaction](compaction.md)); pass a
 `tokenizer` callable for accuracy. `Truncate.max_chars` is always characters -- truncation is a
 character operation regardless of the threshold unit. The cap includes the truncation marker
-and applies separately to each reduced text value. If no content and complete marker fit,
-truncation keeps the selected slice without a marker; a non-positive cap returns an empty
-string. Set `strip_ansi=True` to strip ANSI escape sequences from text returns before
-measuring and reducing.
+and applies separately to each reduced text value. If the budget cannot fit both retained
+content and a complete marker, truncation keeps the selected slice without a marker. A
+non-positive cap returns an empty string. Set `strip_ansi=True` to strip ANSI escape sequences
+from text returns before measuring and reducing.
 
 ## Pageable structured spills
 

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -524,13 +524,9 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
         return out
 
     def _truncate(self, text: str, max_chars: int | None = None) -> str:
-        from pydantic_ai_harness.tool_output_limits import TruncationStrategy
-        from pydantic_ai_harness.tool_output_limits._payload import truncate_text
-
         limit = self.keep_user_messages_max_chars if max_chars is None else max_chars
-        truncated = truncate_text(text, limit, TruncationStrategy.head)
-        if len(truncated) <= limit:
-            return truncated
+        if len(text) <= limit:
+            return text
         marker = '[...]'
         if limit <= len(marker):
             return marker[:limit]

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -104,8 +104,11 @@ agent = Agent(
 Thresholds are measured in characters by default. Set `over_tokens=True` to measure in
 estimated tokens (the same ~4-chars-per-token heuristic as `compaction`); pass a `tokenizer`
 callable for accuracy. `Truncate.max_chars` is always characters -- truncation is a
-character operation regardless of the threshold unit. Set `strip_ansi=True` to strip ANSI
-escape sequences from text returns before measuring and reducing.
+character operation regardless of the threshold unit. The cap includes the truncation marker
+and applies separately to each reduced text value. If no content and complete marker fit,
+truncation keeps the selected slice without a marker; a non-positive cap returns an empty
+string. Set `strip_ansi=True` to strip ANSI escape sequences from text returns before
+measuring and reducing.
 
 ## Pageable structured spills
 

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -99,6 +99,55 @@ agent = Agent(
 )
 ```
 
+## Layering with Shell
+
+Keep Shell's native `max_output_chars` above the `ToolOutputLimits` thresholds. Use
+`tail` truncation for moderate command output and `Spill` for large output:
+
+```python
+from pydantic_ai import Agent
+
+from pydantic_ai_harness.shell import Shell
+from pydantic_ai_harness.tool_output_limits import (
+    Band,
+    Spill,
+    ToolOutputLimits,
+    Truncate,
+    TruncationStrategy,
+)
+
+tail = Truncate(max_chars=4_000, strategy=TruncationStrategy.tail)
+agent = Agent(
+    'openai:gpt-5.6-sol',
+    capabilities=[
+        Shell(allowed_commands=['git', 'rg', 'pytest'], max_output_chars=100_000),
+        ToolOutputLimits(
+            bands=[],
+            per_tool={
+                'run_command': [
+                    Band(over=20_000, action=Spill(then=tail)),
+                    Band(over=4_000, action=tail),
+                ],
+            },
+        ),
+    ],
+)
+```
+
+Only `run_command` uses these bands; `bands=[]` leaves other tools to their native limits.
+A tail slice retains an exit-code trailer when it fits in the retained suffix. It does not
+guarantee that an entire line survives a small budget; `head` can remove the trailer.
+
+Shell applies its native cap before `ToolOutputLimits` sees the result. With the spill
+threshold below that cap, a natively truncated result is stored instead of being truncated
+again, unless the store fails. The spill preview shows both ends and the model can use
+`read_tool_result` to inspect the stored text.
+
+Spilling preserves only the result received from Shell. It cannot recover content already
+removed by the native cap. A preview can contain both spill and native truncation notices;
+a native notice describes the stored result, not the shorter preview. `Spill.preview_chars`
+controls the preview's content budget; its header and omission marker add to that length.
+
 ## Size unit
 
 Thresholds are measured in characters by default. Set `over_tokens=True` to measure in

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -145,8 +145,9 @@ again, unless the store fails. The spill preview shows both ends and the model c
 
 Spilling preserves only the result received from Shell. It cannot recover content already
 removed by the native cap. A preview can contain both spill and native truncation notices;
-a native notice describes the stored result, not the shorter preview. `Spill.preview_chars`
-controls the preview's content budget; its header and omission marker add to that length.
+a native notice describes the stored result, not the shorter preview. A positive
+`Spill.preview_chars` value controls the preview's content budget; its header and omission
+marker add to that length.
 
 ## Size unit
 
@@ -154,10 +155,10 @@ Thresholds are measured in characters by default. Set `over_tokens=True` to meas
 estimated tokens (the same ~4-chars-per-token heuristic as `compaction`); pass a `tokenizer`
 callable for accuracy. `Truncate.max_chars` is always characters -- truncation is a
 character operation regardless of the threshold unit. The cap includes the truncation marker
-and applies separately to each reduced text value. If no content and complete marker fit,
-truncation keeps the selected slice without a marker; a non-positive cap returns an empty
-string. Set `strip_ansi=True` to strip ANSI escape sequences from text returns before
-measuring and reducing.
+and applies separately to each reduced text value. If the budget cannot fit both retained
+content and a complete marker, truncation keeps the selected slice without a marker. A
+non-positive cap returns an empty string. Set `strip_ansi=True` to strip ANSI escape sequences
+from text returns before measuring and reducing.
 
 ## Pageable structured spills
 

--- a/pydantic_ai_harness/tool_output_limits/_bands.py
+++ b/pydantic_ai_harness/tool_output_limits/_bands.py
@@ -35,11 +35,12 @@ class Passthrough:
 
 @dataclass(frozen=True)
 class Truncate:
-    """Clamp the stringified return to `max_chars`. Lossy, zero-cost, no read-back.
+    """Clamp the stringified return to `max_chars`, including the truncation marker.
 
-    `max_chars` is always characters, independent of the capability's `over_tokens` size
-    unit (truncation is a character operation). Falls back to `then` for binary payloads,
-    which cannot be stringify-truncated.
+    Lossy, zero-cost, no read-back. `max_chars` is always characters, independent of the
+    capability's `over_tokens` size unit. A cap too small for content and a complete marker
+    keeps only the selected slice. A non-positive cap returns an empty string. Falls back
+    to `then` for binary payloads, which cannot be stringify-truncated.
     """
 
     strategy: TruncationStrategy = TruncationStrategy.head_tail

--- a/pydantic_ai_harness/tool_output_limits/_bands.py
+++ b/pydantic_ai_harness/tool_output_limits/_bands.py
@@ -38,9 +38,9 @@ class Truncate:
     """Clamp the stringified return to `max_chars`, including the truncation marker.
 
     Lossy, zero-cost, no read-back. `max_chars` is always characters, independent of the
-    capability's `over_tokens` size unit. A cap too small for content and a complete marker
-    keeps only the selected slice. A non-positive cap returns an empty string. Falls back
-    to `then` for binary payloads, which cannot be stringify-truncated.
+    capability's `over_tokens` size unit. If the budget cannot fit both retained content and
+    a complete marker, truncation keeps only the selected slice. A non-positive cap returns
+    an empty string. Falls back to `then` for binary payloads, which cannot be stringify-truncated.
     """
 
     strategy: TruncationStrategy = TruncationStrategy.head_tail

--- a/pydantic_ai_harness/tool_output_limits/_payload.py
+++ b/pydantic_ai_harness/tool_output_limits/_payload.py
@@ -15,6 +15,7 @@ from typing import TypeGuard
 from pydantic_ai.messages import ModelMessage, ModelRequest, SystemPromptPart
 from pydantic_core import to_json
 
+from pydantic_ai_harness._output import truncate_tail
 from pydantic_ai_harness.compaction._shared import estimate_token_count
 
 
@@ -147,25 +148,34 @@ def _sketch_sequence(items: Sequence[object]) -> str:
 
 
 def truncate_text(text: str, max_chars: int, strategy: TruncationStrategy) -> str:
-    """Cut `text` down to roughly `max_chars`, annotating what was removed.
+    """Limit `text` to `max_chars`, including the truncation marker.
 
-    Returns `text` unchanged when it already fits.
+    Keep the selected slice without a marker if no content and complete marker fit.
     """
+    if max_chars <= 0:
+        return ''
     total = len(text)
     if total <= max_chars:
         return text
+    if strategy is TruncationStrategy.tail:
+        return truncate_tail(text, max_chars)
+
+    # Check each count: digit and thousands-separator changes can shorten the marker.
+    for retained in range(max_chars, 0, -1):
+        if strategy is TruncationStrategy.head:
+            marker = f'\n\n[truncated: showing first {retained:,} of {total:,} chars]'
+        else:
+            head_chars = retained * 2 // 5
+            marker = (
+                f'\n\n[truncated: {total - retained:,} chars omitted from the middle; '
+                f'showing first {head_chars:,} + last {retained - head_chars:,} of {total:,} chars]\n\n'
+            )
+        if retained + len(marker) <= max_chars:
+            break
+    else:
+        retained, marker = max_chars, ''
 
     if strategy is TruncationStrategy.head:
-        return f'{text[:max_chars]}\n\n[truncated: showing first {max_chars:,} of {total:,} chars]'
-    if strategy is TruncationStrategy.tail:
-        return f'[truncated: showing last {max_chars:,} of {total:,} chars]\n\n{text[-max_chars:]}'
-
-    head_chars = max_chars * 2 // 5
-    tail_chars = max_chars - head_chars
-    omitted = total - head_chars - tail_chars
-    return (
-        f'{text[:head_chars]}\n\n'
-        f'[truncated: {omitted:,} chars omitted from the middle; '
-        f'showing first {head_chars:,} + last {tail_chars:,} of {total:,} chars]\n\n'
-        f'{text[-tail_chars:]}'
-    )
+        return text[:retained] + marker
+    head_chars = retained * 2 // 5
+    return text[:head_chars] + marker + text[-(retained - head_chars) :]

--- a/pydantic_ai_harness/tool_output_limits/_payload.py
+++ b/pydantic_ai_harness/tool_output_limits/_payload.py
@@ -150,7 +150,8 @@ def _sketch_sequence(items: Sequence[object]) -> str:
 def truncate_text(text: str, max_chars: int, strategy: TruncationStrategy) -> str:
     """Limit `text` to `max_chars`, including the truncation marker.
 
-    Keep the selected slice without a marker if no content and complete marker fit.
+    If the budget cannot fit both retained content and a complete marker, return the
+    selected slice without a marker.
     """
     if max_chars <= 0:
         return ''

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -3948,7 +3948,11 @@ class TestStructuralFeaturesThroughAgent:
         )
 
     @pytest.mark.anyio
-    async def test_keep_user_messages_reaches_the_model_truncated(self):
+    @pytest.mark.parametrize(
+        'max_chars,expected',
+        [(3, '[..'), (5, '[...]'), (10, 'v' * 5 + '[...]'), (200, 'v' * 195 + '[...]'), (1000, 'v' * 1000)],
+    )
+    async def test_keep_user_messages_reaches_the_model_truncated(self, max_chars: int, expected: str):
         seen: list[list[ModelMessage]] = []
         prompts: list[str] = []
         agent = Agent(
@@ -3959,15 +3963,15 @@ class TestStructuralFeaturesThroughAgent:
                     max_messages=3,
                     keep_messages=2,
                     keep_user_messages=True,
-                    keep_user_messages_max_chars=10,
+                    keep_user_messages_max_chars=max_chars,
                 )
             ],
         )
-        await agent.run('go', message_history=[_user('u' * 40), _assistant('b'), _user('v' * 40), _assistant('d')])
+        await agent.run('go', message_history=[_user('u' * 40), _assistant('b'), _user('v' * 1000), _assistant('d')])
 
         assert len(prompts) == 1
         texts = _user_texts(seen[0])
-        assert any(text.startswith('vvvvv') and text.endswith('[...]') for text in texts)
+        assert expected in texts
 
     @pytest.mark.anyio
     async def test_retained_user_turns_arrive_as_a_single_request(self):

--- a/tests/tool_output_limits/test_shell_composition.py
+++ b/tests/tool_output_limits/test_shell_composition.py
@@ -1,0 +1,78 @@
+"""Exercise the documented Shell and ToolOutputLimits stacking recipe."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart, ToolCallPart, ToolReturnPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from pydantic_ai_harness.shell import Shell
+from pydantic_ai_harness.tool_output_limits import (
+    Band,
+    LocalFileStore,
+    Spill,
+    ToolOutputLimits,
+    Truncate,
+    TruncationStrategy,
+)
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+@pytest.mark.parametrize('output_chars', [6_000, 25_000, 120_000], ids=['truncate', 'spill', 'native-cap-then-spill'])
+async def test_shell_stacking_recipe(tmp_path: Path, output_chars: int):
+    executable = Path(sys.executable).as_posix()
+    command = f'"{executable}" -c "import sys; sys.stdout.write(\'x\' * {output_chars}); sys.exit(7)"'
+
+    def respond(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        if any(isinstance(part, ToolReturnPart) for message in messages for part in message.parts):
+            return ModelResponse(parts=[TextPart('done')])
+        return ModelResponse(parts=[ToolCallPart('run_command', {'command': command})])
+
+    store = LocalFileStore(base_dir=tmp_path / 'results')
+    tail = Truncate(max_chars=4_000, strategy=TruncationStrategy.tail)
+    agent = Agent(
+        FunctionModel(respond),
+        capabilities=[
+            Shell(cwd=tmp_path, allowed_commands=[executable], max_output_chars=100_000),
+            ToolOutputLimits(
+                store=store,
+                bands=[],
+                per_tool={
+                    'run_command': [
+                        Band(over=20_000, action=Spill(then=tail)),
+                        Band(over=4_000, action=tail),
+                    ],
+                },
+            ),
+        ],
+    )
+    result = await agent.run('run the command')
+    returns = [part for message in result.all_messages() for part in message.parts if isinstance(part, ToolReturnPart)]
+    assert len(returns) == 1
+    part = returns[0]
+    assert isinstance(part.content, str)
+    assert part.content.endswith('[exit code: 7]')
+    if output_chars == 6_000:
+        assert len(part.content) == 4_000
+        assert part.content.startswith('[... output truncated, showing last 3952 chars]\n')
+        assert part.metadata is None
+    else:
+        assert 'read_tool_result' in part.content
+        assert part.metadata is not None
+        stored = (await store.read(part.metadata['overflow_handle'])).decode('utf-8')
+        original = f'[stdout]\n{"x" * output_chars}\n[exit code: 7]'
+        if output_chars == 25_000:
+            assert stored == original
+        else:
+            assert len(stored) == 100_000
+            assert stored.startswith('[... output truncated, showing last ')
+            assert stored.endswith('[exit code: 7]')
+            assert stored != original

--- a/tests/tool_output_limits/test_tool_output_limits.py
+++ b/tests/tool_output_limits/test_tool_output_limits.py
@@ -21,6 +21,7 @@ from pydantic_ai.messages import (
     ToolCallPart,
     ToolReturn,
     ToolReturnPart,
+    UserPromptPart,
 )
 from pydantic_ai.models import AbstractModel
 from pydantic_ai.models.function import AgentInfo, FunctionModel
@@ -58,7 +59,6 @@ from pydantic_ai_harness.tool_output_limits._payload import (
     strip_ansi,
     to_bytes,
     to_text,
-    truncate_text,
 )
 from pydantic_ai_harness.tool_output_limits._store import _safe_segment
 from tests._recording_durability import RecordingDurability  # pyright: ignore[reportMissingTypeStubs]
@@ -191,23 +191,6 @@ class TestPayloadHelpers:
     def test_json_sketch_scalar(self):
         assert json_sketch(42) == ''
         assert json_sketch('plain') == ''
-
-    def test_truncate_under_limit(self):
-        assert truncate_text('short', 100, TruncationStrategy.head_tail) == 'short'
-
-    def test_truncate_head(self):
-        out = truncate_text('a' * 100, 10, TruncationStrategy.head)
-        assert out.startswith('aaaaaaaaaa')
-        assert 'showing first 10' in out
-
-    def test_truncate_tail(self):
-        out = truncate_text('a' * 100, 10, TruncationStrategy.tail)
-        assert out.endswith('aaaaaaaaaa')
-        assert 'showing last 10' in out
-
-    def test_truncate_head_tail(self):
-        out = truncate_text('a' * 100, 10, TruncationStrategy.head_tail)
-        assert 'omitted from the middle' in out
 
 
 # ---------------------------------------------------------------------------
@@ -372,7 +355,7 @@ class TestPassthrough:
 
     async def test_callable_filter(self):
         cap: ToolOutputLimits[object] = ToolOutputLimits(
-            bands=[Band(over=1, action=Truncate(max_chars=2))],
+            bands=[Band(over=1, action=Truncate(max_chars=95))],
             tool_filter=lambda ctx, td: td.name == 'big_tool',
         )
         out = await _run(cap, 'x' * 100)
@@ -402,12 +385,106 @@ class TestPassthrough:
 
 
 class TestTruncate:
-    async def test_truncates_text(self):
+    @pytest.mark.parametrize('strategy', TruncationStrategy)
+    @pytest.mark.parametrize(
+        'total,kept',
+        [(1000, 1), (1000, 9), (1000, 10), (1000, 99), (1000, 100), (10000, 999), (10000, 1000), (1001, 2)],
+    )
+    async def test_marker_counts_toward_budget(self, strategy: TruncationStrategy, total: int, kept: int):
+        text = ''.join(chr(0x4E00 + i) for i in range(total))
+        if strategy is TruncationStrategy.head:
+            expected = text[:kept] + f'\n\n[truncated: showing first {kept:,} of {total:,} chars]'
+        elif strategy is TruncationStrategy.tail:
+            expected = f'[... output truncated, showing last {kept} chars]\n' + text[-kept:]
+        else:
+            head = kept * 2 // 5
+            tail = kept - head
+            expected = (
+                f'{text[:head]}\n\n[truncated: {total - kept:,} chars omitted from the middle; '
+                f'showing first {head:,} + last {tail:,} of {total:,} chars]\n\n{text[-tail:]}'
+            )
+        max_chars = len(expected)
         cap: ToolOutputLimits[object] = ToolOutputLimits(
-            bands=[Band(over=10, action=Truncate(max_chars=20, strategy=TruncationStrategy.head))]
+            bands=[Band(over=0, action=Truncate(max_chars=max_chars, strategy=strategy))]
         )
-        out = await _run(cap, 'a' * 100)
-        assert isinstance(out, str) and out.startswith('a' * 20)
+        agent = Agent(TestModel(call_tools=['big_tool']), capabilities=[cap])
+
+        @agent.tool_plain
+        def big_tool() -> str:
+            return text
+
+        result = await agent.run('go')
+        returns = [p for m in result.all_messages() for p in m.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 1
+        assert returns[0].content == expected
+
+    @pytest.mark.parametrize(
+        'strategy,max_chars',
+        [(strategy, cap) for strategy in TruncationStrategy for cap in [-1, 0, 1, 2, 10]]
+        + [(TruncationStrategy.head, 45), (TruncationStrategy.tail, 45), (TruncationStrategy.head_tail, 91)],
+    )
+    async def test_budget_too_small_for_marker(self, strategy: TruncationStrategy, max_chars: int):
+        text = ''.join(chr(0x4E00 + i) for i in range(1000))
+        kept = max(0, max_chars)
+        if strategy is TruncationStrategy.head:
+            expected = text[:kept]
+        elif strategy is TruncationStrategy.tail:
+            expected = text[len(text) - kept :]
+        else:
+            head = kept * 2 // 5
+            expected = text[:head] + text[len(text) - (kept - head) :]
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=0, action=Truncate(max_chars=max_chars, strategy=strategy))]
+        )
+        agent = Agent(TestModel(call_tools=['big_tool']), capabilities=[cap])
+
+        @agent.tool_plain
+        def big_tool() -> str:
+            return text
+
+        result = await agent.run('go')
+        returns = [p for m in result.all_messages() for p in m.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 1
+        assert returns[0].content == expected
+
+    @pytest.mark.parametrize('strategy', TruncationStrategy)
+    @pytest.mark.parametrize('max_chars', [5, 6])
+    async def test_output_that_fits_is_unchanged(self, strategy: TruncationStrategy, max_chars: int):
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=0, action=Truncate(max_chars=max_chars, strategy=strategy))]
+        )
+        agent = Agent(TestModel(call_tools=['small_tool']), capabilities=[cap])
+
+        @agent.tool_plain
+        def small_tool() -> str:
+            return 'short'
+
+        result = await agent.run('go')
+        returns = [p for m in result.all_messages() for p in m.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 1
+        assert returns[0].content == 'short'
+
+    @pytest.mark.parametrize('strategy', TruncationStrategy)
+    async def test_tool_return_value_and_content_are_bounded(self, strategy: TruncationStrategy):
+        cap: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=0, action=Truncate(max_chars=200, strategy=strategy))]
+        )
+        agent = Agent(TestModel(call_tools=['big_tool']), capabilities=[cap])
+
+        @agent.tool_plain
+        def big_tool() -> ToolReturn:
+            return ToolReturn(return_value='v' * 1000, content='c' * 2000, metadata={'k': 1})
+
+        result = await agent.run('go')
+        returns = [p for m in result.all_messages() for p in m.parts if isinstance(p, ToolReturnPart)]
+        assert len(returns) == 1
+        assert returns[0].metadata == {'k': 1}
+        value = returns[0].content
+        assert isinstance(value, str) and len(value) <= 200 and 'truncated' in value
+        prompts = [p for m in result.all_messages() for p in m.parts if isinstance(p, UserPromptPart)]
+        assert len(prompts) == 2
+        content = prompts[-1].content
+        assert isinstance(content, str) and len(content) <= 200 and 'truncated' in content
 
     async def test_strip_ansi_applied(self):
         cap: ToolOutputLimits[object] = ToolOutputLimits(
@@ -534,7 +611,7 @@ class TestSpill:
 
     async def test_spill_failure_falls_back_to_truncate(self):
         cap: ToolOutputLimits[object] = ToolOutputLimits(
-            bands=[Band(over=10, action=Spill(then=Truncate(max_chars=15)))], store=_BrokenStore()
+            bands=[Band(over=10, action=Spill(then=Truncate(max_chars=95)))], store=_BrokenStore()
         )
         out = await _run(cap, 'a' * 100)
         assert isinstance(out, str) and 'truncated' in out
@@ -589,7 +666,7 @@ class TestContentReduction:
         assert await store.read(handle) == ('C' * 5000).encode('utf-8')
 
     async def test_large_content_truncated(self):
-        cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=10, action=Truncate(max_chars=20))])
+        cap: ToolOutputLimits[object] = ToolOutputLimits(bands=[Band(over=10, action=Truncate(max_chars=95))])
         out = await _run(cap, ToolReturn(return_value='small', content='C' * 200))
         assert isinstance(out, ToolReturn)
         assert isinstance(out.content, str) and 'truncated' in out.content
@@ -775,7 +852,7 @@ class TestSummarize:
             raise RuntimeError('model down')
 
         cap: ToolOutputLimits[object] = ToolOutputLimits(
-            bands=[Band(over=5, action=Summarize(summarize=boom, then=Truncate(max_chars=10)))]
+            bands=[Band(over=5, action=Summarize(summarize=boom, then=Truncate(max_chars=95)))]
         )
         out = await _run(cap, 'a' * 100)
         assert isinstance(out, str) and 'truncated' in out


### PR DESCRIPTION
## Summary

Truncation markers can make tool results exceed `Truncate.max_chars`. Count the markers within the cap and report the actual retained counts. Also document layering Shell's native cap above per-tool truncation and spill thresholds.

New public surface: none. Dependencies are unchanged.

With a 1,000-character return and a 200-character cap, head / tail / head-tail results now contain 200 characters instead of 247 / 246 / 294.

### Verification

- [Public `Agent` regressions](https://github.com/pydantic/pydantic-ai-harness/pull/816/files#diff-f6655b67f9a387393d45c358430c70e5e024646b49fe476093f1c2e49a2c62f0R393) cover marker boundaries, tiny budgets, and independent `ToolReturn` value/content limits; [compaction regressions](https://github.com/pydantic/pydantic-ai-harness/pull/816/files#diff-75bee58a60e138d5c14f63b5e19b8fb9aaf32a3b794dfc749fe437cd9fe39a41R3955) preserve existing prompt markers.
- [Real Shell tests](https://github.com/pydantic/pydantic-ai-harness/pull/816/files#diff-0bb06ca40a2fad8ab2f10b1a8ead3e80bc694813e912b2a64ec5c07c0c975662R30) cover truncation, spilling, and spilling after the native cap.
- Ubuntu / Python 3.10: 749 affected-module tests pass. Ruff, scoped strict Pyright, and documentation checks pass.

### Boundary notes

Existing users get fewer retained content characters when truncation is needed because markers share the budget, and the tail marker adopts the shared helper's wording; text that already fits is unchanged. `SummarizingCompaction` retains its existing short ellipsis.

A budget too small for content and a complete marker keeps the selected slice without a marker; non-positive caps return empty text.

## Linked Issue

Refs #510, items 1 and 3. Item 2 (protected control trailers) remains separate.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)
