### PR TITLE
Add hosted MCP tools with `Ordinal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Connections to systems outside the agent's workspace, and abilities the provider
 | [MCP](https://ai.pydantic.dev/capabilities/mcp/) | Core | Connect any MCP server's tools; local by default, provider-native connectors opt-in |
 | [Image Generation](https://ai.pydantic.dev/capabilities/image-generation/) | Core | Generate and edit images; provider-native where supported, sub-agent fallback elsewhere |
 | [StackOne](pydantic_ai_harness/stackone/) | Harness | Act on linked SaaS accounts (HRIS, ATS, CRM, …) via [StackOne](https://www.stackone.com) |
+| [Ordinal](pydantic_ai_harness/ordinal/) | Harness | Draft, schedule, and analyze social posts through [Ordinal](https://www.tryordinal.com)'s hosted MCP server |
 | [LocalStack](pydantic_ai_harness/localstack/) | Harness | An emulated AWS environment with AWS CLI tools |
 | [Macroscope](pydantic_ai_harness/macroscope/) | Harness | Run a local [Macroscope](https://docs.macroscope.com/cli) code review and hand the findings to the agent |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,7 @@ Connections to systems outside the agent's workspace, and abilities the provider
 | [MCP](/ai/capabilities/mcp/) | Core | Connect any MCP server's tools; local by default, provider-native connectors opt-in |
 | [Image Generation](/ai/capabilities/image-generation/) | Core | Generate and edit images; provider-native where supported, sub-agent fallback elsewhere |
 | [StackOne](stackone.md) | Harness | Act on linked SaaS accounts (HRIS, ATS, CRM, …) via [StackOne](https://www.stackone.com) |
+| [Ordinal](ordinal.md) | Harness | Draft, schedule, and analyze social posts through [Ordinal](https://www.tryordinal.com)'s hosted MCP server |
 | [LocalStack](localstack.md) | Harness | An emulated AWS environment with AWS CLI tools |
 | [Macroscope](macroscope.md) | Harness | Run a local [Macroscope](https://docs.macroscope.com/cli) code review and hand the findings to the agent |
 

--- a/docs/ordinal.md
+++ b/docs/ordinal.md
@@ -1,0 +1,63 @@
+---
+title: Ordinal
+description: Connect a Pydantic AI agent to Ordinal's hosted MCP server to draft, schedule, and analyze social posts.
+---
+
+# Ordinal
+
+`Ordinal` connects an agent to [Ordinal](https://www.tryordinal.com)'s hosted MCP server so it can draft, schedule, and analyze social posts in the signed-in user's workspaces.
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/ordinal/)
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](index.md#version-policy).
+
+## Before you start
+
+Ordinal MCP is available on the Pro plan or higher, same as the REST API. You need an Ordinal account with access to at least one workspace. Sign-in is OAuth -- there is no API key to copy.
+
+If you previously configured the old server at `https://app.tryordinal.com/api/mcp` with a workspace API key, remove it. The old and new servers cannot coexist: duplicate tool names confuse the agent.
+
+## Installation
+
+```bash
+pip/uv-add "pydantic-ai-harness[ordinal]" "pydantic-ai-slim[openai]"
+```
+
+The second package installs the OpenAI provider used by the example. For another model, install its matching provider extra instead.
+
+## Connect
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import Ordinal
+
+agent = Agent('openai:gpt-5', capabilities=[Ordinal()])
+result = agent.run_sync('List my Ordinal workspaces')
+print(result.output)
+```
+
+The first Ordinal tool call opens a browser. Sign in and approve access. After that, start by listing workspaces -- every other Ordinal tool needs a `workspaceSlug` from `ordinal_get_workspace_context`.
+
+`Ordinal` only configures the connection. For custom clients, tool filtering, or approval policy, use Pydantic AI's generic [`MCP`](/ai/capabilities/mcp/) capability or [`MCPToolset`](/ai/mcp/) directly.
+
+## Define the agent in YAML or JSON
+
+```yaml
+# agent.yaml
+model: openai:gpt-5
+capabilities:
+  - Ordinal: {}
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import Ordinal
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[Ordinal])
+```
+
+Pass `custom_capability_types` so the spec loader knows how to instantiate `Ordinal`.
+
+## API reference
+
+::: pydantic_ai_harness.ordinal.Ordinal

--- a/pydantic_ai_harness/__init__.py
+++ b/pydantic_ai_harness/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from .macroscope import Macroscope
     from .memory import Memory
     from .modal_sandbox import ModalSandbox
+    from .ordinal import Ordinal
     from .planning import Planning
     from .prompt_injection_defender import PromptInjectionDefender
     from .pydantic_ai_docs import PydanticAIDocs
@@ -87,6 +88,7 @@ __all__ = [
     'ManagedPrompt',
     'Memory',
     'ModalSandbox',
+    'Ordinal',
     'OutputBlocked',
     'OutputGuardrail',
     'OutputGuardrailFunc',
@@ -137,6 +139,7 @@ _CAPABILITY_EXPORTS = {
     'ManagedPrompt': 'logfire',
     'Memory': 'memory',
     'ModalSandbox': 'modal_sandbox',
+    'Ordinal': 'ordinal',
     'Planning': 'planning',
     'PromptInjectionDefender': 'prompt_injection_defender',
     'PydanticAIDocs': 'pydantic_ai_docs',

--- a/pydantic_ai_harness/ordinal/README.md
+++ b/pydantic_ai_harness/ordinal/README.md
@@ -1,0 +1,74 @@
+# Ordinal
+
+`Ordinal` connects an agent to [Ordinal](https://www.tryordinal.com)'s hosted MCP
+server so it can draft, schedule, and analyze social posts in the signed-in
+user's workspaces.
+
+[Source](https://github.com/pydantic/pydantic-ai-harness/tree/main/pydantic_ai_harness/ordinal/)
+
+> While Pydantic AI Harness is on 0.x releases, the API may change between minor releases; when it does, deprecation warnings and release-note migration guidance tell you (or your agent) exactly how to upgrade. See the [version policy](https://github.com/pydantic/pydantic-ai-harness#version-policy).
+
+## Before you start
+
+Ordinal MCP is available on the Pro plan or higher, same as the REST API. You
+need an Ordinal account with access to at least one workspace. Sign-in is OAuth
+-- there is no API key to copy.
+
+If you previously configured the old server at `https://app.tryordinal.com/api/mcp`
+with a workspace API key, remove it. The old and new servers cannot coexist:
+duplicate tool names confuse the agent.
+
+## Installation
+
+uv:
+
+```bash
+uv add "pydantic-ai-harness[ordinal]" "pydantic-ai-slim[openai]"
+```
+
+pip:
+
+```bash
+pip install "pydantic-ai-harness[ordinal]" "pydantic-ai-slim[openai]"
+```
+
+The second package installs the OpenAI provider used by the example. For
+another model, install its matching provider extra instead.
+
+## Connect
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import Ordinal
+
+agent = Agent('openai:gpt-5', capabilities=[Ordinal()])
+result = agent.run_sync('List my Ordinal workspaces')
+print(result.output)
+```
+
+The first Ordinal tool call opens a browser. Sign in and approve access. After
+that, start by listing workspaces -- every other Ordinal tool needs a
+`workspaceSlug` from `ordinal_get_workspace_context`.
+
+`Ordinal` only configures the connection. For custom clients, tool filtering,
+or approval policy, use Pydantic AI's generic
+[`MCP`](https://pydantic.dev/docs/ai/capabilities/mcp/) capability or
+[`MCPToolset`](https://pydantic.dev/docs/ai/mcp/) directly.
+
+## Define the agent in YAML or JSON
+
+```yaml
+# agent.yaml
+model: openai:gpt-5
+capabilities:
+  - Ordinal: {}
+```
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai_harness import Ordinal
+
+agent = Agent.from_file('agent.yaml', custom_capability_types=[Ordinal])
+```
+
+Pass `custom_capability_types` so the spec loader knows how to instantiate `Ordinal`.

--- a/pydantic_ai_harness/ordinal/__init__.py
+++ b/pydantic_ai_harness/ordinal/__init__.py
@@ -1,0 +1,8 @@
+"""Connect Pydantic AI agents to Ordinal's hosted MCP server.
+
+Requires the `ordinal` extra: `uv add "pydantic-ai-harness[ordinal]"`.
+"""
+
+from pydantic_ai_harness.ordinal._capability import Ordinal
+
+__all__ = ['Ordinal']

--- a/pydantic_ai_harness/ordinal/_capability.py
+++ b/pydantic_ai_harness/ordinal/_capability.py
@@ -1,0 +1,59 @@
+"""Ordinal hosted MCP capability.
+
+Provider contract, verified 2026-09-11:
+
+- `https://app.tryordinal.com/mcp` is the Streamable HTTP endpoint.
+- Authentication is OAuth. The previous API-key server at
+  `https://app.tryordinal.com/api/mcp` is deprecated and is not used here.
+
+Source: https://docs.tryordinal.com/mcp/introduction
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.tools import AgentDepsT
+
+try:
+    from pydantic_ai.mcp import MCPToolset
+except ImportError as _import_error:  # pragma: no cover
+    raise ImportError(
+        'MCP support is required for the Ordinal capability. Install it with: uv add "pydantic-ai-harness[ordinal]"'
+    ) from _import_error
+
+_ORDINAL_MCP_URL = 'https://app.tryordinal.com/mcp'
+_DEFAULT_DESCRIPTION = 'Work inside an Ordinal workspace: draft, schedule, and analyze social posts.'
+
+
+@dataclass
+class Ordinal(AbstractCapability[AgentDepsT]):
+    """Connect an agent to Ordinal's hosted MCP server.
+
+    The first tool call opens a browser for OAuth. After sign-in, the agent
+    can reach every workspace the user belongs to.
+
+    ```python
+    from pydantic_ai import Agent
+    from pydantic_ai_harness import Ordinal
+
+    agent = Agent('openai:gpt-5', capabilities=[Ordinal()])
+    ```
+    """
+
+    description: str | None = _DEFAULT_DESCRIPTION
+    """Routing description used when the capability is loaded on demand."""
+
+    def get_toolset(self) -> MCPToolset[AgentDepsT]:
+        """Build the Ordinal MCP connection.
+
+        This capability does not emit its own spans. It only constructs the
+        hosted connection; Pydantic AI's MCP toolset traces tool calls.
+        """
+        return MCPToolset(
+            _ORDINAL_MCP_URL,
+            id=self.id if self.id is not None else 'ordinal',
+            auth='oauth',
+            include_instructions=True,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,9 @@ stackone = [
     "fastmcp>=3.4.5,<4",
     "pydantic-ai-slim[mcp]>=2.18.0",
 ]
+ordinal = [
+    "pydantic-ai-slim[mcp]>=2.40.0",
+]
 prompt-injection-defender = [
     "stackone-defender>=0.7.3,<0.8 ; python_full_version >= '3.11'",
 ]

--- a/tests/ordinal/conftest.py
+++ b/tests/ordinal/conftest.py
@@ -1,0 +1,20 @@
+"""Shared collection rules for the Ordinal capability tests."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+# `mcp` is gated on the `ordinal` extra, so slim CI runs (no extras) can't import
+# these modules. Ignore them at collection; `test_packaging.py` stays collected
+# because it checks package metadata, which holds on base installs too.
+# A conditional expression rather than an `if` statement: branch coverage traces
+# statement arcs, and no single environment can take both arms of an
+# install-dependent branch.
+collect_ignore = ['test_ordinal.py'] if importlib.util.find_spec('mcp') is None else []
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return 'asyncio'

--- a/tests/ordinal/test_ordinal.py
+++ b/tests/ordinal/test_ordinal.py
@@ -1,0 +1,80 @@
+"""Behavioral tests for Ordinal through `Agent(capabilities=[...])`."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pytest
+from fastmcp.client.transports import StreamableHttpTransport
+from mcp.server.fastmcp.server import FastMCP, Settings
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPToolset
+from pydantic_ai.models.test import TestModel
+
+from pydantic_ai_harness.ordinal import Ordinal
+
+# The MCP SDK leaves a settings annotation unresolved in some supported dependency
+# combinations. Rebuild it before warnings are escalated by the test suite.
+Settings.model_rebuild()
+
+
+def _http_transport(toolset: MCPToolset[Any]) -> StreamableHttpTransport:
+    transport = toolset.client.transport
+    assert isinstance(transport, StreamableHttpTransport)
+    return transport
+
+
+class TestOrdinal:
+    def test_agent_accepts_capability(self) -> None:
+        capability = Ordinal()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            agent = Agent(TestModel(), capabilities=[capability])
+
+        assert capability in agent.root_capability.capabilities
+
+    @pytest.mark.anyio
+    async def test_agent_runs_with_ordinal_tools(self) -> None:
+        server = FastMCP('ordinal-fake')
+
+        @server.tool()
+        def ordinal_get_workspace_context() -> dict[str, str]:
+            """List Ordinal workspaces."""
+            return {'slug': 'acme'}
+
+        class FakeOrdinal(Ordinal):
+            def get_toolset(self) -> MCPToolset[Any]:
+                return MCPToolset(server)
+
+        agent = Agent(
+            TestModel(call_tools=['ordinal_get_workspace_context']),
+            capabilities=[FakeOrdinal()],
+        )
+
+        result = await agent.run('List my workspaces')
+
+        assert 'acme' in result.output
+
+    def test_serialization_name(self) -> None:
+        assert Ordinal.get_serialization_name() == 'Ordinal'
+
+    def test_hosted_url_uses_oauth_and_forwards_instructions(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            toolset = Ordinal().get_toolset()
+        transport = _http_transport(toolset)
+
+        assert transport.url == 'https://app.tryordinal.com/mcp'
+        assert transport.auth is not None
+        assert toolset.include_instructions is True
+        assert toolset.id == 'ordinal'
+
+    def test_custom_id_is_forwarded(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            toolset = Ordinal(id='tenant-ordinal').get_toolset()
+
+        assert isinstance(toolset, MCPToolset)
+        assert toolset.id == 'tenant-ordinal'

--- a/tests/ordinal/test_packaging.py
+++ b/tests/ordinal/test_packaging.py
@@ -1,0 +1,26 @@
+"""The Ordinal integration ships as the optional `ordinal` extra.
+
+Only metadata checks belong here: this file stays collected on base (no-extras)
+installs, so it must not import `pydantic_ai_harness.ordinal`.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+
+def _requires_dist() -> list[str]:
+    return importlib.metadata.metadata('pydantic-ai-harness').get_all('Requires-Dist') or []
+
+
+def test_ordinal_extra_is_advertised() -> None:
+    provides = importlib.metadata.metadata('pydantic-ai-harness').get_all('Provides-Extra') or []
+    assert 'ordinal' in provides
+
+
+def test_mcp_is_an_optional_ordinal_dependency() -> None:
+    ordinal_requirements = [
+        req for req in _requires_dist() if 'extra == "ordinal"' in req or "extra == 'ordinal'" in req
+    ]
+    assert ordinal_requirements, 'the ordinal extra must be declared'
+    assert any('pydantic-ai-slim' in req and 'mcp' in req for req in ordinal_requirements)

--- a/tests/test_capability_combine.py
+++ b/tests/test_capability_combine.py
@@ -284,6 +284,7 @@ COMBINE_POLICY: dict[str, Policy] = {
         'its toolset registers `aws_cli` and `localstack_health` under fixed names',
         lambda cls: (cls(), cls()),
     ),
+    'Ordinal': Collides('its toolset registers the hosted Ordinal MCP tools under fixed names'),
     'CodeMode': Collides('`run_code` is reserved, so a second one is rejected by name'),
     'BrowserUse': Collides('its toolset registers its browser tools under fixed names'),
     'PlaywrightBrowser': Collides('its toolset registers `click` and friends under fixed names'),

--- a/tests/test_docs_parity.py
+++ b/tests/test_docs_parity.py
@@ -157,6 +157,7 @@ _CAPABILITY_PAGE_META = {
     'prompt-injection-defender.md': ('prompt_injection_defender', 'Prompt Injection Defender'),
     'spend.md': ('spend', 'Spend'),
     'localstack.md': ('localstack', 'LocalStack'),
+    'ordinal.md': ('ordinal', 'Ordinal'),
     'stackone.md': ('stackone', 'StackOne'),
     'acp.md': ('experimental/acp', 'ACP (Agent Client Protocol)'),
 }

--- a/uv.lock
+++ b/uv.lock
@@ -3971,6 +3971,9 @@ modal = [
 mongodb = [
     { name = "pymongo" },
 ]
+ordinal = [
+    { name = "pydantic-ai-slim", extra = ["mcp"] },
+]
 playwright = [
     { name = "idna" },
     { name = "playwright" },
@@ -4041,6 +4044,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'code-mode'", specifier = ">=2.40.0" },
     { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'codemode'", specifier = ">=2.40.0" },
     { name = "pydantic-ai-slim", extras = ["duckduckgo", "web-fetch"], marker = "extra == 'researcher'", specifier = ">=2.40.0" },
+    { name = "pydantic-ai-slim", extras = ["mcp"], marker = "extra == 'ordinal'", specifier = ">=2.40.0" },
     { name = "pydantic-ai-slim", extras = ["mcp"], marker = "extra == 'stackone'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["spec"], marker = "extra == 'logfire'", specifier = ">=2.18.0" },
     { name = "pydantic-ai-slim", extras = ["temporal"], marker = "extra == 'temporal'" },
@@ -4053,7 +4057,7 @@ requires-dist = [
     { name = "stackone-defender", extras = ["onnx"], marker = "python_full_version >= '3.11' and extra == 'prompt-injection-defender-ml'", specifier = ">=0.7.3,<0.8" },
     { name = "youdotcom", marker = "extra == 'youdotcom'", specifier = ">=3.1.2,<4" },
 ]
-provides-extras = ["acp", "anthropic", "aws-lambda", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
+provides-extras = ["acp", "anthropic", "aws-lambda", "browser-use", "cli", "code-mode", "codemode", "dbos", "dynamic-workflow", "exa", "logfire", "modal", "mongodb", "ordinal", "playwright", "prompt-injection-defender", "prompt-injection-defender-ml", "researcher", "skills", "stackone", "temporal", "youdotcom"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Connect an agent to Ordinal's hosted MCP tools with `Ordinal`:

```python
from pydantic_ai import Agent
from pydantic_ai_harness import Ordinal

agent = Agent('openai:gpt-5', capabilities=[Ordinal()])
```

The capability is a thin wrapper around core `MCPToolset`. It pins the official Streamable HTTP URL (`https://app.tryordinal.com/mcp`) and `auth='oauth'`. Ordinal's current server is OAuth-only; there is no API-key path on this preset.

`pydantic-ai-harness[ordinal]` only adds `pydantic-ai-slim[mcp]`, the same extra StackOne already uses. Please add the `dependencies:approved` label.

Both documentation pages cover install, OAuth, and the first `ordinal_get_workspace_context` call. Tests exercise Agent construction, serialization, the pinned URL, and tool execution through `Agent(TestModel(...))` with an in-process MCP server. These are not authenticated provider smoke tests.

Validation: focused capability tests, combination tests, docs parity, Ruff, and Pyright pass. Full CI runs on the PR.

Relates to #787.

Made with [Cursor](https://cursor.com)