### PR TITLE
Offer `pip` and `uv` installation commands throughout the Harness docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Everything here is one primitive: a [capability](https://ai.pydantic.dev/capabil
 
 Install with [`uv`](https://docs.astral.sh/uv/):
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[anthropic]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[anthropic]"
 ```
@@ -40,6 +48,14 @@ uvx --with pydantic-ai-harness clai -a pydantic_ai_harness.coder:coder_agent -m 
 ```
 
 Every model works: swap the string for [any provider's](https://ai.pydantic.dev/models/). Need more? Add capabilities to the list; here's the same coder on `gpt-5.6-sol`, with web search and cross-session memory:
+
+pip:
+
+```bash
+pip install "pydantic-ai-slim[openai]"
+```
+
+uv:
 
 ```bash
 uv add "pydantic-ai-slim[openai]"
@@ -292,6 +308,14 @@ Everything is observable: `logfire.instrument_pydantic_ai()` gives you [a full t
 "Harness" is the field's term for everything around the model that turns it into an agent: the loop, the tools, the context management. Reach for this package when your agent should *do* more than core's lean harness covers: touch files, run code, browse, remember, delegate, or stay coherent through hours-long runs. The boundary between the packages is mechanical, not a maturity tier: core ships the capabilities that require model or framework support (provider-native tools like [image generation](https://ai.pydantic.dev/capabilities/image-generation/), provider APIs like [compaction](https://ai.pydantic.dev/capabilities/compaction/), deep loop integration like [tool search](https://ai.pydantic.dev/capabilities/tool-search/), and fundamentals like [thinking](https://ai.pydantic.dev/capabilities/thinking/), [MCP](https://ai.pydantic.dev/capabilities/mcp/), and [web search](https://ai.pydantic.dev/capabilities/web-search/)) and the Harness ships everything else, as a separate package so capabilities can iterate at the speed the field moves while Pydantic AI itself stays lean.
 
 ## Installation
+
+pip:
+
+```bash
+pip install pydantic-ai-harness
+```
+
+uv:
 
 ```bash
 uv add pydantic-ai-harness

--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ Everything here is one primitive: a [capability](https://ai.pydantic.dev/capabil
 
 Install with [`uv`](https://docs.astral.sh/uv/):
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[anthropic]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[anthropic]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[anthropic]"
 ```
 
 ```python
@@ -49,16 +49,16 @@ uvx --with pydantic-ai-harness clai -a pydantic_ai_harness.coder:coder_agent -m 
 
 Every model works: swap the string for [any provider's](https://ai.pydantic.dev/models/). Need more? Add capabilities to the list; here's the same coder on `gpt-5.6-sol`, with web search and cross-session memory:
 
-pip:
-
-```bash
-pip install "pydantic-ai-slim[openai]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-slim[openai]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-slim[openai]"
 ```
 
 ```python
@@ -309,16 +309,16 @@ Everything is observable: `logfire.instrument_pydantic_ai()` gives you [a full t
 
 ## Installation
 
-pip:
-
-```bash
-pip install pydantic-ai-harness
-```
-
 uv:
 
 ```bash
 uv add pydantic-ai-harness
+```
+
+pip:
+
+```bash
+pip install pydantic-ai-harness
 ```
 
 This installs [`pydantic-ai-slim`](https://ai.pydantic.dev/install/) with it, so it works on its own; you don't need to install Pydantic AI separately. Model providers and the CLI come via extras that pass through to Pydantic AI: `pydantic-ai-harness[anthropic]`, `[cli]`. Some capabilities need their own extra for optional dependencies; each capability's page gives its exact install line. Requires Python 3.10+.

--- a/agent_docs/docs-conventions.md
+++ b/agent_docs/docs-conventions.md
@@ -33,9 +33,10 @@ PR that updates pydantic-ai's `docs/navigation.yml`. Keep slugs
 
 ## Page Conventions
 
-- **Installation commands**: show equivalent `pip install` and `uv add` commands in
-  `=== "pip"` / `=== "uv"` tabs on docs pages. In READMEs, use plain `pip:` / `uv:`
-  labels and fenced blocks because GitHub does not render these tabs. Keep package
+- **Installation commands**: show equivalent `uv add` and `pip install` commands in
+  `=== "uv"` / `=== "pip"` tabs on docs pages, with uv first as the default tab.
+  In READMEs, use plain `uv:` / `pip:` labels in the same order
+  and fenced blocks because GitHub does not render these tabs. Keep package
   arguments identical, including extras. Put inline dependency-install examples in
   paired blocks too. Use `uv run` for follow-up executables installed in the uv
   project environment. Workflow YAML and repository-development commands retain

--- a/agent_docs/docs-conventions.md
+++ b/agent_docs/docs-conventions.md
@@ -33,13 +33,16 @@ PR that updates pydantic-ai's `docs/navigation.yml`. Keep slugs
 
 ## Page Conventions
 
-- **Installation commands**: show equivalent `uv add` and `pip install` commands in
-  `=== "uv"` / `=== "pip"` tabs on docs pages, with uv first as the default tab.
-  In READMEs, use plain `uv:` / `pip:` labels in the same order
-  and fenced blocks because GitHub does not render these tabs. Keep package
-  arguments identical, including extras. Put inline dependency-install examples in
-  paired blocks too. Use `uv run` for follow-up executables installed in the uv
-  project environment. Workflow YAML and repository-development commands retain
+- **Installation commands**: on docs pages, put `pip/uv-add <packages>` on its own
+  line in a `bash` fence. The [unified-docs preprocessor](https://github.com/pydantic/unified-docs/blob/main/src/integrations/docs-sync.ts)
+  expands this shorthand into pip / uv tabs. Use a separate `bash` fence with
+  `py-cli <command>` for follow-up executables; it generates the bare command and
+  its `uv run` equivalent. Do not hand-write installation tabs.
+  In READMEs, use executable commands under plain `uv:` / `pip:` labels, uv first,
+  because GitHub does not run the preprocessor. Keep package arguments identical,
+  including extras. Put inline dependency-install examples in fenced blocks too.
+  Use `uv run` for README follow-up executables in the uv project environment.
+  Workflow YAML and repository-development commands retain
   their required execution environment rather than becoming `uv add` examples.
 - **Purpose-first lead**: the opening paragraph says what the capability is for and when to use
   it. Lifecycle hook names (`before_model_request`, …) never appear in the lead — mechanism goes

--- a/agent_docs/docs-conventions.md
+++ b/agent_docs/docs-conventions.md
@@ -33,6 +33,13 @@ PR that updates pydantic-ai's `docs/navigation.yml`. Keep slugs
 
 ## Page Conventions
 
+- **Installation commands**: show equivalent `pip install` and `uv add` commands in
+  `=== "pip"` / `=== "uv"` tabs on docs pages. In READMEs, use plain `pip:` / `uv:`
+  labels and fenced blocks because GitHub does not render these tabs. Keep package
+  arguments identical, including extras. Put inline dependency-install examples in
+  paired blocks too. Use `uv run` for follow-up executables installed in the uv
+  project environment. Workflow YAML and repository-development commands retain
+  their required execution environment rather than becoming `uv add` examples.
 - **Purpose-first lead**: the opening paragraph says what the capability is for and when to use
   it. Lifecycle hook names (`before_model_request`, …) never appear in the lead — mechanism goes
   below the purpose.

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -41,16 +41,16 @@ To plug a Pydantic AI agent into an ACP editor you would otherwise have to imple
 
 ## Installation
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[acp]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[acp]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[acp]"
     ```
 
 This pulls in the [`agent-client-protocol`](https://pypi.org/project/agent-client-protocol/) SDK. The rest of the harness does not depend on it -- only `pydantic_ai_harness.experimental.acp` does.

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -41,17 +41,9 @@ To plug a Pydantic AI agent into an ACP editor you would otherwise have to imple
 
 ## Installation
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[acp]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[acp]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[acp]"
+```
 
 This pulls in the [`agent-client-protocol`](https://pypi.org/project/agent-client-protocol/) SDK. The rest of the harness does not depend on it -- only `pydantic_ai_harness.experimental.acp` does.
 

--- a/docs/acp.md
+++ b/docs/acp.md
@@ -41,9 +41,17 @@ To plug a Pydantic AI agent into an ACP editor you would otherwise have to imple
 
 ## Installation
 
-```bash
-uv add "pydantic-ai-harness[acp]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[acp]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[acp]"
+    ```
 
 This pulls in the [`agent-client-protocol`](https://pypi.org/project/agent-client-protocol/) SDK. The rest of the harness does not depend on it -- only `pydantic_ai_harness.experimental.acp` does.
 

--- a/docs/aws-lambda.md
+++ b/docs/aws-lambda.md
@@ -17,16 +17,16 @@ checkpointing, a resumed run would repeat every model request and tool call.
 
 ## Installation
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[aws-lambda,bedrock]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[aws-lambda,bedrock]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[aws-lambda,bedrock]"
     ```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.

--- a/docs/aws-lambda.md
+++ b/docs/aws-lambda.md
@@ -17,17 +17,9 @@ checkpointing, a resumed run would repeat every model request and tool call.
 
 ## Installation
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[aws-lambda,bedrock]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[aws-lambda,bedrock]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[aws-lambda,bedrock]"
+```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.
 

--- a/docs/aws-lambda.md
+++ b/docs/aws-lambda.md
@@ -17,9 +17,17 @@ checkpointing, a resumed run would repeat every model request and tool call.
 
 ## Installation
 
-```bash
-pip install "pydantic-ai-harness[aws-lambda,bedrock]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[aws-lambda,bedrock]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[aws-lambda,bedrock]"
+    ```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.
 

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -48,17 +48,9 @@ Install the `browser-use` extra (Python 3.11+; the rest of the harness
 supports 3.10). browser-use talks to Chromium directly over CDP and downloads
 a browser on first run when none is found locally:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[browser-use]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[browser-use]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[browser-use]"
+```
 
 Then pass `BrowserUse` to an `Agent` via the `capabilities` parameter, with a
 model for the sub-agent:

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -48,16 +48,16 @@ Install the `browser-use` extra (Python 3.11+; the rest of the harness
 supports 3.10). browser-use talks to Chromium directly over CDP and downloads
 a browser on first run when none is found locally:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[browser-use]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[browser-use]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[browser-use]"
     ```
 
 Then pass `BrowserUse` to an `Agent` via the `capabilities` parameter, with a

--- a/docs/browser-use.md
+++ b/docs/browser-use.md
@@ -48,9 +48,17 @@ Install the `browser-use` extra (Python 3.11+; the rest of the harness
 supports 3.10). browser-use talks to Chromium directly over CDP and downloads
 a browser on first run when none is found locally:
 
-```bash
-uv add "pydantic-ai-harness[browser-use]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[browser-use]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[browser-use]"
+    ```
 
 Then pass `BrowserUse` to an `Agent` via the `capabilities` parameter, with a
 model for the sub-agent:

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -32,16 +32,16 @@ Durable execution integrations can record nested calls for deterministic replay.
 
 Code mode requires the Monty sandbox, available via the `codemode` extra (the `code-mode` extra is an equivalent alias):
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[codemode]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[codemode]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[codemode]"
     ```
 
 ## Usage
@@ -287,16 +287,16 @@ Keep these limitations in mind:
 
 Install both integrations:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[codemode,temporal]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[codemode,temporal]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[codemode,temporal]"
     ```
 
 Construct the named agent and its stable-ID toolsets outside the workflow, then attach

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -32,17 +32,9 @@ Durable execution integrations can record nested calls for deterministic replay.
 
 Code mode requires the Monty sandbox, available via the `codemode` extra (the `code-mode` extra is an equivalent alias):
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[codemode]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[codemode]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[codemode]"
+```
 
 ## Usage
 
@@ -287,17 +279,9 @@ Keep these limitations in mind:
 
 Install both integrations:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[codemode,temporal]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[codemode,temporal]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[codemode,temporal]"
+```
 
 Construct the named agent and its stable-ID toolsets outside the workflow, then attach
 `TemporalDurability` alongside `CodeMode`:

--- a/docs/code-mode.md
+++ b/docs/code-mode.md
@@ -32,9 +32,17 @@ Durable execution integrations can record nested calls for deterministic replay.
 
 Code mode requires the Monty sandbox, available via the `codemode` extra (the `code-mode` extra is an equivalent alias):
 
-```bash
-uv add "pydantic-ai-harness[codemode]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[codemode]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[codemode]"
+    ```
 
 ## Usage
 
@@ -279,9 +287,17 @@ Keep these limitations in mind:
 
 Install both integrations:
 
-```bash
-uv add "pydantic-ai-harness[codemode,temporal]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[codemode,temporal]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[codemode,temporal]"
+    ```
 
 Construct the named agent and its stable-ID toolsets outside the workflow, then attach
 `TemporalDurability` alongside `CodeMode`:

--- a/docs/dynamic-workflow.md
+++ b/docs/dynamic-workflow.md
@@ -30,9 +30,17 @@ Start with `SubAgents` if you are not sure. A `delegate_task` orchestrator conve
 
 The script runs inside the Monty sandbox, so install the extra:
 
-```bash
-uv add "pydantic-ai-harness[dynamic-workflow]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[dynamic-workflow]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[dynamic-workflow]"
+    ```
 
 ## Your first workflow
 

--- a/docs/dynamic-workflow.md
+++ b/docs/dynamic-workflow.md
@@ -30,17 +30,9 @@ Start with `SubAgents` if you are not sure. A `delegate_task` orchestrator conve
 
 The script runs inside the Monty sandbox, so install the extra:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[dynamic-workflow]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[dynamic-workflow]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[dynamic-workflow]"
+```
 
 ## Your first workflow
 

--- a/docs/dynamic-workflow.md
+++ b/docs/dynamic-workflow.md
@@ -30,16 +30,16 @@ Start with `SubAgents` if you are not sure. A `delegate_task` orchestrator conve
 
 The script runs inside the Monty sandbox, so install the extra:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[dynamic-workflow]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[dynamic-workflow]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[dynamic-workflow]"
     ```
 
 ## Your first workflow

--- a/docs/exa-search.md
+++ b/docs/exa-search.md
@@ -34,17 +34,9 @@ output budgets, and short research guidance in the system prompt.
 Install the `exa` extra and set the `EXA_API_KEY` environment variable (create
 a key at <https://dashboard.exa.ai>):
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[exa]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[exa]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[exa]"
+```
 
 Then pass `ExaSearch` to an `Agent` via the `capabilities` parameter:
 

--- a/docs/exa-search.md
+++ b/docs/exa-search.md
@@ -34,9 +34,17 @@ output budgets, and short research guidance in the system prompt.
 Install the `exa` extra and set the `EXA_API_KEY` environment variable (create
 a key at <https://dashboard.exa.ai>):
 
-```bash
-uv add "pydantic-ai-harness[exa]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[exa]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[exa]"
+    ```
 
 Then pass `ExaSearch` to an `Agent` via the `capabilities` parameter:
 

--- a/docs/exa-search.md
+++ b/docs/exa-search.md
@@ -34,16 +34,16 @@ output budgets, and short research guidance in the system prompt.
 Install the `exa` extra and set the `EXA_API_KEY` environment variable (create
 a key at <https://dashboard.exa.ai>):
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[exa]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[exa]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[exa]"
     ```
 
 Then pass `ExaSearch` to an `Agent` via the `capabilities` parameter:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,17 +17,9 @@ Everything here is one primitive: a [capability](/ai/capabilities/overview/), a 
 
 Install with [`uv`](https://docs.astral.sh/uv/):
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[anthropic]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[anthropic]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[anthropic]"
+```
 
 ```python
 from pydantic_ai import Agent
@@ -48,17 +40,9 @@ uvx --with pydantic-ai-harness clai -a pydantic_ai_harness.coder:coder_agent -m 
 
 Every model works: swap the string for [any provider's](/ai/models/overview/). Need more? Add capabilities to the list; here's the same coder on `gpt-5.6-sol`, with web search and cross-session memory:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-slim[openai]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-slim[openai]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-slim[openai]"
+```
 
 ```python
 from pydantic_ai import Agent
@@ -274,17 +258,9 @@ Community packages extend the same capability system further; see [third-party c
 
 ## Installation
 
-=== "uv"
-
-    ```bash
-    uv add pydantic-ai-harness
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install pydantic-ai-harness
-    ```
+```bash
+pip/uv-add pydantic-ai-harness
+```
 
 This installs [`pydantic-ai-slim`](/ai/install/) with it, so it works on its own; you don't need to install Pydantic AI separately. Model providers and the CLI come via extras that pass through to Pydantic AI: `pydantic-ai-harness[anthropic]`, `[cli]`. Some capabilities need their own extra for optional dependencies; each capability's page gives its exact install line. Requires Python 3.10+.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,16 +17,16 @@ Everything here is one primitive: a [capability](/ai/capabilities/overview/), a 
 
 Install with [`uv`](https://docs.astral.sh/uv/):
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[anthropic]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[anthropic]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[anthropic]"
     ```
 
 ```python
@@ -48,16 +48,16 @@ uvx --with pydantic-ai-harness clai -a pydantic_ai_harness.coder:coder_agent -m 
 
 Every model works: swap the string for [any provider's](/ai/models/overview/). Need more? Add capabilities to the list; here's the same coder on `gpt-5.6-sol`, with web search and cross-session memory:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-slim[openai]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-slim[openai]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-slim[openai]"
     ```
 
 ```python
@@ -274,16 +274,16 @@ Community packages extend the same capability system further; see [third-party c
 
 ## Installation
 
-=== "pip"
-
-    ```bash
-    pip install pydantic-ai-harness
-    ```
-
 === "uv"
 
     ```bash
     uv add pydantic-ai-harness
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install pydantic-ai-harness
     ```
 
 This installs [`pydantic-ai-slim`](/ai/install/) with it, so it works on its own; you don't need to install Pydantic AI separately. Model providers and the CLI come via extras that pass through to Pydantic AI: `pydantic-ai-harness[anthropic]`, `[cli]`. Some capabilities need their own extra for optional dependencies; each capability's page gives its exact install line. Requires Python 3.10+.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,17 @@ Everything here is one primitive: a [capability](/ai/capabilities/overview/), a 
 
 Install with [`uv`](https://docs.astral.sh/uv/):
 
-```bash
-uv add "pydantic-ai-harness[anthropic]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[anthropic]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[anthropic]"
+    ```
 
 ```python
 from pydantic_ai import Agent
@@ -40,9 +48,17 @@ uvx --with pydantic-ai-harness clai -a pydantic_ai_harness.coder:coder_agent -m 
 
 Every model works: swap the string for [any provider's](/ai/models/overview/). Need more? Add capabilities to the list; here's the same coder on `gpt-5.6-sol`, with web search and cross-session memory:
 
-```bash
-uv add "pydantic-ai-slim[openai]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-slim[openai]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-slim[openai]"
+    ```
 
 ```python
 from pydantic_ai import Agent
@@ -258,9 +274,17 @@ Community packages extend the same capability system further; see [third-party c
 
 ## Installation
 
-```bash
-uv add pydantic-ai-harness
-```
+=== "pip"
+
+    ```bash
+    pip install pydantic-ai-harness
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add pydantic-ai-harness
+    ```
 
 This installs [`pydantic-ai-slim`](/ai/install/) with it, so it works on its own; you don't need to install Pydantic AI separately. Model providers and the CLI come via extras that pass through to Pydantic AI: `pydantic-ai-harness[anthropic]`, `[cli]`. Some capabilities need their own extra for optional dependencies; each capability's page gives its exact install line. Requires Python 3.10+.
 

--- a/docs/managed-prompt.md
+++ b/docs/managed-prompt.md
@@ -15,17 +15,9 @@ wire it in through the `capabilities=` parameter on `Agent`.
 
 Install the `logfire` extra:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[logfire]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[logfire]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[logfire]"
+```
 
 !!! note "A first-party `Managed` capability is in flight"
     A broader, first-party `Managed` capability is being built in

--- a/docs/managed-prompt.md
+++ b/docs/managed-prompt.md
@@ -15,16 +15,16 @@ wire it in through the `capabilities=` parameter on `Agent`.
 
 Install the `logfire` extra:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[logfire]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[logfire]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[logfire]"
     ```
 
 !!! note "A first-party `Managed` capability is in flight"

--- a/docs/managed-prompt.md
+++ b/docs/managed-prompt.md
@@ -15,9 +15,17 @@ wire it in through the `capabilities=` parameter on `Agent`.
 
 Install the `logfire` extra:
 
-```bash
-uv add "pydantic-ai-harness[logfire]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[logfire]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[logfire]"
+    ```
 
 !!! note "A first-party `Managed` capability is in flight"
     A broader, first-party `Managed` capability is being built in

--- a/docs/media.md
+++ b/docs/media.md
@@ -47,17 +47,9 @@ Every store implements the `MediaStore` protocol -- `put`, `get`, `exists`, `pub
 
 `MongoMediaStore` needs the `mongodb` extra (which installs `pymongo>=4.17.0`). Pass a shared `AsyncMongoClient` as `client=`, or a connection string as `db_url=` (the store then owns the client -- call `await store.aclose()` to release it); `database=` is always required. Each blob is stored as sha256-addressed chunks in a `media_chunks` collection, with a `media` manifest document per blob (`_id = <digest>`). The chunking bounds each BSON document, so a blob larger than MongoDB's 16 MiB document cap still stores and reads back. It does not bound memory: `put` takes the whole payload as `bytes` and `get` reassembles every chunk into one `bytearray`, so a blob has to fit in process memory in both directions -- there is no streaming API. The manifest holds `MediaContext.metadata` inline and is not chunked, so keep per-blob metadata small. Manual chunking is used rather than the GridFS driver on purpose: the digest is the manifest `_id`, so identical bytes deduplicate (GridFS keys files by `ObjectId` and does no dedup), and the plain-collection surface stays fully testable in-memory.
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[mongodb]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[mongodb]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[mongodb]"
+```
 
 Two constructor knobs shape that layout. `collection=` (default `'media'`) names the manifest collection and derives the chunk collection as `<collection>_chunks`; names outside `[A-Za-z_][A-Za-z0-9_]*` are rejected. `chunk_size_bytes=` (default 8 MiB) sets the split size and is rejected below 1 byte or above 16 MiB minus 64 KiB of headroom for the chunk document's own fields, since a larger chunk would build a document MongoDB refuses on insert.
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -45,7 +45,19 @@ Every store implements the `MediaStore` protocol -- `put`, `get`, `exists`, `pub
 
 `S3MediaStore` uses path-style URLs plus handrolled SigV4, so it is compatible with AWS S3, Cloudflare R2 (`region='auto'`), MinIO, and other S3-compatible providers. `SqliteMediaStore` also accepts `connection=` instead of `database=` to share a `sqlite3.Connection`.
 
-`MongoMediaStore` needs the `mongodb` extra (`pip install pydantic-ai-harness[mongodb]`, which installs `pymongo>=4.17.0`). Pass a shared `AsyncMongoClient` as `client=`, or a connection string as `db_url=` (the store then owns the client -- call `await store.aclose()` to release it); `database=` is always required. Each blob is stored as sha256-addressed chunks in a `media_chunks` collection, with a `media` manifest document per blob (`_id = <digest>`). The chunking bounds each BSON document, so a blob larger than MongoDB's 16 MiB document cap still stores and reads back. It does not bound memory: `put` takes the whole payload as `bytes` and `get` reassembles every chunk into one `bytearray`, so a blob has to fit in process memory in both directions -- there is no streaming API. The manifest holds `MediaContext.metadata` inline and is not chunked, so keep per-blob metadata small. Manual chunking is used rather than the GridFS driver on purpose: the digest is the manifest `_id`, so identical bytes deduplicate (GridFS keys files by `ObjectId` and does no dedup), and the plain-collection surface stays fully testable in-memory.
+`MongoMediaStore` needs the `mongodb` extra (which installs `pymongo>=4.17.0`). Pass a shared `AsyncMongoClient` as `client=`, or a connection string as `db_url=` (the store then owns the client -- call `await store.aclose()` to release it); `database=` is always required. Each blob is stored as sha256-addressed chunks in a `media_chunks` collection, with a `media` manifest document per blob (`_id = <digest>`). The chunking bounds each BSON document, so a blob larger than MongoDB's 16 MiB document cap still stores and reads back. It does not bound memory: `put` takes the whole payload as `bytes` and `get` reassembles every chunk into one `bytearray`, so a blob has to fit in process memory in both directions -- there is no streaming API. The manifest holds `MediaContext.metadata` inline and is not chunked, so keep per-blob metadata small. Manual chunking is used rather than the GridFS driver on purpose: the digest is the manifest `_id`, so identical bytes deduplicate (GridFS keys files by `ObjectId` and does no dedup), and the plain-collection surface stays fully testable in-memory.
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[mongodb]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[mongodb]"
+    ```
 
 Two constructor knobs shape that layout. `collection=` (default `'media'`) names the manifest collection and derives the chunk collection as `<collection>_chunks`; names outside `[A-Za-z_][A-Za-z0-9_]*` are rejected. `chunk_size_bytes=` (default 8 MiB) sets the split size and is rejected below 1 byte or above 16 MiB minus 64 KiB of headroom for the chunk document's own fields, since a larger chunk would build a document MongoDB refuses on insert.
 

--- a/docs/media.md
+++ b/docs/media.md
@@ -47,16 +47,16 @@ Every store implements the `MediaStore` protocol -- `put`, `get`, `exists`, `pub
 
 `MongoMediaStore` needs the `mongodb` extra (which installs `pymongo>=4.17.0`). Pass a shared `AsyncMongoClient` as `client=`, or a connection string as `db_url=` (the store then owns the client -- call `await store.aclose()` to release it); `database=` is always required. Each blob is stored as sha256-addressed chunks in a `media_chunks` collection, with a `media` manifest document per blob (`_id = <digest>`). The chunking bounds each BSON document, so a blob larger than MongoDB's 16 MiB document cap still stores and reads back. It does not bound memory: `put` takes the whole payload as `bytes` and `get` reassembles every chunk into one `bytearray`, so a blob has to fit in process memory in both directions -- there is no streaming API. The manifest holds `MediaContext.metadata` inline and is not chunked, so keep per-blob metadata small. Manual chunking is used rather than the GridFS driver on purpose: the digest is the manifest `_id`, so identical bytes deduplicate (GridFS keys files by `ObjectId` and does no dedup), and the plain-collection surface stays fully testable in-memory.
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[mongodb]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[mongodb]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[mongodb]"
     ```
 
 Two constructor knobs shape that layout. `collection=` (default `'media'`) names the manifest collection and derives the chunk collection as `<collection>_chunks`; names outside `[A-Za-z_][A-Za-z0-9_]*` are rejected. `chunk_size_bytes=` (default 8 MiB) sets the split size and is rejected below 1 byte or above 16 MiB minus 64 KiB of headroom for the chunk document's own fields, since a larger chunk would build a document MongoDB refuses on insert.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -96,17 +96,9 @@ sqlite_memory = Memory(SqliteMemoryStore(database='.agent-memory.db'))
 
 `PostgresMemoryStore` accepts the driver-neutral `PostgresPool` protocol, so the harness does not require a particular PostgreSQL driver. Install and manage the driver in your application, for example:
 
-=== "uv"
-
-    ```bash
-    uv add asyncpg
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install asyncpg
-    ```
+```bash
+pip/uv-add asyncpg
+```
 
 ```python
 import asyncpg

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -94,7 +94,19 @@ sqlite_memory = Memory(SqliteMemoryStore(database='.agent-memory.db'))
 
 `FileStore` keeps the journal at `.memory-store.sqlite3` inside its root. Keep it with the Markdown files when copying or backing up the store. Editing a Markdown file outside the capability changes its content version and can produce a conflict with a prepared operation; the journal recovers operations interrupted between transaction preparation and filesystem replacement.
 
-`PostgresMemoryStore` accepts the driver-neutral `PostgresPool` protocol, so the harness does not require a particular PostgreSQL driver. Install and manage the driver in your application (for example, `uv add asyncpg`):
+`PostgresMemoryStore` accepts the driver-neutral `PostgresPool` protocol, so the harness does not require a particular PostgreSQL driver. Install and manage the driver in your application, for example:
+
+=== "pip"
+
+    ```bash
+    pip install asyncpg
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add asyncpg
+    ```
 
 ```python
 import asyncpg

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -96,16 +96,16 @@ sqlite_memory = Memory(SqliteMemoryStore(database='.agent-memory.db'))
 
 `PostgresMemoryStore` accepts the driver-neutral `PostgresPool` protocol, so the harness does not require a particular PostgreSQL driver. Install and manage the driver in your application, for example:
 
-=== "pip"
-
-    ```bash
-    pip install asyncpg
-    ```
-
 === "uv"
 
     ```bash
     uv add asyncpg
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install asyncpg
     ```
 
 ```python

--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -22,18 +22,18 @@ one across several runs.
 Install the `modal` extra and authenticate with the Modal CLI. In CI, set
 `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead.
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[modal]"
-    modal token new                # writes ~/.modal.toml
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[modal]"
     uv run modal token new                # writes ~/.modal.toml
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[modal]"
+    modal token new                # writes ~/.modal.toml
     ```
 
 In CI, use environment variables instead of interactive authentication:

--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -22,10 +22,23 @@ one across several runs.
 Install the `modal` extra and authenticate with the Modal CLI. In CI, set
 `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead.
 
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[modal]"
+    modal token new                # writes ~/.modal.toml
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[modal]"
+    uv run modal token new                # writes ~/.modal.toml
+    ```
+
+In CI, use environment variables instead of interactive authentication:
+
 ```bash
-uv add "pydantic-ai-harness[modal]"
-modal token new                # writes ~/.modal.toml
-# or, e.g. in CI:
 export MODAL_TOKEN_ID=...
 export MODAL_TOKEN_SECRET=...
 ```

--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -22,19 +22,13 @@ one across several runs.
 Install the `modal` extra and authenticate with the Modal CLI. In CI, set
 `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead.
 
-=== "uv"
+```bash
+pip/uv-add "pydantic-ai-harness[modal]"
+```
 
-    ```bash
-    uv add "pydantic-ai-harness[modal]"
-    uv run modal token new                # writes ~/.modal.toml
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[modal]"
-    modal token new                # writes ~/.modal.toml
-    ```
+```bash
+py-cli modal token new                # writes ~/.modal.toml
+```
 
 In CI, use environment variables instead of interactive authentication:
 

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -31,10 +31,19 @@ JavaScript-rendered SPAs, and interactive multi-step flows.
 The `playwright` extra pulls in Playwright, and Chromium is a separate binary
 download:
 
-```bash
-uv add "pydantic-ai-harness[playwright]"
-playwright install chromium
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[playwright]"
+    playwright install chromium
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[playwright]"
+    uv run playwright install chromium
+    ```
 
 If the Chromium binary is missing at runtime, the browser tool returns the
 `playwright install chromium` hint as its result rather than ending the run, so

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -31,19 +31,13 @@ JavaScript-rendered SPAs, and interactive multi-step flows.
 The `playwright` extra pulls in Playwright, and Chromium is a separate binary
 download:
 
-=== "uv"
+```bash
+pip/uv-add "pydantic-ai-harness[playwright]"
+```
 
-    ```bash
-    uv add "pydantic-ai-harness[playwright]"
-    uv run playwright install chromium
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[playwright]"
-    playwright install chromium
-    ```
+```bash
+py-cli playwright install chromium
+```
 
 If the Chromium binary is missing at runtime, the browser tool returns the
 `playwright install chromium` hint as its result rather than ending the run, so

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -31,18 +31,18 @@ JavaScript-rendered SPAs, and interactive multi-step flows.
 The `playwright` extra pulls in Playwright, and Chromium is a separate binary
 download:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[playwright]"
-    playwright install chromium
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[playwright]"
     uv run playwright install chromium
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[playwright]"
+    playwright install chromium
     ```
 
 If the Chromium binary is missing at runtime, the browser tool returns the

--- a/docs/prompt-injection-defender.md
+++ b/docs/prompt-injection-defender.md
@@ -20,16 +20,16 @@ to observe flagged verdicts.
 
 ## Installation
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[prompt-injection-defender]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[prompt-injection-defender]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[prompt-injection-defender]"
     ```
 
 The capability requires Python 3.11 or newer. The base extra provides pattern
@@ -37,16 +37,16 @@ detection over recognized text fields, bare string results, and `ToolReturn`
 content. To classify text under other fields, install the ML extra and enable
 `semantic_detection`:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[prompt-injection-defender-ml]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[prompt-injection-defender-ml]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[prompt-injection-defender-ml]"
     ```
 
 ```python

--- a/docs/prompt-injection-defender.md
+++ b/docs/prompt-injection-defender.md
@@ -20,18 +20,34 @@ to observe flagged verdicts.
 
 ## Installation
 
-```bash
-uv add "pydantic-ai-harness[prompt-injection-defender]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[prompt-injection-defender]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[prompt-injection-defender]"
+    ```
 
 The capability requires Python 3.11 or newer. The base extra provides pattern
 detection over recognized text fields, bare string results, and `ToolReturn`
 content. To classify text under other fields, install the ML extra and enable
 `semantic_detection`:
 
-```bash
-uv add "pydantic-ai-harness[prompt-injection-defender-ml]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[prompt-injection-defender-ml]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[prompt-injection-defender-ml]"
+    ```
 
 ```python
 from pydantic_ai_harness import PromptInjectionDefender

--- a/docs/prompt-injection-defender.md
+++ b/docs/prompt-injection-defender.md
@@ -20,34 +20,18 @@ to observe flagged verdicts.
 
 ## Installation
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[prompt-injection-defender]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[prompt-injection-defender]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[prompt-injection-defender]"
+```
 
 The capability requires Python 3.11 or newer. The base extra provides pattern
 detection over recognized text fields, bare string results, and `ToolReturn`
 content. To classify text under other fields, install the ML extra and enable
 `semantic_detection`:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[prompt-injection-defender-ml]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[prompt-injection-defender-ml]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[prompt-injection-defender-ml]"
+```
 
 ```python
 from pydantic_ai_harness import PromptInjectionDefender

--- a/docs/researcher.md
+++ b/docs/researcher.md
@@ -14,17 +14,9 @@ It is a regular [combined capability](https://pydantic.dev/docs/ai/capabilities/
 
 Install the local search and fetch fallbacks (DuckDuckGo search, page-to-Markdown fetching):
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[researcher]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[researcher]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[researcher]"
+```
 
 Then ask it a question:
 

--- a/docs/researcher.md
+++ b/docs/researcher.md
@@ -14,9 +14,17 @@ It is a regular [combined capability](https://pydantic.dev/docs/ai/capabilities/
 
 Install the local search and fetch fallbacks (DuckDuckGo search, page-to-Markdown fetching):
 
-```bash
-uv add "pydantic-ai-harness[researcher]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[researcher]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[researcher]"
+    ```
 
 Then ask it a question:
 

--- a/docs/researcher.md
+++ b/docs/researcher.md
@@ -14,16 +14,16 @@ It is a regular [combined capability](https://pydantic.dev/docs/ai/capabilities/
 
 Install the local search and fetch fallbacks (DuckDuckGo search, page-to-Markdown fetching):
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[researcher]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[researcher]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[researcher]"
     ```
 
 Then ask it a question:

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,16 +21,16 @@ Pydantic AI's `load_capability` tool to receive that skill's instructions.
 
 Install the `skills` extra for YAML frontmatter support:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[skills]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[skills]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[skills]"
     ```
 
 ## Quick start

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,17 +21,9 @@ Pydantic AI's `load_capability` tool to receive that skill's instructions.
 
 Install the `skills` extra for YAML frontmatter support:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[skills]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[skills]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[skills]"
+```
 
 ## Quick start
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,9 +21,17 @@ Pydantic AI's `load_capability` tool to receive that skill's instructions.
 
 Install the `skills` extra for YAML frontmatter support:
 
-```bash
-uv add "pydantic-ai-harness[skills]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[skills]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[skills]"
+    ```
 
 ## Quick start
 

--- a/docs/stackone.md
+++ b/docs/stackone.md
@@ -25,9 +25,17 @@ You also need an API key for the model your agent uses.
 
 ## Installation
 
-```bash
-uv add "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
+    ```
 
 The `openai` and `spec` extras support the model and agent-spec examples below. Install the provider extra for a
 different model provider instead.

--- a/docs/stackone.md
+++ b/docs/stackone.md
@@ -25,17 +25,9 @@ You also need an API key for the model your agent uses.
 
 ## Installation
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
+```
 
 The `openai` and `spec` extras support the model and agent-spec examples below. Install the provider extra for a
 different model provider instead.

--- a/docs/stackone.md
+++ b/docs/stackone.md
@@ -25,16 +25,16 @@ You also need an API key for the model your agent uses.
 
 ## Installation
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
     ```
 
 The `openai` and `spec` extras support the model and agent-spec examples below. Install the provider extra for a

--- a/docs/step-persistence.md
+++ b/docs/step-persistence.md
@@ -328,17 +328,9 @@ The store issues `createIndex` on its first write, for ten indexes: `conversatio
 
 Install MongoDB support:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[mongodb]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[mongodb]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[mongodb]"
+```
 
 ## Bounding snapshot growth
 

--- a/docs/step-persistence.md
+++ b/docs/step-persistence.md
@@ -310,7 +310,7 @@ The helper reads the active `run_id` from the `StepPersistence` `ContextVar` and
     - `snapshot-keys.jsonl` -- replay-suppression keys retained independently of snapshot pruning
     - `snapshots/{seq}.json` -- `ContinuableSnapshot`s, named by a per-run monotonic counter (not `step_index`, which would collide when the same `run_id` is reused across `Agent.run` calls, since `ctx.run_step` resets to 0 each call).
 - `SqliteStepStore(database='runs.db')` -- single SQLite file with tables `runs`, `events`, `snapshots`, `snapshot_idempotency_keys`, `tool_effects`, and a sibling `media` table for externalized blobs (see [Persisting media](#persisting-media) below). WAL mode is enabled; `tool_effects` upserts per `(run_id, tool_call_id)` so the latest state wins; snapshots use `AUTOINCREMENT seq` to mirror `FileStepStore._next_snapshot_seq`. Databases created before the snapshot `state` column existed gain it automatically on open (existing rows read as `complete`). Pass `connection=` instead of `database=` to share a `sqlite3.Connection` with the rest of your application; the connection must be opened with `check_same_thread=False` because hook calls are dispatched onto a worker thread.
-- `MongoStepStore(client= or db_url=, database=...)` -- MongoDB collections `runs`, `events`, `snapshots`, `snapshot_idempotency_keys`, `tool_effects`, and `counters` (atomic `$inc` allocates the monotonic `seq`). Run registration uses an atomic insert by `runs._id = run_id`; duplicate ids raise `ValueError`. Needs the `mongodb` extra (`pip install pydantic-ai-harness[mongodb]`, which installs `pymongo>=4.17.0`); pass a shared `AsyncMongoClient` as `client=`, or a connection string as `db_url=` (the store then owns the client -- call `await store.aclose()` to release it). Individual parts at or above `media_threshold_bytes` externalize by default to a `MongoMediaStore` on the same client. That is a per-value offload, not an aggregate cap: a snapshot of many below-threshold parts can still exceed MongoDB's 16 MiB document limit and fail on insert, so lower the threshold if that is a risk for your workload.
+- `MongoStepStore(client= or db_url=, database=...)` -- MongoDB collections `runs`, `events`, `snapshots`, `snapshot_idempotency_keys`, `tool_effects`, and `counters` (atomic `$inc` allocates the monotonic `seq`). Run registration uses an atomic insert by `runs._id = run_id`; duplicate ids raise `ValueError`. Needs the `mongodb` extra (which installs `pymongo>=4.17.0`); pass a shared `AsyncMongoClient` as `client=`, or a connection string as `db_url=` (the store then owns the client -- call `await store.aclose()` to release it). Individual parts at or above `media_threshold_bytes` externalize by default to a `MongoMediaStore` on the same client. That is a per-value offload, not an aggregate cap: a snapshot of many below-threshold parts can still exceed MongoDB's 16 MiB document limit and fail on insert, so lower the threshold if that is a risk for your workload.
 
 All implement the same async `StepStore` protocol, so capability hooks never block the event loop on the file/sqlite backends (I/O is dispatched via `anyio.to_thread`); the Mongo backend is natively async.
 
@@ -325,6 +325,20 @@ The store issues `createIndex` on its first write, for ten indexes: `conversatio
 - Index builds against already-populated collections cost time and I/O on that first call.
 
 `RunRecord.metadata` and `StepEvent.metadata` are stored as nested documents, so their keys become BSON field names: keys containing `.` or starting with `$` need [MongoDB 5.0 or later](https://www.mongodb.com/docs/manual/core/dot-dollar-considerations/), and a key containing a NULL byte is rejected by the BSON encoder before it reaches the server. CI exercises both Mongo backends against `mongo:8`.
+
+Install MongoDB support:
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[mongodb]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[mongodb]"
+    ```
 
 ## Bounding snapshot growth
 

--- a/docs/step-persistence.md
+++ b/docs/step-persistence.md
@@ -328,16 +328,16 @@ The store issues `createIndex` on its first write, for ten indexes: `conversatio
 
 Install MongoDB support:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[mongodb]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[mongodb]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[mongodb]"
     ```
 
 ## Bounding snapshot growth

--- a/docs/youdotcom.md
+++ b/docs/youdotcom.md
@@ -35,17 +35,9 @@ Install the `youdotcom` extra and set the `YDC_API_KEY` environment variable
 honored). The examples below use an Anthropic model and `Agent.from_file`, so
 they also pull in the `anthropic` provider and the `spec` YAML support:
 
-=== "uv"
-
-    ```bash
-    uv add "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
-    ```
-
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
-    ```
+```bash
+pip/uv-add "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
+```
 
 Then pass the capabilities to an `Agent` via the `capabilities` parameter:
 

--- a/docs/youdotcom.md
+++ b/docs/youdotcom.md
@@ -35,9 +35,17 @@ Install the `youdotcom` extra and set the `YDC_API_KEY` environment variable
 honored). The examples below use an Anthropic model and `Agent.from_file`, so
 they also pull in the `anthropic` provider and the `spec` YAML support:
 
-```bash
-uv add "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
-```
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
+    ```
+
+=== "uv"
+
+    ```bash
+    uv add "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
+    ```
 
 Then pass the capabilities to an `Agent` via the `capabilities` parameter:
 

--- a/docs/youdotcom.md
+++ b/docs/youdotcom.md
@@ -35,16 +35,16 @@ Install the `youdotcom` extra and set the `YDC_API_KEY` environment variable
 honored). The examples below use an Anthropic model and `Agent.from_file`, so
 they also pull in the `anthropic` provider and the `spec` YAML support:
 
-=== "pip"
-
-    ```bash
-    pip install "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
-    ```
-
 === "uv"
 
     ```bash
     uv add "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
+    ```
+
+=== "pip"
+
+    ```bash
+    pip install "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
     ```
 
 Then pass the capabilities to an `Agent` via the `capabilities` parameter:

--- a/pydantic_ai_harness/aws_lambda/README.md
+++ b/pydantic_ai_harness/aws_lambda/README.md
@@ -12,16 +12,16 @@ checkpointing, a resumed run would repeat every model request and tool call.
 
 ## Installation
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[aws-lambda,bedrock]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[aws-lambda,bedrock]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[aws-lambda,bedrock]"
 ```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.

--- a/pydantic_ai_harness/aws_lambda/README.md
+++ b/pydantic_ai_harness/aws_lambda/README.md
@@ -12,8 +12,16 @@ checkpointing, a resumed run would repeat every model request and tool call.
 
 ## Installation
 
+pip:
+
 ```bash
 pip install "pydantic-ai-harness[aws-lambda,bedrock]"
+```
+
+uv:
+
+```bash
+uv add "pydantic-ai-harness[aws-lambda,bedrock]"
 ```
 
 The AWS Durable Execution SDK requires Python 3.11 or newer.

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -19,6 +19,14 @@ the tool returns a text result.
 
 ## Installation
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[browser-use]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[browser-use]"
 ```

--- a/pydantic_ai_harness/browser_use/README.md
+++ b/pydantic_ai_harness/browser_use/README.md
@@ -19,16 +19,16 @@ the tool returns a text result.
 
 ## Installation
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[browser-use]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[browser-use]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[browser-use]"
 ```
 
 The extra needs Python 3.11+ (browser-use's floor; the rest of the harness

--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -69,16 +69,16 @@ The [harness Quick start](../../README.md#quick-start) wires `CodeMode` up again
 
 Code mode requires the Monty sandbox:
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[codemode]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[codemode]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[codemode]"
 ```
 
 The `code-mode` extra is also supported as an alias.
@@ -306,16 +306,16 @@ Keep these limitations in mind:
 
 Install both integrations:
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[codemode,temporal]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[codemode,temporal]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[codemode,temporal]"
 ```
 
 Construct the named agent and its stable-ID toolsets outside the workflow, then attach

--- a/pydantic_ai_harness/code_mode/README.md
+++ b/pydantic_ai_harness/code_mode/README.md
@@ -69,6 +69,14 @@ The [harness Quick start](../../README.md#quick-start) wires `CodeMode` up again
 
 Code mode requires the Monty sandbox:
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[codemode]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[codemode]"
 ```
@@ -297,6 +305,14 @@ Keep these limitations in mind:
 ## Temporal durability
 
 Install both integrations:
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[codemode,temporal]"
+```
+
+uv:
 
 ```bash
 uv add "pydantic-ai-harness[codemode,temporal]"

--- a/pydantic_ai_harness/dynamic_workflow/README.md
+++ b/pydantic_ai_harness/dynamic_workflow/README.md
@@ -56,16 +56,16 @@ catalog without changing the sub-agents themselves.
 
 The script runs inside the [Monty](https://github.com/pydantic/monty) sandbox, so install the extra:
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[dynamic-workflow]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[dynamic-workflow]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[dynamic-workflow]"
 ```
 
 ## Your first workflow

--- a/pydantic_ai_harness/dynamic_workflow/README.md
+++ b/pydantic_ai_harness/dynamic_workflow/README.md
@@ -56,6 +56,14 @@ catalog without changing the sub-agents themselves.
 
 The script runs inside the [Monty](https://github.com/pydantic/monty) sandbox, so install the extra:
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[dynamic-workflow]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[dynamic-workflow]"
 ```

--- a/pydantic_ai_harness/exa/README.md
+++ b/pydantic_ai_harness/exa/README.md
@@ -11,6 +11,14 @@ Exa Agent API as deferred tool calls.
 
 ## Installation
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[exa]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[exa]"
 ```

--- a/pydantic_ai_harness/exa/README.md
+++ b/pydantic_ai_harness/exa/README.md
@@ -11,16 +11,16 @@ Exa Agent API as deferred tool calls.
 
 ## Installation
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[exa]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[exa]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[exa]"
 ```
 
 Set the `EXA_API_KEY` environment variable (create a key at

--- a/pydantic_ai_harness/experimental/acp/README.md
+++ b/pydantic_ai_harness/experimental/acp/README.md
@@ -41,6 +41,14 @@ Editors like [Zed](https://zed.dev/docs/ai/external-agents) speak ACP: a stdio J
 
 ## Installation
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[acp]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[acp]"
 ```

--- a/pydantic_ai_harness/experimental/acp/README.md
+++ b/pydantic_ai_harness/experimental/acp/README.md
@@ -41,16 +41,16 @@ Editors like [Zed](https://zed.dev/docs/ai/external-agents) speak ACP: a stdio J
 
 ## Installation
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[acp]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[acp]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[acp]"
 ```
 
 This pulls in the [`agent-client-protocol`](https://pypi.org/project/agent-client-protocol/) SDK. The rest of the harness does not depend on it -- only `pydantic_ai_harness.experimental.acp` does.

--- a/pydantic_ai_harness/logfire/README.md
+++ b/pydantic_ai_harness/logfire/README.md
@@ -5,8 +5,16 @@ so you can iterate on it from the Logfire UI -- versioned, labelled, and rolled 
 
 Install the extra:
 
+pip:
+
 ```bash
 pip install 'pydantic-ai-harness[logfire]'
+```
+
+uv:
+
+```bash
+uv add 'pydantic-ai-harness[logfire]'
 ```
 
 [Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/logfire/)

--- a/pydantic_ai_harness/logfire/README.md
+++ b/pydantic_ai_harness/logfire/README.md
@@ -5,16 +5,16 @@ so you can iterate on it from the Logfire UI -- versioned, labelled, and rolled 
 
 Install the extra:
 
-pip:
-
-```bash
-pip install 'pydantic-ai-harness[logfire]'
-```
-
 uv:
 
 ```bash
 uv add 'pydantic-ai-harness[logfire]'
+```
+
+pip:
+
+```bash
+pip install 'pydantic-ai-harness[logfire]'
 ```
 
 [Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/logfire/)

--- a/pydantic_ai_harness/media/README.md
+++ b/pydantic_ai_harness/media/README.md
@@ -36,7 +36,19 @@ Every store implements the `MediaStore` protocol: `put`, `get`, `exists`, `publi
 | `S3MediaStore(...)` | S3 or an S3-compatible bucket | Shared or production storage |
 | `MongoMediaStore(...)` | MongoDB (sha256-addressed manual chunking) | A MongoDB deployment; blobs larger than one BSON document, split so no chunk hits the 16 MiB cap |
 
-`MongoMediaStore` needs the `mongodb` extra (`pip install pydantic-ai-harness[mongodb]`, which installs `pymongo>=4.17.0`) and is imported the same way (`from pydantic_ai_harness.media import MongoMediaStore`). It stores each blob as sha256-addressed chunks in a `media_chunks` collection, with a `media` manifest document per blob. The chunking bounds each BSON document, so a blob larger than MongoDB's 16 MiB document cap still stores and reads back; it does not bound memory, since `put` takes the whole payload as `bytes` and `get` reassembles every chunk into one `bytearray` (there is no streaming API). The manifest itself holds `MediaContext.metadata` inline and is not chunked, so keep per-blob metadata small. Manual chunking is used instead of GridFS: it keeps content-addressed dedup (GridFS keys files by `ObjectId` and does none) and stays fully testable in-memory.
+`MongoMediaStore` needs the `mongodb` extra (which installs `pymongo>=4.17.0`) and is imported the same way (`from pydantic_ai_harness.media import MongoMediaStore`). It stores each blob as sha256-addressed chunks in a `media_chunks` collection, with a `media` manifest document per blob. The chunking bounds each BSON document, so a blob larger than MongoDB's 16 MiB document cap still stores and reads back; it does not bound memory, since `put` takes the whole payload as `bytes` and `get` reassembles every chunk into one `bytearray` (there is no streaming API). The manifest itself holds `MediaContext.metadata` inline and is not chunked, so keep per-blob metadata small. Manual chunking is used instead of GridFS: it keeps content-addressed dedup (GridFS keys files by `ObjectId` and does none) and stays fully testable in-memory.
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[mongodb]"
+```
+
+uv:
+
+```bash
+uv add "pydantic-ai-harness[mongodb]"
+```
 
 `collection=` (default `'media'`) names the manifest collection and derives the chunk collection as `<collection>_chunks`. `chunk_size_bytes=` (default 8 MiB) sets the split size and is rejected below 1 byte or above 16 MiB minus 64 KiB of headroom for the chunk document's own fields. On the first `put` or `get` the store issues `createIndex` for a compound `(files_id, n)` index on the chunk collection, without which reassembly is a collection scan -- so the connecting user needs the privilege to create indexes, and an already-populated collection pays the index build on that first call.
 

--- a/pydantic_ai_harness/media/README.md
+++ b/pydantic_ai_harness/media/README.md
@@ -38,16 +38,16 @@ Every store implements the `MediaStore` protocol: `put`, `get`, `exists`, `publi
 
 `MongoMediaStore` needs the `mongodb` extra (which installs `pymongo>=4.17.0`) and is imported the same way (`from pydantic_ai_harness.media import MongoMediaStore`). It stores each blob as sha256-addressed chunks in a `media_chunks` collection, with a `media` manifest document per blob. The chunking bounds each BSON document, so a blob larger than MongoDB's 16 MiB document cap still stores and reads back; it does not bound memory, since `put` takes the whole payload as `bytes` and `get` reassembles every chunk into one `bytearray` (there is no streaming API). The manifest itself holds `MediaContext.metadata` inline and is not chunked, so keep per-blob metadata small. Manual chunking is used instead of GridFS: it keeps content-addressed dedup (GridFS keys files by `ObjectId` and does none) and stays fully testable in-memory.
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[mongodb]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[mongodb]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[mongodb]"
 ```
 
 `collection=` (default `'media'`) names the manifest collection and derives the chunk collection as `<collection>_chunks`. `chunk_size_bytes=` (default 8 MiB) sets the split size and is rejected below 1 byte or above 16 MiB minus 64 KiB of headroom for the chunk document's own fields. On the first `put` or `get` the store issues `createIndex` for a compound `(files_id, n)` index on the chunk collection, without which reassembly is a collection scan -- so the connecting user needs the privilege to create indexes, and an already-populated collection pays the index build on that first call.

--- a/pydantic_ai_harness/memory/README.md
+++ b/pydantic_ai_harness/memory/README.md
@@ -89,7 +89,19 @@ sqlite_memory = Memory(SqliteMemoryStore(database='.agent-memory.db'))
 
 `FileStore` keeps the journal at `.memory-store.sqlite3` inside its root. Keep it with the Markdown files when copying or backing up the store. Editing a Markdown file outside the capability changes its content version and can produce a conflict with a prepared operation; the journal recovers operations interrupted between transaction preparation and filesystem replacement.
 
-`PostgresMemoryStore` accepts the driver-neutral `PostgresPool` protocol, so the harness does not require a particular PostgreSQL driver. Install and manage the driver in your application (for example, `uv add asyncpg`):
+`PostgresMemoryStore` accepts the driver-neutral `PostgresPool` protocol, so the harness does not require a particular PostgreSQL driver. Install and manage the driver in your application, for example:
+
+pip:
+
+```bash
+pip install asyncpg
+```
+
+uv:
+
+```bash
+uv add asyncpg
+```
 
 ```python
 import asyncpg

--- a/pydantic_ai_harness/memory/README.md
+++ b/pydantic_ai_harness/memory/README.md
@@ -91,16 +91,16 @@ sqlite_memory = Memory(SqliteMemoryStore(database='.agent-memory.db'))
 
 `PostgresMemoryStore` accepts the driver-neutral `PostgresPool` protocol, so the harness does not require a particular PostgreSQL driver. Install and manage the driver in your application, for example:
 
-pip:
-
-```bash
-pip install asyncpg
-```
-
 uv:
 
 ```bash
 uv add asyncpg
+```
+
+pip:
+
+```bash
+pip install asyncpg
 ```
 
 ```python

--- a/pydantic_ai_harness/modal_sandbox/README.md
+++ b/pydantic_ai_harness/modal_sandbox/README.md
@@ -15,18 +15,18 @@ one across several runs.
 Install the `modal` extra and authenticate with the Modal CLI. In CI, set
 `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead.
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[modal]"
-modal token new                # writes ~/.modal.toml
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[modal]"
 uv run modal token new                # writes ~/.modal.toml
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[modal]"
+modal token new                # writes ~/.modal.toml
 ```
 
 In CI, use environment variables instead of interactive authentication:

--- a/pydantic_ai_harness/modal_sandbox/README.md
+++ b/pydantic_ai_harness/modal_sandbox/README.md
@@ -15,10 +15,23 @@ one across several runs.
 Install the `modal` extra and authenticate with the Modal CLI. In CI, set
 `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` instead.
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[modal]"
+modal token new                # writes ~/.modal.toml
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[modal]"
-modal token new                # writes ~/.modal.toml
-# or, e.g. in CI:
+uv run modal token new                # writes ~/.modal.toml
+```
+
+In CI, use environment variables instead of interactive authentication:
+
+```bash
 export MODAL_TOKEN_ID=...
 export MODAL_TOKEN_SECRET=...
 ```

--- a/pydantic_ai_harness/playwright/README.md
+++ b/pydantic_ai_harness/playwright/README.md
@@ -26,18 +26,18 @@ JavaScript-rendered SPAs, and interactive multi-step flows.
 The `playwright` extra pulls in Playwright, and Chromium is a separate binary
 download:
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[playwright]"
-playwright install chromium
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[playwright]"
 uv run playwright install chromium
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[playwright]"
+playwright install chromium
 ```
 
 If the Chromium binary is missing at runtime, the browser tool returns the

--- a/pydantic_ai_harness/playwright/README.md
+++ b/pydantic_ai_harness/playwright/README.md
@@ -26,9 +26,18 @@ JavaScript-rendered SPAs, and interactive multi-step flows.
 The `playwright` extra pulls in Playwright, and Chromium is a separate binary
 download:
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[playwright]"
+playwright install chromium
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[playwright]"
-playwright install chromium
+uv run playwright install chromium
 ```
 
 If the Chromium binary is missing at runtime, the browser tool returns the

--- a/pydantic_ai_harness/prompt_injection_defender/README.md
+++ b/pydantic_ai_harness/prompt_injection_defender/README.md
@@ -16,6 +16,14 @@ to observe flagged verdicts.
 
 ## Installation
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[prompt-injection-defender]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[prompt-injection-defender]"
 ```
@@ -24,6 +32,14 @@ The capability requires Python 3.11 or newer. The base extra provides pattern
 detection over recognized text fields, bare string results, and `ToolReturn`
 content. To classify text under other fields, install the ML extra and enable
 `semantic_detection`:
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[prompt-injection-defender-ml]"
+```
+
+uv:
 
 ```bash
 uv add "pydantic-ai-harness[prompt-injection-defender-ml]"

--- a/pydantic_ai_harness/prompt_injection_defender/README.md
+++ b/pydantic_ai_harness/prompt_injection_defender/README.md
@@ -16,16 +16,16 @@ to observe flagged verdicts.
 
 ## Installation
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[prompt-injection-defender]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[prompt-injection-defender]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[prompt-injection-defender]"
 ```
 
 The capability requires Python 3.11 or newer. The base extra provides pattern
@@ -33,16 +33,16 @@ detection over recognized text fields, bare string results, and `ToolReturn`
 content. To classify text under other fields, install the ML extra and enable
 `semantic_detection`:
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[prompt-injection-defender-ml]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[prompt-injection-defender-ml]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[prompt-injection-defender-ml]"
 ```
 
 ```python

--- a/pydantic_ai_harness/researcher/README.md
+++ b/pydantic_ai_harness/researcher/README.md
@@ -5,16 +5,16 @@ It is a regular [combined capability](https://pydantic.dev/docs/ai/capabilities/
 
 Install the local search and fetch fallbacks (DuckDuckGo search, page-to-Markdown fetching):
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[researcher]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[researcher]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[researcher]"
 ```
 
 ```python

--- a/pydantic_ai_harness/researcher/README.md
+++ b/pydantic_ai_harness/researcher/README.md
@@ -5,6 +5,14 @@ It is a regular [combined capability](https://pydantic.dev/docs/ai/capabilities/
 
 Install the local search and fetch fallbacks (DuckDuckGo search, page-to-Markdown fetching):
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[researcher]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[researcher]"
 ```

--- a/pydantic_ai_harness/skills/README.md
+++ b/pydantic_ai_harness/skills/README.md
@@ -16,16 +16,16 @@ Pydantic AI's `load_capability` tool to receive that skill's instructions.
 
 Install the `skills` extra for YAML frontmatter support:
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[skills]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[skills]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[skills]"
 ```
 
 ## Quick start

--- a/pydantic_ai_harness/skills/README.md
+++ b/pydantic_ai_harness/skills/README.md
@@ -16,6 +16,14 @@ Pydantic AI's `load_capability` tool to receive that skill's instructions.
 
 Install the `skills` extra for YAML frontmatter support:
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[skills]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[skills]"
 ```

--- a/pydantic_ai_harness/stackone/README.md
+++ b/pydantic_ai_harness/stackone/README.md
@@ -20,16 +20,16 @@ You also need an API key for the model your agent uses.
 
 ## Installation
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
 ```
 
 The `openai` and `spec` extras support the model and agent-spec examples below. Install the provider extra for a

--- a/pydantic_ai_harness/stackone/README.md
+++ b/pydantic_ai_harness/stackone/README.md
@@ -20,6 +20,14 @@ You also need an API key for the model your agent uses.
 
 ## Installation
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[stackone]" "pydantic-ai-slim[openai,spec]"
 ```

--- a/pydantic_ai_harness/step_persistence/README.md
+++ b/pydantic_ai_harness/step_persistence/README.md
@@ -404,16 +404,16 @@ reaches the server. CI exercises both Mongo backends against `mongo:8`.
 
 Install MongoDB support:
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[mongodb]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[mongodb]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[mongodb]"
 ```
 
 ## Bounding snapshot growth

--- a/pydantic_ai_harness/step_persistence/README.md
+++ b/pydantic_ai_harness/step_persistence/README.md
@@ -359,8 +359,7 @@ configured retention can delete older snapshots.
   and `counters` (atomic `$inc` for monotonic `seq`). Run registration uses an
   atomic insert by `runs._id = run_id`; duplicate ids raise `ValueError`.
   Needs the `mongodb` extra
-  (`pip install pydantic-ai-harness[mongodb]`, which installs
-  `pymongo>=4.17.0`); pass a shared `AsyncMongoClient` as `client=`, or a
+  (which installs `pymongo>=4.17.0`); pass a shared `AsyncMongoClient` as `client=`, or a
   connection string as `db_url=` (the store then owns the client -- call
   `await store.aclose()` to release it).
   Externalizes individual parts at or above `media_threshold_bytes` by
@@ -402,6 +401,20 @@ so their keys become BSON field names: keys containing `.` or starting with
 `$` need [MongoDB 5.0 or later](https://www.mongodb.com/docs/manual/core/dot-dollar-considerations/),
 and a key containing a NULL byte is rejected by the BSON encoder before it
 reaches the server. CI exercises both Mongo backends against `mongo:8`.
+
+Install MongoDB support:
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[mongodb]"
+```
+
+uv:
+
+```bash
+uv add "pydantic-ai-harness[mongodb]"
+```
 
 ## Bounding snapshot growth
 

--- a/pydantic_ai_harness/youdotcom/README.md
+++ b/pydantic_ai_harness/youdotcom/README.md
@@ -13,6 +13,14 @@ lookup cannot settle.
 The examples below use an Anthropic model and `Agent.from_file`, so they also
 pull in the `anthropic` provider and the `spec` YAML support:
 
+pip:
+
+```bash
+pip install "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
+```
+
+uv:
+
 ```bash
 uv add "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
 ```

--- a/pydantic_ai_harness/youdotcom/README.md
+++ b/pydantic_ai_harness/youdotcom/README.md
@@ -13,16 +13,16 @@ lookup cannot settle.
 The examples below use an Anthropic model and `Agent.from_file`, so they also
 pull in the `anthropic` provider and the `spec` YAML support:
 
-pip:
-
-```bash
-pip install "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
-```
-
 uv:
 
 ```bash
 uv add "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[youdotcom,anthropic]" "pydantic-ai-slim[spec]"
 ```
 
 Set the `YDC_API_KEY` environment variable (create a key at

--- a/tests/test_docs_installation.py
+++ b/tests/test_docs_installation.py
@@ -18,12 +18,12 @@ def test_installation_commands_are_paired(path: Path) -> None:
     pip_label = '=== "pip"' if path in _PAGES else 'pip:'
     uv_label = '=== "uv"' if path in _PAGES else 'uv:'
     pair = re.compile(
-        rf'^{re.escape(pip_label)}\n\n{indent}```bash\n'
-        rf'{indent}pip install (?P<args>[^\n]+)\n'
-        rf'(?P<pip_followup>(?:(?!{indent}```)[^\n]*\n)*){indent}```\n\n'
-        rf'{re.escape(uv_label)}\n\n{indent}```bash\n'
-        rf'{indent}uv add (?P=args)\n'
-        rf'(?P<uv_followup>(?:(?!{indent}```)[^\n]*\n)*){indent}```',
+        rf'^{re.escape(uv_label)}\n\n{indent}```bash\n'
+        rf'{indent}uv add (?P<args>[^\n]+)\n'
+        rf'(?P<uv_followup>(?:(?!{indent}```)[^\n]*\n)*){indent}```\n\n'
+        rf'{re.escape(pip_label)}\n\n{indent}```bash\n'
+        rf'{indent}pip install (?P=args)\n'
+        rf'(?P<pip_followup>(?:(?!{indent}```)[^\n]*\n)*){indent}```',
         re.MULTILINE,
     )
     for match in pair.finditer(text):
@@ -31,7 +31,7 @@ def test_installation_commands_are_paired(path: Path) -> None:
             f'{path}: additional installation commands need their own paired blocks'
         )
     assert not _INSTALL.search(pair.sub('', text)), (
-        f'{path}: each installation needs adjacent labeled pip / uv blocks with identical package arguments'
+        f'{path}: each installation needs adjacent labeled uv / pip blocks, uv first, with identical package arguments'
     )
 
 

--- a/tests/test_docs_installation.py
+++ b/tests/test_docs_installation.py
@@ -1,0 +1,35 @@
+"""Keep user-facing Python installation examples available for pip and uv."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).parent.parent
+_PAGES = sorted((_ROOT / 'docs').rglob('*.md'))
+_READMES = [_ROOT / 'README.md', *sorted((_ROOT / 'pydantic_ai_harness').rglob('README.md'))]
+_INSTALL = re.compile(r'^\s*(pip install|uv add) (.+)$', re.MULTILINE)
+
+
+@pytest.mark.parametrize('path', [*_PAGES, *_READMES], ids=lambda path: str(path.relative_to(_ROOT)))
+def test_installation_commands_are_paired(path: Path) -> None:
+    text = path.read_text(encoding='utf-8')
+    commands = _INSTALL.findall(text)
+    pip_args = [args for command, args in commands if command == 'pip install']
+    uv_args = [args for command, args in commands if command == 'uv add']
+    assert pip_args == uv_args, f'{path}: pip and uv must install the same packages in the same order'
+    for manager, command in commands:
+        label = 'pip' if manager == 'pip install' else 'uv'
+        if path in _PAGES:
+            expected = f'=== "{label}"\n\n    ```bash\n    {manager} {command}\n'
+        else:
+            expected = f'{label}:\n\n```bash\n{manager} {command}\n'
+        assert expected in text, f'{path}: installation command needs its {label} label or tab'
+
+
+@pytest.mark.parametrize('path', [*_PAGES, *_READMES], ids=lambda path: str(path.relative_to(_ROOT)))
+def test_installation_commands_are_not_inline(path: Path) -> None:
+    text = path.read_text(encoding='utf-8')
+    assert not re.search(r'`(?:pip install|uv add) [^`]+`', text), (
+        f'{path}: move inline installation commands into paired pip / uv blocks'
+    )

--- a/tests/test_docs_installation.py
+++ b/tests/test_docs_installation.py
@@ -11,19 +11,27 @@ _READMES = [_ROOT / 'README.md', *sorted((_ROOT / 'pydantic_ai_harness').rglob('
 _INSTALL = re.compile(r'^\s*(pip install|uv add) (.+)$', re.MULTILINE)
 
 
-@pytest.mark.parametrize('path', [*_PAGES, *_READMES], ids=lambda path: str(path.relative_to(_ROOT)))
+@pytest.mark.parametrize('path', _PAGES, ids=lambda path: str(path.relative_to(_ROOT)))
+def test_docs_installation_commands_use_shorthand(path: Path) -> None:
+    text = path.read_text(encoding='utf-8')
+    assert not _INSTALL.search(text), f'{path}: use pip/uv-add in a bash fence instead of hand-written install tabs'
+    shorthand = re.compile(r'^```bash\n(?:pip/uv-add|py-cli) [^\n]+\n```', re.MULTILINE)
+    assert not re.search(r'\b(?:pip/uv-add|py-cli)\b', shorthand.sub('', text)), (
+        f'{path}: each shorthand command needs its own single-line bash fence'
+    )
+
+
+@pytest.mark.parametrize('path', _READMES, ids=lambda path: str(path.relative_to(_ROOT)))
 def test_installation_commands_are_paired(path: Path) -> None:
     text = path.read_text(encoding='utf-8')
-    indent = '    ' if path in _PAGES else ''
-    pip_label = '=== "pip"' if path in _PAGES else 'pip:'
-    uv_label = '=== "uv"' if path in _PAGES else 'uv:'
+    assert not re.search(r'\b(?:pip/uv-add|py-cli)\b', text), f'{path}: READMEs need executable commands'
     pair = re.compile(
-        rf'^{re.escape(uv_label)}\n\n{indent}```bash\n'
-        rf'{indent}uv add (?P<args>[^\n]+)\n'
-        rf'(?P<uv_followup>(?:(?!{indent}```)[^\n]*\n)*){indent}```\n\n'
-        rf'{re.escape(pip_label)}\n\n{indent}```bash\n'
-        rf'{indent}pip install (?P=args)\n'
-        rf'(?P<pip_followup>(?:(?!{indent}```)[^\n]*\n)*){indent}```',
+        r'^uv:\n\n```bash\n'
+        r'uv add (?P<args>[^\n]+)\n'
+        r'(?P<uv_followup>(?:(?!```)[^\n]*\n)*)```\n\n'
+        r'pip:\n\n```bash\n'
+        r'pip install (?P=args)\n'
+        r'(?P<pip_followup>(?:(?!```)[^\n]*\n)*)```',
         re.MULTILINE,
     )
     for match in pair.finditer(text):
@@ -39,5 +47,5 @@ def test_installation_commands_are_paired(path: Path) -> None:
 def test_installation_commands_are_not_inline(path: Path) -> None:
     text = path.read_text(encoding='utf-8')
     assert not re.search(r'`(?:pip install|uv add) [^`]+`', text), (
-        f'{path}: move inline installation commands into paired pip / uv blocks'
+        f'{path}: move inline installation commands into fenced installation examples'
     )

--- a/tests/test_docs_installation.py
+++ b/tests/test_docs_installation.py
@@ -14,17 +14,25 @@ _INSTALL = re.compile(r'^\s*(pip install|uv add) (.+)$', re.MULTILINE)
 @pytest.mark.parametrize('path', [*_PAGES, *_READMES], ids=lambda path: str(path.relative_to(_ROOT)))
 def test_installation_commands_are_paired(path: Path) -> None:
     text = path.read_text(encoding='utf-8')
-    commands = _INSTALL.findall(text)
-    pip_args = [args for command, args in commands if command == 'pip install']
-    uv_args = [args for command, args in commands if command == 'uv add']
-    assert pip_args == uv_args, f'{path}: pip and uv must install the same packages in the same order'
-    for manager, command in commands:
-        label = 'pip' if manager == 'pip install' else 'uv'
-        if path in _PAGES:
-            expected = f'=== "{label}"\n\n    ```bash\n    {manager} {command}\n'
-        else:
-            expected = f'{label}:\n\n```bash\n{manager} {command}\n'
-        assert expected in text, f'{path}: installation command needs its {label} label or tab'
+    indent = '    ' if path in _PAGES else ''
+    pip_label = '=== "pip"' if path in _PAGES else 'pip:'
+    uv_label = '=== "uv"' if path in _PAGES else 'uv:'
+    pair = re.compile(
+        rf'^{re.escape(pip_label)}\n\n{indent}```bash\n'
+        rf'{indent}pip install (?P<args>[^\n]+)\n'
+        rf'(?P<pip_followup>(?:(?!{indent}```)[^\n]*\n)*){indent}```\n\n'
+        rf'{re.escape(uv_label)}\n\n{indent}```bash\n'
+        rf'{indent}uv add (?P=args)\n'
+        rf'(?P<uv_followup>(?:(?!{indent}```)[^\n]*\n)*){indent}```',
+        re.MULTILINE,
+    )
+    for match in pair.finditer(text):
+        assert not _INSTALL.search(match['pip_followup'] + match['uv_followup']), (
+            f'{path}: additional installation commands need their own paired blocks'
+        )
+    assert not _INSTALL.search(pair.sub('', text)), (
+        f'{path}: each installation needs adjacent labeled pip / uv blocks with identical package arguments'
+    )
 
 
 @pytest.mark.parametrize('path', [*_PAGES, *_READMES], ids=lambda path: str(path.relative_to(_ROOT)))

--- a/tests/test_docs_installation.py
+++ b/tests/test_docs_installation.py
@@ -8,7 +8,7 @@ import pytest
 _ROOT = Path(__file__).parent.parent
 _PAGES = sorted((_ROOT / 'docs').rglob('*.md'))
 _READMES = [_ROOT / 'README.md', *sorted((_ROOT / 'pydantic_ai_harness').rglob('README.md'))]
-_INSTALL = re.compile(r'^\s*(pip install|uv add) (.+)$', re.MULTILINE)
+_INSTALL = re.compile(r'^[ \t]*(?:pip[ \t]+install|uv[ \t]+add)[ \t]+(.+)$', re.MULTILINE)
 
 
 @pytest.mark.parametrize('path', _PAGES, ids=lambda path: str(path.relative_to(_ROOT)))
@@ -46,6 +46,6 @@ def test_installation_commands_are_paired(path: Path) -> None:
 @pytest.mark.parametrize('path', [*_PAGES, *_READMES], ids=lambda path: str(path.relative_to(_ROOT)))
 def test_installation_commands_are_not_inline(path: Path) -> None:
     text = path.read_text(encoding='utf-8')
-    assert not re.search(r'`(?:pip install|uv add) [^`]+`', text), (
+    assert not re.search(r'`(?:pip[ \t]+install|uv[ \t]+add)[ \t]+[^`]+`', text), (
         f'{path}: move inline installation commands into fenced installation examples'
     )


### PR DESCRIPTION
## Summary
- Use `pip/uv-add` in single-line `bash` fences for docs-site installation examples. The shared unified-docs preprocessor generates executable pip / uv tabs.
- Use separate `py-cli` shorthand blocks for Playwright and Modal follow-up commands.
- Keep executable commands under plain uv / pip labels in READMEs because GitHub does not run the preprocessor.
- Update authoring conventions and regression tests for docs shorthand and matching README installation arguments.
- Preserve workflow YAML and repository-development commands with their required execution environments.

## Verification
- Repository-wide Ruff formatting and lint checks passed.
- Focused Pyright on documentation tests passed.
- 443 docs parity and installation tests passed after merging main.
- Verified the shorthand examples through the actual unified-docs transforms.

## Related work
Merged main with #854 included, preserving its corrected AWS dependency arguments and separate Bedrock quick-start installation.