### PR TITLE
Register TrajectoryJudge in the capability combination policy

### DIFF
--- a/tests/test_capability_combine.py
+++ b/tests/test_capability_combine.py
@@ -253,6 +253,7 @@ COMBINE_POLICY: dict[str, Policy] = {
     'TieredCompaction': Anonymous('drives other strategies; one per tier list'),
     'WarnNearLimits': Anonymous('a passive observer; several thresholds compose'),
     'WarnOnCacheBusts': Anonymous('a passive observer; several thresholds compose'),
+    'TrajectoryJudge': Anonymous('each judge independently evaluates and steers the run'),
     'AWSLambdaDurability': Rejected(
         'a durability engine is one per agent; `from_agent` rejects a second when the engine looks '
         'itself up, before any id is consulted'


### PR DESCRIPTION
`TrajectoryJudge` was added in #724 without an entry in `COMBINE_POLICY`, so `test_every_capability_declares_a_combine_policy` fails on current main and downstream PRs.

Register it as `Anonymous`: it has no default ID, and multiple judges independently evaluate and steer the same run. This changes only the test policy table.

Validation: lint, file-scoped Pyright, and `tests/test_capability_combine.py` pass. The same one-line fix also passed a full local test run on the Notion integration branch (5,855 passed, 71 skipped) before being moved here.
