### PR TITLE
Add `tool_return_max_chars` to `SummarizingCompaction`

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -350,7 +350,7 @@ agent = Agent(
 
 Both prompt surfaces of the summary request are fields: `summary_prompt` is the user-turn template (it must contain a `{messages}` placeholder), and `instructions` sets the internal agent's static instructions, which Pydantic AI sends in the request's system prompt. Override `instructions` when the summarizer endpoint requires a fixed leading instruction.
 
-The messages served into that template are rendered to text, and each tool return is capped per return at `tool_return_max_chars` (default 500) characters using the same explicit truncation marker as kept user turns. Raise it, or set it to `None` to render each return whole, when the summarizer's context window is large enough to absorb the payloads; a `max_tokens` / `keep_tokens` budget still bounds the total.
+The messages served into that template are rendered to text, and each tool return is capped per return at `tool_return_max_chars` (default 500) characters using the same explicit truncation marker as kept user turns. Raise it, or set it to `None` to render each return whole, when the summarizer's context window is large enough to absorb the payloads. `max_tokens` and `keep_tokens` control when compaction runs and which history messages are retained; they do not cap the summary-request payload.
 
 The summary request is non-streaming unless `event_stream_handler` is set. Supply a handler to watch the summary as it is written, or pass `drain_summary_events` to take the streaming request path without handling the events -- which is what a summarizer endpoint that rejects non-streaming requests needs:
 

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -350,6 +350,8 @@ agent = Agent(
 
 Both prompt surfaces of the summary request are fields: `summary_prompt` is the user-turn template (it must contain a `{messages}` placeholder), and `instructions` sets the internal agent's static instructions, which Pydantic AI sends in the request's system prompt. Override `instructions` when the summarizer endpoint requires a fixed leading instruction.
 
+The messages served into that template are rendered to text, and each tool return is capped per return at `tool_return_max_chars` (default 500) characters using the same explicit truncation marker as kept user turns. Raise it, or set it to `None` to render each return whole, when the summarizer's context window is large enough to absorb the payloads; a `max_tokens` / `keep_tokens` budget still bounds the total.
+
 The summary request is non-streaming unless `event_stream_handler` is set. Supply a handler to watch the summary as it is written, or pass `drain_summary_events` to take the streaming request path without handling the events -- which is what a summarizer endpoint that rejects non-streaming requests needs:
 
 ```python
@@ -487,7 +489,7 @@ As with receipts, the update instruction and the bridge-prefix wording are conte
 
 ## Out of scope
 
-These strategies compress or drop context *inside* the window. Moving large tool outputs *out* of the window -- overflowing them to a file the agent (or a subagent) can query on demand -- is a separate capability ([tool output limits](tool-output-limits.md)), not lossy truncation. Prefer it over capping individual tool outputs.
+These strategies compress or drop context *inside* the window. Moving large tool outputs *out* of the window -- overflowing them to a file the agent (or a subagent) can query on demand -- is a separate capability ([tool output limits](tool-output-limits.md)), not lossy truncation. Within `SummarizingCompaction`, `tool_return_max_chars` makes the summarizer's per-return cap tunable (or `None` to render returns whole), but the summary request still reads a lossy rendering; prefer tool output limits when a payload must be queryable in full.
 
 ## API reference
 

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -422,6 +422,11 @@ must contain a `{messages}` placeholder), and `instructions` sets the internal a
 which Pydantic AI sends in the request's system prompt. Override `instructions` when the summarizer
 endpoint requires a fixed leading instruction.
 
+The messages served into that template are rendered to text, and each tool return is capped per return at
+`tool_return_max_chars` (default 500) characters using the same explicit truncation marker as kept user
+turns. Raise it, or set it to `None` to render each return whole, when the summarizer's context window is
+large enough to absorb the payloads; a `max_tokens` / `keep_tokens` budget still bounds the total.
+
 ## Usage accounting
 
 The summary call is a real request to the model, so its full usage -- tokens **and** the request
@@ -599,4 +604,6 @@ outcome changes what compaction keeps or drops.
 
 These strategies compress or drop context *inside* the window. Moving large tool outputs *out* of the
 window -- overflowing them to a file the agent (or a subagent) can query on demand -- is a separate
-capability, not lossy truncation. Prefer it over capping individual tool outputs.
+capability, not lossy truncation. Within `SummarizingCompaction`, `tool_return_max_chars` makes the
+summarizer's per-return cap tunable (or `None` to render returns whole), but the summary request still
+reads a lossy rendering; prefer tool output limits when a payload must be queryable in full.

--- a/pydantic_ai_harness/compaction/README.md
+++ b/pydantic_ai_harness/compaction/README.md
@@ -425,7 +425,8 @@ endpoint requires a fixed leading instruction.
 The messages served into that template are rendered to text, and each tool return is capped per return at
 `tool_return_max_chars` (default 500) characters using the same explicit truncation marker as kept user
 turns. Raise it, or set it to `None` to render each return whole, when the summarizer's context window is
-large enough to absorb the payloads; a `max_tokens` / `keep_tokens` budget still bounds the total.
+large enough to absorb the payloads. `max_tokens` and `keep_tokens` control when compaction runs and which
+history messages are retained; they do not cap the summary-request payload.
 
 ## Usage accounting
 

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -156,8 +156,27 @@ def _model_family(model: str | AbstractModel | None) -> str | None:
     return tail or None
 
 
-def _format_messages(messages: Sequence[ModelMessage], *, skip_previous_summary: bool = False) -> str:
-    """Render messages into a human-readable string for summarization."""
+def _truncate_with_marker(text: str, max_chars: int) -> str:
+    """Truncate *text* to *max_chars* characters, an explicit marker counted within the cap."""
+    if len(text) <= max_chars:
+        return text
+    marker = '[...]'
+    if max_chars <= len(marker):
+        return marker[:max_chars]
+    return f'{text[: max_chars - len(marker)]}{marker}'
+
+
+def _format_messages(
+    messages: Sequence[ModelMessage],
+    *,
+    skip_previous_summary: bool = False,
+    tool_return_max_chars: int | None = 500,
+) -> str:
+    """Render messages into a human-readable string for summarization.
+
+    Tool returns are truncated to `tool_return_max_chars` characters with the shared
+    truncation marker; `None` renders them whole.
+    """
     lines: list[str] = []
     for msg in messages:
         if isinstance(msg, ModelRequest):
@@ -171,9 +190,9 @@ def _format_messages(messages: Sequence[ModelMessage], *, skip_previous_summary:
                 ):
                     lines.append(f'System: {part.content}')
                 elif isinstance(part, ToolReturnPart):
-                    content_str = str(part.content)[:500]
-                    if len(str(part.content)) > 500:
-                        content_str += '...'
+                    content_str = str(part.content)
+                    if tool_return_max_chars is not None:
+                        content_str = _truncate_with_marker(content_str, tool_return_max_chars)
                     lines.append(f'Tool [{part.tool_name}]: {content_str}')
         else:
             for part in msg.parts:
@@ -395,6 +414,10 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
     """Per-message character cap for ``keep_user_messages``; oversized messages are truncated
     with an explicit marker (the shared truncation-marker convention)."""
 
+    tool_return_max_chars: int | None = 500
+    """Per-return character cap when rendering tool results for the summarizer. `None` renders
+    them whole."""
+
     receipts: bool = False
     """When ``True``, append a deterministic compaction receipt after the summary noting how
     much history was summarized, that the summary is secondhand, and -- when a
@@ -420,6 +443,8 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
             raise ValueError('keep_tokens must be non-negative.')
         if self.keep_user_messages_max_chars < 1:
             raise ValueError('keep_user_messages_max_chars must be positive.')
+        if self.tool_return_max_chars is not None and self.tool_return_max_chars < 1:
+            raise ValueError('tool_return_max_chars must be positive.')
 
     def with_focus(self, focus: str) -> SummarizingCompaction[AgentDepsT]:
         """Return a copy whose summary prompt prioritizes `focus`.
@@ -525,12 +550,7 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
 
     def _truncate(self, text: str, max_chars: int | None = None) -> str:
         limit = self.keep_user_messages_max_chars if max_chars is None else max_chars
-        if len(text) <= limit:
-            return text
-        marker = '[...]'
-        if limit <= len(marker):
-            return marker[:limit]
-        return f'{text[: limit - len(marker)]}{marker}'
+        return _truncate_with_marker(text, limit)
 
     def _bound_sequence(self, content: Sequence[UserContent]) -> tuple[list[UserContent], bool]:
         """Apply the same per-part character budget to a sequence-shaped user prompt.
@@ -648,7 +668,11 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
         """Generate a summary for the given messages using the configured model."""
         from pydantic_ai import Agent
 
-        formatted = _format_messages(messages, skip_previous_summary=previous_summary is not None)
+        formatted = _format_messages(
+            messages,
+            skip_previous_summary=previous_summary is not None,
+            tool_return_max_chars=self.tool_return_max_chars,
+        )
         prompt = self.summary_prompt.format(messages=formatted)
 
         if previous_summary is not None:

--- a/pydantic_ai_harness/compaction/_summarizing_compaction.py
+++ b/pydantic_ai_harness/compaction/_summarizing_compaction.py
@@ -414,7 +414,7 @@ class SummarizingCompaction(AbstractCapability[AgentDepsT]):
     """Per-message character cap for ``keep_user_messages``; oversized messages are truncated
     with an explicit marker (the shared truncation-marker convention)."""
 
-    tool_return_max_chars: int | None = 500
+    tool_return_max_chars: int | None = field(default=500, kw_only=True)
     """Per-return character cap when rendering tool results for the summarizer. `None` renders
     them whole."""
 

--- a/tests/compaction/test_compaction.py
+++ b/tests/compaction/test_compaction.py
@@ -739,6 +739,14 @@ class TestCompaction:
         with pytest.raises(ValueError, match='keep_tokens must be non-negative'):
             SummarizingCompaction(model='test', max_messages=10, keep_tokens=-1)
 
+    def test_validation_bad_tool_return_max_chars(self):
+        with pytest.raises(ValueError, match='tool_return_max_chars must be positive'):
+            SummarizingCompaction(model='test', max_messages=10, tool_return_max_chars=0)
+
+    def test_tool_return_max_chars_none_is_accepted(self):
+        comp = SummarizingCompaction(model='test', max_messages=10, tool_return_max_chars=None)
+        assert comp.tool_return_max_chars is None
+
     @pytest.mark.anyio
     async def test_no_compaction_below_threshold(self):
         comp = SummarizingCompaction(model='test', max_messages=100)
@@ -937,7 +945,18 @@ class TestFormatMessages:
     def test_long_tool_return_truncated(self):
         msgs: list[ModelMessage] = [_tool_return('fn', 'tc1', 'x' * 600)]
         text = _format_messages(msgs)
-        assert '...' in text
+        # Default cap of 500, marker counted within the cap, like kept user turns.
+        assert text == 'Tool [fn]: ' + 'x' * 495 + '[...]'
+
+    def test_tool_return_custom_max_chars(self):
+        msgs: list[ModelMessage] = [_tool_return('fn', 'tc1', 'x' * 600)]
+        text = _format_messages(msgs, tool_return_max_chars=10)
+        assert text == 'Tool [fn]: ' + 'x' * 5 + '[...]'
+
+    def test_tool_return_none_renders_full(self):
+        msgs: list[ModelMessage] = [_tool_return('fn', 'tc1', 'x' * 600)]
+        text = _format_messages(msgs, tool_return_max_chars=None)
+        assert text == 'Tool [fn]: ' + 'x' * 600
 
 
 # ---------------------------------------------------------------------------
@@ -3917,6 +3936,59 @@ class TestStructuralFeaturesThroughAgent:
             if isinstance(message, ModelRequest)
             for part in message.parts
         )
+
+    @pytest.mark.anyio
+    async def test_tool_return_max_chars_threads_through_summarize(self):
+        """The field reaches `_format_messages` via `_summarize` in a real run."""
+        prompts: list[str] = []
+        agent = Agent(
+            _recording_model([]),
+            capabilities=[
+                SummarizingCompaction(
+                    model=_recording_summarizer(prompts),
+                    max_messages=3,
+                    keep_messages=1,
+                    tool_return_max_chars=10,
+                )
+            ],
+        )
+        await agent.run(
+            'go',
+            message_history=[
+                _tool_call('read', 'c1'),
+                _tool_return('read', 'c1', 'z' * 600),
+                _assistant('b'),
+                _user('recent'),
+            ],
+        )
+        assert len(prompts) == 1
+        assert f'Tool [read]: {"z" * 5}[...]' in prompts[0]
+
+    @pytest.mark.anyio
+    async def test_tool_return_max_chars_none_renders_whole_return(self):
+        prompts: list[str] = []
+        agent = Agent(
+            _recording_model([]),
+            capabilities=[
+                SummarizingCompaction(
+                    model=_recording_summarizer(prompts),
+                    max_messages=3,
+                    keep_messages=1,
+                    tool_return_max_chars=None,
+                )
+            ],
+        )
+        await agent.run(
+            'go',
+            message_history=[
+                _tool_call('read', 'c1'),
+                _tool_return('read', 'c1', 'z' * 600),
+                _assistant('b'),
+                _user('recent'),
+            ],
+        )
+        assert len(prompts) == 1
+        assert f'Tool [read]: {"z" * 600}' in prompts[0]
 
     @pytest.mark.anyio
     async def test_summary_events_reach_a_caller_supplied_handler(self):


### PR DESCRIPTION
## Summary

`SummarizingCompaction` renders the messages it is about to summarize with
`_format_messages`, which hard-capped every tool return at 500 characters
in the summary prompt. There was no field to change that, so a workflow
whose summarizer has a large context window could not let the condenser
read a full tool return without overriding the private `_summarize`.

This adds a `tool_return_max_chars: int | None = 500` field:

- default stays 500, so existing summaries are unchanged;
- `None` renders each tool return whole;
- any other positive integer caps each return with the same explicit
  `[...]` marker convention kept user turns already use (marker counted
  within the cap), now shared via a single `_truncate_with_marker` helper;
- validated in `__post_init__` like `keep_user_messages_max_chars`.

The field is threaded through `_summarize` into `_format_messages`, and
documented in the capability README and the docs page. The more general
renderer from the issue proposal is deliberately out of scope.

## Linked Issue

Closes #823

## Checklist

- [x] Linked issue exists and is referenced above
- [x] Tests added/updated for new behavior
- [x] `ruff`, `pyright`, and `pytest` pass locally
- [x] `pyproject.toml` and `uv.lock` are unchanged
- [x] Docstrings use single backticks