### PR TITLE
Stop `SnapshotHistorySource.run_history` duplicating messages with serializing stores

### DIFF
--- a/pydantic_ai_harness/conversation_search/_source.py
+++ b/pydantic_ai_harness/conversation_search/_source.py
@@ -21,6 +21,7 @@ search layer.
 from __future__ import annotations
 
 import hashlib
+from dataclasses import replace
 from typing import Protocol, runtime_checkable
 
 from pydantic_ai.messages import (
@@ -92,6 +93,24 @@ class SnapshotStore(Protocol):
     async def list_snapshots(self, *, run_id: str) -> list[ContinuableSnapshot]: ...  # pragma: no cover
 
 
+def _canonical_message(message: ModelMessage) -> ModelMessage:
+    """Return a copy of `message` with framework-stamped fields cleared.
+
+    pydantic-ai stamps `timestamp`, `run_id`, and `conversation_id` onto a
+    message (and fills `instructions` on requests) after the boundary snapshot
+    that first carries it is serialized, so the same logical message has
+    different bytes before and after stamping. Clearing exactly those fields
+    makes the dedup key stable across the boundary; every other field keeps
+    participating in the key, so two genuinely distinct messages sharing parts
+    stay distinct.
+    """
+    if isinstance(message, ModelRequest):
+        return replace(message, timestamp=None, run_id=None, conversation_id=None, instructions=None)
+    # `ModelMessage` is exactly the `ModelRequest | ModelResponse` union, so any
+    # other message is a `ModelResponse`.
+    return replace(message, timestamp=None, run_id=None, conversation_id=None)
+
+
 def message_hash(message: ModelMessage) -> str:
     """Return a stable content hash of a single message.
 
@@ -99,9 +118,11 @@ def message_hash(message: ModelMessage) -> str:
     re-serialize the same growing history, and durable executors (Temporal, DBOS)
     re-instantiate messages between steps, so identity-based dedup would re-append.
     The hash is computed over `ModelMessagesTypeAdapter` bytes, so it is stable
-    across snapshot round-trips and replay.
+    across snapshot round-trips and replay. Framework-stamped metadata is cleared
+    first, see `_canonical_message`, so the overlap survives the stamping that
+    pydantic-ai applies after the boundary snapshot is saved.
     """
-    return hashlib.sha256(ModelMessagesTypeAdapter.dump_json([message])).hexdigest()
+    return hashlib.sha256(ModelMessagesTypeAdapter.dump_json([_canonical_message(message)])).hexdigest()
 
 
 def _overlap_length(history: list[str], snapshot: list[str]) -> int:

--- a/tests/conversation_search/test_conversation_search.py
+++ b/tests/conversation_search/test_conversation_search.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import re
 import warnings
+from dataclasses import replace
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pydantic_ai.messages as messages_module
@@ -49,6 +51,7 @@ from pydantic_ai_harness.conversation_search import (
     SnapshotHistorySource,
     SnapshotStore,
 )
+from pydantic_ai_harness.conversation_search._source import message_hash
 from pydantic_ai_harness.step_persistence import (
     ContinuableSnapshot,
     FileStepStore,
@@ -225,6 +228,65 @@ class TestSnapshotHistorySource:
             assert sum('ZEBRA' in text for text in rendered) == 1
             assert sum('noted' in text for text in rendered) == 1
             assert not any('Summary of previous conversation' in text for text in rendered)
+
+    async def test_message_hash_ignores_framework_stamped_metadata(self) -> None:
+        # pydantic-ai-harness#810: pydantic-ai stamps `timestamp`, `run_id`, and
+        # `conversation_id` (and fills request `instructions`) after the boundary
+        # snapshot that first carries a message is serialized. The overlap key
+        # must hash the same logical message equally before and after stamping,
+        # so those fields are cleared before hashing; distinct parts still hash
+        # differently.
+        request = ModelRequest(parts=[ToolReturnPart(tool_name='lookup', content='result', tool_call_id='call-1')])
+        stamped_request = replace(request, timestamp=datetime.now(timezone.utc), run_id='r1', conversation_id='c1')
+        assert message_hash(request) == message_hash(stamped_request)
+
+        reply = _reply('done')
+        stamped_reply = replace(reply, timestamp=datetime.now(timezone.utc), run_id='r1', conversation_id='c1')
+        assert message_hash(reply) == message_hash(stamped_reply)
+        assert message_hash(request) != message_hash(_reply('done'))
+
+    async def test_stamped_boundary_request_does_not_duplicate_serialized_history(self, tmp_path: Path) -> None:
+        # pydantic-ai-harness#810: `StepPersistence.after_node_run` saves the
+        # boundary snapshot before pydantic-ai stamps the tool-return request it
+        # carries, so hashing the full serialized message makes the prefix overlap
+        # fail and `run_history` returns each tool-return request twice (14
+        # instead of 6). Serializing stores (`SqliteStepStore`, `FileStepStore`)
+        # reproduce it; `InMemoryStepStore` hides it because stamping mutates the
+        # very objects the in-memory store holds, so their bytes stay aligned.
+
+        def model_fn(messages: list[ModelMessage], _info: AgentInfo) -> ModelResponse:
+            returns = sum(isinstance(p, ToolReturnPart) for message in messages for p in message.parts)
+            if returns < 2:
+                return ModelResponse(parts=[ToolCallPart(tool_name='lookup', args={'q': str(returns)})])
+            return ModelResponse(parts=[TextPart(content='done')])
+
+        stores: list[SqliteStepStore | FileStepStore] = [
+            SqliteStepStore(database=tmp_path / 'runs.db'),
+            FileStepStore(tmp_path / 'runs'),
+        ]
+        for store in stores:
+            agent: Agent[object, str] = Agent(
+                FunctionModel(model_fn),
+                capabilities=[StepPersistence(store=store, agent_name='a')],
+            )
+
+            @agent.tool_plain
+            def lookup(q: str) -> str:  # pyright: ignore[reportUnusedFunction]
+                return f'result-{q}'
+
+            result = await agent.run('hi', conversation_id='c1')
+            (run,) = await store.list_runs(conversation_id='c1')
+            history = await SnapshotHistorySource(store).run_history(run_id=run.run_id)
+            expected = result.all_messages()
+            # Counts match (6, not 14): each message once, in order. Strict
+            # dataclass equality cannot be used because the boundary request is
+            # persisted before pydantic-ai stamps it, so the recovered copy
+            # carries `None` run metadata while the live one carries the stamped
+            # values; the parts (what the corpus indexes) are identical. Compare
+            # on the dedup key instead, which is exactly the stability `message_hash`
+            # promises.
+            assert len(history) == len(expected) == 6
+            assert [message_hash(message) for message in history] == [message_hash(message) for message in expected]
 
     async def test_list_runs_delegates_to_store(self) -> None:
         store = InMemoryStepStore()


### PR DESCRIPTION
## Summary

`SnapshotHistorySource.run_history` unions a run's snapshots by hashing whole messages and matching the prefix overlap between consecutive snapshots. With a store that serializes at save time (`SqliteStepStore`, `FileStepStore`), `StepPersistence.after_node_run` saves the boundary snapshot before pydantic-ai stamps run metadata (`timestamp`, `run_id`, `conversation_id`, plus request `instructions`) onto the tool-return request that snapshot carries. The same logical message therefore serialized differently before and after stamping, the overlap check rejected it, and `run_history` returned every stamped message twice: the issue's repro went from 6 messages to 14, feeding duplicate entries into the `ConversationSearch` BM25 index and growing the corpus.

The fix hashes a canonical copy of each message with exactly those framework-stamped fields cleared first, then computes the overlap as before. Two regression tests reproduce the duplication with `SqliteStepStore` and `FileStepStore` end to end and assert the stamping-aware hash directly; both fail on the old code and pass on the new code.

## Fix approach

The issue suggested keying the overlap on message `kind` + `parts`, or moving the boundary snapshot save after run-metadata stamping. I chose a precise version of the first: keep the full serialized message in the dedup key, but clear the four fields pydantic-ai stamps after the save (`timestamp`, `run_id`, `conversation_id`, and the request-only `instructions`).

Reasons:

- The stamping happens in pydantic-ai's graph between calls to our hooks; the harness cannot reliably save "after" it lands, so the second option depends on core timing the harness does not control and breaks under replay.
- Clearing only the stamped fields changes behavior for exactly the divergence the bug causes, nothing else. Two genuinely distinct messages that share parts but differ in, say, `usage` or `provider_*` still stay distinct, so the existing guarantee that repeated messages at distinct sequence positions survive (and that compaction artifacts stay excluded) is preserved. A `kind`+`parts`-only key would silently conflate more.
- It applies uniformly to in-memory, serializing, and third-party stores: an in-memory store happened to mask the bug because stamping mutates the very objects it holds, but the fix does not lean on that.

## Issue reference

The `pydantic-ai-harness#810` reference in `_source.py` and the test file documents the constraint this fix imposes on whoever touches the dedup key: it must stay stable across the framework stamping pydantic-ai applies after a boundary snapshot is serialized, or the overlap check silently regresses for serializing stores.

## Checklist

- [x] Linked issue exists, referenced below, and this PR closes it
- [x] Tests added for the new behavior
- [x] `ruff format --check`, `ruff check`, `pyright` (strict), and `pytest` pass locally on the touched modules/tests
- [x] No `pyproject.toml` / `uv.lock` changes

Closes #810
