### PR TITLE
Make `FileSystem` content hashes agree across `read_file`, `write_file`, and `edit_file`

### DIFF
--- a/pydantic_ai_harness/filesystem/README.md
+++ b/pydantic_ai_harness/filesystem/README.md
@@ -100,7 +100,10 @@ applies the same rule to absolute symlink targets.
   binary bytes into the model context.
 - **Optimistic concurrency.** `write_file`/`edit_file` accept an
   `expected_hash` so an agent operating on a stale read is told to re-read
-  rather than silently overwriting newer content.
+  rather than silently overwriting newer content. Content hashes identify
+  the file's bytes decoded without newline translation, so `read_file`,
+  `write_file`, `edit_file`, and `file_info` agree regardless of line
+  endings.
 - **Regular write targets.** `write_file` rejects an existing target that is
   not a regular file. On POSIX, it opens the final target descriptor in
   non-blocking mode and checks that descriptor's type before truncating, so a

--- a/pydantic_ai_harness/filesystem/_toolset.py
+++ b/pydantic_ai_harness/filesystem/_toolset.py
@@ -170,8 +170,28 @@ def _matching_lines(text: str, compiled: re.Pattern[str], rel_str: str, limit: i
 
 
 def _content_hash(content: str) -> str:
-    """Compute a short content hash for conflict detection."""
+    """Compute a short content hash for conflict detection.
+
+    The hash is defined over the file's text as decoded from its bytes with
+    no newline translation, the view `read_file` returns. Every tool that
+    reports a hash (`read_file`, `write_file`, `edit_file`, `file_info`)
+    computes it over that same view, so a hash from any of them identifies
+    the same bytes on disk and the optimistic-concurrency handshake holds
+    regardless of line endings.
+    """
     return hashlib.sha256(content.encode('utf-8')).hexdigest()[:12]
+
+
+def _read_canonical_text(path: Path) -> str:
+    """Read a text file as the canonical hash view, without newline translation.
+
+    `Path.open` is used because `Path.read_text` only accepts `newline` on
+    Python 3.13+, while `open` has had it since 3.10. Keep `errors` strict,
+    matching `read_text`'s default, so invalid UTF-8 surfaces the same way
+    it did before the `newline` handling was made explicit.
+    """
+    with path.open(encoding='utf-8', newline='') as f:
+        return f.read()
 
 
 class FileSystemToolset(FunctionToolset[AgentDepsT]):
@@ -441,8 +461,10 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         # expected hash before changing the file. POSIX non-blocking mode keeps
         # a FIFO swapped into place from waiting for a reader; O_NOFOLLOW keeps
         # a final-component symlink swap from redirecting the descriptor. Windows
-        # has no filesystem FIFO equivalent, and O_BINARY leaves newline handling
-        # to the text wrapper just as Path.write_text does.
+        # has no filesystem FIFO equivalent, and O_BINARY plus `newline=''` on
+        # the text wrapper means the written bytes reproduce the content
+        # argument exactly: no newline translation, so the reported hash always
+        # matches the bytes a later `read_file` hashes.
         platform_flags = os.O_BINARY if os.name == 'nt' else os.O_NONBLOCK | os.O_NOFOLLOW
         access_flags = os.O_RDWR if expected_hash is not None else os.O_WRONLY
         created = False
@@ -478,7 +500,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
                 raise ModelRetry(f'Path {path!r} exists and is not a regular file.')
 
             mode = 'r+' if expected_hash is not None else 'w'
-            text_file = os.fdopen(descriptor, mode, encoding='utf-8', newline=None)
+            text_file = os.fdopen(descriptor, mode, encoding='utf-8', newline='')
             descriptor = -1
             with text_file:
                 if expected_hash is not None and not created:
@@ -547,7 +569,11 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
         if not resolved.is_file():
             raise FileNotFoundError(f'File not found: {path}')
 
-        text = resolved.read_text(encoding='utf-8')
+        # Reading and writing with `newline=''` disables universal-newline
+        # translation, so the text is the canonical bytes-on-disk view that
+        # `read_file` hashes, and the replacement preserves `\r\n` exactly
+        # instead of writing `\r\r\n` through a translating writer on Windows.
+        text = _read_canonical_text(resolved)
         current_hash = _content_hash(text)
 
         # Optimistic concurrency check
@@ -566,7 +592,7 @@ class FileSystemToolset(FunctionToolset[AgentDepsT]):
             )
 
         new_content = text.replace(old_text, new_text, 1)
-        resolved.write_text(new_content, encoding='utf-8')
+        resolved.write_text(new_content, encoding='utf-8', newline='')
         new_hash = _content_hash(new_content)
         if ctx is not None:
             await ctx.emit(FileWrittenEvent(**self._event_location(resolved), content_hash=new_hash))

--- a/tests/filesystem/test_events.py
+++ b/tests/filesystem/test_events.py
@@ -142,6 +142,29 @@ class TestFileSystemEvents:
             )
         ]
 
+    async def test_write_crlf_emits_hash_of_written_bytes(self, tmp_path: Path) -> None:
+        """A `\\r\\n` write event mirrors the on-disk text, not a translated view."""
+        content = 'alpha\r\nbeta\r\n'
+        events = await _run_and_collect(tmp_path, 'write_file', '{"path":"crlf.txt","content":"alpha\\r\\nbeta\\r\\n"}')
+
+        assert (tmp_path / 'crlf.txt').read_bytes() == content.encode()
+        written = [event for event in events if isinstance(event, FileWrittenEvent)]
+        assert len(written) == 1
+        assert written[0].content_hash == _hash(content)
+
+    async def test_edit_crlf_preserves_bytes_and_event_hash(self, tmp_path: Path) -> None:
+        """Editing a CRLF file leaves `\\r\\n` intact and reports its canonical hash."""
+        (tmp_path / 'target.txt').write_bytes(b'old\r\n')
+
+        events = await _run_and_collect(
+            tmp_path, 'edit_file', '{"path":"target.txt","old_text":"old","new_text":"new"}'
+        )
+
+        assert (tmp_path / 'target.txt').read_bytes() == b'new\r\n'
+        written = [event for event in events if isinstance(event, FileWrittenEvent)]
+        assert len(written) == 1
+        assert written[0].content_hash == _hash('new\r\n')
+
     async def test_subdirectory_root_is_carried_on_the_event(self, tmp_path: Path) -> None:
         project = tmp_path / 'project'
         project.mkdir()

--- a/tests/filesystem/test_filesystem.py
+++ b/tests/filesystem/test_filesystem.py
@@ -29,6 +29,11 @@ from pydantic_ai_harness.filesystem._toolset import (
 )
 
 
+def _reported_hash(result: str) -> str:
+    """Extract the content hash a tool reports, from a `[hash:xxxx]` suffix."""
+    return result.partition('hash:')[2].split()[0].rstrip(']')
+
+
 class TestFormatLines:
     def test_basic_formatting(self) -> None:
         text = 'line1\nline2\nline3\n'
@@ -608,6 +613,65 @@ class TestEditFile:
     async def test_edit_returns_new_hash(self, toolset: FileSystemToolset[None]) -> None:
         result = await toolset.edit_file('hello.txt', 'Hello, world!', 'Goodbye!')
         assert 'hash:' in result
+
+
+class TestContentHashNewlineAgreement:
+    """`read_file`, `write_file`, and `edit_file` hashes must agree on `\\r\\n` files.
+
+    Before the #821 fix, `edit_file` and `write_file` hashed a
+    universal-newline-translated view while `read_file` hashed the raw bytes
+    decoded without translation, so the optimistic-concurrency handshake
+    rejected CRLF files that had not changed. All tools now hash the same
+    canonical bytes-on-disk view.
+    """
+
+    async def test_crlf_read_edit_round_trip_hashes_agree(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        (fs_root / 'crlf.txt').write_bytes(b'line one\r\nline two\r\n')
+        read_hash = _reported_hash(await toolset.read_file('crlf.txt'))
+
+        edit_result = await toolset.edit_file('crlf.txt', 'line one', 'line ONE', expected_hash=read_hash)
+        edit_hash = _reported_hash(edit_result)
+
+        assert _reported_hash(await toolset.read_file('crlf.txt')) == edit_hash
+        assert (fs_root / 'crlf.txt').read_bytes() == b'line ONE\r\nline two\r\n'
+
+    async def test_crlf_edit_preserves_carriage_returns(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        """Editing a CRLF file keeps `\\r\\n` byte-for-byte instead of writing `\\r\\r\\n` on Windows."""
+        (fs_root / 'crlf.txt').write_bytes(b'a\r\nb\r\n')
+        await toolset.edit_file('crlf.txt', 'a', 'A')
+        assert (fs_root / 'crlf.txt').read_bytes() == b'A\r\nb\r\n'
+
+    async def test_crlf_write_hash_matches_read_and_file_info(
+        self, toolset: FileSystemToolset[None], fs_root: Path
+    ) -> None:
+        content = 'alpha\r\nbeta\r\n'
+        write_hash = _reported_hash(await toolset.write_file('crlf-new.txt', content))
+        assert write_hash == _content_hash(content)
+
+        read_result = await toolset.read_file('crlf-new.txt')
+        assert _reported_hash(read_result) == write_hash
+
+        info = await toolset.file_info('crlf-new.txt')
+        assert f'hash: {write_hash}' in info
+
+    async def test_crlf_write_expected_hash_handshake(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        """`write_file` accepts the hash `read_file` reports for a CRLF file."""
+        await toolset.write_file('crlf-cc.txt', 'alpha\r\nbeta\r\n')
+        read_hash = _reported_hash(await toolset.read_file('crlf-cc.txt'))
+
+        result = await toolset.write_file('crlf-cc.txt', 'gamma\r\ndelta\r\n', expected_hash=read_hash)
+        assert _reported_hash(result) == _content_hash('gamma\r\ndelta\r\n')
+        assert (fs_root / 'crlf-cc.txt').read_bytes() == b'gamma\r\ndelta\r\n'
+
+    async def test_lf_write_still_writes_plain_newlines(self, toolset: FileSystemToolset[None], fs_root: Path) -> None:
+        """LF content is untouched by the no-translation write path."""
+        content = 'alpha\nbeta\n'
+        write_hash = _reported_hash(await toolset.write_file('lf-new.txt', content))
+        assert write_hash == _content_hash(content)
+        assert (fs_root / 'lf-new.txt').read_bytes() == b'alpha\nbeta\n'
+        assert _reported_hash(await toolset.read_file('lf-new.txt')) == write_hash
 
 
 class TestListDirectory:


### PR DESCRIPTION
Fixes the `FileSystem` optimistic-concurrency handshake on files with `\r\n`
line endings. Closes #821.

### The bug

`read_file`, `write_file`, and `edit_file` computed their `content_hash` over
different views of the same file:

- `read_file` hashes `raw.decode('utf-8')` with no newline translation, so
  `\r\n` stays in the hashed text.
- `edit_file` hashed `Path.read_text(...)`, which folds `\r\n` to `\n`
  through universal newlines.
- `write_file` hashed the `content` argument as given, but writes through a
  `newline=None` text wrapper that on Windows translates `\n` to `\r\n`, so
  its hash (and `FileWrittenEvent.content_hash`) did not identify the bytes
  on disk.

So `read_file` reporting a hash, then `edit_file(expected_hash=...)` or
`write_file(expected_hash=...)` checking it, rejected files that had not
changed whenever the file carried `\r\n` (on Windows, every write).

### The fix

Pick one canonical view, "the bytes on disk decoded without newline
translation" (what `read_file` already did), and hash it everywhere:

- `edit_file` now reads and writes with `newline=''`, so CRLF survives the
  round trip byte-for-byte instead of becoming `\r\r\n` through a
  translating writer on Windows. It reads via `Path.open(..., newline='')`
  because `Path.read_text` only gained `newline` in Python 3.13.
- `write_file` opens its descriptor with `newline=''`, so the written bytes
  reproduce the content argument exactly and the reported hash always
  matches a later `read_file`.

`FileWrittenEvent.content_hash` continues to mirror the tool result (the
#712 contract), so events and tool output stay in agreement.

### Tests

New CRLF fixtures in `tests/filesystem/` cover the read -> edit(expected_hash)
-> read round trip, write/edit hash agreement with `read_file` and
`file_info`, CRLF preservation through edits, and LF writes staying untouched.
The existing suite is unchanged and green.
