### PR TITLE
Require `AnyIO` structured concurrency in contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,11 @@ The house pattern (spans on `ctx.tracer`, attribute naming, content behind
 - prefer the most generic input types possible (reduce dependency chains)
 - don't add comments that restate what the code does
 
+## Async
+
+- Use `anyio.create_task_group()` for structured concurrency. Do not use `asyncio.gather()`.
+- Keep a strong reference to every `asyncio.Task` until it finishes. Do not create unowned background tasks.
+
 ## Writing style
 
 Applies to docs, READMEs, docstrings, comments, commit messages, and PR text.


### PR DESCRIPTION
## Summary

- Require `anyio.create_task_group()` instead of `asyncio.gather()` for structured concurrency.
- Require strong references to `asyncio.Task` instances until they finish.

## Testing

Not run. This change only updates contributor instructions.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
