### PR TITLE
Add a real `bedrock` extra so the `aws-lambda` docs install line stops warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ dependencies = [
 anthropic = [
     "pydantic-ai-slim[anthropic]>=2.38.0",
 ]
+# `aws-lambda` docs install `pydantic-ai-harness[aws-lambda,bedrock]`. The durable SDK alone
+# installs boto3 from a lower floor, so the pass-through keeps the Bedrock floor explicit.
+bedrock = [
+    "pydantic-ai-slim[bedrock]>=2.38.0",
+]
 cli = [
     "pydantic-ai-slim[cli]>=2.38.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3938,6 +3938,9 @@ aws-lambda = [
     { name = "aws-durable-execution-sdk-python", marker = "python_full_version >= '3.11'" },
     { name = "pydantic-ai-slim" },
 ]
+bedrock = [
+    { name = "pydantic-ai-slim", extra = ["bedrock"] },
+]
 browser-use = [
     { name = "browser-use", marker = "python_full_version >= '3.11'" },
 ]
@@ -4036,6 +4039,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", marker = "extra == 'aws-lambda'", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.38.0" },
+    { name = "pydantic-ai-slim", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", extras = ["dbos"], marker = "extra == 'dbos'" },
     { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.38.0" },
@@ -4053,7 +4057,7 @@ requires-dist = [
     { name = "stackone-defender", extras = ["onnx"], marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender-ml'", specifier = ">=0.7.3,<0.8" },
     { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.2,<4" },
 ]
-provides-extras = ["acp", "anthropic", "aws-lambda", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
+provides-extras = ["acp", "anthropic", "aws-lambda", "bedrock", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4103,6 +4107,9 @@ wheels = [
 [package.optional-dependencies]
 anthropic = [
     { name = "anthropic" },
+]
+bedrock = [
+    { name = "boto3" },
 ]
 cli = [
     { name = "argcomplete" },


### PR DESCRIPTION
Fixes the first command a reader copies in `docs/aws-lambda.md`: `pip install "pydantic-ai-harness[aws-lambda,bedrock]"` used to warn because no `bedrock` extra existed.

Add a real `bedrock` pass-through extra to `pyproject.toml` (matching the existing `anthropic` and `cli` pattern) that relies on `pydantic-ai-slim[bedrock]>=2.38.0`, so the documented command installs the `boto3>=1.42.63` floor Bedrock support declares. Verified with a fresh `uv lock --resolution lowest` against this worktree: boto3 lands exactly on the floor and no unknown-extra warning fires. The docs page and the aws_lambda README keep their install lines unchanged because they are now accurate.

This PR changes `pyproject.toml` and `uv.lock`, so it needs the `dependencies:approved` label.

Closes #844
