### PR TITLE
Pin the capability id in the `ContextUsageEvent` test so the latest-core job passes

### DIFF
--- a/tests/test_callback_events.py
+++ b/tests/test_callback_events.py
@@ -68,6 +68,9 @@ async def test_context_usage_event_and_legacy_callback() -> None:
 
     with pytest.warns(HarnessDeprecationWarning, match=r'ReportContextUsage\.on_usage.*ContextUsageEvent.*on_event'):
         capability = ReportContextUsage(on_usage=legacy.append, context_window=1_000)
+    # pydantic-ai 2.41 derives a run-local synthetic id for anonymous capabilities, so pin one
+    # rather than asserting on whichever derivation policy the installed core uses.
+    capability.id = 'report_context_usage'
     await Agent(TestModel(), capabilities=[capability, hooks]).run('go')
 
     assert len(legacy) == 1


### PR DESCRIPTION
Since #714 merged, `test on latest pydantic-ai` (and therefore `check`) is red on main: `tests/test_callback_events.py::test_context_usage_event_and_legacy_callback` asserts `capability_id='report_context_usage'`, but pydantic-ai 2.41 derives a run-local synthetic id for anonymous capabilities, so the event carries something like `<report_context_usage:6e36fc>` instead.

The test now sets the id explicitly, so it asserts what the harness emits rather than which id policy the installed core happens to use. Verified locally on 2.38.0 (the lock) and 2.41.0.

Surfaced while a sub-agent was greening #712, which had the same latent issue in its own event tests and fixed it the same way.