### PR TITLE
Add optional tail-line retention to `Truncate`

### DIFF
--- a/docs/tool-output-limits.md
+++ b/docs/tool-output-limits.md
@@ -124,6 +124,37 @@ agent = Agent(
 schemas), `tail` (keep the last characters, good for build and test output where errors land
 last), and `head_tail` (keep both ends, elide the middle -- the default).
 
+### Prefer complete tail lines
+
+Set `Truncate(keep_tail_lines=N)` to reserve the final N lines before allocating the rest of
+the character budget. The default is zero, which leaves existing truncation behavior unchanged.
+
+```python
+from pydantic_ai_harness.tool_output_limits import Band, ToolOutputLimits, Truncate, TruncationStrategy
+
+truncate = Truncate(max_chars=4_000, strategy=TruncationStrategy.head, keep_tail_lines=2)
+limits = ToolOutputLimits(bands=[], per_tool={'run_command': [Band(over=4_000, action=truncate)]})
+```
+
+With `head`, the remaining content budget keeps the beginning of the output. With
+`head_tail`, it is split 2:3 between the beginning and the text immediately before the
+reserved lines. `tail` continues to keep the end. Markers and all retained characters count
+toward `max_chars`.
+
+The cap takes priority. If the requested lines exceed it, truncation falls back to the
+usual tail strategy; if they fit but a full marker would displace them, the result is a
+bare tail slice within the cap. This does not invoke `then` or guarantee that an oversized
+control trailer remains intact.
+
+Lines are separated by LF or CRLF, and their existing endings are retained. A terminating
+newline does not add a line, but a blank final line counts. Requesting more lines than exist
+selects the whole text, subject to the same cap. Negative `keep_tail_lines` values are rejected.
+
+This applies to the text after serialization and optional ANSI stripping, independently
+for `ToolReturn.return_value` and textual `content`. Binary fallbacks are unchanged.
+Tail-line selection adds no telemetry spans: it is a slicing choice within the existing
+tool-result reduction, rather than a separate operation.
+
 ## Layering with Shell
 
 Keep Shell's native `max_output_chars` above the `ToolOutputLimits` thresholds. Use

--- a/pydantic_ai_harness/tool_output_limits/README.md
+++ b/pydantic_ai_harness/tool_output_limits/README.md
@@ -99,6 +99,37 @@ agent = Agent(
 )
 ```
 
+### Prefer complete tail lines
+
+Set `Truncate(keep_tail_lines=N)` to reserve the final N lines before allocating the rest of
+the character budget. The default is zero, which leaves existing truncation behavior unchanged.
+
+```python
+from pydantic_ai_harness.tool_output_limits import Band, ToolOutputLimits, Truncate, TruncationStrategy
+
+truncate = Truncate(max_chars=4_000, strategy=TruncationStrategy.head, keep_tail_lines=2)
+limits = ToolOutputLimits(bands=[], per_tool={'run_command': [Band(over=4_000, action=truncate)]})
+```
+
+With `head`, the remaining content budget keeps the beginning of the output. With
+`head_tail`, it is split 2:3 between the beginning and the text immediately before the
+reserved lines. `tail` continues to keep the end. Markers and all retained characters count
+toward `max_chars`.
+
+The cap takes priority. If the requested lines exceed it, truncation falls back to the
+usual tail strategy; if they fit but a full marker would displace them, the result is a
+bare tail slice within the cap. This does not invoke `then` or guarantee that an oversized
+control trailer remains intact.
+
+Lines are separated by LF or CRLF, and their existing endings are retained. A terminating
+newline does not add a line, but a blank final line counts. Requesting more lines than exist
+selects the whole text, subject to the same cap. Negative `keep_tail_lines` values are rejected.
+
+This applies to the text after serialization and optional ANSI stripping, independently
+for `ToolReturn.return_value` and textual `content`. Binary fallbacks are unchanged.
+Tail-line selection adds no telemetry spans: it is a slicing choice within the existing
+tool-result reduction, rather than a separate operation.
+
 ## Layering with Shell
 
 Keep Shell's native `max_output_chars` above the `ToolOutputLimits` thresholds. Use

--- a/pydantic_ai_harness/tool_output_limits/_bands.py
+++ b/pydantic_ai_harness/tool_output_limits/_bands.py
@@ -13,7 +13,7 @@ works, a bounded truncation otherwise, never a silent drop.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from pydantic_ai_harness.tool_output_limits._payload import TruncationStrategy
@@ -46,6 +46,17 @@ class Truncate:
     strategy: TruncationStrategy = TruncationStrategy.head_tail
     max_chars: int = _DEFAULT_TRUNCATE_CHARS
     then: Action | None = None
+    keep_tail_lines: int = field(default=0, kw_only=True)
+    """Prioritize the last N newline-delimited lines before truncating the remaining text.
+
+    Zero preserves the selected strategy's usual behavior. LF and CRLF endings are kept.
+    If these lines exceed `max_chars`, use tail truncation instead. If a complete marker
+    would displace these lines, keep a bare tail slice within the cap.
+    """
+
+    def __post_init__(self) -> None:
+        if self.keep_tail_lines < 0:
+            raise ValueError('keep_tail_lines must be non-negative.')
 
 
 @dataclass(frozen=True)

--- a/pydantic_ai_harness/tool_output_limits/_bands.py
+++ b/pydantic_ai_harness/tool_output_limits/_bands.py
@@ -13,7 +13,7 @@ works, a bounded truncation otherwise, never a silent drop.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import KW_ONLY, dataclass
 from typing import TYPE_CHECKING
 
 from pydantic_ai_harness.tool_output_limits._payload import TruncationStrategy
@@ -46,7 +46,9 @@ class Truncate:
     strategy: TruncationStrategy = TruncationStrategy.head_tail
     max_chars: int = _DEFAULT_TRUNCATE_CHARS
     then: Action | None = None
-    keep_tail_lines: int = field(default=0, kw_only=True)
+
+    _: KW_ONLY
+    keep_tail_lines: int = 0
     """Prioritize the last N newline-delimited lines before truncating the remaining text.
 
     Zero preserves the selected strategy's usual behavior. LF and CRLF endings are kept.

--- a/pydantic_ai_harness/tool_output_limits/_capability.py
+++ b/pydantic_ai_harness/tool_output_limits/_capability.py
@@ -374,7 +374,10 @@ class ToolOutputLimits(AbstractCapability[AgentDepsT]):
             if unit.binary:
                 return await self._fallback(ctx, call, action.then, unit)
             assert unit.text is not None
-            return truncate_text(unit.text, action.max_chars, action.strategy), None
+            return (
+                truncate_text(unit.text, action.max_chars, action.strategy, keep_tail_lines=action.keep_tail_lines),
+                None,
+            )
 
         if isinstance(action, Spill):
             return await self._spill(ctx, call, action, unit)

--- a/pydantic_ai_harness/tool_output_limits/_payload.py
+++ b/pydantic_ai_harness/tool_output_limits/_payload.py
@@ -147,26 +147,51 @@ def _sketch_sequence(items: Sequence[object]) -> str:
     return f'[{len(items)} items of {elem}]'
 
 
-def truncate_text(text: str, max_chars: int, strategy: TruncationStrategy) -> str:
+def _tail_line_start(text: str, count: int) -> int:
+    """Find the last N LF/CRLF lines without splitting the entire payload."""
+    end = len(text) - int(text.endswith('\n'))
+    for _ in range(count):
+        end = text.rfind('\n', 0, end)
+        if end < 0:
+            return 0
+    return end + 1
+
+
+def truncate_text(text: str, max_chars: int, strategy: TruncationStrategy, *, keep_tail_lines: int = 0) -> str:
     """Limit `text` to `max_chars`, including the truncation marker.
 
-    If the budget cannot fit both retained content and a complete marker, return the
-    selected slice without a marker.
+    Omit the marker when it cannot fit alongside the retained content. Reserved tail
+    lines take priority over both the marker and the remaining content.
     """
     if max_chars <= 0:
         return ''
     total = len(text)
     if total <= max_chars:
         return text
-    if strategy is TruncationStrategy.tail:
+    tail_chars = total - _tail_line_start(text, keep_tail_lines) if keep_tail_lines else 0
+    if tail_chars > max_chars:
         return truncate_tail(text, max_chars)
+    if tail_chars == max_chars:
+        return text[-max_chars:]
+    if strategy is TruncationStrategy.tail:
+        truncated = truncate_tail(text, max_chars)
+        if tail_chars and not truncated.endswith(text[total - tail_chars :]):
+            return text[-max_chars:]
+        return truncated
+
+    return _truncate_head_and_tail(text, max_chars, strategy, tail_chars)
+
+
+def _truncate_head_and_tail(text: str, max_chars: int, strategy: TruncationStrategy, tail_chars: int) -> str:
+    total = len(text)
+    head_share = 5 if strategy is TruncationStrategy.head else 2
 
     # Check each count: digit and thousands-separator changes can shorten the marker.
-    for retained in range(max_chars, 0, -1):
-        if strategy is TruncationStrategy.head:
+    for retained in range(max_chars, max(1, tail_chars) - 1, -1):
+        head_chars = (retained - tail_chars) * head_share // 5
+        if strategy is TruncationStrategy.head and not tail_chars:
             marker = f'\n\n[truncated: showing first {retained:,} of {total:,} chars]'
         else:
-            head_chars = retained * 2 // 5
             marker = (
                 f'\n\n[truncated: {total - retained:,} chars omitted from the middle; '
                 f'showing first {head_chars:,} + last {retained - head_chars:,} of {total:,} chars]\n\n'
@@ -174,9 +199,9 @@ def truncate_text(text: str, max_chars: int, strategy: TruncationStrategy) -> st
         if retained + len(marker) <= max_chars:
             break
     else:
+        if tail_chars:
+            return text[-max_chars:]
         retained, marker = max_chars, ''
+        head_chars = retained * head_share // 5
 
-    if strategy is TruncationStrategy.head:
-        return text[:retained] + marker
-    head_chars = retained * 2 // 5
-    return text[:head_chars] + marker + text[-(retained - head_chars) :]
+    return text[:head_chars] + marker + text[total - (retained - head_chars) :]

--- a/tests/tool_output_limits/test_keep_tail_lines.py
+++ b/tests/tool_output_limits/test_keep_tail_lines.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.messages import ToolReturn, ToolReturnPart, UserPromptPart
+from pydantic_ai.models.test import TestModel
+
+from pydantic_ai_harness.tool_output_limits import Band, Passthrough, ToolOutputLimits, Truncate, TruncationStrategy
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'
+
+
+async def _run(value: object, capability: ToolOutputLimits[object]) -> tuple[ToolReturnPart, list[UserPromptPart]]:
+    agent = Agent(TestModel(call_tools=['output']), capabilities=[capability])
+
+    @agent.tool_plain
+    def output() -> object:
+        return value
+
+    result = await agent.run('go')
+    parts = [part for message in result.all_messages() for part in message.parts]
+    returns = [part for part in parts if isinstance(part, ToolReturnPart)]
+    assert len(returns) == 1
+    return returns[0], [part for part in parts if isinstance(part, UserPromptPart)]
+
+
+async def _truncate(text: str, action: Truncate) -> str:
+    part, _ = await _run(text, ToolOutputLimits(bands=[Band(over=0, action=action)]))
+    assert isinstance(part.content, str)
+    return part.content
+
+
+class TestKeepTailLines:
+    @pytest.mark.parametrize('strategy', TruncationStrategy)
+    @pytest.mark.parametrize('budget', [-1, 0, 1, 100, 200, 2000])
+    async def test_disabled_is_unchanged(self, strategy: TruncationStrategy, budget: int):
+        text = 'header\n' + 'body\r\n' * 200 + 'exit=0\n'
+        fallback = Passthrough()
+        original = Truncate(strategy, budget, fallback)
+        disabled = Truncate(strategy, budget, fallback, keep_tail_lines=0)
+        assert original.then is fallback
+        assert original.keep_tail_lines == 0
+        assert await _truncate(text, original) == await _truncate(text, disabled)
+
+    def test_negative_line_count(self):
+        with pytest.raises(ValueError, match='keep_tail_lines'):
+            Truncate(keep_tail_lines=-1)
+
+    @pytest.mark.parametrize('strategy', TruncationStrategy)
+    @pytest.mark.parametrize('budget', [-1, 0, 6, 7])
+    async def test_nonpositive_and_unnecessary_truncation(self, strategy: TruncationStrategy, budget: int):
+        text = 'a\nb\nc\n'
+        result = await _truncate(text, Truncate(strategy, budget, keep_tail_lines=2))
+        assert result == (text if budget > 0 else '')
+
+    @pytest.mark.parametrize('strategy', [TruncationStrategy.head, TruncationStrategy.head_tail])
+    @pytest.mark.parametrize(
+        'suffix,lines',
+        [
+            ('status=ok', 1),
+            ('status=ok\n', 1),
+            ('pid=123\nexit=0', 2),
+            ('pid=123\nexit=0\n', 2),
+            ('status=ok\r\n', 1),
+            ('pid=123\r\nexit=0\r\n', 2),
+            ('\n', 1),
+            ('status=ok\n\n', 2),
+            ('\r\n', 1),
+            ('状态=好🙂\n', 1),
+            ('state\u2028pid\x85ok\rvalue', 1),
+        ],
+    )
+    async def test_preserves_complete_lines(self, strategy: TruncationStrategy, suffix: str, lines: int):
+        text = 'x' * 500 + '\n' + suffix
+        expected = (
+            f'\n\n[truncated: {len(text) - len(suffix):,} chars omitted from the middle; '
+            f'showing first 0 + last {len(suffix):,} of {len(text):,} chars]\n\n{suffix}'
+        )
+        result = await _truncate(text, Truncate(strategy, len(expected), keep_tail_lines=lines))
+        assert result == expected
+
+    @pytest.mark.parametrize('strategy', TruncationStrategy)
+    @pytest.mark.parametrize('difference', [-1, 0, 1])
+    async def test_tail_budget_boundary(self, strategy: TruncationStrategy, difference: int):
+        suffix = 'process_id=' + '1234567890' * 10
+        text = 'body\n' * 100 + suffix
+        budget = len(suffix) + difference
+        result = await _truncate(text, Truncate(strategy, budget, keep_tail_lines=1))
+        if difference < 0:
+            expected = await _truncate(text, Truncate(TruncationStrategy.tail, budget))
+        else:
+            expected = text[-budget:]
+        assert result == expected
+        assert len(result) <= budget
+
+    @pytest.mark.parametrize('strategy', [TruncationStrategy.head, TruncationStrategy.head_tail])
+    @pytest.mark.parametrize('difference', [-1, 0, 1])
+    async def test_marker_budget_boundary(self, strategy: TruncationStrategy, difference: int):
+        text = 'x' * 500 + '\nexit=0'
+        marker = '\n\n[truncated: 501 chars omitted from the middle; showing first 0 + last 6 of 507 chars]\n\n'
+        budget = len(marker) + 6 + difference
+        result = await _truncate(text, Truncate(strategy, budget, keep_tail_lines=1))
+        if difference < 0:
+            assert result == text[-budget:]
+        elif difference == 0:
+            assert result == marker + 'exit=0'
+        else:
+            assert result.endswith('exit=0') and '[truncated:' in result
+        assert len(result) <= budget
+
+    @pytest.mark.parametrize('strategy', [TruncationStrategy.head, TruncationStrategy.head_tail])
+    async def test_retained_counts_and_body_distribution(self, strategy: TruncationStrategy):
+        text = ''.join(chr(0x4E00 + i) for i in range(1000)) + '\npid=123\nexit=0'
+        head, tail = (100, 14) if strategy is TruncationStrategy.head else (40, 74)
+        expected = (
+            f'{text[:head]}\n\n[truncated: 901 chars omitted from the middle; '
+            f'showing first {head} + last {tail} of 1,015 chars]\n\n{text[-tail:]}'
+        )
+        assert await _truncate(text, Truncate(strategy, len(expected), keep_tail_lines=2)) == expected
+
+    @pytest.mark.parametrize('text,lines', [('x' * 1000, 1), ('x\ny\nz' * 200, 10**12)])
+    @pytest.mark.parametrize('strategy', TruncationStrategy)
+    async def test_oversized_requested_lines_use_tail(self, text: str, lines: int, strategy: TruncationStrategy):
+        result = await _truncate(text, Truncate(strategy, 100, keep_tail_lines=lines))
+        assert result == await _truncate(text, Truncate(TruncationStrategy.tail, 100))
+
+    async def test_tail_strategy_keeps_existing_marker_when_lines_fit(self):
+        text = 'body\n' * 200 + 'pid=123\nexit=0'
+        result = await _truncate(text, Truncate(TruncationStrategy.tail, 200, keep_tail_lines=2))
+        assert result == await _truncate(text, Truncate(TruncationStrategy.tail, 200))
+
+    async def test_tool_return_fields_and_metadata(self):
+        value = 'v' * 1000 + '\nvalue_end'
+        content = 'c' * 1000 + '\ncontent_end'
+        capability: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=0, action=Truncate(TruncationStrategy.head, 200, keep_tail_lines=1))]
+        )
+        part, prompts = await _run(ToolReturn(return_value=value, content=content, metadata={'id': 7}), capability)
+        assert part.metadata == {'id': 7}
+        assert isinstance(part.content, str) and part.content.endswith('value_end') and len(part.content) <= 200
+        assert len(prompts) == 2
+        assert isinstance(prompts[-1].content, str)
+        assert prompts[-1].content.endswith('content_end') and len(prompts[-1].content) <= 200
+
+    async def test_serializer_ansi_and_token_threshold(self):
+        text = 'body\n' * 200 + '\x1b[31mpid=123\nexit=0\x1b[0m'
+
+        def serializer(value: object) -> str:
+            assert value == {'status': 'ok'}
+            return text
+
+        capability: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=1, action=Truncate(TruncationStrategy.head, 200, keep_tail_lines=2))],
+            serializer=serializer,
+            strip_ansi=True,
+            over_tokens=True,
+            tokenizer=lambda text: 1,
+        )
+        part, _ = await _run({'status': 'ok'}, capability)
+        assert isinstance(part.content, str)
+        assert part.content.endswith('pid=123\nexit=0') and '\x1b' not in part.content
+        assert len(part.content) <= 200
+
+    async def test_binary_fallback_is_unchanged(self):
+        capability: ToolOutputLimits[object] = ToolOutputLimits(
+            bands=[Band(over=0, action=Truncate(max_chars=1, then=Passthrough(), keep_tail_lines=1))]
+        )
+        part, _ = await _run(b'raw\nbytes', capability)
+        assert part.content == b'raw\nbytes'


### PR DESCRIPTION
## Summary

Head truncation can drop trailing control lines. Allow callers to reserve those lines explicitly, as requested in #510.

New public surface: keyword-only `Truncate.keep_tail_lines`, defaulting to `0`. For example, `Truncate(strategy=TruncationStrategy.head, max_chars=4_000, keep_tail_lines=2)` reserves the final two lines when they fit, then spends the remaining content budget on the beginning of the output.

### Boundary notes

The character cap takes priority: oversized requested tails use the existing tail strategy. If the lines fit but a complete marker would displace them, keep a bare tail slice. LF/CRLF endings are preserved; this is best-effort retention, not an unconditional guarantee for oversized trailers.

### Verification

- [Public `Agent` tests](https://github.com/pydantic/pydantic-ai-harness/pull/836/files#diff-b42121ae04caf43d8ccba5a4ef209c5f32bc9d971d33d84f4b9f8e64e8b681aeR38) cover default compatibility, line and marker boundaries, exact retained counts, `ToolReturn`, serialization/ANSI handling, and binary fallback.
- Ubuntu / Python 3.10: 833 affected-module tests pass. Ruff, scoped strict Pyright, and documentation checks pass.
- 10,794 default-output comparisons match the baseline exactly.

Existing truncation output and the original three positional parameters are unchanged when the option is disabled. No dependencies are added.

## Linked Issue

Closes #510. Follows #816, which addressed items 1 and 3.

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [ ] `make lint && make typecheck && make test` passes locally (don't stress about CI -- we'll help)
- [x] `pyproject.toml` and `uv.lock` are unchanged, or a maintainer added `dependencies:approved` to the current head
- [x] Docstrings use single backticks (not RST double backticks)
