### PR TITLE
Remove the `bedrock` extra and its `aws-lambda` docs install example

### DIFF
--- a/docs/aws-lambda.md
+++ b/docs/aws-lambda.md
@@ -17,18 +17,34 @@ checkpointing, a resumed run would repeat every model request and tool call.
 
 ## Installation
 
-```bash
-pip install "pydantic-ai-harness[aws-lambda]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[aws-lambda]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[aws-lambda]"
+    ```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.
 
 The quick start below uses a Bedrock provider model, which needs the Bedrock SDK from
 `pydantic-ai-slim[bedrock]`:
 
-```bash
-pip install "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
+    ```
 
 ## Quick start
 

--- a/docs/aws-lambda.md
+++ b/docs/aws-lambda.md
@@ -18,7 +18,7 @@ checkpointing, a resumed run would repeat every model request and tool call.
 ## Installation
 
 ```bash
-pip install "pydantic-ai-harness[aws-lambda,bedrock]"
+pip install "pydantic-ai-harness[aws-lambda]"
 ```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.

--- a/docs/aws-lambda.md
+++ b/docs/aws-lambda.md
@@ -23,6 +23,13 @@ pip install "pydantic-ai-harness[aws-lambda]"
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.
 
+The quick start below uses a Bedrock provider model, which needs the Bedrock SDK from
+`pydantic-ai-slim[bedrock]`:
+
+```bash
+pip install "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
+```
+
 ## Quick start
 
 Attach the capability when you build the agent, then adapt an async handler body with

--- a/docs/aws-lambda.md
+++ b/docs/aws-lambda.md
@@ -17,34 +17,18 @@ checkpointing, a resumed run would repeat every model request and tool call.
 
 ## Installation
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[aws-lambda]"
-    ```
-
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[aws-lambda]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[aws-lambda]"
+```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.
 
 The quick start below uses a Bedrock provider model, which needs the Bedrock SDK from
 `pydantic-ai-slim[bedrock]`:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
-    ```
-
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
+```
 
 ## Quick start
 

--- a/pydantic_ai_harness/aws_lambda/README.md
+++ b/pydantic_ai_harness/aws_lambda/README.md
@@ -18,6 +18,13 @@ pip install "pydantic-ai-harness[aws-lambda]"
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.
 
+The quick start below uses a Bedrock provider model, which needs the Bedrock SDK from
+`pydantic-ai-slim[bedrock]`:
+
+```bash
+pip install "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
+```
+
 ## Quick start
 
 Attach the capability when you build the agent, then adapt an async handler body with

--- a/pydantic_ai_harness/aws_lambda/README.md
+++ b/pydantic_ai_harness/aws_lambda/README.md
@@ -13,7 +13,7 @@ checkpointing, a resumed run would repeat every model request and tool call.
 ## Installation
 
 ```bash
-pip install "pydantic-ai-harness[aws-lambda,bedrock]"
+pip install "pydantic-ai-harness[aws-lambda]"
 ```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.

--- a/pydantic_ai_harness/aws_lambda/README.md
+++ b/pydantic_ai_harness/aws_lambda/README.md
@@ -12,8 +12,16 @@ checkpointing, a resumed run would repeat every model request and tool call.
 
 ## Installation
 
+With pip:
+
 ```bash
 pip install "pydantic-ai-harness[aws-lambda]"
+```
+
+With uv:
+
+```bash
+uv add "pydantic-ai-harness[aws-lambda]"
 ```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.
@@ -21,8 +29,16 @@ The AWS Durable Execution SDK requires Python 3.11 or newer.
 The quick start below uses a Bedrock provider model, which needs the Bedrock SDK from
 `pydantic-ai-slim[bedrock]`:
 
+With pip:
+
 ```bash
 pip install "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
+```
+
+With uv:
+
+```bash
+uv add "pydantic-ai-harness[aws-lambda]" "pydantic-ai-slim[bedrock]"
 ```
 
 ## Quick start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,6 @@ dependencies = [
 anthropic = [
     "pydantic-ai-slim[anthropic]>=2.38.0",
 ]
-# `aws-lambda` docs install `pydantic-ai-harness[aws-lambda,bedrock]`. The durable SDK alone
-# installs boto3 from a lower floor, so the pass-through keeps the Bedrock floor explicit.
-bedrock = [
-    "pydantic-ai-slim[bedrock]>=2.38.0",
-]
 cli = [
     "pydantic-ai-slim[cli]>=2.38.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -3938,9 +3938,6 @@ aws-lambda = [
     { name = "aws-durable-execution-sdk-python", marker = "python_full_version >= '3.11'" },
     { name = "pydantic-ai-slim" },
 ]
-bedrock = [
-    { name = "pydantic-ai-slim", extra = ["bedrock"] },
-]
 browser-use = [
     { name = "browser-use", marker = "python_full_version >= '3.11'" },
 ]
@@ -4039,7 +4036,6 @@ requires-dist = [
     { name = "pydantic-ai-slim", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", marker = "extra == 'aws-lambda'", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'anthropic'", specifier = ">=2.38.0" },
-    { name = "pydantic-ai-slim", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", extras = ["cli"], marker = "extra == 'cli'", specifier = ">=2.38.0" },
     { name = "pydantic-ai-slim", extras = ["dbos"], marker = "extra == 'dbos'" },
     { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.38.0" },
@@ -4057,7 +4053,7 @@ requires-dist = [
     { name = "stackone-defender", extras = ["onnx"], marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender-ml'", specifier = ">=0.7.3,<0.8" },
     { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.2,<4" },
 ]
-provides-extras = ["acp", "anthropic", "aws-lambda", "bedrock", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
+provides-extras = ["acp", "anthropic", "aws-lambda", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -4107,9 +4103,6 @@ wheels = [
 [package.optional-dependencies]
 anthropic = [
     { name = "anthropic" },
-]
-bedrock = [
-    { name = "boto3" },
 ]
 cli = [
     { name = "argcomplete" },


### PR DESCRIPTION
Supersedes the approach merged in #846, per maintainer decision: pydantic-ai-harness should not ship a `bedrock` pass-through extra, and the `aws-lambda` docs should not advertise one.

Changes:
- Drop the `bedrock` extra from `pyproject.toml` and regenerate `uv.lock` (bedrock entries only).
- Change the install example in `docs/aws-lambda.md` and `pydantic_ai_harness/aws_lambda/README.md` to `pip install "pydantic-ai-harness[aws-lambda]"` (both surfaces, identical).

`bedrock:...` provider model strings elsewhere are untouched.

Closes #844