### PR TITLE
Fix `PlanStore` `get_items` and `set_items` docstrings

### DIFF
--- a/pydantic_ai_harness/planning/_postgres.py
+++ b/pydantic_ai_harness/planning/_postgres.py
@@ -123,7 +123,7 @@ class PostgresPlanStore:
         )
 
     async def get_items(self) -> list[PlanItem]:
-        """Return every step for this session in insertion order."""
+        """Return every step for this session in insertion order, as detached objects."""
         await self._ensure_schema()
         async with self._pool.acquire() as connection:
             rows = await connection.fetch(

--- a/pydantic_ai_harness/planning/_redis.py
+++ b/pydantic_ai_harness/planning/_redis.py
@@ -83,7 +83,7 @@ class RedisPlanStore:
         await self._client.set(self._key, payload, ex=self._expire_seconds)
 
     async def get_items(self) -> list[PlanItem]:
-        """Return every step for this session in insertion order."""
+        """Return every step for this session in insertion order, as detached objects."""
         return await self._load()
 
     async def set_items(self, items: list[PlanItem]) -> None:

--- a/pydantic_ai_harness/planning/_store.py
+++ b/pydantic_ai_harness/planning/_store.py
@@ -49,17 +49,24 @@ class PlanStore(Protocol):
     """
 
     async def get_items(self) -> list[PlanItem]:
-        """Return every step in insertion order."""
+        """Return every step in insertion order, as detached copies.
+
+        The returned items must not alias the store's internal state. The
+        `write_plan` tool diffs a before/after snapshot of the store by item id,
+        and a store handing out its own live objects would mutate the `before`
+        snapshot along with itself, erasing the differences it reports.
+        """
         ...  # pragma: no cover
 
     async def set_items(self, items: list[PlanItem]) -> None:
         """Replace the whole list with `items`.
 
-        This is a bulk replacement and does not emit `PlanEvent`s -- so the
-        `write_plan` tool, which calls it, is event-silent. Applications that
-        render off events should also read the plan after a run, or steer the
-        model toward the granular tools (`add_task`, `update_task_status`, ...),
-        which do emit.
+        The store itself emits no `PlanEvent`s, but the `write_plan` tool calls
+        this and then emits typed `Planning` events for the change, diffed by
+        item id: `PlanCreatedEvent` for new items, `PlanUpdatedEvent` (plus
+        `PlanStatusChangedEvent` and `PlanCompletedEvent` on status changes) for
+        changed ones, and `PlanDeletedEvent` for removed ones. Reordering steps
+        without changing a field emits nothing, since the diff is per item id.
         """
         ...  # pragma: no cover
 
@@ -391,7 +398,7 @@ class SqlitePlanStore:
                 connection.close()
 
     async def get_items(self) -> list[PlanItem]:
-        """Return every step for this session in insertion order."""
+        """Return every step for this session in insertion order, as detached objects."""
         return await anyio.to_thread.run_sync(self._get_items_sync)
 
     async def set_items(self, items: list[PlanItem]) -> None:


### PR DESCRIPTION
## Summary

Docstring-only fixes for two gaps on `PlanStore` raised in #824 (parts 2 and 3). Part 1, the reorder-emits-nothing design question, is intentionally left for a separate design discussion and is not touched here.

- `PlanStore.get_items` now documents that it must return detached copies that do not alias the store's internal state. `write_plan` diffs a before/after snapshot by item id to detect changes, so a store handing back its own live objects would let the before state mutate out from under the comparison. The built-in stores (`InMemoryPlanStore`, `SqlitePlanStore`, `PostgresPlanStore`, `RedisPlanStore`) already return detached objects; this just states the contract on the protocol.
- `PlanStore.set_items` no longer claims `write_plan` is event-silent. It now describes what actually happens since #714: the store itself emits nothing, but `write_plan` emits the typed `Planning` events (`PlanCreatedEvent`, `PlanUpdatedEvent`, `PlanStatusChangedEvent`, `PlanCompletedEvent`, `PlanDeletedEvent`) by diffing the before/after snapshots. It also notes that a pure reorder emits nothing, since the diff is per item id.

No behavior change. Verified with `ruff check`, `pyright`, and `tests/planning` (143 tests pass).

## Linked Issue

Closes #824

## Checklist

- [x] Linked issue exists and is referenced above
- [x] No tests needed: docstring-only change; existing `tests/planning` pass
- [x] `make lint && make typecheck && make test` equivalent passed locally (ruff, pyright, pytest)
- [x] `pyproject.toml` and `uv.lock` unchanged
- [x] Docstrings use single backticks