### PR TITLE
Bump the `gh-aw` engine pin to `0.30.0`

### DIFF
--- a/gh-aw/pydantic.md
+++ b/gh-aw/pydantic.md
@@ -20,7 +20,7 @@ pre-agent-steps:
       python3 -P -c "from pydantic_ai_harness import Coder"
 engine:
   id: pydantic-ai
-  version: "0.26.0"
+  version: "0.30.0"
   display-name: Pydantic AI
   description: Pydantic AI CLI (pai) running the pydantic-ai-harness coder agent with MCP tool support
   experimental: true


### PR DESCRIPTION
`gh-aw/pydantic.md` pins `engine.version` to `0.26.0`; this bumps it to `0.30.0`.

gh-aw compiles this definition from the default branch, so a merge ships the new pin to every consumer on their next recompile. `0.30.0` is live on PyPI, so the `--published` lint gate passes; the `gh-aw-engine-pin-reminder` workflow is what filed this issue.

Closes #827