### PR TITLE
Expose parent context through `event_stream_handler_factory`

### DIFF
--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -54,7 +54,7 @@ A delegate's name -- how the parent model refers to it, and how it is listed in 
 - **Usage is shared by default.** The parent's `usage` is passed to each sub-agent run, so token usage aggregates and a parent `usage_limits` applies across the whole agent tree. Set `forward_usage=False` to give each sub-agent run its own accounting.
 - **Tools can be inherited.** With `inherit_tools=True`, the parent agent's own tools (registered directly or via `toolsets`) are added to each sub-agent run, on top of the sub-agent's own. Tools contributed by the parent's capabilities are not inherited: they are bound to capability instances registered in the parent run, and would arrive without the hooks and instructions they depend on. Use `shared_capabilities` to give sub-agents a capability. This also excludes the delegate tool itself, so a sub-agent can't recurse into further delegation. Off by default.
 - **Capabilities can be shared.** `shared_capabilities` are applied to every sub-agent run -- e.g. give all sub-agents a common guardrail, memory, or planning capability without rebuilding each `Agent`.
-- **Sub-agent events can be streamed.** Pass an `event_stream_handler` and it's forwarded to each sub-agent run, so the sub-agent's model-streaming and tool events surface to the caller (the handler receives the sub-agent's own `RunContext`).
+- **Sub-agent events can be streamed.** Pass an `event_stream_handler` to forward every sub-agent's model-streaming and tool events to one handler. Pass `event_stream_handler_factory` instead when each delegation needs its own handler: the factory receives the parent `RunContext` and selected agent name, and its returned handler receives the sub-agent's `RunContext` and event stream. This lets callers correlate or persist child events using the parent `delegate_task` call ID.
 
 ## Per-delegate run controls
 
@@ -230,6 +230,7 @@ SubAgents(
     inherit_tools=False,   # expose the parent's own tools to sub-agents (capability tools excluded)
     shared_capabilities=(),# capabilities applied to every sub-agent run
     event_stream_handler=None,  # forwarded to each sub-agent run to stream its events
+    event_stream_handler_factory=None,  # builds a handler from each parent delegation context
     tool_name='delegate_task',
     tool_retries=2,        # extra delegate-tool attempts after a sub-agent error before aborting (None inherits the agent default)
     contain_errors=False,  # default for SubAgent.contain_errors: contain an unexpected crash as a bounded retry
@@ -256,6 +257,7 @@ SubAgent(
 
 - Sub-agents can themselves have `SubAgents`, forming a tree. Share `usage` (the default) and set a `usage_limits` on the top-level run to bound the whole tree.
 - Delegations the model issues in parallel run as independent sub-agent runs.
+- `SubAgents` adds no spans for event forwarding; the parent tool call and child agent run are already covered by Pydantic AI instrumentation.
 
 ## Further reading
 

--- a/pydantic_ai_harness/subagents/README.md
+++ b/pydantic_ai_harness/subagents/README.md
@@ -4,6 +4,8 @@ Let an agent delegate self-contained tasks to named child agents.
 
 [Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/subagents/)
 
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
+
 ## The problem
 
 A single agent that does everything accumulates a large tool set and a long context. Splitting the work across specialized sub-agents keeps each context focused, but wiring up delegation by hand means writing a tool per agent, forwarding deps, threading usage limits, and telling the model what it can delegate to.
@@ -47,7 +49,7 @@ A delegate's name -- how the parent model refers to it, and how it is listed in 
 - **Usage is shared by default.** The parent's `usage` is passed to each sub-agent run, so token usage aggregates and a parent `usage_limits` applies across the whole agent tree. Set `forward_usage=False` to give each sub-agent run its own accounting.
 - **Tools can be inherited.** With `inherit_tools=True`, the parent agent's own tools (registered directly or via `toolsets`) are added to each sub-agent run, on top of the sub-agent's own. Tools contributed by the parent's capabilities are not inherited: they are bound to capability instances registered in the parent run, and would arrive without the hooks and instructions they depend on. Use `shared_capabilities` to give sub-agents a capability. This also excludes the delegate tool itself, so a sub-agent can't recurse into further delegation. Off by default.
 - **Capabilities can be shared.** `shared_capabilities` are applied to every sub-agent run -- e.g. give all sub-agents a common guardrail, memory, or planning capability without rebuilding each `Agent`.
-- **Sub-agent events can be streamed.** Pass an `event_stream_handler` and it's forwarded to each sub-agent run, so the sub-agent's model-streaming and tool events surface to the caller (the handler receives the sub-agent's own `RunContext`).
+- **Sub-agent events can be streamed.** Pass an `event_stream_handler` to forward every sub-agent's model-streaming and tool events to one handler. Pass `event_stream_handler_factory` instead when each delegation needs its own handler: the factory receives the parent `RunContext` and selected agent name, and its returned handler receives the sub-agent's `RunContext` and event stream. This lets callers correlate or persist child events using the parent `delegate_task` call ID.
 
 ## Per-delegate run controls
 
@@ -223,6 +225,7 @@ SubAgents(
     inherit_tools=False,   # expose the parent's own tools to sub-agents (capability tools excluded)
     shared_capabilities=(),# capabilities applied to every sub-agent run
     event_stream_handler=None,  # forwarded to each sub-agent run to stream its events
+    event_stream_handler_factory=None,  # builds a handler from each parent delegation context
     tool_name='delegate_task',
     tool_retries=2,        # extra delegate-tool attempts after a sub-agent error before aborting (None inherits the agent default)
     contain_errors=False,  # default for SubAgent.contain_errors: contain an unexpected crash as a bounded retry
@@ -249,6 +252,7 @@ SubAgent(
 
 - Sub-agents can themselves have `SubAgents`, forming a tree. Share `usage` (the default) and set a `usage_limits` on the top-level run to bound the whole tree.
 - Delegations the model issues in parallel run as independent sub-agent runs.
+- `SubAgents` adds no spans for event forwarding; the parent tool call and child agent run are already covered by Pydantic AI instrumentation.
 
 ## Further reading
 

--- a/pydantic_ai_harness/subagents/__init__.py
+++ b/pydantic_ai_harness/subagents/__init__.py
@@ -4,13 +4,18 @@ from pydantic_ai_harness.subagents._capability import SubAgents, ToolResolver
 from pydantic_ai_harness.subagents._disk import AgentOverride
 from pydantic_ai_harness.subagents._effort import MINIMUM_EFFORT_FLOOR, clamp_effort
 from pydantic_ai_harness.subagents._models import ModelOption
-from pydantic_ai_harness.subagents._toolset import SubAgent, SubAgentToolset
+from pydantic_ai_harness.subagents._toolset import (
+    SubAgent,
+    SubAgentEventStreamHandlerFactory,
+    SubAgentToolset,
+)
 
 __all__ = [
     'MINIMUM_EFFORT_FLOOR',
     'AgentOverride',
     'ModelOption',
     'SubAgent',
+    'SubAgentEventStreamHandlerFactory',
     'SubAgentToolset',
     'SubAgents',
     'ToolResolver',

--- a/pydantic_ai_harness/subagents/_capability.py
+++ b/pydantic_ai_harness/subagents/_capability.py
@@ -26,7 +26,11 @@ from pydantic_ai_harness.subagents._disk import (
 )
 from pydantic_ai_harness.subagents._effort import clamp_effort
 from pydantic_ai_harness.subagents._models import ModelOption, as_option, model_label, validate_restriction
-from pydantic_ai_harness.subagents._toolset import SubAgent, SubAgentToolset
+from pydantic_ai_harness.subagents._toolset import (
+    SubAgent,
+    SubAgentEventStreamHandlerFactory,
+    SubAgentToolset,
+)
 
 if TYPE_CHECKING:
     from pydantic_ai._instructions import AgentInstructions
@@ -45,7 +49,7 @@ def _option_line(key: str, option: ModelOption) -> str:
 _MERGEABLE_FIELDS = frozenset({'agents', 'models'})
 """The only fields a merge composes: the roster, and the model options that roster may pick from.
 
-An allow-list rather than a list of exceptions. `SubAgents` has fifteen public fields, and all but
+An allow-list rather than a list of exceptions. `SubAgents` has fourteen public fields, and all but
 these two say *how* the delegates run rather than *who* they are -- so merging them applies one
 harness's policy to the other's sub-agents. Enumerating those instead would mean a field added
 later merges silently by default, which is the wrong way round for a decision nobody made.
@@ -88,7 +92,8 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     shared so usage limits apply across the whole agent tree. Optionally, the
     parent's tools can be inherited (`inherit_tools`), extra capabilities can be
     applied to every sub-agent run (`shared_capabilities`), and sub-agent events
-    can be streamed to a handler (`event_stream_handler`).
+    can be streamed to a shared handler (`event_stream_handler`) or a handler
+    built with each parent delegation context (`event_stream_handler_factory`).
 
     ```python
     from pydantic_ai import Agent
@@ -173,6 +178,12 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     model-streaming and tool events surface to the caller. The handler receives
     the sub-agent's own `RunContext` and event stream."""
 
+    event_stream_handler_factory: SubAgentEventStreamHandlerFactory[AgentDepsT] | None = field(
+        default=None, kw_only=True
+    )
+    """If set, called once per delegation with the parent `RunContext` and selected
+    agent name. The returned handler receives that sub-agent's `RunContext` and event stream."""
+
     tool_name: str = 'delegate_task'
     """Name of the delegate tool exposed to the model."""
 
@@ -222,6 +233,8 @@ class SubAgents(AbstractCapability[AgentDepsT]):
     toolset and cleared per run in `wrap_run`. Backs `SubAgent.max_calls`."""
 
     def __post_init__(self) -> None:
+        if self.event_stream_handler is not None and self.event_stream_handler_factory is not None:
+            raise ValueError('event_stream_handler and event_stream_handler_factory are mutually exclusive')
         self._build_roster(self._load_disk_agents())
 
     def _disk_agents(self) -> list[SubAgent[AgentDepsT]]:
@@ -365,6 +378,7 @@ class SubAgents(AbstractCapability[AgentDepsT]):
             inherit_tools=self.inherit_tools,
             shared_capabilities=self.shared_capabilities,
             event_stream_handler=self.event_stream_handler,
+            event_stream_handler_factory=self.event_stream_handler_factory,
             tool_name=self.tool_name,
             tool_retries=self.tool_retries,
             contain_errors=self.contain_errors,

--- a/pydantic_ai_harness/subagents/_toolset.py
+++ b/pydantic_ai_harness/subagents/_toolset.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from typing import Any, Generic, cast
 
@@ -61,6 +61,9 @@ _ALWAYS_PROPAGATE: tuple[type[Exception], ...] = (
     UserError,
     RunCancelled,
 )
+
+SubAgentEventStreamHandlerFactory = Callable[[RunContext[AgentDepsT], str], EventStreamHandler[AgentDepsT] | None]
+"""Builds an event stream handler for one delegation from its parent context and agent name."""
 
 
 @dataclass(frozen=True)
@@ -179,6 +182,7 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
         tool_retries: int | None,
         contain_errors: bool,
         call_counts: dict[str, dict[str, int]],
+        event_stream_handler_factory: SubAgentEventStreamHandlerFactory[AgentDepsT] | None = None,
         models: Mapping[str, ModelOption] | None = None,
     ) -> None:
         super().__init__()
@@ -187,6 +191,7 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
         self._inherit_tools = inherit_tools
         self._shared_capabilities = list(shared_capabilities)
         self._event_stream_handler = event_stream_handler
+        self._event_stream_handler_factory = event_stream_handler_factory
         self._tool_name = tool_name
         self._contain_errors = contain_errors
         self._models: dict[str, ModelOption] = dict(models or {})
@@ -349,6 +354,11 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
                 else None
             )
             settings = None
+        event_stream_handler = (
+            self._event_stream_handler_factory(ctx, agent_name)
+            if self._event_stream_handler_factory is not None
+            else self._event_stream_handler
+        )
         run = sub_agent.agent.run(
             task,
             deps=ctx.deps,
@@ -358,7 +368,7 @@ class SubAgentToolset(FunctionToolset[AgentDepsT]):
             usage_limits=usage_limits,
             toolsets=toolsets,
             capabilities=capabilities,
-            event_stream_handler=self._event_stream_handler,
+            event_stream_handler=event_stream_handler,
         )
         timeout = sub_agent.timeout_seconds
         try:

--- a/tests/subagents/test_subagents.py
+++ b/tests/subagents/test_subagents.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 from pydantic_ai import Agent
+from pydantic_ai.agent import EventStreamHandler
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.exceptions import ModelAPIError, UnexpectedModelBehavior, UsageLimitExceeded, UserError
 from pydantic_ai.messages import (
@@ -136,6 +137,13 @@ class TestConstruction:
 
     def test_empty_agents_no_toolset(self) -> None:
         assert SubAgents[object]().get_toolset() is None
+
+    def test_event_stream_handler_and_factory_are_mutually_exclusive(self) -> None:
+        async def handler(_ctx: RunContext[object], _stream: AsyncIterable[AgentStreamEvent]) -> None:
+            pass
+
+        with pytest.raises(ValueError, match='mutually exclusive'):
+            SubAgents[object](event_stream_handler=handler, event_stream_handler_factory=lambda _ctx, _name: handler)
 
 
 class TestInstructions:
@@ -404,6 +412,36 @@ class TestDelegation:
         result = await parent.run('go')
         assert result.output == 'all done'
         assert events  # the sub-agent's run streamed events to the handler
+
+    async def test_event_stream_handler_factory_receives_each_parent_delegation_context(self) -> None:
+        parent_calls: list[tuple[str | None, str]] = []
+        child_run_ids: list[str | None] = []
+        handlers: list[object] = []
+
+        def factory(ctx: RunContext[object], agent_name: str) -> EventStreamHandler[object]:
+            parent_calls.append((ctx.tool_call_id, agent_name))
+
+            async def handler(child_ctx: RunContext[object], stream: AsyncIterable[AgentStreamEvent]) -> None:
+                child_run_ids.append(child_ctx.run_id)
+                async for _event in stream:
+                    pass
+
+            handlers.append(handler)
+            return handler
+
+        worker = Agent(TestModel(custom_output_text='W'), name='worker')
+        parent: Agent[object, str] = Agent(
+            _delegate_n_then_finish('worker', 2),
+            capabilities=[SubAgents(agents=[SubAgent(worker)], event_stream_handler_factory=factory)],
+        )
+
+        result = await parent.run('go')
+
+        assert result.output == 'all done'
+        assert parent_calls == [('c1', 'worker'), ('c2', 'worker')]
+        assert len(handlers) == 2
+        assert handlers[0] is not handlers[1]
+        assert len(set(child_run_ids)) == 2
 
     async def test_hard_limit_propagates(self) -> None:
         def boom(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:

--- a/tests/test_capability_combine.py
+++ b/tests/test_capability_combine.py
@@ -56,6 +56,7 @@ from pydantic_ai.capabilities.abstract import (
 )
 from pydantic_ai.exceptions import UserError
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import RunContext
 
 import pydantic_ai_harness
 from pydantic_ai_harness import (
@@ -80,6 +81,10 @@ _TMP_A = Path(tempfile.mkdtemp(prefix='combine-a-'))
 _TMP_B = Path(tempfile.mkdtemp(prefix='combine-b-'))
 """Two distinct roots, so a `Collides` pair differs in the way its `Anonymous` reason once claimed
 mattered -- and still collides."""
+
+
+def _no_event_stream_handler(_ctx: RunContext[Any], _agent_name: str) -> None:
+    return None
 
 
 @dataclass
@@ -496,6 +501,12 @@ async def test_two_of_a_colliding_capability_still_raise(name: str, anyio_backen
         pytest.param('inherit_tools', {'inherit_tools': True}, {'inherit_tools': False}, id='inherit_tools'),
         pytest.param('tool_name', {'tool_name': 'delegate_task'}, {'tool_name': 'ask_specialist'}, id='tool_name'),
         pytest.param('forward_usage', {'forward_usage': False}, {'forward_usage': True}, id='forward_usage'),
+        pytest.param(
+            'event_stream_handler_factory',
+            {'event_stream_handler_factory': _no_event_stream_handler},
+            {},
+            id='event_stream_handler_factory',
+        ),
         pytest.param('tool_retries', {'tool_retries': 5}, {'tool_retries': 2}, id='tool_retries'),
         pytest.param('contain_errors', {'contain_errors': True}, {'contain_errors': False}, id='contain_errors'),
         # `None` disables disk loading entirely. The generic merge reads `None` as "not stated" and
@@ -509,7 +520,7 @@ def test_sub_agents_compose_the_roster_and_nothing_else(
 ) -> None:
     """Only `agents` and `models` merge; every other field has to already agree.
 
-    `SubAgents` has fifteen public fields and all but those two say *how* the delegates run rather
+    `SubAgents` has fourteen public fields and all but those two say *how* the delegates run rather
     than who they are, so merging one applies one harness's policy to the other's sub-agents. An
     allow-list is what keeps that true for fields added later: they are refused until someone
     decides, rather than merged by a default nobody chose.


### PR DESCRIPTION
Closes #856

## Summary

- add an optional per-delegation event stream handler factory that receives the parent `RunContext` and selected subagent name
- forward the returned handler to the child run while preserving the existing static handler API
- reject simultaneous static handler and factory configuration
- document correlation, persistence, streaming, and telemetry behavior

This lets callers correlate child events with the parent `delegate_task` tool call and create isolated handlers for concurrent delegations.

## Testing

- `ruff format --check .`
- `ruff check .`
- `pytest -p no:cacheprovider tests/subagents tests/test_capability_combine.py tests/test_docs_parity.py` (447 passed, 10 skipped)
- `pytest -p no:cacheprovider tests/test_docs_parity.py tests/test_doc_snippets.py` (783 passed, 22 skipped)
- strict `pyright` on changed source and tests (0 errors, 0 warnings)