### PR TITLE
Use structured concurrency in `TrajectoryJudge`

### DIFF
--- a/pydantic_ai_harness/trajectory_judge/_capability.py
+++ b/pydantic_ai_harness/trajectory_judge/_capability.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
-import contextlib
 import html
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Annotated, Any, Protocol, TypeAlias, runtime_checkable
 
+import anyio
+from anyio.abc import TaskGroup
 from pydantic import Field, TypeAdapter
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import AbstractCapability, WrapRunHandler
@@ -151,7 +151,9 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
 
     _judge: Agent[None, object] = field(init=False, repr=False, compare=False)
     _steps: int = field(default=0, init=False, repr=False, compare=False)
-    _task: asyncio.Task[None] | None = field(default=None, init=False, repr=False, compare=False)
+    _task_group: TaskGroup | None = field(default=None, init=False, repr=False, compare=False)
+    _evaluation_running: bool = field(default=False, init=False, repr=False, compare=False)
+    _evaluation_error: BaseException | None = field(default=None, init=False, repr=False, compare=False)
     _claim_held: bool = field(default=False, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -183,8 +185,8 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
     async def for_run(self, ctx: RunContext[AgentDepsT]) -> TrajectoryJudge[AgentDepsT]:
         """Return a fresh per-run instance so step counts and in-flight evaluations are not shared.
 
-        `replace` re-runs `__init__` and `__post_init__`, resetting the `init=False` fields:
-        `_steps` to `0`, `_task` to `None`, and `_judge` rebuilt from the same config.
+        `replace` re-runs `__init__` and `__post_init__`, resetting the `init=False` fields,
+        including the cadence and evaluation state, and rebuilding `_judge` from the same config.
         """
         return replace(self)
 
@@ -213,17 +215,30 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
     ) -> ModelResponse:
         """Count the model request and launch an evaluation when the cadence is due.
 
-        A finished evaluation is reaped first, so a failure surfaces here rather than being
-        silently dropped. The evaluation itself runs as a background task: the trajectory is
+        A finished evaluation's failure surfaces here rather than being silently dropped.
+        The evaluation itself runs as a background task: the trajectory is
         rendered synchronously (no race with later mutation), the judge call and any
         steering enqueue happen concurrently with the run, and the steering is delivered
         when the run next drains its pending messages.
         """
-        self._collect_finished()
+        if not self._evaluation_running and self._evaluation_error is not None:
+            error, self._evaluation_error = self._evaluation_error, None
+            raise error
         self._steps += 1
-        if self._steps % self.every == 0 and self._task is None and self._claim_request(ctx):
+        if self._steps % self.every == 0 and not self._evaluation_running:
+            task_group = self._task_group
+            if task_group is None:  # pragma: no cover - core invokes model hooks inside `wrap_run`
+                raise RuntimeError('TrajectoryJudge.after_model_request called outside its run scope')
+            if not self._claim_request(ctx):
+                return response
             prompt = _judge_prompt([*request_context.messages, response], self.window)
-            self._task = asyncio.create_task(self._evaluate(ctx, prompt), name=f'trajectory-judge:{self._judge_name()}')
+            self._evaluation_running = True
+            task_group.start_soon(
+                self._evaluate,
+                ctx,
+                prompt,
+                name=f'trajectory-judge:{self._judge_name()}',
+            )
         return response
 
     def _claim_request(self, ctx: RunContext[AgentDepsT]) -> bool:
@@ -245,19 +260,8 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
         self._claim_held = True
         return True
 
-    def _release_claim(self, ctx: RunContext[AgentDepsT]) -> None:
-        """Release the launch's claim exactly once.
-
-        Both `_evaluate`'s `finally` and `_discard_in_flight` call this: whichever settles
-        the evaluation first wins, and the other is a no-op. The guard is what covers a task
-        cancelled before its coroutine ever starts, where the `finally` never runs.
-        """
-        if self._claim_held:
-            self._claim_held = False
-            ctx.usage.requests -= 1
-
     async def wrap_run(self, ctx: RunContext[AgentDepsT], *, handler: WrapRunHandler) -> AgentRunResult[Any]:
-        """Run the agent, then settle the judge: surface a finished failure, cancel the rest.
+        """Run the agent and its evaluations in one task group, then settle the judge.
 
         An evaluation still in flight when the run ends is cancelled rather than awaited;
         its steering has nowhere to go. One that already finished with an error is
@@ -265,13 +269,42 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
         failing, the evaluation's outcome is discarded entirely so it cannot mask the run's
         own error.
         """
+        result: AgentRunResult[Any] | None = None
+        handler_error: BaseException | None = None
+        evaluation_error: BaseException | None = None
+        handler_done = anyio.Event()
+
+        async def run_handler() -> None:
+            nonlocal result, handler_error
+            try:
+                result = await handler()
+            except BaseException as exc:
+                handler_error = exc
+            finally:
+                handler_done.set()
+
         try:
-            result = await handler()
-        except BaseException:
-            await self._discard_in_flight(ctx)
-            raise
-        self._collect_finished()
-        await self._discard_in_flight(ctx)
+            async with anyio.create_task_group() as task_group:
+                self._task_group = task_group
+                task_group.start_soon(run_handler, name='trajectory-judge:agent-run')
+                await handler_done.wait()
+                if handler_error is None and not self._evaluation_running:
+                    evaluation_error, self._evaluation_error = self._evaluation_error, None
+                elif handler_error is not None:
+                    self._evaluation_error = None
+                task_group.cancel_scope.cancel()
+        finally:
+            self._task_group = None
+            self._evaluation_running = False
+            if self._claim_held:
+                self._claim_held = False
+                ctx.usage.requests -= 1
+
+        if handler_error is not None:
+            raise handler_error
+        if evaluation_error is not None:
+            raise evaluation_error
+        assert result is not None
         return result
 
     async def _evaluate(self, ctx: RunContext[AgentDepsT], prompt: str) -> None:
@@ -284,54 +317,35 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
         one: the launch's claim occupies a slot in `usage.requests` for the whole
         evaluation, so the unadjusted limit would count this evaluation against itself
         twice. The claim is released once the run has recorded the judge's real spend (or
-        recorded nothing, on failure or cancellation); a task cancelled before this
-        coroutine starts never reaches the `finally`, so `_discard_in_flight` releases the
-        claim instead.
+        recorded nothing, on failure or cancellation); an evaluation cancelled before this
+        coroutine starts never reaches the `finally`, so `wrap_run` releases the claim instead.
 
-        Provider failures propagate out of this task as-is (`ModelAPIError` subclasses from
-        the model layer) and are re-raised on the run by `_collect_finished`.
+        Provider failures are recorded as-is (`ModelAPIError` subclasses from the model
+        layer) and re-raised on the next cadence tick or at run end.
         """
         try:
-            result = await self._judge.run(
-                prompt,
-                output_type=[AllGood, Steer],
-                usage=ctx.usage,
-                usage_limits=_claim_offset_limits(ctx.usage_limits),
-            )
+            try:
+                result = await self._judge.run(
+                    prompt,
+                    output_type=[AllGood, Steer],
+                    usage=ctx.usage,
+                    usage_limits=_claim_offset_limits(ctx.usage_limits),
+                )
+            finally:
+                if self._claim_held:
+                    self._claim_held = False
+                    ctx.usage.requests -= 1
+            verdict = result.output
+            if isinstance(verdict, Steer):
+                ctx.enqueue(f'Steering from trajectory judge {self._judge_name()!r}: {verdict.message}')
+            if self.on_verdict is not None:
+                self.on_verdict(verdict)
+        except BaseException as exc:
+            if isinstance(exc, anyio.get_cancelled_exc_class()):
+                raise
+            self._evaluation_error = exc
         finally:
-            self._release_claim(ctx)
-        verdict = result.output
-        if isinstance(verdict, Steer):
-            ctx.enqueue(f'Steering from trajectory judge {self._judge_name()!r}: {verdict.message}')
-        if self.on_verdict is not None:
-            self.on_verdict(verdict)
-
-    def _collect_finished(self) -> None:
-        """Reap a finished evaluation, re-raising its failure on the run."""
-        task = self._task
-        if task is None or not task.done():
-            return
-        self._task = None
-        task.result()
-
-    async def _discard_in_flight(self, ctx: RunContext[AgentDepsT]) -> None:
-        """Cancel and reap the current evaluation without inspecting its outcome.
-
-        The task may already be done, in which case `cancel` is a no-op and awaiting it
-        re-raises its failure; both that and the cancellation are discarded deliberately.
-        The claim is released after the task settles: a task cancelled before its coroutine
-        first ran never reached `_evaluate`'s `finally`, so the release here is what keeps
-        a reused `RunUsage` free of phantom requests, and `_release_claim`'s guard makes it
-        a no-op when the `finally` already ran.
-        """
-        task = self._task
-        self._task = None
-        if task is None:
-            return
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError, Exception):
-            await task
-        self._release_claim(ctx)
+            self._evaluation_running = False
 
     def _judge_name(self) -> str:
         """The attribution name: `name`, then the judge `agent`'s name, then the default."""

--- a/pydantic_ai_harness/trajectory_judge/_capability.py
+++ b/pydantic_ai_harness/trajectory_judge/_capability.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Annotated, Any, Protocol, TypeAlias, runtime_checkable
 
 import anyio
-from anyio.abc import TaskGroup
+from anyio.abc import TaskGroup, TaskStatus
 from pydantic import Field, TypeAdapter
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import AbstractCapability, WrapRunHandler
@@ -154,7 +154,6 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
     _task_group: TaskGroup | None = field(default=None, init=False, repr=False, compare=False)
     _evaluation_running: bool = field(default=False, init=False, repr=False, compare=False)
     _evaluation_error: BaseException | None = field(default=None, init=False, repr=False, compare=False)
-    _claim_held: bool = field(default=False, init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         _positive_int_adapter.validate_python(self.every)
@@ -229,11 +228,8 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
             task_group = self._task_group
             if task_group is None:  # pragma: no cover - core invokes model hooks inside `wrap_run`
                 raise RuntimeError('TrajectoryJudge.after_model_request called outside its run scope')
-            if not self._claim_request(ctx):
-                return response
             prompt = _judge_prompt([*request_context.messages, response], self.window)
-            self._evaluation_running = True
-            task_group.start_soon(
+            await task_group.start(
                 self._evaluate,
                 ctx,
                 prompt,
@@ -257,7 +253,6 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
         if limits is not None and limits.request_limit is not None and ctx.usage.requests + 2 > limits.request_limit:
             return False
         ctx.usage.requests += 1
-        self._claim_held = True
         return True
 
     async def wrap_run(self, ctx: RunContext[AgentDepsT], *, handler: WrapRunHandler) -> AgentRunResult[Any]:
@@ -272,33 +267,23 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
         result: AgentRunResult[Any] | None = None
         handler_error: BaseException | None = None
         evaluation_error: BaseException | None = None
-        handler_done = anyio.Event()
-
-        async def run_handler() -> None:
-            nonlocal result, handler_error
-            try:
-                result = await handler()
-            except BaseException as exc:
-                handler_error = exc
-            finally:
-                handler_done.set()
 
         try:
             async with anyio.create_task_group() as task_group:
                 self._task_group = task_group
-                task_group.start_soon(run_handler, name='trajectory-judge:agent-run')
-                await handler_done.wait()
-                if handler_error is None and not self._evaluation_running:
-                    evaluation_error, self._evaluation_error = self._evaluation_error, None
-                elif handler_error is not None:
+                try:
+                    result = await handler()
+                except BaseException as exc:
+                    handler_error = exc
                     self._evaluation_error = None
-                task_group.cancel_scope.cancel()
+                else:
+                    if not self._evaluation_running:
+                        evaluation_error, self._evaluation_error = self._evaluation_error, None
+                finally:
+                    task_group.cancel_scope.cancel()
         finally:
             self._task_group = None
             self._evaluation_running = False
-            if self._claim_held:
-                self._claim_held = False
-                ctx.usage.requests -= 1
 
         if handler_error is not None:
             raise handler_error
@@ -307,7 +292,13 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
         assert result is not None
         return result
 
-    async def _evaluate(self, ctx: RunContext[AgentDepsT], prompt: str) -> None:
+    async def _evaluate(
+        self,
+        ctx: RunContext[AgentDepsT],
+        prompt: str,
+        *,
+        task_status: TaskStatus[None],
+    ) -> None:
         """Run the judge once and enqueue attributed steering when it says to steer.
 
         `output_type=[AllGood, Steer]` is set here, at the run boundary, so the verdict
@@ -316,25 +307,24 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
         The judge runs against the shared `usage` under a request limit raised by exactly
         one: the launch's claim occupies a slot in `usage.requests` for the whole
         evaluation, so the unadjusted limit would count this evaluation against itself
-        twice. The claim is released once the run has recorded the judge's real spend (or
-        recorded nothing, on failure or cancellation); an evaluation cancelled before this
-        coroutine starts never reaches the `finally`, so `wrap_run` releases the claim instead.
+        twice. `TaskGroup.start` waits until the claim is held and the cleanup scope is in
+        place before the model hook continues.
 
         Provider failures are recorded as-is (`ModelAPIError` subclasses from the model
         layer) and re-raised on the next cadence tick or at run end.
         """
+        if not self._claim_request(ctx):
+            task_status.started()
+            return
+        self._evaluation_running = True
         try:
-            try:
-                result = await self._judge.run(
-                    prompt,
-                    output_type=[AllGood, Steer],
-                    usage=ctx.usage,
-                    usage_limits=_claim_offset_limits(ctx.usage_limits),
-                )
-            finally:
-                if self._claim_held:
-                    self._claim_held = False
-                    ctx.usage.requests -= 1
+            task_status.started()
+            result = await self._judge.run(
+                prompt,
+                output_type=[AllGood, Steer],
+                usage=ctx.usage,
+                usage_limits=_claim_offset_limits(ctx.usage_limits),
+            )
             verdict = result.output
             if isinstance(verdict, Steer):
                 ctx.enqueue(f'Steering from trajectory judge {self._judge_name()!r}: {verdict.message}')
@@ -345,6 +335,7 @@ class TrajectoryJudge(AbstractCapability[AgentDepsT]):
                 raise
             self._evaluation_error = exc
         finally:
+            ctx.usage.requests -= 1
             self._evaluation_running = False
 
     def _judge_name(self) -> str:

--- a/tests/trajectory_judge/test_trajectory_judge.py
+++ b/tests/trajectory_judge/test_trajectory_judge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextvars import ContextVar
 from dataclasses import is_dataclass
 from typing import Any
 from unittest.mock import MagicMock
@@ -210,6 +211,34 @@ class TestJudgeInstructions:
         assert judge_instructions[0] is not None
         assert 'You are a trajectory judge' in judge_instructions[0]
         assert 'Your review focus:\nFlag unsupported claims.' in judge_instructions[0]
+
+    async def test_evaluation_inherits_the_hook_context(self) -> None:
+        marker = ContextVar('trajectory_judge_test_marker', default='outside')
+        seen: list[str] = []
+        done = anyio.Event()
+
+        def judge_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            seen.append(marker.get())
+            return _all_good_response()
+
+        cap = TrajectoryJudge(model=FunctionModel(judge_fn), every=1, on_verdict=lambda _: done.set())
+        ctx = _ctx()
+        run_cap = await cap.for_run(ctx)
+
+        async def handler() -> Any:
+            token = marker.set('handler')
+            try:
+                await run_cap.after_model_request(
+                    ctx, request_context=_request_context(_hi_request()), response=_text_response()
+                )
+                await done.wait()
+            finally:
+                marker.reset(token)
+            return 'run-result'
+
+        await run_cap.wrap_run(ctx, handler=handler)
+
+        assert seen == ['handler']
 
 
 class TestSteering:
@@ -479,6 +508,27 @@ class TestFailureHandling:
         with pytest.raises(RuntimeError, match='judge exploded'):
             await asyncio.wait_for(run_cap.wrap_run(ctx, handler=handler), timeout=_WAIT)
 
+    async def test_judge_failure_surfaces_at_run_end(self) -> None:
+        failed = anyio.Event()
+
+        def on_verdict(verdict: TrajectoryVerdict) -> None:
+            failed.set()
+            raise RuntimeError('judge exploded')
+
+        cap = TrajectoryJudge(model=_all_good_model(), every=1, on_verdict=on_verdict)
+        ctx = _ctx()
+        run_cap = await cap.for_run(ctx)
+
+        async def handler() -> Any:
+            await run_cap.after_model_request(
+                ctx, request_context=_request_context(_hi_request()), response=_text_response()
+            )
+            await failed.wait()
+            return 'run-result'
+
+        with pytest.raises(RuntimeError, match='judge exploded'):
+            await run_cap.wrap_run(ctx, handler=handler)
+
     async def test_run_end_cancels_an_in_flight_evaluation(self) -> None:
         """A run that ends mid-evaluation completes normally; the evaluation is cancelled."""
         gate = asyncio.Event()
@@ -574,7 +624,7 @@ class TestFailureHandling:
 
         with anyio.fail_after(_WAIT):
             with anyio.CancelScope() as run_scope:
-                async with anyio.create_task_group() as task_group:
+                async with anyio.create_task_group() as task_group:  # pragma: no branch - cancellation exits here
                     task_group.start_soon(cancel_when_started, run_scope)
                     await run_cap.wrap_run(ctx, handler=handler)
                     completed = True  # pragma: no cover - cancellation must leave the scope first

--- a/tests/trajectory_judge/test_trajectory_judge.py
+++ b/tests/trajectory_judge/test_trajectory_judge.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextvars import ContextVar
 from dataclasses import is_dataclass
 from typing import Any
@@ -12,7 +14,7 @@ import anyio
 import pytest
 from pydantic import ValidationError
 from pydantic_ai import Agent
-from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.capabilities import AbstractCapability, UseThreadExecutor
 from pydantic_ai.exceptions import UsageLimitExceeded, UserError
 from pydantic_ai.messages import (
     BinaryContent,
@@ -239,6 +241,37 @@ class TestJudgeInstructions:
         await run_cap.wrap_run(ctx, handler=handler)
 
         assert seen == ['handler']
+
+    async def test_evaluation_inherits_a_nested_thread_executor(self) -> None:
+        thread_names: list[str] = []
+        delivered = anyio.Event()
+
+        def judge_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            thread_names.append(threading.current_thread().name)
+            return _all_good_response()
+
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix='judge-bounded') as executor:
+            agent = Agent(
+                TestModel(),
+                capabilities=[
+                    TrajectoryJudge(
+                        model=FunctionModel(judge_fn),
+                        every=1,
+                        on_verdict=lambda _: delivered.set(),
+                    ),
+                    UseThreadExecutor(executor),
+                ],
+            )
+
+            @agent.tool_plain
+            async def wait_for_judge() -> str:
+                await delivered.wait()
+                return 'done'
+
+            await agent.run('Review this run.')
+
+        assert len(thread_names) == 1
+        assert thread_names[0].startswith('judge-bounded')
 
 
 class TestSteering:

--- a/tests/trajectory_judge/test_trajectory_judge.py
+++ b/tests/trajectory_judge/test_trajectory_judge.py
@@ -7,6 +7,7 @@ from dataclasses import is_dataclass
 from typing import Any
 from unittest.mock import MagicMock
 
+import anyio
 import pytest
 from pydantic import ValidationError
 from pydantic_ai import Agent
@@ -112,6 +113,21 @@ def _text_response(text: str = 'ok') -> ModelResponse:
     return ModelResponse(parts=[TextPart(text)])
 
 
+async def _run_hook_until(
+    capability: TrajectoryJudge[Any],
+    ctx: Any,
+    request_context: ModelRequestContext,
+    response: ModelResponse,
+    done: asyncio.Event,
+) -> None:
+    async def handler() -> Any:
+        await capability.after_model_request(ctx, request_context=request_context, response=response)
+        await asyncio.wait_for(done.wait(), timeout=_WAIT)
+        return 'run-result'
+
+    await capability.wrap_run(ctx, handler=handler)
+
+
 class TestConfigValidation:
     def test_is_a_dataclass_with_capability_fields(self) -> None:
         cap = TrajectoryJudge(model='test', id='judge', description='reviews trajectory', defer_loading=True)
@@ -189,10 +205,7 @@ class TestJudgeInstructions:
         )
         ctx = _ctx()
         run_cap = await cap.for_run(ctx)
-        await run_cap.after_model_request(
-            ctx, request_context=_request_context(_hi_request()), response=_text_response()
-        )
-        await asyncio.wait_for(done.wait(), timeout=_WAIT)
+        await _run_hook_until(run_cap, ctx, _request_context(_hi_request()), _text_response(), done)
 
         assert judge_instructions[0] is not None
         assert 'You are a trajectory judge' in judge_instructions[0]
@@ -305,15 +318,16 @@ class TestSteering:
         cap = TrajectoryJudge(model=_steer_model('back on task'), every=1)
         ctx = _ctx()
         run_cap = await cap.for_run(ctx)
-        await run_cap.after_model_request(
-            ctx, request_context=_request_context(_hi_request()), response=_text_response()
-        )
 
-        async def wait_for_enqueue() -> None:
+        async def handler() -> Any:
+            await run_cap.after_model_request(
+                ctx, request_context=_request_context(_hi_request()), response=_text_response()
+            )
             while not ctx.enqueue.called:
                 await asyncio.sleep(0.01)
+            return 'run-result'
 
-        await asyncio.wait_for(wait_for_enqueue(), timeout=_WAIT)
+        await asyncio.wait_for(run_cap.wrap_run(ctx, handler=handler), timeout=_WAIT)
         ctx.enqueue.assert_called_once_with("Steering from trajectory judge 'trajectory-judge': back on task")
         # The judge's own model call was threaded onto the run's usage.
         assert ctx.usage.requests >= 1
@@ -405,19 +419,23 @@ class TestCadence:
         run_cap = await cap.for_run(ctx)
         request_context = _request_context(_hi_request())
 
-        await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
-        await asyncio.sleep(0)  # let the evaluation task start
-        # Due again, but the first evaluation is still blocked on the gate: skipped.
-        await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
-        gate.set()
-        await asyncio.wait_for(done.wait(), timeout=_WAIT)
-        assert calls == 1
+        async def handler() -> Any:
+            await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
+            await asyncio.sleep(0)  # let the evaluation task start
+            # Due again, but the first evaluation is still blocked on the gate: skipped.
+            await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
+            gate.set()
+            await asyncio.wait_for(done.wait(), timeout=_WAIT)
+            assert calls == 1
 
-        # The next tick reaps the finished evaluation and launches a fresh one.
-        done.clear()
-        await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
-        await asyncio.wait_for(done.wait(), timeout=_WAIT)
-        assert calls == 2
+            # The next tick reaps the finished evaluation and launches a fresh one.
+            done.clear()
+            await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
+            await asyncio.wait_for(done.wait(), timeout=_WAIT)
+            assert calls == 2
+            return 'run-result'
+
+        await run_cap.wrap_run(ctx, handler=handler)
 
     async def test_fresh_state_per_run(self) -> None:
         """Cadence counting starts over each run: `every=3` never fires across two 2-step runs."""
@@ -451,15 +469,15 @@ class TestFailureHandling:
         ctx = _ctx()
         run_cap = await cap.for_run(ctx)
         request_context = _request_context(_hi_request())
-        await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
 
-        async def tick_until_raise() -> None:
+        async def handler() -> Any:
+            await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
             while True:
                 await asyncio.sleep(0.01)
                 await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
 
         with pytest.raises(RuntimeError, match='judge exploded'):
-            await asyncio.wait_for(tick_until_raise(), timeout=_WAIT)
+            await asyncio.wait_for(run_cap.wrap_run(ctx, handler=handler), timeout=_WAIT)
 
     async def test_run_end_cancels_an_in_flight_evaluation(self) -> None:
         """A run that ends mid-evaluation completes normally; the evaluation is cancelled."""
@@ -526,6 +544,45 @@ class TestFailureHandling:
         with pytest.raises(RuntimeError, match='run exploded'):
             await run_cap.wrap_run(ctx, handler=handler)
 
+    async def test_run_cancellation_unwinds_the_evaluation(self) -> None:
+        """External cancellation propagates after the task group has unwound the judge."""
+        started = anyio.Event()
+        unwound = anyio.Event()
+
+        async def judge_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+            started.set()
+            try:
+                await anyio.sleep_forever()
+                raise AssertionError('sleep_forever returned')  # pragma: no cover
+            finally:
+                unwound.set()
+
+        cap = TrajectoryJudge(model=FunctionModel(judge_fn), every=1)
+        ctx = _ctx()
+        run_cap = await cap.for_run(ctx)
+        completed = False
+
+        async def handler() -> Any:
+            await run_cap.after_model_request(
+                ctx, request_context=_request_context(_hi_request()), response=_text_response()
+            )
+            await anyio.sleep_forever()
+
+        async def cancel_when_started(scope: anyio.CancelScope) -> None:
+            await started.wait()
+            scope.cancel()
+
+        with anyio.fail_after(_WAIT):
+            with anyio.CancelScope() as run_scope:
+                async with anyio.create_task_group() as task_group:
+                    task_group.start_soon(cancel_when_started, run_scope)
+                    await run_cap.wrap_run(ctx, handler=handler)
+                    completed = True  # pragma: no cover - cancellation must leave the scope first
+
+        assert not completed
+        assert unwound.is_set()
+        assert ctx.usage.requests == 0
+
 
 class TestTranscript:
     async def test_escapes_trajectory_delimiters_in_content(self) -> None:
@@ -546,10 +603,7 @@ class TestTranscript:
             )
         ]
 
-        await run_cap.after_model_request(
-            ctx, request_context=_request_context(messages), response=_text_response('wrap-up')
-        )
-        await asyncio.wait_for(done.wait(), timeout=_WAIT)
+        await _run_hook_until(run_cap, ctx, _request_context(messages), _text_response('wrap-up'), done)
 
         assert seen[0].count('</trajectory>') == 1
         assert '&lt;/trajectory&gt;' in seen[0]
@@ -597,10 +651,7 @@ class TestTranscript:
                 ]
             ),
         ]
-        await run_cap.after_model_request(
-            ctx, request_context=_request_context(messages), response=_text_response('wrap-up')
-        )
-        await asyncio.wait_for(done.wait(), timeout=_WAIT)
+        await _run_hook_until(run_cap, ctx, _request_context(messages), _text_response('wrap-up'), done)
 
         transcript = seen[0]
         assert 'user: hello' in transcript
@@ -629,10 +680,7 @@ class TestTranscript:
         run_cap = await cap.for_run(ctx)
 
         messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart('x' * 2000)])]
-        await run_cap.after_model_request(
-            ctx, request_context=_request_context(messages), response=_text_response('recent-marker')
-        )
-        await asyncio.wait_for(done.wait(), timeout=_WAIT)
+        await _run_hook_until(run_cap, ctx, _request_context(messages), _text_response('recent-marker'), done)
 
         transcript = seen[0].split('<trajectory>\n', 1)[1].rsplit('\n</trajectory>', 1)[0]
         assert 'recent-marker' in transcript
@@ -715,19 +763,18 @@ class TestUsageCoordination:
         ]
 
         request_context = _request_context(_hi_request())
-        for run_cap in run_caps:
-            await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
-        assert ctx.usage.requests == 2  # exactly one claim landed; the skipped launches claimed nothing
-        gate.set()
-        await asyncio.wait_for(done.wait(), timeout=_WAIT)
 
-        async def passthrough() -> Any:
+        async def run_nested(index: int = 0) -> Any:
+            if index < len(run_caps):
+                return await run_caps[index].wrap_run(ctx, handler=lambda: run_nested(index + 1))
+            for run_cap in run_caps:
+                await run_cap.after_model_request(ctx, request_context=request_context, response=_text_response())
+            assert ctx.usage.requests == 2  # exactly one claim landed; the skipped launches claimed nothing
+            gate.set()
+            await asyncio.wait_for(done.wait(), timeout=_WAIT)
             return 'run-result'
 
-        # The winner's `wrap_run` reaps its finished task; the skipped judges have nothing
-        # to reap and nothing to raise.
-        for run_cap in run_caps:
-            assert await run_cap.wrap_run(ctx, handler=passthrough) == 'run-result'
+        assert await run_nested() == 'run-result'
         assert judge_calls == 1
         assert ctx.usage.requests == 2  # parent + the single winning evaluation, within the limit of 3
 
@@ -742,15 +789,17 @@ class TestUsageCoordination:
         ctx = _ctx()
         ctx.usage_limits = UsageLimits(request_limit=5)
         run_cap = await cap.for_run(ctx)
-        await run_cap.after_model_request(
-            ctx, request_context=_request_context(_hi_request()), response=_text_response()
-        )
-        assert ctx.usage.requests == 1  # the claim, made synchronously at launch
+        requests_at_launch: list[int] = []
 
         async def handler() -> Any:
+            await run_cap.after_model_request(
+                ctx, request_context=_request_context(_hi_request()), response=_text_response()
+            )
+            requests_at_launch.append(ctx.usage.requests)
             return 'run-result'
 
         assert await run_cap.wrap_run(ctx, handler=handler) == 'run-result'
+        assert requests_at_launch == [1]  # the claim was made synchronously at launch
         assert ctx.usage.requests == 0  # the never-started evaluation released its claim
 
     async def test_unbounded_limits_pass_through(self) -> None:
@@ -759,15 +808,16 @@ class TestUsageCoordination:
         ctx = _ctx()
         ctx.usage_limits = UsageLimits()
         run_cap = await cap.for_run(ctx)
-        await run_cap.after_model_request(
-            ctx, request_context=_request_context(_hi_request()), response=_text_response()
-        )
 
-        async def wait_for_enqueue() -> None:
+        async def handler() -> Any:
+            await run_cap.after_model_request(
+                ctx, request_context=_request_context(_hi_request()), response=_text_response()
+            )
             while not ctx.enqueue.called:
                 await asyncio.sleep(0.01)
+            return 'run-result'
 
-        await asyncio.wait_for(wait_for_enqueue(), timeout=_WAIT)
+        await asyncio.wait_for(run_cap.wrap_run(ctx, handler=handler), timeout=_WAIT)
         assert ctx.usage.requests == 1  # the judge's real request; the launch claim was released
 
 


### PR DESCRIPTION
## Summary

Run `TrajectoryJudge` evaluations inside an AnyIO task group owned by the agent run. This removes manual `asyncio.Task` storage while preserving cadence, delayed failure propagation, cancellation, and usage accounting.

The cancellation regression test verifies that cancelling the run unwinds the in-flight judge before returning.

## Tests

- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `PYRIGHT_PYTHON_IGNORE_WARNINGS=1 uv run --no-sync pyright pydantic_ai_harness/trajectory_judge/_capability.py tests/trajectory_judge/test_trajectory_judge.py`
- `uv run --no-sync pytest -p no:cacheprovider tests/trajectory_judge`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
